### PR TITLE
Created If operation

### DIFF
--- a/onnx2tf/ops/If.py
+++ b/onnx2tf/ops/If.py
@@ -61,7 +61,6 @@ def make_node(
     cond = tf.constant(True)
     
     # Generation of TF OP section
-    # TODO: Add the logic to generate the TF OP. Note: ONNX If is equivalent to TF cond.
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.cond(cond, 
                 lambda: input_tensor_1, 
@@ -69,7 +68,7 @@ def make_node(
                 name=graph_node.name
         )
     
-    # 5. Generation of Debug Info section
+    # Generation of Debug Info section
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
     make_tf_node_info(
         node_info={

--- a/onnx2tf/ops/If.py
+++ b/onnx2tf/ops/If.py
@@ -1,0 +1,84 @@
+import random
+random.seed(0)
+import numpy as np
+np.random.seed(0)
+import tensorflow as tf
+import onnx_graphsurgeon as gs
+from onnx2tf.utils.common_functions import (
+    get_constant_or_variable,
+    print_node_info,
+    inverted_operation_enable_disable,
+    make_tf_node_info,
+)
+
+@print_node_info
+@inverted_operation_enable_disable
+def make_node(
+    *,
+    graph_node: gs.Node,
+    tf_layers_dict: dict,
+    **kwargs: dict,
+):
+    """If
+    
+    Parameters
+    ----------
+    graph_node: gs.Node
+        graph_surgeon Node
+    
+    tf_layers_dict: dict
+        optype, shape, dtype, tensorflow graph
+    """
+    # Determines type of transposition
+    before_op_output_shape_trans_1 = \
+        tf_layers_dict.get(graph_node.inputs[0].name, {}).get('before_op_output_shape_trans', True)
+    before_op_output_shape_trans = \
+        before_op_output_shape_trans_1
+    
+    # Transposition of input values and conversion process to Numpy.ndarray
+    graph_node_input_1 = get_constant_or_variable(
+        graph_node.inputs[0],
+        before_op_output_shape_trans,
+    )
+    
+    # Type annotation for debugging efficiency
+    input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    
+    # Preserving Graph Structure (Dict) section
+    graph_node_output: gs.Variable = graph_node.outputs[0]
+    
+    shape = graph_node_output.shape
+    dtype = graph_node_output.dtype
+
+    tf_layers_dict[graph_node_output.name] = {
+        'optype': graph_node.op,
+        'shape': shape,
+        'dtype': dtype,
+    }
+    
+    # Define the condition
+    cond = tf.constant(True)
+    
+    # Generation of TF OP section
+    # TODO: Add the logic to generate the TF OP. Note: ONNX If is equivalent to TF cond.
+    tf_layers_dict[graph_node_output.name]['tf_node'] = \
+        tf.cond(cond, 
+                lambda: input_tensor_1, 
+                lambda: tf.constant(False), 
+                name=graph_node.name
+        )
+    
+    # 5. Generation of Debug Info section
+    tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
+    make_tf_node_info(
+        node_info={
+            'tf_op_type': tf.cond,
+            'tf_inputs': {
+                'x': input_tensor_1,
+            },
+            'tf_outputs': {
+                'output': tf_layers_dict[graph_node_output.name]['tf_node'],
+            },
+        }
+    )


### PR DESCRIPTION
### 1. Content and background

I'm working on converting a pre-trained (with COCO2017) SSDLite MobileNet V3 in pytorch to ONNX and then to TensorFlow. However, while converting from ONNX to TensorFlow, a missing `If` operation prevented me from completing the conversion.

### 2. Summary of corrections

I created an If operation using tf.cond along with directions from the [Contribution Guide](https://github.com/PINTO0309/onnx2tf/blob/main/CONTRIBUTING.md).

I can provide the onnx model on request. The param_replacement.json is as follows:
```json
{
    "format_version": 1,
    "operations": 
    [
      {
        "op_name": "/transform/Sub",
        "param_target": "inputs",
        "param_name": "/transform/Constant_output_0",
        "pre_process_transpose_perm": [1, 2, 0]
      },
      {
        "op_name": "/transform/Div",
        "param_target": "inputs",
        "param_name": "/transform/Constant_output_0",
        "pre_process_transpose_perm": [1, 2, 0]
      }
    ]
}
```

### 3. Before/After (If there is an operating log that can be used as a reference)

Before:
```
ERROR: If OP is not yet implemented.
```

After:
```INFO: onnx_op_type: If onnx_op_name: If_3462
INFO:  input_name.1: onnx::Cast_4102 shape: [] dtype: bool
INFO:  output_name.1: onnx::Slice_4104 shape: ['unk__780'] dtype: int64
INFO: tf_op_type: cond_for_tf_v2
INFO:  input.1.x: name: tf.math.equal/Equal:0 shape: () dtype: <dtype: 'bool'> 
INFO:  output.1.output: name: tf.math.equal/Equal:0 shape: () dtype: <dtype: 'bool'>```