### PR TITLE
Support for the case where the `axes` of the slice is None. `transpose_with_flexing_deterrence` support for Inverse and TopK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.16
+  ghcr.io/pinto0309/onnx2tf:1.3.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.16'
+__version__ = '1.3.17'

--- a/onnx2tf/ops/Inverse.py
+++ b/onnx2tf/ops/Inverse.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -88,9 +89,10 @@ def make_node(
                 before_op_output_shape_trans=True
             ) for axis in range(input_tensor_rank)
         ]
-        input_tensor = tf.transpose(
-            a=input_tensor,
+        input_tensor = transpose_with_flexing_deterrence(
+            input_tensor=input_tensor,
             perm=perm,
+            **kwargs,
         )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -108,9 +110,10 @@ def make_node(
             ) for axis in range(input_tensor_rank)
         ]
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.transpose(
-                a=tf_layers_dict[graph_node_output.name]['tf_node'],
+            transpose_with_flexing_deterrence(
+                input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
                 perm=perm,
+                **kwargs,
             )
 
     # Post-process transpose

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -272,9 +272,12 @@ def make_node(
         # Adjust the number of dimensions of the input data according to the number of axes [List]
         ##### Replace max values
         if isinstance(begin_, list):
-            unsqueeze_mask = [1] * input_tensor_rank
-            for axis in axes:
-                unsqueeze_mask[axis] = 0
+            if axes is not None:
+                unsqueeze_mask = [1] * input_tensor_rank
+                for axis in axes:
+                    unsqueeze_mask[axis] = 0
+            else:
+                unsqueeze_mask = [0] * input_tensor_rank
             for axis, maskbit in enumerate(unsqueeze_mask):
                 if maskbit == 1:
                     begin_.insert(axis, 0)
@@ -285,9 +288,12 @@ def make_node(
             )
         ##### Replace negative values
         if isinstance(end_, list):
-            unsqueeze_mask = [1] * input_tensor_rank
-            for axis in axes:
-                unsqueeze_mask[axis] = 0
+            if axes is not None:
+                unsqueeze_mask = [1] * input_tensor_rank
+                for axis in axes:
+                    unsqueeze_mask[axis] = 0
+            else:
+                unsqueeze_mask = [0] * input_tensor_rank
             for axis, maskbit in enumerate(unsqueeze_mask):
                 if maskbit == 1:
                     end_.insert(axis, 0)
@@ -298,9 +304,12 @@ def make_node(
             )
         if strides_ is not None:
             if isinstance(strides_, list):
-                unsqueeze_mask = [1] * input_tensor_rank
-                for axis in axes:
-                    unsqueeze_mask[axis] = 0
+                if axes is not None:
+                    unsqueeze_mask = [1] * input_tensor_rank
+                    for axis in axes:
+                        unsqueeze_mask[axis] = 0
+                else:
+                    unsqueeze_mask = [0] * input_tensor_rank
                 for axis, maskbit in enumerate(unsqueeze_mask):
                     if maskbit == 1:
                         strides_.insert(axis, 1)

--- a/onnx2tf/ops/TopK.py
+++ b/onnx2tf/ops/TopK.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -102,9 +103,10 @@ def make_node(
     if axis != (tensor_rank-1):
         perm = [idx for idx in range(tensor_rank) if idx != axis] + [axis]
         input_tensor = \
-            tf.transpose(
-                a=input_tensor,
+            transpose_with_flexing_deterrence(
+                input_tensor=input_tensor,
                 perm=perm,
+                **kwargs,
             )
 
     # MLIR only accepts scalar values for k-values, thus compressing the dimension
@@ -134,14 +136,16 @@ def make_node(
     if axis != (tensor_rank-1):
         perm = [perm.index(idx) for idx in range(tensor_rank)]
         topked_values = \
-            tf.transpose(
-                a=topked_values,
+            transpose_with_flexing_deterrence(
+                input_tensor=topked_values,
                 perm=perm,
+                **kwargs,
             )
         topked_indices = \
-            tf.transpose(
-                a=topked_indices,
+            transpose_with_flexing_deterrence(
+                input_tensor=topked_indices,
                 perm=perm,
+                **kwargs,
             )
 
     tf_layers_dict[Values.name]['tf_node'] = topked_values

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -121,9 +121,10 @@ def pre_process_transpose(
             and op_rep_param['param_name'] == param_name:
             transpose_perm = op_rep_param.get('pre_process_transpose_perm', None)
             if transpose_perm is not None:
-                transposed_value = tf.transpose(
-                    a=value_before_transpose,
+                transposed_value = transpose_with_flexing_deterrence(
+                    input_tensor=value_before_transpose,
                     perm=transpose_perm,
+                    **kwargs,
                 )
             break
     return transposed_value
@@ -156,9 +157,10 @@ def post_process_transpose(
             and op_rep_param['param_name'] == param_name:
             transpose_perm = op_rep_param.get('post_process_transpose_perm', None)
             if transpose_perm is not None:
-                transposed_value = tf.transpose(
-                    a=value_before_transpose,
+                transposed_value = transpose_with_flexing_deterrence(
+                    input_tensor=value_before_transpose,
                     perm=transpose_perm,
+                    **kwargs,
                 )
             break
     return transposed_value


### PR DESCRIPTION
### 1. Content and background
- `Slice`
  - Support for the case where the `axes` of the slice is None.
- `Inverse`, `TopK`
  - `transpose_with_flexing_deterrence` support for `Inverse` and `TopK`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Avoid creating FlexTranspose for DepthToSpace #93](https://github.com/PINTO0309/onnx2tf/issues/93)