### PR TITLE
Fix explicit_broadcast to consider scalar values, and experimental implementation of `Loop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.13
+  ghcr.io/pinto0309/onnx2tf:1.3.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.13'
+__version__ = '1.3.14'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -817,6 +817,10 @@ def explicit_broadcast(
         graph_node_input_shape2 = list(graph_node.inputs[1].shape) \
             if graph_node.inputs[1].shape is not None else None
 
+    # If shape is empty (scalar value), return it without doing anything.
+    if graph_node_input_shape1 == [] or graph_node_input_shape2 == []:
+        return const_or_var_1, const_or_var_2
+
     # If either operand have shape of all 1's, do not broadcast and return as is
     shape_for_judging_skip_processing_1 = [
         i if i is not None else INF_INDEX_VALUE for i in const_or_var_1.shape


### PR DESCRIPTION
### 1. Content and background
1. Fix `explicit_broadcast` to consider scalar values
    ```python
    # If shape is empty (scalar value), return it without doing anything.
    if graph_node_input_shape1 == [] or graph_node_input_shape2 == []:
        return const_or_var_1, const_or_var_2
    ```
2. [WIP] Experimental implementation of `Loop`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
