### PR TITLE
Fix ConvTranspose behavior when stride, padding > 1

### DIFF
--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -183,13 +183,13 @@ def make_node(
     conv_rs = None
     convolved = []
     for (input_tensor_split, weight_split) in zip(input_tensor_splits, weight_splits):
-        split_conv_output_shape = conv_output_shape[:-1] + [weight_split.shape[spatial_size]]
+        split_conv_output_shape = tf_output_shape[:-1] + [weight_split.shape[spatial_size]]
         if output_shape_ is None:
             # Normal ConvTranspose
             conv_rs = conv_func(
                 input=input_tensor_split,
                 filters=weight_split,
-                output_shape=tf_output_shape,
+                output_shape=split_conv_output_shape,
                 strides=strides,
                 padding=pad_mode,
                 dilations=dilations,

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -115,13 +115,10 @@ def make_node(
                                                        dilation=dilations)
 
     if auto_pad == 'NOTSET':
-        if tf_output_shape == graph_node_output_shape[2:] \
-                and tf_output_shape == [i * s for i, s in zip(graph_node_input_shape[2:], strides)]:
-            pad_mode = "SAME"
-        else:
-            # TODO: check for valid explicit pads.
-            pad_mode = 'VALID'
+        # pad_mode SAME generates flex operation, use VALID always
+        pad_mode = 'VALID'
     elif auto_pad == "SAME_UPPER":
+        # TODO: this may generates flex operation, need to check
         pad_mode = "SAME"
     elif auto_pad == "VALID":
         pad_mode = "VALID"

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -115,7 +115,8 @@ def make_node(
                                                        dilation=dilations)
 
     if auto_pad == 'NOTSET':
-        if tf_output_shape == graph_node_output_shape[2:]:
+        if tf_output_shape == graph_node_output_shape[2:] \
+                and tf_output_shape == [i * s for i, s in zip(graph_node_input_shape[2:], strides)]:
             pad_mode = "SAME"
         else:
             # TODO: check for valid explicit pads.

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -106,14 +106,6 @@ def make_node(
     auto_pad = graph_node.attrs.get('auto_pad', 'NOTSET')
     pad_mode = 'VALID'
 
-    # calculate output shape of tensorflow conv_transpose
-    tf_output_shape = calc_output_shape_conv_transpose(graph_node_input_shape[2:],
-                                                       kernel=kernel_shape,
-                                                       pad_mode='same',
-                                                       output_padding=output_padding,
-                                                       stride=strides,
-                                                       dilation=dilations)
-
     if auto_pad == 'NOTSET':
         # pad_mode SAME generates flex operation, use VALID always
         pad_mode = 'VALID'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -8,6 +8,7 @@ import numpy as np
 np.random.seed(0)
 import tensorflow as tf
 from tensorflow.keras.layers import Lambda # type: ignore
+from tensorflow.python.keras.utils import conv_utils
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.colors import Color
 from typing import Any, List, Optional, Union, Tuple
@@ -2160,3 +2161,18 @@ def shape_unmatched_special_avoidance_workaround(
         input_tensor_2 = values[1]
 
     return input_tensor_1, input_tensor_2
+
+def calc_output_shape_conv_transpose(input_shape, kernel, pad_mode, output_padding, stride, dilation):
+    out_height = conv_utils.deconv_output_length(input_shape[0],
+                                                 kernel[0],
+                                                 padding=pad_mode.lower(),
+                                                 output_padding=output_padding[0],
+                                                 stride=stride[0],
+                                                 dilation=dilation[0])
+    out_width = conv_utils.deconv_output_length(input_shape[1],
+                                                kernel[1],
+                                                padding=pad_mode.lower(),
+                                                output_padding=output_padding[1],
+                                                stride=stride[1],
+                                                dilation=dilation[1])
+    return [out_height, out_width]


### PR DESCRIPTION
### 1. Content and background
https://numbersmithy.com/understanding-transposed-convolutions-in-pytorch/#org9cb8239
After some searching, I found that extra slice layer is required to implement same action of pytorch, onnx `ConvTranspose` in tflite.

https://github.com/PINTO0309/onnx2tf/blob/6b971b8d836cf263763458ff2c18152c9bcfe6e5/onnx2tf/ops/ConvTranspose.py#L180-L187

Also, I found the reason of segmentation fault during invoke. Segmention fault is occured when wrong output shape is assigned to `conv_func`. I added extra code to calculate exact shape of `ConvTranspose` of tensorflow to prevent this.

### 2. Summary of corrections
Now the tensorflow output shape is calculated before setting `pad_mode`. `pad_mode` is always set to `VALID` and extra `slice` layer is added after `ConvTranspose` layer if needed.

ONNX | Tflite
--- | --- 
<img src="https://user-images.githubusercontent.com/34959032/209507181-e028f0f7-4f96-4006-8eeb-c60596a6dc71.png" width="150">| <img src="https://user-images.githubusercontent.com/34959032/209507188-d98d9a35-fad1-41d8-8788-6b2237f36c5c.png" width="150">

I used code below to debug various combination of kernel, stride, padding.
~~However, in some cases like kernel = 3, stride = 1, padding = 1, `ConvTranspose` operation is converted to `FlexConv2DBackpropInput` operation. I tried but couldn't find the reason yet. It seems to occur when calculated padding in one direction does not match to other side when pad_mode is `SAME`. (ex. left padding=3, right padding=2)~~
Flex operation is removed by fixing pad_mode to always `VALID`.

```
import os
import shutil

import onnxruntime
import tensorflow as tf
import torch
from einops import rearrange
from torch import nn
import numpy as np
from onnx2tf import convert


class dummy_network(nn.Module):

    def __init__(self, kernel, stride, padding, groups):
        super(dummy_network, self).__init__()

        self.tconv = torch.nn.ConvTranspose2d(16, 64, kernel, stride=stride, padding=padding, groups=groups)

    def forward(self, x):
        result = self.tconv(x)

        return result


def main():
    os.makedirs("tflite", exist_ok=True)
    np.random.seed(12)
    kernels = [np.random.randint(3, 8) for _ in range(30)]
    strides = [np.random.randint(1, 8) for _ in kernels]
    paddings = [np.random.randint(1, 8) for _ in kernels]
    groups = np.random.choice([1, 2, 4, 8], size=len(kernels))

    for k, s, p, g in zip(kernels, strides, paddings, groups):
        print("kernel, stride, padding, groups : ", k, s, p, g)
        model = dummy_network(k, s, p, g)
        model.eval()

        dummy_name = "dummy_tconv"
        onnx_save_path = f"tflite/{dummy_name}.onnx"
        temp_tflite = "tflite/model_float32.tflite"
        tflite_save_path = f"tflite/{dummy_name}.tflite"

        # y1, x1, y2, x2
        dummy_x = torch.randn(1, 16, 224, 224, dtype=torch.float32)

        torch.onnx.export(model,
                          args=(dummy_x,),
                          f=onnx_save_path,
                          input_names=["x"],
                          output_names=["result"],
                          opset_version=11)

        # get onnx output
        # -----------------------------------------------------------------------------------------------
        onnx_session = onnxruntime.InferenceSession(onnx_save_path, providers=['CPUExecutionProvider'])
        onnx_inputs = dict(x=dummy_x.numpy())
        onnx_outputs = onnx_session.run(None, onnx_inputs)

        convert(onnx_save_path, output_folder_path="tflite")
        shutil.move(temp_tflite, tflite_save_path)

        # get tflite output
        # -----------------------------------------------------------------------------------------------
        tflite_onnx2tf = tf.lite.Interpreter(model_path=tflite_save_path)
        tflite_onnx2tf.allocate_tensors()
        tflite_onnx2tf.set_tensor(tflite_onnx2tf.get_input_details()[0]['index'],
                                  rearrange(dummy_x.numpy(), "n c h w -> n h w c"))
        tflite_onnx2tf.invoke()
        tflite_output = [tflite_onnx2tf.get_tensor(i['index']) for i in tflite_onnx2tf.get_output_details()][0]

        np.testing.assert_allclose(rearrange(tflite_output, "n h w c -> n c h w"), onnx_outputs[0], atol=1e-3, rtol=0.5)
        print("onnx and tflite have same output")

    print("convert done")

    return


if __name__ == "__main__":
    main()


```

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
#56 