### PR TITLE
[Experimental] Workaround functionality to avoid generation of FlexTranspose to the limit is implemented. `Transpose` OP and `DepthToSpace` OP only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ usage: onnx2tf
 [-onimc OUTPUT_NAMES [OUTPUT_NAMES ...]]
 [-dgc]
 [-ebu]
+[-dsft]
 [-rari64 | -rarf32 | -rafi64 | -raff32]
 [-fasr FUSED_ARGMAX_SCALE_RATIO]
 [-rasin]
@@ -336,6 +337,9 @@ optional arguments:
   -ebu, --enaable_batchmatmul_unfold
     BatchMatMul is separated batch by batch to generate a primitive MatMul.
 
+  -dsft, --disable_suppression_flextranspose
+    Disables FlexTranspose generation suppression.
+
   -rari64, --replace_argmax_to_reducemax_and_indicies_is_int64
     Replace ArgMax with a ReduceMax. The returned indicies are int64.
     Only one of replace_argmax_to_reducemax_and_indicies_is_int64
@@ -447,6 +451,7 @@ convert(
   output_names_to_interrupt_model_conversion: Union[List[str], NoneType] = None,
   disable_group_convolution: Union[bool, NoneType] = False,
   enaable_batchmatmul_unfold: Optional[bool] = False,
+  disable_suppression_flextranspose: Optional[bool] = False,
   replace_argmax_to_reducemax_and_indicies_is_int64: Union[bool, NoneType] = False,
   replace_argmax_to_reducemax_and_indicies_is_float32: Union[bool, NoneType] = False,
   replace_argmax_to_fused_argmax_and_indicies_is_int64: Union[bool, NoneType] = False,
@@ -615,6 +620,9 @@ convert(
 
     enaable_batchmatmul_unfold: Optional[bool]
       BatchMatMul is separated batch by batch to generate a primitive MatMul.
+
+    disable_suppression_flextranspose: Optional[bool]
+      Disables FlexTranspose generation suppression.
 
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool]
       Replace ArgMax with a ReduceMax. The returned indicies are int64.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.15
+  ghcr.io/pinto0309/onnx2tf:1.3.16
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.15'
+__version__ = '1.3.16'

--- a/onnx2tf/ops/DepthToSpace.py
+++ b/onnx2tf/ops/DepthToSpace.py
@@ -12,6 +12,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -88,9 +89,10 @@ def make_node(
             tensor=input_tensor,
             shape=[batch, height, width, csize, blocksize, blocksize]
         )
-        transpose_node = tf.transpose(
-            a=reshape_node,
-            perm=[0, 1, 4, 2, 5, 3]
+        transpose_node = transpose_with_flexing_deterrence(
+            input_tensor=reshape_node,
+            perm=[0,1,4,2,5,3],
+            **kwargs,
         )
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.reshape(

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -169,6 +169,7 @@ def make_node(
             perm=perm,
             output_shape=output_shape,
             name=graph_node.name,
+            **kwargs,
         )
 
     # Generation of Debug Info

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -163,55 +163,6 @@ def make_node(
         **kwargs,
     )
 
-    # # Special Transpose
-    # # https://zenn.dev/pinto0309/scraps/cfb59856ac0453
-    # # Get dimension with 1 element
-    # x_shape_one_dims = [
-    #     idx for idx in range(len(input_tensor_shape)) \
-    #         if isinstance(input_tensor_shape[idx], int) and input_tensor_shape[idx]==1
-    # ]
-    # x_shape_none_dims_count = len(
-    #     [dim for dim in input_tensor_shape if not isinstance(dim, int) or dim < 1]
-    # )
-    # # Delete dimension with 1 element
-    # squeezed_original_x = tf.squeeze(input_tensor, x_shape_one_dims)
-    # # Obtain a shape with the dimension with 1 element removed
-    # squeezed_original_shapes = squeezed_original_x.shape
-
-    # # Generation of TF OP
-    # if tensor_rank >= 6 and len(squeezed_original_shapes) <= 5 and x_shape_none_dims_count < 2:
-    #     # Special Transpose
-    #     # Suppresses as much as possible the conversion of transposes
-    #     # of 6 or more dimensions into FlexTransposes
-    #     remove_one_target_perm = [
-    #         idx for idx in perm if idx not in x_shape_one_dims
-    #     ]
-    #     sorted_remove_one_target_perm = sorted(remove_one_target_perm)
-    #     replaced_remove_one_target_perm = [
-    #         sorted_remove_one_target_perm.index(idx) \
-    #             for idx in remove_one_target_perm
-    #     ]
-    #     transposed_no_one_data = \
-    #         tf.transpose(
-    #             a=squeezed_original_x,
-    #             perm=replaced_remove_one_target_perm,
-    #         )
-    #     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-    #         tf.reshape(
-    #             tensor=transposed_no_one_data,
-    #             shape=[
-    #                 dim if not isinstance(dim, str) else -1 for dim in output_shape
-    #             ],
-    #         )
-    # else:
-    #     # Normal Transpose
-    #     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-    #         tf.transpose(
-    #             a=input_tensor,
-    #             perm=perm,
-    #             name=graph_node.name,
-    #         )
-
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         transpose_with_flexing_deterrence(
             input_tensor=input_tensor,

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -12,6 +12,7 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -162,54 +163,62 @@ def make_node(
         **kwargs,
     )
 
-    # Special Transpose
-    # https://zenn.dev/pinto0309/scraps/cfb59856ac0453
-    # Get dimension with 1 element
-    x_shape_one_dims = [
-        idx for idx in range(len(input_tensor_shape)) \
-            if isinstance(input_tensor_shape[idx], int) and input_tensor_shape[idx]==1
-    ]
-    x_shape_none_dims_count = len(
-        [dim for dim in input_tensor_shape if not isinstance(dim, int) or dim < 1]
-    )
-    # Delete dimension with 1 element
-    squeezed_original_x = tf.squeeze(input_tensor, x_shape_one_dims)
-    # Obtain a shape with the dimension with 1 element removed
-    squeezed_original_shapes = squeezed_original_x.shape
+    # # Special Transpose
+    # # https://zenn.dev/pinto0309/scraps/cfb59856ac0453
+    # # Get dimension with 1 element
+    # x_shape_one_dims = [
+    #     idx for idx in range(len(input_tensor_shape)) \
+    #         if isinstance(input_tensor_shape[idx], int) and input_tensor_shape[idx]==1
+    # ]
+    # x_shape_none_dims_count = len(
+    #     [dim for dim in input_tensor_shape if not isinstance(dim, int) or dim < 1]
+    # )
+    # # Delete dimension with 1 element
+    # squeezed_original_x = tf.squeeze(input_tensor, x_shape_one_dims)
+    # # Obtain a shape with the dimension with 1 element removed
+    # squeezed_original_shapes = squeezed_original_x.shape
 
-    # Generation of TF OP
-    if tensor_rank >= 6 and len(squeezed_original_shapes) <= 5 and x_shape_none_dims_count < 2:
-        # Special Transpose
-        # Suppresses as much as possible the conversion of transposes
-        # of 6 or more dimensions into FlexTransposes
-        remove_one_target_perm = [
-            idx for idx in perm if idx not in x_shape_one_dims
-        ]
-        sorted_remove_one_target_perm = sorted(remove_one_target_perm)
-        replaced_remove_one_target_perm = [
-            sorted_remove_one_target_perm.index(idx) \
-                for idx in remove_one_target_perm
-        ]
-        transposed_no_one_data = \
-            tf.transpose(
-                a=squeezed_original_x,
-                perm=replaced_remove_one_target_perm,
-            )
-        tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.reshape(
-                tensor=transposed_no_one_data,
-                shape=[
-                    dim if not isinstance(dim, str) else -1 for dim in output_shape
-                ],
-            )
-    else:
-        # Normal Transpose
-        tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.transpose(
-                a=input_tensor,
-                perm=perm,
-                name=graph_node.name,
-            )
+    # # Generation of TF OP
+    # if tensor_rank >= 6 and len(squeezed_original_shapes) <= 5 and x_shape_none_dims_count < 2:
+    #     # Special Transpose
+    #     # Suppresses as much as possible the conversion of transposes
+    #     # of 6 or more dimensions into FlexTransposes
+    #     remove_one_target_perm = [
+    #         idx for idx in perm if idx not in x_shape_one_dims
+    #     ]
+    #     sorted_remove_one_target_perm = sorted(remove_one_target_perm)
+    #     replaced_remove_one_target_perm = [
+    #         sorted_remove_one_target_perm.index(idx) \
+    #             for idx in remove_one_target_perm
+    #     ]
+    #     transposed_no_one_data = \
+    #         tf.transpose(
+    #             a=squeezed_original_x,
+    #             perm=replaced_remove_one_target_perm,
+    #         )
+    #     tf_layers_dict[graph_node_output.name]['tf_node'] = \
+    #         tf.reshape(
+    #             tensor=transposed_no_one_data,
+    #             shape=[
+    #                 dim if not isinstance(dim, str) else -1 for dim in output_shape
+    #             ],
+    #         )
+    # else:
+    #     # Normal Transpose
+    #     tf_layers_dict[graph_node_output.name]['tf_node'] = \
+    #         tf.transpose(
+    #             a=input_tensor,
+    #             perm=perm,
+    #             name=graph_node.name,
+    #         )
+
+    tf_layers_dict[graph_node_output.name]['tf_node'] = \
+        transpose_with_flexing_deterrence(
+            input_tensor=input_tensor,
+            perm=perm,
+            output_shape=output_shape,
+            name=graph_node.name,
+        )
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2569,10 +2569,13 @@ def transpose_with_flexing_deterrence(
                 axeses_idx += 1
                 if axeses_idx > len(axeses)-1:
                     break
-                np_axeses = np.asarray(axeses)
-                axeses = [
-                    axis for axis in np_axeses[:axeses_idx]] + [axis-1 for axis in np_axeses[axeses_idx:]
-                ]
+                new_axeses = []
+                for axes in axeses:
+                    if axes <= axis:
+                        new_axeses.append(axes)
+                    else:
+                        new_axeses.append(axes-1)
+                axeses = new_axeses
 
             # 3. Transpose a divided tensor (splited_squeezed_tensors)
             """


### PR DESCRIPTION
### 1. Content and background
- `Transpose`, `DepthToSpace`
  - **[Experimental]** Workaround functionality to avoid generation of `FlexTranspose` to the limit is implemented.
  - Addition of `--disable_suppression_flextranspose` option
    ```
    -dsft, --disable_suppression_flextranspose
      Disables FlexTranspose generation suppression.
    ```

- before
  ![image](https://user-images.githubusercontent.com/33194443/210756448-a844366f-c396-4b85-b199-cad59ae02c51.png)
- after
  ![image](https://user-images.githubusercontent.com/33194443/210756557-e3bfe0fc-1a5c-4184-b467-b6164c11b16f.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Avoid creating FlexTranspose for DepthToSpace #93](https://github.com/PINTO0309/onnx2tf/issues/93)
