### PR TITLE
Added processing to determine if INPUT OP has been transposed. #22

### DIFF
--- a/replace.json
+++ b/replace.json
@@ -2,106 +2,10 @@
   "format_version": 1,
   "operations": [
     {
-      "op_name": "Resize_0",
+      "op_name": "/Gather_1",
       "param_target": "inputs",
-      "param_name": "Concat_0",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_1",
-      "param_target": "inputs",
-      "param_name": "Concat_1",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_2",
-      "param_target": "inputs",
-      "param_name": "Concat_2",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_3",
-      "param_target": "inputs",
-      "param_name": "Concat_3",
-      "values": [24,24]
-    },
-    {
-      "op_name": "Resize_4",
-      "param_target": "inputs",
-      "param_name": "Concat_4",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_5",
-      "param_target": "inputs",
-      "param_name": "Concat_5",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_6",
-      "param_target": "inputs",
-      "param_name": "Concat_6",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_7",
-      "param_target": "inputs",
-      "param_name": "Concat_7",
-      "values": [24,24]
-    },
-    {
-      "op_name": "Resize_8",
-      "param_target": "inputs",
-      "param_name": "Concat_8",
-      "values": [24,24]
-    },
-    {
-      "op_name": "Resize_9",
-      "param_target": "inputs",
-      "param_name": "Concat_9",
-      "values": [12,12]
-    },
-    {
-      "op_name": "Resize_10",
-      "param_target": "inputs",
-      "param_name": "Concat_10",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_11",
-      "param_target": "inputs",
-      "param_name": "Concat_11",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_12",
-      "param_target": "inputs",
-      "param_name": "Concat_12",
-      "values": [48,48]
-    },
-    {
-      "op_name": "Resize_13",
-      "param_target": "inputs",
-      "param_name": "Concat_14",
-      "values": [192,192]
-    },
-    {
-      "op_name": "Transpose_0",
-      "param_target": "attributes",
-      "param_name": "perm",
-      "values": [0,1,2,3]
-    },
-    {
-      "op_name": "Transpose_1",
-      "param_target": "attributes",
-      "param_name": "perm",
-      "values": [0,1,2,3]
-    },
-    {
-      "op_name": "Softmax_0",
-      "param_target": "attributes",
-      "param_name": "axis",
-      "values": 3
+      "param_name": "/Constant_1_output_0",
+      "values": [1,2,3,4]
     }
   ]
 }


### PR DESCRIPTION
### 1. Content and background
Added processing to determine if INPUT OP has been transposed.

### 2. Summary of corrections
Added a process at the end of the input OP generation process to determine if the shape of the ONNX input tensor and the TF input tensor are the same or different.

This avoids incorrect transposition of `indices` in `Gather` immediately after the input OP. However, it is not a universal process.

### 3. Before/After (If there is an operating log that can be used as a reference)
- Before
  ![image](https://user-images.githubusercontent.com/33194443/204092716-9fbaa6db-56ac-4db6-981f-35570a27105e.png)
- After
  ![image](https://user-images.githubusercontent.com/33194443/204092720-8e791022-89dd-482c-a819-08ab6cb9c211.png)
  ![image](https://user-images.githubusercontent.com/33194443/204092721-c3e4dfca-cdbf-4db5-abb3-8aeee8c19c2a.png)

### 4. Issue number (only if there is a related issue)
[Weird bug in RoiAlign #22](https://github.com/PINTO0309/onnx2tf/issues/22) 