### PR TITLE
Improvement of opset=18 partial processing of ReduceXX and axes empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.2.16
+  ghcr.io/pinto0309/onnx2tf:1.2.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.2.16'
+__version__ = '1.2.17'

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,19 +37,38 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     tensor_rank = len(input_tensor.shape)
 
-    axes = graph_node.attrs.get('axes', [])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
             convert_axis(
@@ -63,6 +83,10 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
+
+    # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -83,8 +83,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,19 +37,38 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     tensor_rank = len(input_tensor.shape)
 
-    axes = graph_node.attrs.get('axes', [])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
             convert_axis(
@@ -63,6 +83,10 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
+
+    # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -83,8 +83,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,19 +37,38 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     tensor_rank = len(input_tensor.shape)
 
-    axes = graph_node.attrs.get('axes', [])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
             convert_axis(
@@ -63,6 +83,10 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
+
+    # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -83,8 +83,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,19 +37,38 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     tensor_rank = len(input_tensor.shape)
 
-    axes = graph_node.attrs.get('axes', [])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
             convert_axis(
@@ -63,6 +83,10 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
+
+    # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -83,8 +83,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -108,7 +108,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemaxed_tensor
 
     # Generation of Debug Info
-    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)}
+    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)} if axes is not None else {"axis": None}
     tf_inputs['input_tensor'] = input_tensor
     tf_inputs['keepdims'] = keepdims
 

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,17 +37,36 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    tensor_rank = len(graph_node_input.shape)
+    tensor_rank = len(graph_node_input_1.shape)
 
-    axes = graph_node.attrs.get('axes', [-1])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     # NCHW->NHWC, NCDHW->NDHWC
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
@@ -62,6 +82,8 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
@@ -74,8 +96,8 @@ def make_node(
     }
 
     # Generation of TF OP
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
 
     reducemaxed_tensor = input_tensor
     reducemaxed_tensor = tf.math.reduce_max(

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -82,8 +82,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -107,7 +107,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemeaned_tensor
 
     # Generation of Debug Info
-    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)}
+    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)} if axes is not None else {"axis": None}
     tf_inputs['input_tensor'] = input_tensor
     tf_inputs['keepdims'] = keepdims
 

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,17 +37,36 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    tensor_rank = len(graph_node_input.shape)
+    tensor_rank = len(graph_node_input_1.shape)
 
-    axes = graph_node.attrs.get('axes', [-1])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     # NCHW->NHWC, NCDHW->NDHWC
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
@@ -62,6 +82,8 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
@@ -74,8 +96,8 @@ def make_node(
     }
 
     # Generation of TF OP
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
 
     reducemeaned_tensor = input_tensor
     reducemeaned_tensor = tf.math.reduce_mean(

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -82,8 +82,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,17 +37,36 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    tensor_rank = len(graph_node_input.shape)
+    tensor_rank = len(graph_node_input_1.shape)
 
-    axes = graph_node.attrs.get('axes', [-1])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     # NCHW->NHWC, NCDHW->NDHWC
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
@@ -62,6 +82,8 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
@@ -74,8 +96,8 @@ def make_node(
     }
 
     # Generation of TF OP
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
 
     reducemined_tensor = input_tensor
     reducemined_tensor = tf.math.reduce_min(

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -82,8 +82,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -107,7 +107,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemined_tensor
 
     # Generation of Debug Info
-    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)}
+    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)} if axes is not None else {"axis": None}
     tf_inputs['input_tensor'] = input_tensor
     tf_inputs['keepdims'] = keepdims
 

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -107,7 +107,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = reduceproded_tensor
 
     # Generation of Debug Info
-    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)}
+    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)} if axes is not None else {"axis": None}
     tf_inputs['input_tensor'] = input_tensor
     tf_inputs['keepdims'] = keepdims
 

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -11,6 +11,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.colors import Color
 
 
 @print_node_info
@@ -36,17 +37,36 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    graph_node_input = get_constant_or_variable(
+    graph_node_input_1 = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
+    graph_node_input_2 = None
+    if len(graph_node.inputs) >= 2:
+        graph_node_input_2 = get_constant_or_variable(
+            graph_node.inputs[1],
+            before_op_output_shape_trans,
+        )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    tensor_rank = len(graph_node_input.shape)
+    tensor_rank = len(graph_node_input_1.shape)
 
-    axes = graph_node.attrs.get('axes', [-1])
+    axes = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    if axes is not None and axes.shape is None:
+        axes = None
+
+    axes = graph_node.attrs.get('axes', axes)
+    noop_with_empty_axes = bool(graph_node.attrs.get('noop_with_empty_axes', 0))
+    if noop_with_empty_axes:
+        error_msg = f'' +\
+            f'{Color.RED}ERROR:{Color.RESET} ' +\
+            f'TensorFlow does not support noop_with_empty_axes=1 (True).'
+        print(error_msg)
+        assert not noop_with_empty_axes, error_msg
+
     # NCHW->NHWC, NCDHW->NDHWC
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
@@ -62,6 +82,8 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))
@@ -74,8 +96,8 @@ def make_node(
     }
 
     # Generation of TF OP
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
 
     reduceproded_tensor = input_tensor
     reduceproded_tensor = tf.math.reduce_prod(

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -82,8 +82,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -83,6 +83,8 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
+    elif axes is None and not noop_with_empty_axes:
+        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -83,8 +83,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -105,7 +105,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducesumed_tensor
 
     # Generation of Debug Info
-    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)}
+    tf_inputs = {f"axis{idx}": value for idx, value in enumerate(axes)} if axes is not None else {"axis": None}
     tf_inputs['input_tensor'] = input_tensor
     tf_inputs['keepdims'] = keepdims
 

--- a/onnx2tf/ops/ReduceSumSquare.py
+++ b/onnx2tf/ops/ReduceSumSquare.py
@@ -84,8 +84,6 @@ def make_node(
             tensor_rank=tensor_rank,
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
-    elif axes is None and not noop_with_empty_axes:
-        axes = [idx for idx in range(tensor_rank)]
 
     # 0: False, 1: True
     keepdims = bool(graph_node.attrs.get('keepdims', 1))


### PR DESCRIPTION
### 1. Content and background
Improvement of `opset=18` partial processing of `ReduceXX` and axes empty

- `ReduceSum`
- `ReduceL1`
- `ReduceL2`
- `ReduceLogSum`
- `ReduceLogSumExp`
- `ReduceMax`
- `ReduceMean`
- `ReduceMin`
- `ReduceProd`
- `ReduceSumSquare`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
