### PR TITLE
Unique operation implementation, bug fix in NonMaxSuppression

### DIFF
--- a/onnx2tf/ops/NonMaxSuppression.py
+++ b/onnx2tf/ops/NonMaxSuppression.py
@@ -62,6 +62,8 @@ def make_node(
             graph_node.inputs[2],
             before_op_output_shape_trans,
         )
+        # onnx may contain invalid max_output_boxes_per_class
+        graph_node_input_3 = np.clip(graph_node_input_3, 0, boxes.shape[1])
     graph_node_input_4 = None
     if len(graph_node.inputs) >= 4:
         graph_node_input_4 = get_constant_or_variable(

--- a/onnx2tf/ops/Unique.py
+++ b/onnx2tf/ops/Unique.py
@@ -1,0 +1,130 @@
+import random
+from typing import List
+
+random.seed(0)
+import numpy as np
+
+np.random.seed(0)
+import tensorflow as tf
+import onnx_graphsurgeon as gs
+from onnx2tf.utils.common_functions import (
+    get_constant_or_variable,
+    print_node_info,
+    inverted_operation_enable_disable,
+    make_tf_node_info,
+)
+from onnx2tf.utils.colors import Color
+
+
+class tfUnique(tf.keras.layers.Layer):
+
+    def __init__(self):
+        super(tfUnique, self).__init__()
+        self.unique_ops = tf.raw_ops.UniqueWithCountsV2
+
+    def call(self, x, axis):
+        return self.unique_ops(x=x, axis=[axis], out_idx=tf.int64)
+
+
+@print_node_info
+@inverted_operation_enable_disable
+def make_node(
+        *,
+        graph_node: gs.Node,
+        tf_layers_dict: dict,
+        **kwargs: dict,
+):
+    """Unique
+
+    Parameters
+    ----------
+    graph_node: gs.Node
+        graph_surgeon Node
+
+    tf_layers_dict: dict
+        optype, shape, dtype, tensorflow graph
+    """
+    before_op_output_shape_trans = \
+        tf_layers_dict.get(graph_node.inputs[0].name, {}).get('before_op_output_shape_trans', True)
+
+    graph_node_input = get_constant_or_variable(
+        graph_node.inputs[0],
+        before_op_output_shape_trans,
+    )
+    graph_node_outputs: List[gs.Variable] = [
+        graph_node_output for graph_node_output in graph_node.outputs
+    ]
+
+    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
+        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+
+    axis = graph_node.attrs.get('axis', None)
+    sorted = graph_node.attrs.get('sorted', 1)
+
+    # Preserving Graph Structure (Dict)
+    tf_layers_dict[graph_node_outputs[0].name] = {
+        'optype': graph_node.op,
+        'shape': graph_node_outputs[0].shape,
+        'dtype': graph_node_outputs[0].dtype,
+    }
+    tf_layers_dict[graph_node_outputs[1].name] = {
+        'optype': graph_node.op,
+        'shape': graph_node_outputs[1].shape,
+        'dtype': graph_node_outputs[1].dtype,
+    }
+    tf_layers_dict[graph_node_outputs[2].name] = {
+        'optype': graph_node.op,
+        'shape': graph_node_outputs[1].shape,
+        'dtype': graph_node_outputs[1].dtype,
+    }
+    tf_layers_dict[graph_node_outputs[3].name] = {
+        'optype': graph_node.op,
+        'shape': graph_node_outputs[3].shape,
+        'dtype': graph_node_outputs[3].dtype,
+    }
+
+    # Generation of TF OP
+    # tensorflow raw_ops does not support direct call to KerasTensor, need to call through keras layer
+    tf_unique_ops = tfUnique()
+
+    # flatten tensor if axis is not specified
+    if axis is None:
+        input_tensor = tf.reshape(input_tensor, [-1])
+
+    # CAUTION: tensorflow unique returns inverse indices only
+    y, inverse_indices, count = tf_unique_ops(x=input_tensor, axis=axis)
+
+    # use tf.unique again to get true unique indices
+    rey, reidx = tf.unique(inverse_indices)
+    num_segments = tf.shape(rey)[0]
+    num_elems = tf.shape(inverse_indices)[0]
+    indices = tf.math.unsorted_segment_min(tf.range(num_elems), reidx, num_segments)
+
+    # tf unique returns unsorted tensor, need to sort if option is enabled
+    if sorted:
+        # TODO: implement sort
+        error_msg = f'' + \
+                    f'{Color.RED}WARNING:{Color.RESET} ' + \
+                    f'Sort option in Unique ops is not implemented yet.'
+        print(error_msg)
+        assert False, error_msg
+
+    tf_layers_dict[graph_node_outputs[0].name]['tf_node'] = y
+    tf_layers_dict[graph_node_outputs[1].name]['tf_node'] = indices
+    tf_layers_dict[graph_node_outputs[2].name]['tf_node'] = inverse_indices
+    tf_layers_dict[graph_node_outputs[3].name]['tf_node'] = count
+
+    # Generation of Debug Info
+    tf_outputs = {f"output{idx}": value for idx, value in enumerate([y, indices, inverse_indices, count])}
+    tf_layers_dict[graph_node_outputs[0].name]['tf_node_info'] = \
+        make_tf_node_info(
+            node_info={
+                'tf_op_type': tf.split,
+                'tf_inputs': {
+                    'value': input_tensor,
+                    'axis': axis,
+                    'sorted': sorted
+                },
+                'tf_outputs': tf_outputs,
+            }
+        )

--- a/onnx2tf/ops/Unique.py
+++ b/onnx2tf/ops/Unique.py
@@ -107,7 +107,7 @@ def make_node(
     tf_layers_dict[graph_node_outputs[0].name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.split,
+                'tf_op_type': tf.raw_ops.UniqueWithCountsV2,
                 'tf_inputs': {
                     'value': input_tensor,
                     'axis': axis,

--- a/onnx2tf/ops/Unique.py
+++ b/onnx2tf/ops/Unique.py
@@ -89,6 +89,7 @@ def make_node(
 
     # flatten tensor if axis is not specified
     if axis is None:
+        axis = 0
         input_tensor = tf.reshape(input_tensor, [-1])
 
     # CAUTION: tensorflow unique returns inverse indices only

--- a/onnx2tf/ops/Unique.py
+++ b/onnx2tf/ops/Unique.py
@@ -62,26 +62,12 @@ def make_node(
     sorted = graph_node.attrs.get('sorted', 1)
 
     # Preserving Graph Structure (Dict)
-    tf_layers_dict[graph_node_outputs[0].name] = {
-        'optype': graph_node.op,
-        'shape': graph_node_outputs[0].shape,
-        'dtype': graph_node_outputs[0].dtype,
-    }
-    tf_layers_dict[graph_node_outputs[1].name] = {
-        'optype': graph_node.op,
-        'shape': graph_node_outputs[1].shape,
-        'dtype': graph_node_outputs[1].dtype,
-    }
-    tf_layers_dict[graph_node_outputs[2].name] = {
-        'optype': graph_node.op,
-        'shape': graph_node_outputs[1].shape,
-        'dtype': graph_node_outputs[1].dtype,
-    }
-    tf_layers_dict[graph_node_outputs[3].name] = {
-        'optype': graph_node.op,
-        'shape': graph_node_outputs[3].shape,
-        'dtype': graph_node_outputs[3].dtype,
-    }
+    for graph_node_output in graph_node_outputs:
+        tf_layers_dict[graph_node_output.name] = {
+            'optype': graph_node.op,
+            'shape': graph_node_output.shape,
+            'dtype': graph_node_output.dtype,
+        }
 
     # Generation of TF OP
     # tensorflow raw_ops does not support direct call to KerasTensor, need to call through keras layer
@@ -100,6 +86,7 @@ def make_node(
     num_segments = tf.shape(rey)[0]
     num_elems = tf.shape(inverse_indices)[0]
     indices = tf.math.unsorted_segment_min(tf.range(num_elems), reidx, num_segments)
+    indices = tf.cast(indices, dtype=inverse_indices.dtype)
 
     # tf unique returns unsorted tensor, need to sort if option is enabled
     if sorted:


### PR DESCRIPTION
### 1. Content and background
I used attached codes to convert and compare outputs between onnx and tflite.
[test_codes.zip](https://github.com/PINTO0309/onnx2tf/files/10081131/test_codes.zip)


### 2. Summary of corrections

- I implemented `Unique` operation and tested by comparing output between onnx and tflite. Tensorflow native unique operation `tf.unique` is only works for 1d tensors, not applicable for multidimensional tensors. So I implemented using `tf.raw_ops.UniqueWithCountsV2`.
Unfortunately, this function is not exist in tflite builtin operators, thus it converted to flex operations. Also, tensorflow unique has no option for `return_index` unlike numpy, pytorch and onnx. The official document says it returns `indices`, but it is actually `inverse_indices`. Extra `tf.unique` and `tf.math.unsorted_segment_min`are used to calculate true `indices` as shown below.
For now, only unsorted unique is implemented. I couldn't find proper way to sort the output without hurting the performance.


| unique.onnx |  unique.tflite |
|:-------------------------:|:-------------------------:|
|<img src="https://user-images.githubusercontent.com/34959032/203700410-9bdda655-6351-412c-88c6-edbfdce852d2.png">|<img src="https://user-images.githubusercontent.com/34959032/203700465-02f635d1-23b7-470b-bf6e-ad18a3e72d01.png">|


![Screenshot from 2022-11-24 13-43-02](https://user-images.githubusercontent.com/34959032/203702709-2f9db576-d62d-4d78-bc3c-1e5444737766.png)

- I found bug in NonMaxSuppression. In current version, `max_output_size` parameter is directly migrated during conversion. This does not affect to conversion itself, but it affects to inference and occurs error as above. 
Onnx exported from `torchvision.ops.nms` has no option like `max_output_size`. So unexpectedly huge value is automatically assigned as shown below. I added clipping part to limit maximum value of `max_output_size` to initial number of boxes. Tflite inference works after the modification. However, the output size of tflite inference is fixed to initial number of boxes as below.

![Screenshot from 2022-11-24 13-53-42](https://user-images.githubusercontent.com/34959032/203703197-843eefb8-425f-4380-9c20-c37a815d2320.png)

| unexpected value in nms.onnx |  corresponding nms.tflite |
|:-------------------------:|:-------------------------:|
|<img src="https://user-images.githubusercontent.com/34959032/203702212-a8df658d-4891-4c54-80bd-42a5bc782bcd.png">|<img src="https://user-images.githubusercontent.com/34959032/203702257-787d1b78-12a8-4f8b-ae33-0b6b14da9b66.png">|


### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
N/A