### PR TITLE
Fix incorrect conversion of DepthToSpace in CRD mode

### DIFF
--- a/onnx2tf/ops/DepthToSpace.py
+++ b/onnx2tf/ops/DepthToSpace.py
@@ -86,11 +86,11 @@ def make_node(
 
         reshape_node = tf.reshape(
             tensor=input_tensor,
-            shape=[batch, blocksize, blocksize, height, width, csize]
+            shape=[batch, height, width, csize, blocksize, blocksize]
         )
         transpose_node = tf.transpose(
             a=reshape_node,
-            perm=[0, 3, 1, 4, 2, 5]
+            perm=[0, 1, 4, 2, 5, 3]
         )
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.reshape(


### PR DESCRIPTION
### 1. Content and background
Pixelshuffle layer in PyTorch (CRD mode for ONNX) was not converting correctly to TF. There was a bug in the DepthToSpace op. 

### 2. Summary of corrections
Corrected the reshape and the transpose nodes.
### 3. Issue number (only if there is a related issue)
Closes #91 
