### PR TITLE
Disable unnecessary transpose, and optimize wasteful loop processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.1.37
+  ghcr.io/pinto0309/onnx2tf:1.1.38
 
   or
 
@@ -1013,36 +1013,37 @@ ONNX file for testing. https://github.com/PINTO0309/onnx2tf/releases/tag/1.1.28
 |13|face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx|:heavy_check_mark:|
 |14|face_recognition_sface_2021dec.onnx|:heavy_check_mark:|
 |15|gender_googlenet.onnx|:heavy_check_mark:|
-|16|iat_llie_180x320.onnx|:heavy_check_mark:|
-|17|inception-v2-9.onnx|:heavy_check_mark:|
-|18|mobilenetv2-12.onnx|:heavy_check_mark:|
-|19|mosaic_11.onnx|:heavy_check_mark:|
-|20|mosaic-9.onnx|:heavy_check_mark:|
-|21|movenet_multipose_lightning_192x256_p6.onnx|:heavy_check_mark:|
-|22|nanodet-plus-m_416.onnx|:heavy_check_mark:|
-|23|object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx|:heavy_check_mark:|
-|24|object_tracking_dasiamrpn_kernel_r1_2021nov.onnx|:heavy_check_mark:|
-|25|object_tracking_dasiamrpn_model_2021nov.onnx|:heavy_check_mark:|
-|26|qlinear_conv_tensor_test.onnx|:heavy_check_mark:|
-|27|rcnn-ilsvrc13-9.onnx|:heavy_check_mark:|
-|28|regnet_x_400mf.onnx|:heavy_check_mark:|
-|29|ResNet101-DUC-12.onnx|:heavy_check_mark:|
-|30|resnet18-v1-7.onnx|:heavy_check_mark:|
-|31|resnet50-v1-12.onnx|:heavy_check_mark:|
-|32|resnet50-v2-7.onnx|:heavy_check_mark:|
-|33|retinanet-9.onnx|:heavy_check_mark:|
-|34|squeezenet1.0-12.onnx|:heavy_check_mark:|
-|35|super-resolution-10.onnx|:heavy_check_mark:|
-|36|tinyyolov2-8.onnx|:heavy_check_mark:|
-|37|version-RFB-640.onnx|:heavy_check_mark:|
-|38|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
-|39|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
-|40|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
-|41|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
-|42|yolox_nano_192x192.onnx|:heavy_check_mark:|
-|43|yolox_nano_416x416.onnx|:heavy_check_mark:|
-|44|yolox_s.onnx|:heavy_check_mark:|
-|45|zfnet512-12.onnx|:heavy_check_mark:|
+|16|handpose_estimation_mediapipe_2022may.onnx|:heavy_check_mark:|
+|17|iat_llie_180x320.onnx|:heavy_check_mark:|
+|18|inception-v2-9.onnx|:heavy_check_mark:|
+|19|mobilenetv2-12.onnx|:heavy_check_mark:|
+|20|mosaic_11.onnx|:heavy_check_mark:|
+|21|mosaic-9.onnx|:heavy_check_mark:|
+|22|movenet_multipose_lightning_192x256_p6.onnx|:heavy_check_mark:|
+|23|nanodet-plus-m_416.onnx|:heavy_check_mark:|
+|24|object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx|:heavy_check_mark:|
+|25|object_tracking_dasiamrpn_kernel_r1_2021nov.onnx|:heavy_check_mark:|
+|26|object_tracking_dasiamrpn_model_2021nov.onnx|:heavy_check_mark:|
+|27|qlinear_conv_tensor_test.onnx|:heavy_check_mark:|
+|28|rcnn-ilsvrc13-9.onnx|:heavy_check_mark:|
+|29|regnet_x_400mf.onnx|:heavy_check_mark:|
+|30|ResNet101-DUC-12.onnx|:heavy_check_mark:|
+|31|resnet18-v1-7.onnx|:heavy_check_mark:|
+|32|resnet50-v1-12.onnx|:heavy_check_mark:|
+|33|resnet50-v2-7.onnx|:heavy_check_mark:|
+|34|retinanet-9.onnx|:heavy_check_mark:|
+|35|squeezenet1.0-12.onnx|:heavy_check_mark:|
+|36|super-resolution-10.onnx|:heavy_check_mark:|
+|37|tinyyolov2-8.onnx|:heavy_check_mark:|
+|38|version-RFB-640.onnx|:heavy_check_mark:|
+|39|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
+|40|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
+|41|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
+|42|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
+|43|yolox_nano_192x192.onnx|:heavy_check_mark:|
+|44|yolox_nano_416x416.onnx|:heavy_check_mark:|
+|45|yolox_s.onnx|:heavy_check_mark:|
+|46|zfnet512-12.onnx|:heavy_check_mark:|
 
 ## Related tools
 1. [tflite2tensorflow](https://github.com/PINTO0309/tflite2tensorflow)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.1.37'
+__version__ = '1.1.38'

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -12,6 +12,7 @@ from onnx2tf.utils.common_functions import (
     explicit_broadcast,
     pre_process_transpose,
     post_process_transpose,
+    disable_unnecessary_transpose,
 )
 
 
@@ -65,6 +66,19 @@ def make_node(
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+
+    # Disable unnecessary Transpose
+    #   1. If both x and y are gs.Variable
+    #   2. If only one of the two is the output of Transpose
+    #   3. If the perm of the Transpose is [0,2,1] or [0,3,1,2] or [0,4,1,2,3]
+    #   4. Furthermore, if the shape of x and y are mismatched
+    graph_node_input_1, graph_node_input_2, input_tensor_1, input_tensor_2 = \
+        disable_unnecessary_transpose(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+        )
 
     input_tensor_1, input_tensor_2 = explicit_broadcast(
         const_or_var_1=input_tensor_1,

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -78,13 +78,13 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
     reducemaxed_tensor = input_tensor
-    for idx in axes:
-        reducemaxed_tensor = tf.math.reduce_max(
-            input_tensor=reducemaxed_tensor,
-            axis=idx,
-            keepdims=keepdims,
-            name=f'{graph_node.name}_{idx}',
-        )
+    reducemaxed_tensor = tf.math.reduce_max(
+        input_tensor=reducemaxed_tensor,
+        axis=axes,
+        keepdims=keepdims,
+        name=f'{graph_node.name}',
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemaxed_tensor
 
     # Generation of Debug Info

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -78,13 +78,12 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
     reducemeaned_tensor = input_tensor
-    for idx in axes:
-        reducemeaned_tensor = tf.math.reduce_mean(
-            input_tensor=reducemeaned_tensor,
-            axis=idx,
-            keepdims=keepdims,
-            name=f'{graph_node.name}_{idx}',
-        )
+    reducemeaned_tensor = tf.math.reduce_mean(
+        input_tensor=reducemeaned_tensor,
+        axis=axes,
+        keepdims=keepdims,
+        name=f'{graph_node.name}',
+    )
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemeaned_tensor
 
     # Generation of Debug Info

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -78,13 +78,12 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
     reducemined_tensor = input_tensor
-    for idx in axes:
-        reducemined_tensor = tf.math.reduce_min(
-            input_tensor=reducemined_tensor,
-            axis=idx,
-            keepdims=keepdims,
-            name=f'{graph_node.name}_{idx}',
-        )
+    reducemined_tensor = tf.math.reduce_min(
+        input_tensor=reducemined_tensor,
+        axis=axes,
+        keepdims=keepdims,
+        name=f'{graph_node.name}',
+    )
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemined_tensor
 
     # Generation of Debug Info

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -78,13 +78,12 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
     reduceproded_tensor = input_tensor
-    for idx in axes:
-        reduceproded_tensor = tf.math.reduce_prod(
-            input_tensor=reduceproded_tensor,
-            axis=idx,
-            keepdims=keepdims,
-            name=f'{graph_node.name}_{idx}',
-        )
+    reduceproded_tensor = tf.math.reduce_prod(
+        input_tensor=reduceproded_tensor,
+        axis=axes,
+        keepdims=keepdims,
+        name=f'{graph_node.name}',
+    )
     tf_layers_dict[graph_node_output.name]['tf_node'] = reduceproded_tensor
 
     # Generation of Debug Info

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -96,14 +96,12 @@ def make_node(
 
     # Generation of TF OP
     reducesumed_tensor = input_tensor
-    for idx in axes:
-        reducesumed_tensor = \
-            tf.reduce_sum(
-                input_tensor=reducesumed_tensor,
-                axis=idx,
-                keepdims=keepdims,
-                name=f'{graph_node.name}_{idx}',
-            )
+    reducesumed_tensor = tf.reduce_sum(
+        input_tensor=reducesumed_tensor,
+        axis=axes,
+        keepdims=keepdims,
+        name=f'{graph_node.name}',
+    )
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducesumed_tensor
 
     # Generation of Debug Info

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1907,8 +1907,12 @@ def disable_unnecessary_transpose(
                 graph_node_input_1, graph_node_input_2 = graph_node_input_2, graph_node_input_1
 
             node_y_perm: list = graph_node_input_2.inputs[0].attrs['perm']
-            input_tensor_1_shape = input_tensor_1.shape
-            input_tensor_2_shape = input_tensor_2.shape
+            input_tensor_1_shape = [
+                dim if isinstance(dim, int) else None for dim in input_tensor_1.shape
+            ]
+            input_tensor_2_shape = [
+                dim if isinstance(dim, int) else None for dim in input_tensor_2.shape
+            ]
             tensor_rank = len(input_tensor_1_shape)
             perm = [
                 convert_axis(

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1883,3 +1883,51 @@ def is_integer_num(
         and x.squeeze().ndim == 0 and int(x) == x:
         return True
     return False
+
+
+def disable_unnecessary_transpose(
+    *,
+    graph_node_input_1: Any,
+    graph_node_input_2: Any,
+    input_tensor_1: Any,
+    input_tensor_2: Any,
+):
+    if isinstance(graph_node_input_1, gs.Variable) \
+        and isinstance(graph_node_input_2, gs.Variable):
+
+        node_x_op_type = graph_node_input_1.inputs[0].op
+        node_y_op_type = graph_node_input_2.inputs[0].op
+
+        if ((node_x_op_type == 'Transpose' and not node_y_op_type == 'Transpose') \
+            or (not node_x_op_type == 'Transpose' and node_y_op_type == 'Transpose')) \
+            and (len(graph_node_input_1.shape) == len(graph_node_input_2.shape)):
+
+            if (node_x_op_type == 'Transpose' and not node_y_op_type == 'Transpose'):
+                input_tensor_1, input_tensor_2 = input_tensor_2, input_tensor_1
+                graph_node_input_1, graph_node_input_2 = graph_node_input_2, graph_node_input_1
+
+            node_y_perm: list = graph_node_input_2.inputs[0].attrs['perm']
+            input_tensor_1_shape = input_tensor_1.shape
+            input_tensor_2_shape = input_tensor_2.shape
+            tensor_rank = len(input_tensor_1_shape)
+            perm = [
+                convert_axis(
+                    axis=idx,
+                    tensor_rank=tensor_rank,
+                    before_op_output_shape_trans=True,
+                ) for idx in range(tensor_rank)
+            ]
+            reverse_perm = [
+                convert_reverse_axis(
+                    axis=idx,
+                    tensor_rank=tensor_rank,
+                    before_op_output_shape_trans=True,
+                ) for idx in range(tensor_rank)
+            ]
+            if node_y_perm == perm:
+                if input_tensor_1_shape != input_tensor_2_shape:
+                    input_tensor_2 = tf.transpose(
+                        a=input_tensor_2,
+                        perm=reverse_perm,
+                    )
+    return graph_node_input_1, graph_node_input_2, input_tensor_1, input_tensor_2

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1929,7 +1929,13 @@ def disable_unnecessary_transpose(
                 ) for idx in range(tensor_rank)
             ]
             if node_y_perm == perm:
-                if input_tensor_1_shape != input_tensor_2_shape:
+                unmatch = False
+                for dim1, dim2 in zip(input_tensor_1_shape, input_tensor_2_shape):
+                    if isinstance(dim1, int) and dim1 != 1 and isinstance(dim2, int) and dim2 != 1:
+                        if dim1 != dim2:
+                            unmatch = True
+                            break
+                if unmatch:
                     input_tensor_2 = tf.transpose(
                         a=input_tensor_2,
                         perm=reverse_perm,

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1895,8 +1895,10 @@ def disable_unnecessary_transpose(
     if isinstance(graph_node_input_1, gs.Variable) \
         and isinstance(graph_node_input_2, gs.Variable):
 
-        node_x_op_type = graph_node_input_1.inputs[0].op
-        node_y_op_type = graph_node_input_2.inputs[0].op
+        node_x_op_type = graph_node_input_1.inputs[0].op \
+            if len(graph_node_input_1.inputs) > 0 else 'Input'
+        node_y_op_type = graph_node_input_2.inputs[0].op \
+            if len(graph_node_input_2.inputs) > 0 else 'Input'
 
         if ((node_x_op_type == 'Transpose' and not node_y_op_type == 'Transpose') \
             or (not node_x_op_type == 'Transpose' and node_y_op_type == 'Transpose')) \


### PR DESCRIPTION
### 1. Content and background
1. [handpose_estimation_mediapipe_2022may.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/10098483/handpose_estimation_mediapipe_2022may.onnx.zip)
2. ConvNext

### 2. Summary of corrections
- `Add`,`Sub`,`Mul`,`Div`
  - Fixed to disable as much as possible unnecessary transpose inverted to NCHW.
- `ReduceMax`,`ReduceMean`,`ReduceMin`,`ReduceProd`,`ReduceSum`
  - Optimize wasteful loop processing.

### 3. Before/After (If there is an operating log that can be used as a reference)
- Fixed to disable as much as possible unnecessary transpose inverted to NCHW.
  - Before
    ![image](https://user-images.githubusercontent.com/33194443/204140033-1346b041-892d-4a95-b630-7f0f4184d858.png)
  - After
    ![image](https://user-images.githubusercontent.com/33194443/204140123-b6a12458-565f-46e9-94cd-3e9a34e64595.png)

### 4. Issue number (only if there is a related issue)
[[ConvNext] Add layer shape wrong #17](https://github.com/PINTO0309/onnx2tf/issues/17)