### PR TITLE
bug fix in explicit_broadcast

### DIFF
--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -58,6 +58,8 @@ def make_node(
     _, slope = explicit_broadcast(
         const_or_var_1=input_tensor,
         const_or_var_2=slope,
+        graph_node=graph_node,
+        tf_layers_dict= tf_layers_dict
     )
     slope_rank = len(slope.shape)
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -669,11 +669,14 @@ def explicit_broadcast(
         graph_node_input_shape1 = list(graph_node.inputs[0].shape)
         graph_node_input_shape2 = list(graph_node.inputs[1].shape)
 
-    # If const_or_var_2.shape is all 1's, do not broadcast and return as is
-    shape_for_judging_skip_processing = [
+    # If either operand have shape of all 1's, do not broadcast and return as is
+    shape_for_judging_skip_processing_1 = [
+        i if i is not None else INF_INDEX_VALUE for i in const_or_var_1.shape
+    ]
+    shape_for_judging_skip_processing_2 = [
         i if i is not None else INF_INDEX_VALUE for i in const_or_var_2.shape
     ]
-    if np.prod(shape_for_judging_skip_processing) == 1:
+    if np.prod(shape_for_judging_skip_processing_1) == 1 or np.prod(shape_for_judging_skip_processing_2) == 1:
         return const_or_var_1, const_or_var_2
 
     # Swap: len(const_or_var_1.shape) > len(const_or_var_2.shape)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -10,7 +10,7 @@ import tensorflow as tf
 from tensorflow.keras.layers import Lambda # type: ignore
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.colors import Color
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union
 from functools import wraps
 from collections import namedtuple
 from onnx2tf.utils.enums import (
@@ -625,6 +625,32 @@ def simple_arithmetic_validity_check(
         pass
 
 
+def dimension_compare(shape1: Union[np.ndarray, List], shape2: Union[np.ndarray, List]):
+    """
+    Compare dimension shape including 1
+    Parameters
+    ----------
+    shape1
+    shape2
+
+    Returns
+    -------
+    result: True if shape1 and shape2 is valid for broadcasting, else False
+    """
+    result = False
+
+    if len(shape1) != len(shape2):
+        return result
+    else:
+        for i, j in zip(shape1, shape2):
+            if i == j or i == 1 or j == 1:
+                result = True
+            else:
+                result = False
+                break
+
+    return result
+
 def explicit_broadcast(
     *,
     const_or_var_1: Any,
@@ -634,44 +660,49 @@ def explicit_broadcast(
 ):
     graph_node_input_name1 = None
     graph_node_input_name2 = None
+    graph_node_input_shape1 = []
+    graph_node_input_shape2 = []
     if graph_node is not None:
         graph_node_input_name1 = graph_node.inputs[0].name
         graph_node_input_name2 = graph_node.inputs[1].name
+        graph_node_input_shape1 = list(graph_node.inputs[0].shape)
+        graph_node_input_shape2 = list(graph_node.inputs[1].shape)
 
     # Swap: len(const_or_var_1.shape) > len(const_or_var_2.shape)
+    swapped = False
     if len(const_or_var_1.shape) < len(const_or_var_2.shape):
         const_or_var_1, const_or_var_2 = const_or_var_2, const_or_var_1
         graph_node_input_name1, graph_node_input_name2 = graph_node_input_name2, graph_node_input_name1
+        graph_node_input_shape1, graph_node_input_shape2 = graph_node_input_shape2, graph_node_input_shape1
+        swapped = True
 
     # If const_or_var_2.shape is all 1's, do not broadcast and return as is
     shape_for_judging_skip_processing = [
         i if i is not None else INF_INDEX_VALUE for i in const_or_var_2.shape
     ]
     if np.prod(shape_for_judging_skip_processing) == 1:
-        return const_or_var_1, const_or_var_2
-
-    const_or_var_1_shape = const_or_var_1.shape
-    const_or_var_1_rank = len(const_or_var_1_shape)
-    const_or_var_2_shape = const_or_var_2.shape
-    const_or_var_2_rank = len(const_or_var_2_shape)
+        if swapped:
+            return const_or_var_2, const_or_var_1
+        else:
+            return const_or_var_1, const_or_var_2
 
     """
-    UnSqueeze 1 at the beginning of const_or_var_2_shape until const_or_var_1_shape
-    and const_or_var_2_shape have the same rank
+    UnSqueeze 1 at the beginning of const_or_var_2_shape until const_or_var_1.shape
+    and const_or_var_2.shape have the same rank
     e.g.
-        const_or_var_1_shape (TF)  : [1,64,128,128,3], onnx[1,3,64,128,128]
-        const_or_var_2_shape (ONNX const pettern): [3,64,128,128]
-        new_const_or_var_2_shape (ONNX): [1,3,64,128,128] -> [1,64,128,128,3]
+        const_or_var_1.shape (TF)  : [1,64,128,128,3], onnx[1,3,64,128,128]
+        const_or_var_2.shape (ONNX const pettern): [3,64,128,128]
+        new_const_or_var_2.shape (ONNX): [1,3,64,128,128] -> [1,64,128,128,3]
 
-        const_or_var_1_shape (TF)  : [1,64,128,128,3]
-        const_or_var_2_shape (TF ver pettern): [128,128,3]
-        new_const_or_var_2_shape (ONNX): [1,1,128,128,3]
+        const_or_var_1.shape (TF)  : [1,64,128,128,3]
+        const_or_var_2.shape (TF ver pettern): [128,128,3]
+        new_const_or_var_2.shape (ONNX): [1,1,128,128,3]
 
-        const_or_var_1_shape (TF)  : [1,128,3], onnx[1,3,128]
-        const_or_var_2_shape (ONNX const pettern): [3,128]
-        new_const_or_var_2_shape (ONNX): [1,3,128] -> [1,128,3]
+        const_or_var_1.shape (TF)  : [1,128,3], onnx[1,3,128]
+        const_or_var_2.shape (ONNX const pettern): [3,128]
+        new_const_or_var_2.shape (ONNX): [1,3,128] -> [1,128,3]
     """
-    for _ in range(const_or_var_1_rank - const_or_var_2_rank):
+    for _ in range(len(const_or_var_1.shape) - len(const_or_var_2.shape)):
         if isinstance(const_or_var_2, np.ndarray):
             const_or_var_2 = const_or_var_2[np.newaxis, ...]
         elif isinstance(const_or_var_2, tf.Tensor):
@@ -685,44 +716,96 @@ def explicit_broadcast(
                 input=const_or_var_2,
                 axis=0,
             )
-    transpose_perm = [0] + [i+2 for i in range(const_or_var_1_rank-2)] + [1]
-    if isinstance(const_or_var_2, np.ndarray):
-        const_or_var_2: np.ndarray = const_or_var_2.transpose(transpose_perm)
-        # # Check output values by brute force only if the shape of const_or_var_2
-        # # is different between const_or_var_1 and const_or_var_2 in dimensions other than 1
-        # const_or_var_1_shape_not_none = [
-        #     i if not isinstance(i, str) else 1 for i in const_or_var_1_shape
-        # ]
-        # for var1_shape, var2_shape in zip(const_or_var_1_shape_not_none, const_or_var_2.shape):
-        #     if var2_shape != 1 and var1_shape != 1 and var1_shape != var2_shape:
-        #         dummy_data_onnx = np.random.random_sample(graph_node.inputs[0].shape)
-        #         dummy_data_onnx = dummy_data_onnx.astype(graph_node.inputs[0].dtype)
-        #         dummy_data_tf = dummy_data_onnx.copy()
-        #         dummy_data_tf = dummy_data_tf.reshape(const_or_var_1_shape).astype(graph_node.inputs[0].dtype)
-        #         simple_arithmetic_validity_check(
-        #             op_type=graph_node.op,
-        #             onnx_x=dummy_data_onnx,
-        #             onnx_y=graph_node.inputs[1].values,
-        #             tf_x=dummy_data_tf,
-        #             tf_y=const_or_var_2,
-        #         )
-        #         break
+        graph_node_input_shape2 = [1] + graph_node_input_shape2
 
-    elif isinstance(const_or_var_2, tf.Tensor) \
-        or (
-            not isinstance(const_or_var_2, np.ndarray) \
-            and tf.keras.backend.is_keras_tensor(const_or_var_2)
-        ):
-        if graph_node_input_name2 is not None \
-            and tf_layers_dict is not None \
-            and graph_node_input_name2 in tf_layers_dict \
-            and tf_layers_dict[graph_node_input_name2]['optype'] == 'Input':
-            const_or_var_2: np.ndarray = tf.transpose(
-                a=const_or_var_2,
-                perm=transpose_perm
-            )
-    else:
+    # Check location of channel dimension in onnx and tflite
+    const_or_var_dim_check_1 = np.where(np.array(const_or_var_1.shape)[:, None]
+                                        == np.unique(const_or_var_1.shape)[None, :])[1]
+    graph_node_input_dim_check1 = np.where(np.array(graph_node_input_shape1)[:, None]
+                                           == np.unique(graph_node_input_shape1)[None, :])[1]
+    const_or_var_dim_check_2 = np.where(np.array(const_or_var_2.shape)[:, None]
+                                        == np.unique(const_or_var_2.shape)[None, :])[1]
+    graph_node_input_dim_check2 = np.where(np.array(graph_node_input_shape2)[:, None]
+                                           == np.unique(graph_node_input_shape2)[None, :])[1]
+
+    transpose_perm = []
+    channel_candidates = []
+
+    # Swap x and y to apply transpose to correct target if needed
+    if dimension_compare(list(const_or_var_1.shape), graph_node_input_shape1) and \
+            not dimension_compare(list(const_or_var_2.shape), graph_node_input_shape2):
+        const_or_var_1, const_or_var_2 = const_or_var_2, const_or_var_1
+        graph_node_input_name1, graph_node_input_name2 = graph_node_input_name2, graph_node_input_name1
+        graph_node_input_shape1, graph_node_input_shape2 = graph_node_input_shape2, graph_node_input_shape1
+        const_or_var_dim_check_1, const_or_var_dim_check_2 = const_or_var_dim_check_2, const_or_var_dim_check_1
+        graph_node_input_dim_check1, graph_node_input_dim_check2 = graph_node_input_dim_check2, graph_node_input_dim_check1
+        swapped = True
+
+    # Check if operands need transpose
+    # CAUTION: this part may occur problem when there are more than two same numbers in tensor shape.
+    #          please consider manual debugging if channel number is same with other dimensions.
+    if dimension_compare(list(const_or_var_1.shape), list(const_or_var_2.shape)) and \
+            dimension_compare(graph_node_input_shape1, graph_node_input_shape2):
         pass
+    else:
+        for i, (od, td) in enumerate(zip(graph_node_input_dim_check1, const_or_var_dim_check_1)):
+            if td == od or (i > 1 and const_or_var_dim_check_1[i - 1] == od):
+                transpose_perm.append(i)
+            else:
+                channel_candidates.append(i)
+
+        # Simply extend to transpose_perm when unique channel dimension is detected,
+        # otherwise need to compare output brute-force
+        if len(channel_candidates) == 1:
+            transpose_perm.extend(channel_candidates)
+        else:
+            # TODO: brute-force output comparison
+            transpose_perm.extend(channel_candidates[1:])
+            pass
+
+
+        if isinstance(const_or_var_2, np.ndarray):
+            const_or_var_2: np.ndarray = const_or_var_2.transpose(transpose_perm)
+            # # Check output values by brute force only if the shape of const_or_var_2
+            # # is different between const_or_var_1 and const_or_var_2 in dimensions other than 1
+            # const_or_var_1_shape_not_none = [
+            #     i if not isinstance(i, str) else 1 for i in const_or_var_1_shape
+            # ]
+            # for var1_shape, var2_shape in zip(const_or_var_1_shape_not_none, const_or_var_2.shape):
+            #     if var2_shape != 1 and var1_shape != 1 and var1_shape != var2_shape:
+            #         dummy_data_onnx = np.random.random_sample(graph_node.inputs[0].shape)
+            #         dummy_data_onnx = dummy_data_onnx.astype(graph_node.inputs[0].dtype)
+            #         dummy_data_tf = dummy_data_onnx.copy()
+            #         dummy_data_tf = dummy_data_tf.reshape(const_or_var_1_shape).astype(graph_node.inputs[0].dtype)
+            #         simple_arithmetic_validity_check(
+            #             op_type=graph_node.op,
+            #             onnx_x=dummy_data_onnx,
+            #             onnx_y=graph_node.inputs[1].values,
+            #             tf_x=dummy_data_tf,
+            #             tf_y=const_or_var_2,
+            #         )
+            #         break
+
+        elif isinstance(const_or_var_2, tf.Tensor) \
+            or (
+                not isinstance(const_or_var_2, np.ndarray) \
+                and tf.keras.backend.is_keras_tensor(const_or_var_2)
+            ):
+            if graph_node_input_name2 is not None \
+                and tf_layers_dict is not None \
+                and graph_node_input_name2 in tf_layers_dict \
+                and tf_layers_dict[graph_node_input_name2]['optype'] == 'Input':
+                const_or_var_2: np.ndarray = tf.transpose(
+                    a=const_or_var_2,
+                    perm=transpose_perm
+                )
+        else:
+            pass
+
+    # Re-swap operand if swapped in early steps to match shapes. order of operands is important for Sub and Div.
+    if swapped:
+        const_or_var_1, const_or_var_2 = const_or_var_2, const_or_var_1
+
     return const_or_var_1, const_or_var_2
 
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -735,7 +735,7 @@ def explicit_broadcast(
             broadcast_validity_check(graph_node_input_shape1, graph_node_input_shape2):
         pass
     else:
-        transpose_perm = [0] + [i+2 for i in range(len(const_or_var_1.shape)-2)] + [1]        
+        transpose_perm = [0] + [i+2 for i in range(len(const_or_var_1.shape)-2)] + [1]
 
         if isinstance(const_or_var_2, np.ndarray):
             const_or_var_2: np.ndarray = const_or_var_2.transpose(transpose_perm)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -728,8 +728,6 @@ def explicit_broadcast(
     graph_node_input_dim_check2 = np.where(np.array(graph_node_input_shape2)[:, None]
                                            == np.unique(graph_node_input_shape2)[None, :])[1]
 
-    transpose_perm = []
-    channel_candidates = []
 
     # Swap x and y to apply transpose to correct target if needed
     if dimension_compare(list(const_or_var_1.shape), graph_node_input_shape1) and \
@@ -748,21 +746,7 @@ def explicit_broadcast(
             dimension_compare(graph_node_input_shape1, graph_node_input_shape2):
         pass
     else:
-        for i, (od, td) in enumerate(zip(graph_node_input_dim_check1, const_or_var_dim_check_1)):
-            if td == od or (i > 1 and const_or_var_dim_check_1[i - 1] == od):
-                transpose_perm.append(i)
-            else:
-                channel_candidates.append(i)
-
-        # Simply extend to transpose_perm when unique channel dimension is detected,
-        # otherwise need to compare output brute-force
-        if len(channel_candidates) == 1:
-            transpose_perm.extend(channel_candidates)
-        else:
-            # TODO: brute-force output comparison
-            transpose_perm.extend(channel_candidates[1:])
-            pass
-
+        transpose_perm = [0] + [i+2 for i in range(len(const_or_var_1.shape)-2)] + [1]        
 
         if isinstance(const_or_var_2, np.ndarray):
             const_or_var_2: np.ndarray = const_or_var_2.transpose(transpose_perm)


### PR DESCRIPTION
### 1. Content and background
#18 

### 2. Summary of corrections
Fixed swap bug in `explicit_broadcast` and fixed calculation of `transpose_perm`

Attached code is used to compare outputs between onnx and converted tflite.
[dummy_tflite_output_check.zip](https://github.com/PINTO0309/onnx2tf/files/10054818/dummy_tflite_output_check.zip)

### 3. Before/After (If there is an operating log that can be used as a reference)

| dumm1.onnx |  dumm1.tflite |
:-------------------------:|:-------------------------:|
|![Screenshot from 2022-11-21 17-43-17](https://user-images.githubusercontent.com/34959032/203005115-e3a22173-71c6-45a2-8c29-17d4ca21032e.png)|![Screenshot from 2022-11-21 17-43-24](https://user-images.githubusercontent.com/34959032/203005142-ea6fff75-9b6f-4131-b0ec-4f5f3746c1b9.png)|
| dumm2.onnx |  dumm2.tflite |
|![Screenshot from 2022-11-21 17-43-31](https://user-images.githubusercontent.com/34959032/203005591-c4c99478-cec7-49f2-a412-286ce79fe4c0.png)|![Screenshot from 2022-11-21 17-43-36](https://user-images.githubusercontent.com/34959032/203005609-68639a7e-8d9f-426b-8b64-39a4b84fe140.png)|
| dumm4.onnx |  dumm4.tflite |
|![Screenshot from 2022-11-21 17-43-44](https://user-images.githubusercontent.com/34959032/203005690-934c6449-5e17-4aab-b978-e1509294b3cb.png)|![Screenshot from 2022-11-21 17-43-48](https://user-images.githubusercontent.com/34959032/203005729-71f9be29-1791-4248-abf8-74bef032e98b.png)|




### 4. Issue number (only if there is a related issue)
#18 
