### PR TITLE
Fixed a bug that caused `Slice` to fail if `starts`, `ends`, or `steps` were input as `tf.Tensor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.2
+  ghcr.io/pinto0309/onnx2tf:1.3.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -244,13 +244,22 @@ def make_node(
     # Generation of TF OP
     if begin_ is None:
         ##### begin
-        begin_ = [dim for dim in starts]
+        if isinstance(starts, tf.Tensor) and hasattr(starts, "numpy"):
+            begin_ = [dim for dim in starts.numpy()]
+        else:
+            begin_ = [dim for dim in starts]
         ##### end
-        end_ = [dim for dim in ends]
+        if isinstance(ends, tf.Tensor) and hasattr(ends, "numpy"):
+            end_ = [dim for dim in ends.numpy()]
+        else:
+            end_ = [dim for dim in ends]
         ##### strides
         strides_ = None
         if steps is not None:
-            strides_ = [dim for dim in steps]
+            if isinstance(steps, tf.Tensor) and hasattr(steps, "numpy"):
+                strides_ = [dim for dim in steps.numpy()]
+            else:
+                strides_ = [dim for dim in steps]
 
         if input_tensor_rank > len(begin_):
             # Adjust the number of dimensions of the input data according to the number of axes

--- a/replace.json
+++ b/replace.json
@@ -2,88 +2,118 @@
   "format_version": 1,
   "operations": [
     {
-      "op_name": "Reshape_136",
-      "param_target": "outputs",
-      "param_name": "194",
-      "post_process_transpose_perm": [0,2,1]
+      "op_name": "Resize_0",
+      "param_target": "inputs",
+      "param_name": "Concat_0",
+      "values": [48,48]
     },
     {
-      "op_name": "Reshape_143",
+      "op_name": "Resize_1",
+      "param_target": "inputs",
+      "param_name": "Concat_1",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_2",
+      "param_target": "inputs",
+      "param_name": "Concat_2",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_3",
+      "param_target": "inputs",
+      "param_name": "Concat_3",
+      "values": [24,24]
+    },
+    {
+      "op_name": "Resize_4",
+      "param_target": "inputs",
+      "param_name": "Concat_4",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_5",
+      "param_target": "inputs",
+      "param_name": "Concat_5",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_6",
+      "param_target": "inputs",
+      "param_name": "Concat_6",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_7",
+      "param_target": "inputs",
+      "param_name": "Concat_7",
+      "values": [24,24]
+    },
+    {
+      "op_name": "Resize_8",
+      "param_target": "inputs",
+      "param_name": "Concat_8",
+      "values": [24,24]
+    },
+    {
+      "op_name": "Resize_9",
+      "param_target": "inputs",
+      "param_name": "Concat_9",
+      "values": [12,12]
+    },
+    {
+      "op_name": "Resize_10",
+      "param_target": "inputs",
+      "param_name": "Concat_10",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_11",
+      "param_target": "inputs",
+      "param_name": "Concat_11",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_12",
+      "param_target": "inputs",
+      "param_name": "Concat_12",
+      "values": [48,48]
+    },
+    {
+      "op_name": "Resize_13",
+      "param_target": "inputs",
+      "param_name": "Concat_14",
+      "values": [192,192]
+    },
+    {
+      "op_name": "Reshape_0",
       "param_target": "outputs",
-      "param_name": "205",
+      "param_name": "Reshape_0",
       "post_process_transpose_perm": [0,2,3,1]
     },
     {
-      "op_name": "Reshape_170",
+      "op_name": "Reshape_1",
       "param_target": "outputs",
-      "param_name": "234",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "Reshape_177",
-      "param_target": "outputs",
-      "param_name": "245",
+      "param_name": "Reshape_1",
       "post_process_transpose_perm": [0,2,3,1]
     },
     {
-      "op_name": "Reshape_206",
-      "param_target": "outputs",
-      "param_name": "276",
-      "post_process_transpose_perm": [0,2,1]
+      "op_name": "Transpose_0",
+      "param_target": "attributes",
+      "param_name": "perm",
+      "values": [0,1,2,3]
     },
     {
-      "op_name": "Reshape_213",
-      "param_target": "outputs",
-      "param_name": "287",
-      "post_process_transpose_perm": [0,2,3,1]
+      "op_name": "Transpose_1",
+      "param_target": "attributes",
+      "param_name": "perm",
+      "values": [0,1,2,3]
     },
     {
-      "op_name": "Reshape_240",
-      "param_target": "outputs",
-      "param_name": "316",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "Reshape_247",
-      "param_target": "outputs",
-      "param_name": "327",
-      "post_process_transpose_perm": [0,2,3,1]
-    },
-    {
-      "op_name": "Reshape_303",
-      "param_target": "outputs",
-      "param_name": "385",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "Reshape_310",
-      "param_target": "outputs",
-      "param_name": "396",
-      "post_process_transpose_perm": [0,2,3,1]
-    },
-    {
-      "op_name": "Reshape_364",
-      "param_target": "outputs",
-      "param_name": "452",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "Reshape_371",
-      "param_target": "outputs",
-      "param_name": "463",
-      "post_process_transpose_perm": [0,2,3,1]
-    },
-    {
-      "op_name": "Reshape_425",
-      "param_target": "outputs",
-      "param_name": "519",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "Reshape_432",
-      "param_target": "outputs",
-      "param_name": "530",
-      "post_process_transpose_perm": [0,2,3,1]
+      "op_name": "Softmax_0",
+      "param_target": "attributes",
+      "param_name": "axis",
+      "values": 3
     }
   ]
 }


### PR DESCRIPTION
### 1. Content and background
- Fixed a bug that caused `Slice` to fail if `starts`, `ends`, or `steps` were input as `tf.Tensor`
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.27/human_segmentation_pphumanseg_2021oct.onnx
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.27/replace.json

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
