### PR TITLE
BatchNormalization opset=9, Support for Variable scale,B,mean,var

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.1.44
+  ghcr.io/pinto0309/onnx2tf:1.1.45
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.1.44'
+__version__ = '1.1.45'

--- a/onnx2tf/ops/BatchNormalization.py
+++ b/onnx2tf/ops/BatchNormalization.py
@@ -31,14 +31,14 @@ def make_node(
     """
     # Inputs
     X: gs.Variable = graph_node.inputs[0]
-    scale: gs.Constant = graph_node.inputs[1]
-    B: gs.Constant = graph_node.inputs[2]
-    input_mean: gs.Constant = graph_node.inputs[3]
-    input_var: gs.Constant = graph_node.inputs[4]
+    scale = graph_node.inputs[1]
+    B = graph_node.inputs[2]
+    input_mean = graph_node.inputs[3]
+    input_var = graph_node.inputs[4]
     # Outputs
     Y: gs.Variable = graph_node.outputs[0]
-    # running_mean: gs.Variable = graph_node.outputs[1] # disuse
-    # running_var: gs.Variable = graph_node.outputs[2] # disuse
+    if len(graph_node.outputs) > 1:
+        graph_node.outputs = [graph_node.outputs[0]]
 
     if hasattr(scale, 'inputs') \
         and len(scale.inputs) > 0 \
@@ -86,10 +86,14 @@ def make_node(
     input_tensor = tf_layers_dict[X.name]['tf_node']
     tf_layers_dict[Y.name]['tf_node'] = tf.nn.batch_normalization(
         x=input_tensor,
-        mean=input_mean.values,
-        variance=input_var.values,
-        offset=B.values,
-        scale=scale.values,
+        mean=input_mean.values \
+            if not isinstance(input_mean, gs.Variable) else tf_layers_dict[input_mean.name]['tf_node'],
+        variance=input_var.values \
+            if not isinstance(input_var, gs.Variable) else tf_layers_dict[input_var.name]['tf_node'],
+        offset=B.values \
+            if not isinstance(B, gs.Variable) else tf_layers_dict[B.name]['tf_node'],
+        scale=scale.values \
+            if not isinstance(scale, gs.Variable) else tf_layers_dict[scale.name]['tf_node'],
         variance_epsilon=epsilon,
     )
 

--- a/replace.json
+++ b/replace.json
@@ -2,10 +2,88 @@
   "format_version": 1,
   "operations": [
     {
-      "op_name": "/Gather_1",
-      "param_target": "inputs",
-      "param_name": "/Constant_1_output_0",
-      "values": [1,2,3,4]
+      "op_name": "Reshape_136",
+      "param_target": "outputs",
+      "param_name": "194",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_143",
+      "param_target": "outputs",
+      "param_name": "205",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+    {
+      "op_name": "Reshape_170",
+      "param_target": "outputs",
+      "param_name": "234",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_177",
+      "param_target": "outputs",
+      "param_name": "245",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+    {
+      "op_name": "Reshape_206",
+      "param_target": "outputs",
+      "param_name": "276",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_213",
+      "param_target": "outputs",
+      "param_name": "287",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+    {
+      "op_name": "Reshape_240",
+      "param_target": "outputs",
+      "param_name": "316",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_247",
+      "param_target": "outputs",
+      "param_name": "327",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+    {
+      "op_name": "Reshape_303",
+      "param_target": "outputs",
+      "param_name": "385",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_310",
+      "param_target": "outputs",
+      "param_name": "396",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+    {
+      "op_name": "Reshape_364",
+      "param_target": "outputs",
+      "param_name": "452",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_371",
+      "param_target": "outputs",
+      "param_name": "463",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+    {
+      "op_name": "Reshape_425",
+      "param_target": "outputs",
+      "param_name": "519",
+      "post_process_transpose_perm": [0,2,1]
+    },
+    {
+      "op_name": "Reshape_432",
+      "param_target": "outputs",
+      "param_name": "530",
+      "post_process_transpose_perm": [0,2,3,1]
     }
   ]
 }


### PR DESCRIPTION
### 1. Content and background
ONNX model yields spurious predictions #693
https://github.com/onnx/onnx-tensorflow/issues/693
[[TUNIT] conversion error, TypeError: 'Variable' object is not iterable #32](https://github.com/PINTO0309/onnx2tf/issues/32)
![image](https://user-images.githubusercontent.com/33194443/205091068-ddb2f0a0-6422-4cdd-8b83-16a6bed76ceb.png)

### 2. Summary of corrections
- `BatchNormalization`
  -  opset=9
  - Support for Variable scale,B,mean,var

### 3. Before/After (If there is an operating log that can be used as a reference)
.

### 4. Issue number (only if there is a related issue)
https://github.com/onnx/onnx-tensorflow/issues/693