### PR TITLE
Support for FreeYOLO+E2E_Post-Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.2.7
+  ghcr.io/pinto0309/onnx2tf:1.2.8
 
   or
 
@@ -1044,13 +1044,14 @@ ONNX file for testing. https://github.com/PINTO0309/onnx2tf/releases/tag/1.1.28
 |43|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
 |44|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
 |45|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
-|46|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
-|47|yolox_nano_192x192.onnx|:heavy_check_mark:|
-|48|yolox_nano_416x416.onnx|:heavy_check_mark:|
-|49|yolox_s.onnx|:heavy_check_mark:|
-|50|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
-|51|zero_dce_640_dele.onnx|:heavy_check_mark:|
-|52|zfnet512-12.onnx|:heavy_check_mark:|
+|46|yolo_free_nano_crowdhuman_192x320_post.onnx|:heavy_check_mark:|
+|47|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
+|48|yolox_nano_192x192.onnx|:heavy_check_mark:|
+|49|yolox_nano_416x416.onnx|:heavy_check_mark:|
+|50|yolox_s.onnx|:heavy_check_mark:|
+|51|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
+|52|zero_dce_640_dele.onnx|:heavy_check_mark:|
+|53|zfnet512-12.onnx|:heavy_check_mark:|
 
 ## Related tools
 1. [tflite2tensorflow](https://github.com/PINTO0309/tflite2tensorflow)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.2.7'
+__version__ = '1.2.8'


### PR DESCRIPTION
### 1. Content and background
- https://github.com/yjh0410/FreeYOLO
- https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/yolo_free_nano_crowdhuman_192x320_post.onnx
- Demo - FreeYOLO Nano 192x320 PINTO_special - Corei9 Gen.10 CPU

  https://user-images.githubusercontent.com/33194443/207497782-f2266373-75e9-43a0-8740-dd733d8eaeb6.mp4



### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
