### PR TITLE
[Experimental] Added the ability to validate the model final output tensor in ONNX and TensorFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.4.2
+  ghcr.io/pinto0309/onnx2tf:1.5.0
 
   or
 
@@ -197,9 +197,12 @@ usage: onnx2tf
 [-rng]
 [-rhs]
 [-rerf]
-[-me]
+[-me MVN_EPSILON]
 [-prf PARAM_REPLACEMENT_FILE]
 [-cgdc]
+[-coto]
+[-cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL]
+[-cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL]
 [-n]
 
 optional arguments:
@@ -490,6 +493,20 @@ optional arguments:
       You can find more details from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema.fbs
     """
 
+  -coto, --check_onnx_tf_outputs_elementwise_close
+    Returns true if the two arrays, the output of onnx and the output of TF,
+    are elementwise close within an acceptable range.
+
+  -cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL,\
+    --check_onnx_tf_outputs_elementwise_close_rtol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL
+    The relative tolerance parameter.
+    Default: 1e-5
+
+  -cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL,\
+    --check_onnx_tf_outputs_elementwise_close_atol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL
+    The absolute tolerance parameter.
+    Default: 1e-5
+
   -n, --non_verbose
     Do not show all information logs. Only error logs are displayed.
 ```
@@ -540,6 +557,9 @@ convert(
   mvn_epsilon: Union[float, NoneType] = 0.0000000001,
   param_replacement_file: Optional[str] = '',
   check_gpu_delegate_compatibility: Optional[bool] = False,
+  check_onnx_tf_outputs_elementwise_close: Optional[bool] = False,
+  check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 1e-5,
+  check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-5,
   non_verbose: Union[bool, NoneType] = False
 ) -> keras.engine.training.Model
 
@@ -837,6 +857,21 @@ convert(
         You can find more details from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/schema/schema.fbs
       """
 
+    check_onnx_tf_outputs_elementwise_close: Optional[bool]
+        Returns true if the two arrays, the output of onnx and the output of TF,
+        are elementwise close within an acceptable range.
+
+    check_onnx_tf_outputs_elementwise_close_rtol: Optional[float]
+        The relative tolerance parameter.
+        Default: 1e-5
+
+    check_onnx_tf_outputs_elementwise_close_atol: Optional[float]
+        The absolute tolerance parameter.
+        Default: 1e-5
+
+    non_verbose: Optional[bool]
+        Do not show all information logs. Only error logs are displayed.
+        Default: False
 
     non_verbose: Optional[bool]
       Do not show all information logs. Only error logs are displayed.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.4.2'
+__version__ = '1.5.0'


### PR DESCRIPTION
### 1. Content and background
- [Experimental] Added the ability to validate the model final output tensor in ONNX and TensorFlow.
  https://numpy.org/doc/stable/reference/generated/numpy.allclose.html#numpy-allclose
  ```
  numpy.allclose(a, b, rtol=1e-05, atol=1e-05, equal_nan=True)
  ```
- This option in combination with the `--output_names_to_interrupt_model_conversion` option can be used to investigate which operations at which locations in the model cause errors in the output.
- Since ONNX assumes NCHW and TensorFlow assumes NHWC output, a simple comparison of output tensors will not match values in most cases. Therefore, the tool automatically tries to match the final output tensor of TensorFlow to the shape of the output tensor of ONNX with a brute force check. If the shape still does not match or there is no exact matching value combination, `Unmatched` is assumed.
- Currently, the function only provides validation with the output OP specified by the user, but eventually a function will be added to automatically search for OPs with large output errors.
  ```
    -coto, --check_onnx_tf_outputs_elementwise_close
      Returns true if the two arrays, the output of onnx and the output of TF,
      are elementwise close within an acceptable range.
  
    -cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL,\
      --check_onnx_tf_outputs_elementwise_close_rtol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL
      The relative tolerance parameter.
      Default: 1e-5
  
    -cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL,\
      --check_onnx_tf_outputs_elementwise_close_atol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL
      The absolute tolerance parameter.
      Default: 1e-5
  ```

- e.g.
  ```
  onnx2tf -i xxx.onnx -coto -onimc keypoints descriptors scores scores_map
  ```

  ![image](https://user-images.githubusercontent.com/33194443/211456312-4311a675-6d6c-4fd6-ae95-2393617f47fc.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[MobileFormer] Converted model outputs values mismatch with original ones.](https://github.com/PINTO0309/onnx2tf/issues/105)
