### PR TITLE
Pad, Bug fixes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.2.4
+  ghcr.io/pinto0309/onnx2tf:1.2.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.2.4'
+__version__ = '1.2.5'


### PR DESCRIPTION
### 1. Content and background
Fixed a bug in padding operation. `Pad`

### 2. Summary of corrections
1. remove all padding operations diverted from onnx-tensorflow
2. replaced with home-made padding operations
3. removed negative padding operations

### 3. Before/After (If there is an operating log that can be used as a reference)
- After
  ```
  onnx2tf -i silero_vad.onnx --overwrite_input_shape "input:1,512"
  ```
  ```
  INFO: onnx_op_type: Relu onnx_op_name: Relu_579
  INFO:  input_name.1: 887 shape: [1, 64, 3] dtype: float32
  INFO:  output_name.1: 724 shape: [1, 64, 3] dtype: float32
  INFO: tf_op_type: relu
  INFO:  input.1.features: name: tf.math.add_61/Add:0 shape: (1, 3, 64) dtype: <dtype: 'float32'> 
  INFO:  output.1.output: name: tf.nn.relu_15/Relu:0 shape: (1, 3, 64) dtype: <dtype: 'float32'> 
  
  INFO: onnx_op_type: Transpose onnx_op_name: Transpose_580
  INFO:  input_name.1: 724 shape: [1, 64, 3] dtype: float32
  INFO:  output_name.1: 725 shape: [3, 1, 64] dtype: float32
  INFO: tf_op_type: transpose_v2
  INFO:  input.1.a: name: tf.nn.relu_15/Relu:0 shape: (1, 3, 64) dtype: <dtype: 'float32'> 
  INFO:  input.2.perm: val: [1, 0, 2] 
  INFO:  output.1.output: name: tf.compat.v1.transpose_62/transpose:0 shape: (3, 1, 64) dtype: <dtype: 'float32'> 
  ERROR: LSTM OP is not yet implemented.
  ```

### 4. Issue number (only if there is a related issue)
[Question about Pad #42](https://github.com/PINTO0309/onnx2tf/issues/42)