### PR TITLE
pre_process_transpose, post_process_transpose. `E-I`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.2.23
+  ghcr.io/pinto0309/onnx2tf:1.2.24
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.2.23'
+__version__ = '1.2.24'

--- a/onnx2tf/ops/Einsum.py
+++ b/onnx2tf/ops/Einsum.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -37,7 +41,7 @@ def make_node(
         before_op_output_shape_trans = \
             before_op_output_shape_trans and before_op_output_shape_trans_n
 
-    inputs = []
+    values = []
     for graph_node_input in graph_node.inputs:
         graph_node_input_perm = get_constant_or_variable(
             graph_node_input,
@@ -45,7 +49,7 @@ def make_node(
         )
         input_tensor = tf_layers_dict[graph_node_input_perm.name]['tf_node'] \
             if isinstance(graph_node_input_perm, gs.Variable) else graph_node_input_perm
-        inputs.append(input_tensor)
+        values.append(input_tensor)
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
@@ -59,16 +63,36 @@ def make_node(
         'dtype': dtype,
     }
 
+    # Pre-process transpose
+    new_values = []
+    for graph_node_input, value in zip(graph_node.inputs, values):
+        value = pre_process_transpose(
+            value_before_transpose=value,
+            param_target='inputs',
+            param_name=graph_node_input.name,
+            **kwargs,
+        )
+        new_values.append(value)
+    values = new_values
+
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.einsum(
             equation,
-            *inputs,
+            *values,
             name=graph_node.name,
         )
 
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
+
     # Generation of Debug Info
-    tf_inputs = {f"input{idx}": input for idx, input in enumerate(inputs)}
+    tf_inputs = {f"input{idx}": input for idx, input in enumerate(values)}
     tf_inputs['equation'] = equation
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
         make_tf_node_info(

--- a/onnx2tf/ops/Elu.py
+++ b/onnx2tf/ops/Elu.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -58,6 +62,14 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     # Generation of TF OP
     if alpha != 1.0:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -76,6 +88,14 @@ def make_node(
                 features=input_tensor,
                 name=graph_node.name,
             )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Equal.py
+++ b/onnx2tf/ops/Equal.py
@@ -10,11 +10,15 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
     shape_unmatched_special_avoidance_workaround,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -76,12 +80,34 @@ def make_node(
         tf_layers_dict=tf_layers_dict,
     )
 
+    # Pre-process transpose
+    input_tensor_1 = pre_process_transpose(
+        value_before_transpose=input_tensor_1,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+    input_tensor_2 = pre_process_transpose(
+        value_before_transpose=input_tensor_2,
+        param_target='inputs',
+        param_name=graph_node.inputs[1].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.equal(
             x=input_tensor_1,
             y=input_tensor_2,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Erf.py
+++ b/onnx2tf/ops/Erf.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -60,6 +64,14 @@ def make_node(
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     if not replace_erf_to_pseudo_erf:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.math.erf(
@@ -81,6 +93,14 @@ def make_node(
         y = 1.0 - (((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*tf.math.exp(-x_abs*x_abs)
         erf_tensor = sign*y
         tf_layers_dict[graph_node_output.name]['tf_node'] = erf_tensor
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Exp.py
+++ b/onnx2tf/ops/Exp.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -58,11 +62,27 @@ def make_node(
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.exp(
             x=input_tensor,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/EyeLike.py
+++ b/onnx2tf/ops/EyeLike.py
@@ -5,11 +5,13 @@ np.random.seed(0)
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
-    get_replacement_parameter,
     get_constant_or_variable,
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
@@ -45,6 +47,15 @@ def make_node(
 
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
+
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     input_tensor_shape = tf.shape(input_tensor)
 
     shape = graph_node_output.shape
@@ -149,6 +160,14 @@ def make_node(
                 paddings=paddings,
                 name=graph_node.name,
             )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Floor.py
+++ b/onnx2tf/ops/Floor.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -58,11 +62,27 @@ def make_node(
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.floor(
             x=input_tensor,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/GatherElements.py
+++ b/onnx2tf/ops/GatherElements.py
@@ -11,11 +11,15 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
     process_neg_idx_along_axis,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -56,6 +60,21 @@ def make_node(
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     indices_tensor = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+    indices_tensor = pre_process_transpose(
+        value_before_transpose=indices_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[1].name,
+        **kwargs,
+    )
+
     tensor_rank = len(input_tensor.shape)
 
     axis = graph_node.attrs.get('axis', 0)
@@ -112,6 +131,14 @@ def make_node(
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.transpose(gathered, perm=axis_perm)
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/GlobalAveragePool.py
+++ b/onnx2tf/ops/GlobalAveragePool.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -55,6 +59,14 @@ def make_node(
         'dtype': dtype,
     }
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     # Generation of TF OP
     axis = [dim for dim in range(1, input_tensor_rank - 1)]
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -64,6 +76,14 @@ def make_node(
             keepdims=True,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/GlobalLpPool.py
+++ b/onnx2tf/ops/GlobalLpPool.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -57,6 +61,14 @@ def make_node(
         'dtype': dtype,
     }
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     # Generation of TF OP
     dims = list(range(input_tensor_rank))
     dim_window = dims[1:-1]
@@ -69,6 +81,14 @@ def make_node(
             axis=dim_window,
             keepdims=True,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/GlobalMaxPool.py
+++ b/onnx2tf/ops/GlobalMaxPool.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -55,6 +59,14 @@ def make_node(
         'dtype': dtype,
     }
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     # Generation of TF OP
     axis = [dim for dim in range(1, input_tensor_rank - 1)]
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -64,6 +76,14 @@ def make_node(
             keepdims=True,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Greater.py
+++ b/onnx2tf/ops/Greater.py
@@ -10,11 +10,15 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
     shape_unmatched_special_avoidance_workaround,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -76,12 +80,34 @@ def make_node(
         tf_layers_dict=tf_layers_dict,
     )
 
+    # Pre-process transpose
+    input_tensor_1 = pre_process_transpose(
+        value_before_transpose=input_tensor_1,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+    input_tensor_2 = pre_process_transpose(
+        value_before_transpose=input_tensor_2,
+        param_target='inputs',
+        param_name=graph_node.inputs[1].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.greater(
             x=input_tensor_1,
             y=input_tensor_2,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/GreaterOrEqual.py
+++ b/onnx2tf/ops/GreaterOrEqual.py
@@ -10,11 +10,15 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
     shape_unmatched_special_avoidance_workaround,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -76,12 +80,34 @@ def make_node(
         tf_layers_dict=tf_layers_dict,
     )
 
+    # Pre-process transpose
+    input_tensor_1 = pre_process_transpose(
+        value_before_transpose=input_tensor_1,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+    input_tensor_2 = pre_process_transpose(
+        value_before_transpose=input_tensor_2,
+        param_target='inputs',
+        param_name=graph_node.inputs[1].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.greater_equal(
             x=input_tensor_1,
             y=input_tensor_2,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/HardSigmoid.py
+++ b/onnx2tf/ops/HardSigmoid.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -58,8 +62,24 @@ def make_node(
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.keras.activations.hard_sigmoid(input_tensor)
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/HardSwish.py
+++ b/onnx2tf/ops/HardSwish.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -59,6 +63,14 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     # Generation of TF OP
     # For TPU workaround
     if not replace_hardswish_to_pseudo_hardswish:
@@ -69,6 +81,14 @@ def make_node(
         multiplier = 0.16666666
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             input_tensor * tf.nn.relu6(input_tensor + 3) * multiplier
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Hardmax.py
+++ b/onnx2tf/ops/Hardmax.py
@@ -10,11 +10,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -46,6 +50,15 @@ def make_node(
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     input_tensor_shape = input_tensor.shape
     tensor_rank = len(input_tensor_shape)
 
@@ -113,6 +126,14 @@ def make_node(
     )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = onehoted_tensor
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -48,6 +52,14 @@ def make_node(
 
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
+
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
 
     input_tensor_shape = input_tensor.shape
     input_tensor_rank = len(input_tensor.shape)
@@ -107,6 +119,14 @@ def make_node(
             variance_epsilon=epsilon,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     if len(shape) == 3 and graph_node.o().op == 'Reshape':
         tf_layers_dict[graph_node_output.name]['is_instance_norm_3d'] = True

--- a/onnx2tf/ops/IsInf.py
+++ b/onnx2tf/ops/IsInf.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -58,6 +62,14 @@ def make_node(
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
 
+    # Pre-process transpose
+    input_tensor_1 = pre_process_transpose(
+        value_before_transpose=input_tensor_1,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     zero = tf.zeros(shape, dtype)
     dn = bool(graph_node.attrs.get('detect_negative', 1))
     dp = bool(graph_node.attrs.get('detect_positive', 1))
@@ -72,6 +84,14 @@ def make_node(
             x=inp,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/IsNaN.py
+++ b/onnx2tf/ops/IsNaN.py
@@ -9,11 +9,15 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    get_replacement_parameter,
+    pre_process_transpose,
+    post_process_transpose,
 )
 
 
 @print_node_info
 @inverted_operation_enable_disable
+@get_replacement_parameter
 def make_node(
     *,
     graph_node: gs.Node,
@@ -58,11 +62,27 @@ def make_node(
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
 
+    # Pre-process transpose
+    input_tensor_1 = pre_process_transpose(
+        value_before_transpose=input_tensor_1,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.is_nan(
             x=input_tensor_1,
             name=graph_node.name,
         )
+
+    # Post-process transpose
+    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+        value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
+        param_target='outputs',
+        param_name=graph_node.outputs[0].name,
+        **kwargs,
+    )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \


### PR DESCRIPTION
### 1. Content and background
- `Exxxx` op - `Ixxxx` op
  - pre_process_transpose
  - post_process_transpose.
- `ConvTranspose`
  - Support for `group > 1`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Problem in padding in ConvTranspose when stride is larger than 1](https://github.com/PINTO0309/onnx2tf/issues/56)