### PR TITLE
If the spartial shape is an undefined dimension, run inference with dummy input tensors in onnxruntime to try to estimate the output shape.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.12
+  ghcr.io/pinto0309/onnx2tf:1.3.13
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.12'
+__version__ = '1.3.13'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -492,6 +492,7 @@ def convert(
 
     # Define additional parameters
     additional_parameters = {
+        'gs_graph': graph,
         'opset': graph.opset,
         'batch_size': batch_size,
         'non_verbose': non_verbose,

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import random
 random.seed(0)
@@ -183,6 +184,7 @@ def make_node(
         tf_output_shape = []
         for idx in range(input_tensor_rank):
             tf_output_shape.append(onnx_output_shape[converted_axis[idx]])
+        os.remove(DUMMY_ONNXFILE_NAME)
 
     if auto_pad == 'NOTSET':
         # pad_mode SAME generates flex operation, use VALID always

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -1,4 +1,3 @@
-import os
 import sys
 import random
 random.seed(0)

--- a/onnx2tf/utils/enums.py
+++ b/onnx2tf/utils/enums.py
@@ -35,7 +35,7 @@ ONNX_DTYPES_TO_TF_DTYPES = {
 }
 
 NUMPY_DTYPES_TO_TF_DTYPES = {
-    np.dtype('int32'): tf.float16,
+    np.dtype('float16'): tf.float16,
     np.dtype('float32'): tf.float32,
     np.dtype('float64'): tf.float64,
 
@@ -53,7 +53,7 @@ NUMPY_DTYPES_TO_TF_DTYPES = {
 }
 
 TF_DTYPES_TO_NUMPY_DTYPES = {
-    tf.float16: np.dtype('int32'),
+    tf.float16: np.dtype('float16'),
     tf.float32: np.dtype('float32'),
     tf.float64: np.dtype('float64'),
 


### PR DESCRIPTION
### 1. Content and background
- `ConvTranspose`
  - If the spartial shape is an undefined dimension, run inference with dummy input tensors in onnxruntime to try to estimate the output shape.
  - https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/mask-rcnn

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
