### PR TITLE
[YOLOv7] Bug fixes for MaxPool's pad

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.1.45
+  ghcr.io/pinto0309/onnx2tf:1.1.46
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.1.45'
+__version__ = '1.1.46'


### PR DESCRIPTION
### 1. Content and background
YOLOv7-tiny output results do not match.
https://github.com/triptec/detection-models/blob/master/yolov7/yolov7-tiny.onnx

- onnx2tf
[model_float32.tflite.zip](https://github.com/PINTO0309/onnx2tf/files/10137612/model_float32.tflite.zip)

- compare tflite
[yolov7-tiny.tflite.zip](https://github.com/PINTO0309/onnx2tf/files/10137609/yolov7-tiny.tflite.zip)

Input Data
![zidane](https://user-images.githubusercontent.com/33194443/205200168-731bf892-bde8-470c-b918-e71b77c108a9.jpg)

The correct output is shown in the figure below.
![image](https://user-images.githubusercontent.com/33194443/205199925-8da1be62-ad66-4fb5-ae82-79366b9a5f7d.png)

### 2. Summary of corrections

Test Code
```python
import os
os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
import tensorflow as tf
import numpy as np
from pprint import pprint
np.random.seed(0)

import cv2

dummy_input = cv2.imread('zidane.jpg')
dummy_input = cv2.resize(dummy_input, [640,640])
dummy_input = dummy_input.astype(np.float32)[np.newaxis, ...]

# onnx2tf
interpreter = tf.lite.Interpreter('onnx2tf/saved_model/model_float32.tflite')
interpreter.allocate_tensors()
input_details = interpreter.get_input_details()
output_details = interpreter.get_output_details()
interpreter.set_tensor(input_details[0]['index'], dummy_input)
interpreter.invoke()
ret1 = interpreter.get_tensor(output_details[0]['index'])
pprint(ret1)

# Float32
interpreter = tf.lite.Interpreter('onnx2tf/saved_model/yolov7-tiny.tflite')
interpreter.allocate_tensors()
input_details = interpreter.get_input_details()
output_details = interpreter.get_output_details()
interpreter.set_tensor(input_details[0]['index'], dummy_input)
interpreter.invoke()
ret2 = interpreter.get_tensor(output_details[0]['index'])
pprint(ret2)

ret2 = ret2.transpose(0,2,1)

print(f'total ret1: {ret1.flatten().shape}, ret2: {ret2.flatten().shape}')
print(f'total isclose ret1-ret2: {np.isclose(ret1.flatten(), ret2.flatten()).all()}')
```

Results
```
total ret1: (2142000,), ret2: (2142000,)
total isclose ret1-ret2: True
```
### 3. Before/After (If there is an operating log that can be used as a reference)
.

### 4. Issue number (only if there is a related issue)
[Yolov7 problem with detection coordinates #34](https://github.com/PINTO0309/onnx2tf/issues/34)