### PR TITLE
handle NOTSET padding case for ConvTranspose op

### DIFF
--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -667,7 +667,6 @@ def convert(
         converter = tf.lite.TFLiteConverter.from_concrete_functions(
             [concrete_func]
         )
-        converter.optimizations = [tf.lite.Optimize.DEFAULT]
         converter.target_spec.supported_ops = [
             tf.lite.OpsSet.TFLITE_BUILTINS,
             tf.lite.OpsSet.SELECT_TF_OPS,


### PR DESCRIPTION
- handle NOTSET padding case for ConvTranspose op
   Duplicate logic used in Conv op to deal with explicit padding. Before this, TF op has NOTSET paddig mode, resulting in incorrect
  output shape
- enable default optimizations for float32 conversion
   to match all the other conversions
- pass onnx_graph to op_name_auto_generate
  The top level convert function takes either a filename or a on ONNX graph When passing a graph, it is no passed down to op_name_auto_generate, causing conversion to fail
- clean up controlflow logic around output_integer_quantized_tflite
   remove it from nested ifs, as it's already true i
checkpoint

### 1. Content and background

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
