### PR TITLE
Minor fix in NonMaxSuppression and Gather

### DIFF
--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -69,6 +69,9 @@ def make_node(
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
 
+    # tensorflow gather supports only positive indices
+    indices = tf.cast(indices, tf.int64) + tf.cast(tf.where(indices < 0, 1, 0) * tf.shape(input_tensor)[axis], tf.int64)
+
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,


### PR DESCRIPTION
### 1. Content and background
I fixed minor problems found during conversion of YOLOX-X model from mmdetection. (https://github.com/open-mmlab/mmdetection)

### 2. Summary of corrections

1. NonMaxSuppression.py
Last time I proposed clipping of `graph_node_input_3`, which is related to `max_output_boxes_per_class` in `NonMaxSuppression`.
https://github.com/PINTO0309/onnx2tf/blob/9fef217f40e772a7d3d32352e51e5471cf905baa/onnx2tf/ops/NonMaxSuppression.py#L65-L66
Line number 66 occurs problem when `graph_node_input_3` is not appropriate type for `np.clip` as below.
![Screenshot from 2022-12-12 15-53-41](https://user-images.githubusercontent.com/34959032/206982889-674d68f2-43b5-4c1a-9401-f83bb292d66b.png)
https://github.com/PINTO0309/onnx2tf/blob/9fef217f40e772a7d3d32352e51e5471cf905baa/onnx2tf/ops/NonMaxSuppression.py#L86-L89
Also, comparing `max_output_boxes_per_class` with empty string in line number 89 occurs error when it is not the type of `np.ndarray` as below.
![Screenshot from 2022-12-12 15-54-45](https://user-images.githubusercontent.com/34959032/206983131-f8864ae6-3ac4-42ed-94f2-2e41f319a760.png)
NonMaxSuppression is now fixed to clip the values of `max_output_boxes_per_class` after try-catch.

2. Gather.py
Tensorflow gather supports only non-negative indices. However, ONNX supports positive and negative indices together as below. 
![Screenshot from 2022-12-12 16-20-11](https://user-images.githubusercontent.com/34959032/206984468-e5155efa-2fe3-491b-88fc-4253ac26f707.png)
I added few lines of code to convert negative indices to positive indices.


### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
