### PR TITLE
fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install pip -U \
     && pip install -U onnx2tf \
     && pip install -U simple_onnx_processing_tools \
     && pip install tensorflow==2.10.0 \
+    && pip install protobuf==3.20.3 \
     && python -m pip cache purge
 
 ENV USERNAME=user


### PR DESCRIPTION
### 1. Content and background
onnx import error has occurred.
because onnx requires version 3.20.2 or higher and tsensorflow requires lower than 3.20.

```bash
user@57088d45b9a1:/workdir$ onnx2tf

Traceback (most recent call last):
  File "/usr/local/bin/onnx2tf", line 5, in <module>
    from onnx2tf import main
  File "/usr/local/lib/python3.8/dist-packages/onnx2tf/__init__.py", line 1, in <module>
    from onnx2tf.onnx2tf import convert, main
  File "/usr/local/lib/python3.8/dist-packages/onnx2tf/onnx2tf.py", line 36, in <module>
    import onnx
  File "/usr/local/lib/python3.8/dist-packages/onnx/__init__.py", line 7, in <module>
    from onnx.external_data_helper import (
  File "/usr/local/lib/python3.8/dist-packages/onnx/external_data_helper.py", line 9, in <module>
    from .onnx_pb import AttributeProto, GraphProto, ModelProto, TensorProto
  File "/usr/local/lib/python3.8/dist-packages/onnx/onnx_pb.py", line 4, in <module>
    from .onnx_ml_pb2 import *  # noqa
  File "/usr/local/lib/python3.8/dist-packages/onnx/onnx_ml_pb2.py", line 5, in <module>
    from google.protobuf.internal import builder as _builder
ImportError: cannot import name 'builder' from 'google.protobuf.internal' (/usr/local/lib/python3.8/dist-packages/google/protobuf/internal/__init__.py)
```

### 2. Summary of corrections
Specify version of protobuf==3.20.3

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
