### PR TITLE
Only when `Squeeze` and `Unsqueeze` are consecutive and each is performing a useless process of compressing and decompressing the same `axis`, the two operations are disabled at the same time.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.4.1
+  ghcr.io/pinto0309/onnx2tf:1.4.2
 
   or
 
@@ -1218,33 +1218,34 @@ ONNX file for testing. https://github.com/PINTO0309/onnx2tf/releases/tag/1.1.28
 |48|object_tracking_dasiamrpn_kernel_r1_2021nov.onnx|:heavy_check_mark:|
 |49|object_tracking_dasiamrpn_model_2021nov.onnx|:heavy_check_mark:|
 |50|pidnet_S_cityscapes_192x320.onnx|:heavy_check_mark:|
-|51|qlinear_conv_tensor_test.onnx|:heavy_check_mark:|
-|52|rcnn-ilsvrc13-9.onnx|:heavy_check_mark:|
-|53|regnet_x_400mf.onnx|:heavy_check_mark:|
-|54|ResNet101-DUC-12.onnx|:heavy_check_mark:|
-|55|resnet18-v1-7.onnx|:heavy_check_mark:|
-|56|resnet50-v1-12.onnx|:heavy_check_mark:|
-|57|resnet50-v2-7.onnx|:heavy_check_mark:|
-|58|retinanet-9.onnx|:heavy_check_mark:|
-|59|sinet_320_op.onnx|:heavy_check_mark:|
-|60|squeezenet1.0-12.onnx|:heavy_check_mark:|
-|61|super-resolution-10.onnx|:heavy_check_mark:|
-|62|swinir-m_64x64_12.onnx|:heavy_check_mark:|
-|63|tinyyolov2-8.onnx|:heavy_check_mark:|
-|64|version-RFB-640.onnx|:heavy_check_mark:|
-|65|vit-b-32_textual.onnx|:heavy_check_mark:|
-|66|vit-b-32_visual.onnx|:heavy_check_mark:|
-|67|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
-|68|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
-|69|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
-|70|yolo_free_nano_crowdhuman_192x320_post.onnx|:heavy_check_mark:|
-|71|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
-|72|yolox_nano_192x192.onnx|:heavy_check_mark:|
-|73|yolox_nano_416x416.onnx|:heavy_check_mark:|
-|74|yolox_s.onnx|:heavy_check_mark:|
-|75|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
-|76|zero_dce_640_dele.onnx|:heavy_check_mark:|
-|77|zfnet512-12.onnx|:heavy_check_mark:|
+|51|ppmattingv2_stdc1_human_480x640.onnx|:heavy_check_mark:|
+|52|qlinear_conv_tensor_test.onnx|:heavy_check_mark:|
+|53|rcnn-ilsvrc13-9.onnx|:heavy_check_mark:|
+|54|regnet_x_400mf.onnx|:heavy_check_mark:|
+|55|ResNet101-DUC-12.onnx|:heavy_check_mark:|
+|56|resnet18-v1-7.onnx|:heavy_check_mark:|
+|57|resnet50-v1-12.onnx|:heavy_check_mark:|
+|58|resnet50-v2-7.onnx|:heavy_check_mark:|
+|59|retinanet-9.onnx|:heavy_check_mark:|
+|60|sinet_320_op.onnx|:heavy_check_mark:|
+|61|squeezenet1.0-12.onnx|:heavy_check_mark:|
+|62|super-resolution-10.onnx|:heavy_check_mark:|
+|63|swinir-m_64x64_12.onnx|:heavy_check_mark:|
+|64|tinyyolov2-8.onnx|:heavy_check_mark:|
+|65|version-RFB-640.onnx|:heavy_check_mark:|
+|66|vit-b-32_textual.onnx|:heavy_check_mark:|
+|67|vit-b-32_visual.onnx|:heavy_check_mark:|
+|68|yolact_edge_mobilenetv2_550x550.onnx|:heavy_check_mark:|
+|69|yolact_regnetx_600mf_d2s_31classes_512x512.onnx|:heavy_check_mark:|
+|70|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
+|71|yolo_free_nano_crowdhuman_192x320_post.onnx|:heavy_check_mark:|
+|72|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
+|73|yolox_nano_192x192.onnx|:heavy_check_mark:|
+|74|yolox_nano_416x416.onnx|:heavy_check_mark:|
+|75|yolox_s.onnx|:heavy_check_mark:|
+|76|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
+|77|zero_dce_640_dele.onnx|:heavy_check_mark:|
+|78|zfnet512-12.onnx|:heavy_check_mark:|
 
 ## Related tools
 1. [tflite2tensorflow](https://github.com/PINTO0309/tflite2tensorflow)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'

--- a/onnx2tf/ops/Squeeze.py
+++ b/onnx2tf/ops/Squeeze.py
@@ -110,8 +110,7 @@ def make_node(
             workaround_exec_flg = True
         if workaround_exec_flg \
             and graph_node.o().op == 'Unsqueeze' \
-            and hasattr(graph_node.o(), 'attrs') \
-            and ('axes' in graph_node.o().attrs or len(graph_node.o().inputs) >= 2):
+            and (hasattr(graph_node.o(), 'attrs') and 'axes' in graph_node.o().attrs) or len(graph_node.o().inputs) >= 2:
             # Remove useless squeeze/unsqueeze combinations
             #   Only when squeeze and unsqueeze are consecutive
             #   and each is performing a useless process of
@@ -128,8 +127,8 @@ def make_node(
                     if isinstance(next_node_axes, gs.Variable) else next_node_axes
                 if next_node_axes is not None and next_node_axes.shape is None:
                     next_node_axes = None
-            next_unsqueezed_axes = next_unsqueeze_node.attrs['axes'] \
-                if 'axes' in next_unsqueeze_node.attrs else next_node_axes
+            next_unsqueezed_axes = next_node_axes \
+                if next_node_axes is not None else next_unsqueeze_node.attrs['axes']
             if next_unsqueezed_axes == non_transpose_axes:
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     tf.identity(input=input_tensor)

--- a/onnx2tf/ops/Squeeze.py
+++ b/onnx2tf/ops/Squeeze.py
@@ -1,3 +1,4 @@
+import copy
 import random
 random.seed(0)
 import numpy as np
@@ -64,6 +65,8 @@ def make_node(
         axes = None
 
     axes = graph_node.attrs.get('axes', axes)
+    # axes for determining the deletion of unnecessary squeeze/unsqueeze combinations
+    non_transpose_axes = copy.deepcopy(axes)
 
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
         axes = [
@@ -99,33 +102,35 @@ def make_node(
     axes = list(axes) if axes is not None else None
 
     try:
-        if graph_node.o().op == 'Unsqueeze' \
+        workaround_exec_flg = False
+        try:
+            graph_node.o(consumer_idx=1)
+        except Exception as ex:
+            # Error == Only one node connected next
+            workaround_exec_flg = True
+        if workaround_exec_flg \
+            and graph_node.o().op == 'Unsqueeze' \
             and hasattr(graph_node.o(), 'attrs') \
-            and 'axes' in graph_node.o().attrs:
+            and ('axes' in graph_node.o().attrs or len(graph_node.o().inputs) >= 2):
             # Remove useless squeeze/unsqueeze combinations
             #   Only when squeeze and unsqueeze are consecutive
             #   and each is performing a useless process of
             #   compressing and decompressing the same axis,
             #   the two operations are disabled at the same time.
             next_unsqueeze_node = graph_node.o()
-            next_unsqueeze_output_shape = next_unsqueeze_node.outputs[0].shape
-            next_unsqueeze_output_rank = len(next_unsqueeze_output_shape)
-            next_unsqueezed_axes = next_unsqueeze_node.attrs['axes']
-            if isinstance(next_unsqueezed_axes, list) or (isinstance(next_unsqueezed_axes, np.ndarray) and len(next_unsqueezed_axes.shape) > 0):
-                next_unsqueezed_axes = [
-                    convert_axis(
-                        axis=idx,
-                        tensor_rank=next_unsqueeze_output_rank,
-                        before_op_output_shape_trans=before_op_output_shape_trans,
-                    ) for idx in next_unsqueezed_axes
-                ]
-            elif next_unsqueezed_axes is not None and isinstance(next_unsqueezed_axes, np.ndarray) and len(next_unsqueezed_axes.shape) == 0:
-                next_unsqueezed_axes = convert_axis(
-                    axis=next_unsqueezed_axes,
-                    tensor_rank=next_unsqueeze_output_rank,
-                    before_op_output_shape_trans=before_op_output_shape_trans,
+            next_node_axes = None
+            if len(next_unsqueeze_node.inputs) >= 2:
+                next_node_axes = get_constant_or_variable(
+                    next_unsqueeze_node.inputs[1],
+                    before_op_output_shape_trans,
                 )
-            if next_unsqueezed_axes == axes:
+                next_node_axes = tf_layers_dict[next_node_axes.name]['tf_node'] \
+                    if isinstance(next_node_axes, gs.Variable) else next_node_axes
+                if next_node_axes is not None and next_node_axes.shape is None:
+                    next_node_axes = None
+            next_unsqueezed_axes = next_unsqueeze_node.attrs['axes'] \
+                if 'axes' in next_unsqueeze_node.attrs else next_node_axes
+            if next_unsqueezed_axes == non_transpose_axes:
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     tf.identity(input=input_tensor)
                 tf_layers_dict[graph_node_output.name]['unnecessary_squeeze'] = True

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -135,7 +135,16 @@ def make_node(
     test pattern.8 : axes=[3,6], [2,3,4,1,5,6,1,7]
     test pattern.9 : axes=[3,-1], [2,3,4,1,5,6,1,7]
     """
-    if len(new_shape) >= 2 \
+    if 'unnecessary_squeeze' in tf_layers_dict[graph_node_input_1.name] \
+        and tf_layers_dict[graph_node_input_1.name]['unnecessary_squeeze'] == True:
+        # Remove useless squeeze/unsqueeze combinations
+        #   Only when squeeze and unsqueeze are consecutive
+        #   and each is performing a useless process of
+        #   compressing and decompressing the same axis,
+        #   the two operations are disabled at the same time.
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.identity(input=input_tensor)
+    elif len(new_shape) >= 2 \
         and len([dim for dim in new_shape if dim is None or dim == -1]) >= 2 \
         and not isinstance(axes, int) \
         and len(axes) == 1:


### PR DESCRIPTION
### 1. Content and background
- `Squeeze`, `Unsqueeze`
  - Only when `squeeze` and `unsqueeze` are consecutive and each is performing a useless process of compressing and decompressing the same `axis`, the two operations are disabled at the same time. This is an optimization to avoid as much as possible the risk of shape irregularities in the next connected operation of `Unsqueeze`.
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/ppmattingv2_stdc1_human_480x640.onnx
    ![image](https://user-images.githubusercontent.com/33194443/211158978-7f85e45c-7f27-406f-acc2-1f530330a307.png)
    ![image](https://user-images.githubusercontent.com/33194443/211176526-500ab3bb-959b-4e60-a8d0-0985a5ff3d69.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
