### PR TITLE
Substitution because saved_model does not allow leading slashes in op names

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.2.13
+  ghcr.io/pinto0309/onnx2tf:1.2.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.2.13'
+__version__ = '1.2.14'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -539,7 +539,10 @@ def convert(
 
             # make input
             op = importlib.import_module(f'onnx2tf.ops.Input')
+            # substitution because saved_model does not allow colons
             graph_input.name = graph_input.name.replace(':','_')
+            # Substitution because saved_model does not allow leading slashes in op names
+            graph_input.name = re.sub('^/', 'wa/', graph_input.name)
             op.make_node(
                 graph_input=graph_input,
                 tf_layers_dict=tf_layers_dict,
@@ -561,7 +564,10 @@ def convert(
                 )
                 sys.exit(1)
 
+            # substitution because saved_model does not allow colons
             graph_node.name = graph_node.name.replace(':','_')
+            # Substitution because saved_model does not allow leading slashes in op names
+            graph_node.name = re.sub('^/', 'wa/', graph_node.name)
             op.make_node(
                 graph_node=graph_node,
                 tf_layers_dict=tf_layers_dict,
@@ -625,8 +631,6 @@ def convert(
             # Switch to .pb
             if not non_verbose:
                 print(f'{Color.GREEN}Switch to the output of an optimized protocol buffer file (.pb).{Color.RESET}')
-            output_pb = True
-            flag_for_output_switching_from_saved_model_to_pb_due_to_error = True
         except KeyError as e:
             msg_list = [s for s in e.args if isinstance(s, str)]
             if len(msg_list) > 0:


### PR DESCRIPTION
### 1. Content and background
 Substitution because `saved_model` does not allow leading slashes in op names.

### 2. Summary of corrections
```python
graph_input.name = re.sub('^/', 'wa/', graph_input.name)

graph_node.name = re.sub('^/', 'wa/', graph_node.name)
```

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
