### PR TITLE
Minor fix for ConvTranspose

### DIFF
--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2197,17 +2197,20 @@ def shape_unmatched_special_avoidance_workaround(
 
     return input_tensor_1, input_tensor_2
 
+
 def calc_output_shape_conv_transpose(input_shape, kernel, pad_mode, output_padding, stride, dilation):
-    out_height = conv_utils.deconv_output_length(input_shape[0],
-                                                 kernel[0],
-                                                 padding=pad_mode.lower(),
-                                                 output_padding=output_padding[0],
-                                                 stride=stride[0],
-                                                 dilation=dilation[0])
-    out_width = conv_utils.deconv_output_length(input_shape[1],
-                                                kernel[1],
-                                                padding=pad_mode.lower(),
-                                                output_padding=output_padding[1],
-                                                stride=stride[1],
-                                                dilation=dilation[1])
-    return [out_height, out_width]
+
+    assert len(input_shape) == len(kernel) == len(output_padding) == len(stride) == len(dilation),\
+        "All parameters should have same length"
+
+    output_shape = []
+
+    for i, k, p, s, d in zip(input_shape, kernel, output_padding, stride, dilation):
+        output_shape.append(conv_utils.deconv_output_length(input_length=i,
+                                                            filter_size=k,
+                                                            padding=pad_mode.lower(),
+                                                            output_padding=p,
+                                                            stride=s,
+                                                            dilation=d))
+
+    return output_shape


### PR DESCRIPTION
### 1. Content and background

### 2. Summary of corrections

1. Last pull request I added `calc_output_shape_conv_transpose` in `common_functions.py`. This fucntion worked correctly only when dimension is 2. I fixed the function so it can work for other cases.

2. `ConvTranspose.py` does explicit split for weights and inputs when group is larger than 1. However, it generates extra layer because of bias. `TransposeConv` support bias addition in layer itself for 1d and 2d. I fixed few lines of code to remove extra `Add` layer. 

### 3. Before/After (If there is an operating log that can be used as a reference)

Before | After
---|---
<img src="https://user-images.githubusercontent.com/34959032/209759389-94634ff4-02c7-4e12-9724-17b8c3ba9874.png" width="300">|<img src="https://user-images.githubusercontent.com/34959032/209759394-4c45c93e-dfed-46e0-9b00-937a1b5b942a.png" width="300">

3d TransposeConv does not support bias addition | After fix
---|---
<img src="https://user-images.githubusercontent.com/34959032/209759395-90bf6dde-d878-4883-9437-b1697c047a50.png" width="400">|<img src="https://user-images.githubusercontent.com/34959032/209759398-36d1eda5-fb91-4ff4-883b-2c2afd6d24bc.png" width="400">


### 4. Issue number (only if there is a related issue)
