### PR TITLE
Support for `FusedConv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.6
+  ghcr.io/pinto0309/onnx2tf:1.3.7
 
   or
 
@@ -868,6 +868,7 @@ Please don't post such low level questions as issues.
   |EyeLike|:heavy_check_mark:|
   |Flatten|:heavy_check_mark:|
   |Floor|:heavy_check_mark:|
+  |FusedConv|:heavy_check_mark:|
   |GatherElements|:heavy_check_mark:|
   |GatherND|:heavy_check_mark:|
   |Gather|:heavy_check_mark:|
@@ -1042,47 +1043,53 @@ ONNX file for testing. https://github.com/PINTO0309/onnx2tf/releases/tag/1.1.28
 |20|face_recognition_sface_2021dec-act_int8-wt_int8-quantized.onnx|:heavy_check_mark:|
 |21|face_recognition_sface_2021dec.onnx|:heavy_check_mark:|
 |22|fastestdet.onnx|:heavy_check_mark:|
-|23|gender_googlenet.onnx|:heavy_check_mark:|
-|24|handpose_estimation_mediapipe_2022may.onnx|:heavy_check_mark:|
-|25|iat_llie_180x320.onnx|:heavy_check_mark:|
-|26|imageclassifier.onnx|:heavy_check_mark:|
-|27|inception-v2-9.onnx|:heavy_check_mark:|
-|28|mnist-12.onnx|:heavy_check_mark:|
-|29|mobilenetv2-12.onnx|:heavy_check_mark:|
-|30|mosaic_11.onnx|:heavy_check_mark:|
-|31|mosaic-9.onnx|:heavy_check_mark:|
-|32|movenet_multipose_lightning_192x256_p6.onnx|:heavy_check_mark:|
-|33|nanodet-plus-m_416.onnx|:heavy_check_mark:|
-|34|object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx|:heavy_check_mark:|
-|35|object_tracking_dasiamrpn_kernel_r1_2021nov.onnx|:heavy_check_mark:|
-|36|object_tracking_dasiamrpn_model_2021nov.onnx|:heavy_check_mark:|
-|37|pidnet_S_cityscapes_192x320.onnx|:heavy_check_mark:|
-|38|qlinear_conv_tensor_test.onnx|:heavy_check_mark:|
-|39|rcnn-ilsvrc13-9.onnx|:heavy_check_mark:|
-|40|regnet_x_400mf.onnx|:heavy_check_mark:|
-|41|ResNet101-DUC-12.onnx|:heavy_check_mark:|
-|42|resnet18-v1-7.onnx|:heavy_check_mark:|
-|43|resnet50-v1-12.onnx|:heavy_check_mark:|
-|44|resnet50-v2-7.onnx|:heavy_check_mark:|
-|45|retinanet-9.onnx|:heavy_check_mark:|
-|46|sinet_320_op.onnx|:heavy_check_mark:|
-|47|squeezenet1.0-12.onnx|:heavy_check_mark:|
-|48|super-resolution-10.onnx|:heavy_check_mark:|
-|49|tinyyolov2-8.onnx|:heavy_check_mark:|
-|50|version-RFB-640.onnx|:heavy_check_mark:|
-|51|vit-b-32_textual.onnx|:heavy_check_mark:|
-|52|vit-b-32_visual.onnx|:heavy_check_mark:|
-|53|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
-|54|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
-|55|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
-|56|yolo_free_nano_crowdhuman_192x320_post.onnx|:heavy_check_mark:|
-|57|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
-|58|yolox_nano_192x192.onnx|:heavy_check_mark:|
-|59|yolox_nano_416x416.onnx|:heavy_check_mark:|
-|60|yolox_s.onnx|:heavy_check_mark:|
-|61|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
-|62|zero_dce_640_dele.onnx|:heavy_check_mark:|
-|63|zfnet512-12.onnx|:heavy_check_mark:|
+|23|fused_conv_clip.onnx|:heavy_check_mark:|
+|24|fused_conv_hardsigmoid.onnx|:heavy_check_mark:|
+|25|fused_conv_leakyrelu.onnx|:heavy_check_mark:|
+|26|fused_conv_relu.onnx|:heavy_check_mark:|
+|27|fused_conv_sigmoid.onnx|:heavy_check_mark:|
+|28|fused_conv_tanh.onnx|:heavy_check_mark:|
+|29|gender_googlenet.onnx|:heavy_check_mark:|
+|30|handpose_estimation_mediapipe_2022may.onnx|:heavy_check_mark:|
+|31|iat_llie_180x320.onnx|:heavy_check_mark:|
+|32|imageclassifier.onnx|:heavy_check_mark:|
+|33|inception-v2-9.onnx|:heavy_check_mark:|
+|34|mnist-12.onnx|:heavy_check_mark:|
+|35|mobilenetv2-12.onnx|:heavy_check_mark:|
+|36|mosaic_11.onnx|:heavy_check_mark:|
+|37|mosaic-9.onnx|:heavy_check_mark:|
+|38|movenet_multipose_lightning_192x256_p6.onnx|:heavy_check_mark:|
+|39|nanodet-plus-m_416.onnx|:heavy_check_mark:|
+|40|object_tracking_dasiamrpn_kernel_cls1_2021nov.onnx|:heavy_check_mark:|
+|41|object_tracking_dasiamrpn_kernel_r1_2021nov.onnx|:heavy_check_mark:|
+|42|object_tracking_dasiamrpn_model_2021nov.onnx|:heavy_check_mark:|
+|43|pidnet_S_cityscapes_192x320.onnx|:heavy_check_mark:|
+|44|qlinear_conv_tensor_test.onnx|:heavy_check_mark:|
+|45|rcnn-ilsvrc13-9.onnx|:heavy_check_mark:|
+|46|regnet_x_400mf.onnx|:heavy_check_mark:|
+|47|ResNet101-DUC-12.onnx|:heavy_check_mark:|
+|48|resnet18-v1-7.onnx|:heavy_check_mark:|
+|49|resnet50-v1-12.onnx|:heavy_check_mark:|
+|50|resnet50-v2-7.onnx|:heavy_check_mark:|
+|51|retinanet-9.onnx|:heavy_check_mark:|
+|52|sinet_320_op.onnx|:heavy_check_mark:|
+|53|squeezenet1.0-12.onnx|:heavy_check_mark:|
+|54|super-resolution-10.onnx|:heavy_check_mark:|
+|55|tinyyolov2-8.onnx|:heavy_check_mark:|
+|56|version-RFB-640.onnx|:heavy_check_mark:|
+|57|vit-b-32_textual.onnx|:heavy_check_mark:|
+|58|vit-b-32_visual.onnx|:heavy_check_mark:|
+|59|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
+|60|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
+|61|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
+|62|yolo_free_nano_crowdhuman_192x320_post.onnx|:heavy_check_mark:|
+|63|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
+|64|yolox_nano_192x192.onnx|:heavy_check_mark:|
+|65|yolox_nano_416x416.onnx|:heavy_check_mark:|
+|66|yolox_s.onnx|:heavy_check_mark:|
+|67|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
+|68|zero_dce_640_dele.onnx|:heavy_check_mark:|
+|69|zfnet512-12.onnx|:heavy_check_mark:|
 
 ## Related tools
 1. [tflite2tensorflow](https://github.com/PINTO0309/tflite2tensorflow)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.6'
+__version__ = '1.3.7'

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -102,7 +102,7 @@ def make_node(
     GroupConv1D
     GroupConv2D
     GroupConv3D
-    SeparableConv2D
+    SeparableConv
     """
     # Check auto_pad nonexistent or NOTSET first
     pad_mode = 'VALID'
@@ -244,23 +244,25 @@ def make_node(
                             y=input_bias,
                         )
                     tf_op_type = 'GroupedConvolution2D'
-                elif kernel_size == 3 and not disable_group_convolution:
-                    tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                        tf.add(
-                            x=Conv3D(
-                                filters=input_weights.shape[-1],
-                                kernel_size=input_weights.shape[:3],
-                                strides=strides,
-                                padding=pad_mode.lower(),
-                                dilation_rate=dilations,
-                                groups=group,
-                                use_bias=False,
-                                kernel_initializer=tf.keras.initializers.constant(input_weights),
-                                name=graph_node.name,
-                            )(input_tensor),
-                            y=input_bias,
-                        )
-                    tf_op_type = 'GroupedConvolution3D'
+                # TODO: As of TensorFlow Lite v2.10.0, GroupedConvolution3D is converted to FlexConv3D.
+                # TODO: Uncomment out when TensorFlow Lite officially supports GroupedConvolution3D.
+                # elif kernel_size == 3 and not disable_group_convolution:
+                #     tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                #         tf.add(
+                #             x=Conv3D(
+                #                 filters=input_weights.shape[-1],
+                #                 kernel_size=input_weights.shape[:3],
+                #                 strides=strides,
+                #                 padding=pad_mode.lower(),
+                #                 dilation_rate=dilations,
+                #                 groups=group,
+                #                 use_bias=False,
+                #                 kernel_initializer=tf.keras.initializers.constant(input_weights),
+                #                 name=graph_node.name,
+                #             )(input_tensor),
+                #             y=input_bias,
+                #         )
+                #     tf_op_type = 'GroupedConvolution3D'
                 else:
                     # SeparableConv
                     input_tensor_splits = tf.split(input_tensor, num_or_size_splits=group, axis=-1)

--- a/onnx2tf/ops/FusedConv.py
+++ b/onnx2tf/ops/FusedConv.py
@@ -1,0 +1,136 @@
+import sys
+import random
+random.seed(0)
+import numpy as np
+np.random.seed(0)
+import importlib
+import tensorflow as tf
+import onnx_graphsurgeon as gs
+from onnx2tf.utils.common_functions import (
+    print_node_info,
+    inverted_operation_enable_disable,
+    make_tf_node_info,
+)
+from onnx2tf.utils.colors import Color
+
+
+@print_node_info
+@inverted_operation_enable_disable
+def make_node(
+    *,
+    graph_node: gs.Node,
+    tf_layers_dict: dict,
+    **kwargs: dict,
+):
+    """FusedConv
+
+    Parameters
+    ----------
+    graph_node: gs.Node
+        graph_surgeon Node
+
+    tf_layers_dict: dict
+        optype, shape, dtype, tensorflow graph
+    """
+    graph_node_output: gs.Variable = graph_node.outputs[0]
+    op = importlib.import_module(f'onnx2tf.ops.Conv')
+    op.make_node(
+        graph_node=graph_node,
+        tf_layers_dict=tf_layers_dict,
+        **kwargs,
+    )
+    conv_op = tf_layers_dict[graph_node_output.name]['tf_node']
+
+    activation = graph_node.attrs.get('activation', 'Relu')
+    activation_params = graph_node.attrs.get('activation_params', [])
+
+    # Generation of TF OP
+    # FusedConv activations: https://zenn.dev/pinto0309/scraps/1ac42ec0518d3b
+    # 1. Relu
+    # 2. Tanh
+    # 3. Sigmoid
+    # 4. LeakyRelu
+    # 5. Clip
+    # 6. HardSigmoid
+    conv_act_op = None
+    if activation == 'Relu':
+        conv_act_op = tf.nn.relu(
+            features=conv_op,
+        )
+    elif activation == 'Tanh':
+        conv_act_op = tf.nn.tanh(
+            x=conv_op,
+        )
+    elif activation == 'Sigmoid':
+        conv_act_op = tf.nn.sigmoid(
+            x=conv_op,
+        )
+    elif activation == 'LeakyRelu':
+        conv_act_op = tf.nn.leaky_relu(
+            features=conv_op,
+            alpha=activation_params[0] \
+                if (isinstance(activation_params, list) or isinstance(activation_params, np.ndarray)) \
+                    and len(activation_params) > 0 \
+                else activation_params,
+        )
+    elif activation == 'Clip':
+        min_value = activation_params[0]
+        max_value = activation_params[1]
+        if (isinstance(min_value, np.ndarray) or isinstance(min_value, float)) and min_value == 0.0 \
+            and (isinstance(max_value, np.ndarray)  or isinstance(max_value, float)) and max_value == 6.0:
+            conv_act_op = tf.nn.relu6(features=conv_op)
+        elif (isinstance(min_value, np.ndarray) or isinstance(min_value, float)) and min_value == 0.0 \
+            and (max_value is None or max_value.shape is None):
+            conv_act_op = tf.nn.relu(features=conv_op)
+        else:
+            if (isinstance(min_value, np.ndarray) and min_value.shape is not None) \
+                and (isinstance(max_value, np.ndarray) and max_value.shape is not None):
+                conv_act_op = \
+                    tf.clip_by_value(
+                        t=conv_op,
+                        clip_value_min=min_value,
+                        clip_value_max=max_value,
+                    )
+            elif (isinstance(min_value, np.ndarray) and min_value.shape is not None) \
+                and (max_value is None or max_value.shape is None):
+                conv_act_op = \
+                    tf.maximum(
+                        x=conv_op,
+                        y=min_value,
+                    )
+            elif (min_value is None or min_value.shape is None) \
+                and (max_value is not None and max_value.shape is not None):
+                conv_act_op = \
+                    tf.minimum(
+                        x=conv_op,
+                        y=max_value,
+                    )
+    elif activation == 'HardSigmoid':
+        alpha = activation_params[0]
+        beta = activation_params[1]
+        conv_act_op = tf.maximum(0.0, tf.minimum(1.0, alpha * conv_op + beta))
+    else:
+        print(
+            f'{Color.RED}ERROR:{Color.RESET} ' +
+            f'FusedConv {activation} is not yet supported. ' +
+            f'graph_node.name: {graph_node.name}'
+        )
+        sys.exit(1)
+
+    tf_layers_dict[graph_node_output.name]['tf_node'] = conv_act_op
+
+    # Generation of Debug Info
+    tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
+        make_tf_node_info(
+            node_info={
+                'tf_op_type': f'FusedConv_{activation}',
+                'tf_inputs': {
+                    'input': conv_op,
+                    'activation': activation,
+                    'activation_params': activation_params,
+                },
+                'tf_outputs': {
+                    'output': conv_act_op,
+                },
+            }
+        )

--- a/onnx2tf/ops/HardSigmoid.py
+++ b/onnx2tf/ops/HardSigmoid.py
@@ -73,7 +73,7 @@ def make_node(
     )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.maximum(0.0, tf.minimum(1.0, alpha * input_tensor + beta)),
+        tf.maximum(0.0, tf.minimum(1.0, alpha * input_tensor + beta))
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/HardSigmoid.py
+++ b/onnx2tf/ops/HardSigmoid.py
@@ -44,9 +44,11 @@ def make_node(
         before_op_output_shape_trans,
     )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
+
+    alpha = graph_node.attrs.get('alpha', 0.2)
+    beta = graph_node.attrs.get('beta', 0.5)
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -71,7 +73,7 @@ def make_node(
     )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.keras.activations.hard_sigmoid(input_tensor)
+        tf.maximum(0.0, tf.minimum(1.0, alpha * input_tensor + beta)),
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- Support for `FusedConv`
  - FusedConv activations: https://zenn.dev/pinto0309/scraps/1ac42ec0518d3b
    - `Relu`
      ![image](https://user-images.githubusercontent.com/33194443/210130923-02d9e6cb-fb1a-40e2-9144-d2dd572f6cd9.png)
    - `Tanh`
      ![image](https://user-images.githubusercontent.com/33194443/210130912-a5eefe19-8bb6-416b-a92b-89a3c848b3e0.png)
    - `Sigmoid`
      ![image](https://user-images.githubusercontent.com/33194443/210130905-655061ba-4332-4c46-ad2f-d5a8cb45a92c.png)
    - `LeakyRelu`
      ![image](https://user-images.githubusercontent.com/33194443/210130898-fb874eeb-046b-4539-84d5-54f8ccab6135.png)
    - `Clip`
      ![image](https://user-images.githubusercontent.com/33194443/210130875-6bfe1838-d694-4218-b308-adb4d94140d6.png)
    - `HardSigmoid`
      ![image](https://user-images.githubusercontent.com/33194443/210130884-20bc02cc-b508-463f-a69b-825828db36cc.png)
- `HardSigmoid`
  - Improved processing

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
