### PR TITLE
Changed the type of `TopK` return value indices to int64 and fixed `bug in explicit_broadcast`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.3.18
+  ghcr.io/pinto0309/onnx2tf:1.3.19
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.3.18'
+__version__ = '1.3.19'

--- a/onnx2tf/ops/TopK.py
+++ b/onnx2tf/ops/TopK.py
@@ -123,6 +123,7 @@ def make_node(
                 sorted=sorted,
                 name=graph_node.name,
             )
+        topked_indices = tf.cast(x=topked_indices, dtype=tf.int64)
     else:
         topked_values, topked_indices = \
             tf.math.top_k(
@@ -132,6 +133,7 @@ def make_node(
                 name=graph_node.name,
             )
         topked_values = tf.negative(topked_values)
+        topked_indices = tf.cast(x=topked_indices, dtype=tf.int64)
 
     if axis != (tensor_rank-1):
         perm = [perm.index(idx) for idx in range(tensor_rank)]

--- a/onnx2tf/ops/TopK.py
+++ b/onnx2tf/ops/TopK.py
@@ -15,6 +15,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     transpose_with_flexing_deterrence,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -123,7 +124,6 @@ def make_node(
                 sorted=sorted,
                 name=graph_node.name,
             )
-        topked_indices = tf.cast(x=topked_indices, dtype=tf.int64)
     else:
         topked_values, topked_indices = \
             tf.math.top_k(
@@ -133,7 +133,10 @@ def make_node(
                 name=graph_node.name,
             )
         topked_values = tf.negative(topked_values)
-        topked_indices = tf.cast(x=topked_indices, dtype=tf.int64)
+    topked_indices = tf.cast(
+        x=topked_indices,
+        dtype=NUMPY_DTYPES_TO_TF_DTYPES[Indices_dtype],
+    )
 
     if axis != (tensor_rank-1):
         perm = [perm.index(idx) for idx in range(tensor_rank)]

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -846,6 +846,14 @@ def explicit_broadcast(
         graph_node_input_shape1, graph_node_input_shape2 = graph_node_input_shape2, graph_node_input_shape1
         swapped += 1
 
+        # Skip subsequent processing in the following patterns.
+        #   const_or_var_1: [1,1,5000]
+        #   const_or_var_2: [5000]
+        if len(const_or_var_1.shape) >= 1 \
+            and len(const_or_var_2.shape) == 1 \
+            and const_or_var_1.shape[-1] == const_or_var_2.shape[-1]:
+            return const_or_var_1, const_or_var_2
+
     """
     UnSqueeze 1 at the beginning of const_or_var_2_shape until const_or_var_1.shape
     and const_or_var_2.shape have the same rank


### PR DESCRIPTION
### 1. Content and background
- Changed the type of `TopK` return value indices to int64
- Fixed `bug in explicit_broadcast`
  - Skip subsequent processing in the following patterns.
    ```
    const_or_var_1: [1,1,5000]
    const_or_var_2: [5000]
    ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
