### PR TITLE
Fixed a bug in pre_explicit_broadcast that caused the order of operations to be reversed for Sub, Div, and Mod.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.0
+  ghcr.io/pinto0309/onnx2tf:1.5.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -744,49 +744,49 @@ def pre_explicit_broadcast(
         and None not in input_tensor_2.shape \
         and len(input_tensor_1.shape) == len(input_tensor_2.shape):
 
-        input_tensor_1_shape = input_tensor_1.shape
-        squeezed_input_tensor_1_shape = [idx for idx in input_tensor_1_shape if idx != 1]
-        squeezed_input_tensor_1_shape_rank = len(squeezed_input_tensor_1_shape)
         input_tensor_2_shape = input_tensor_2.shape
-        if squeezed_input_tensor_1_shape_rank == 1 \
-            and squeezed_input_tensor_1_shape[0] in input_tensor_2_shape:
-            input_tensor_1 = tf.squeeze(input_tensor_1)
-            reversed_input_tensor_2_shape = []
-            if isinstance(input_tensor_2_shape, list):
-                reversed_input_tensor_2_shape = input_tensor_2_shape.reverse()
-            elif isinstance(input_tensor_2_shape, tuple):
-                reversed_input_tensor_2_shape = list(input_tensor_2_shape[::-1])
-            elif isinstance(input_tensor_2_shape, np.ndarray):
-                reversed_input_tensor_2_shape = input_tensor_2_shape[::-1].tolist()
-            elif isinstance(input_tensor_2_shape, tf.TensorShape):
-                reversed_input_tensor_2_shape = list(input_tensor_2_shape[::-1])
-            expand_count = reversed_input_tensor_2_shape.index(squeezed_input_tensor_1_shape[0])
+        squeezed_input_tensor_2_shape = [idx for idx in input_tensor_2_shape if idx != 1]
+        squeezed_input_tensor_2_shape_rank = len(squeezed_input_tensor_2_shape)
+        input_tensor_1_shape = input_tensor_1.shape
+        if squeezed_input_tensor_2_shape_rank == 1 \
+            and squeezed_input_tensor_2_shape[0] in input_tensor_1_shape:
+            input_tensor_2 = tf.squeeze(input_tensor_2)
+            reversed_input_tensor_1_shape = []
+            if isinstance(input_tensor_1_shape, list):
+                reversed_input_tensor_1_shape = input_tensor_1_shape.reverse()
+            elif isinstance(input_tensor_1_shape, tuple):
+                reversed_input_tensor_1_shape = list(input_tensor_1_shape[::-1])
+            elif isinstance(input_tensor_1_shape, np.ndarray):
+                reversed_input_tensor_1_shape = input_tensor_1_shape[::-1].tolist()
+            elif isinstance(input_tensor_1_shape, tf.TensorShape):
+                reversed_input_tensor_1_shape = list(input_tensor_1_shape[::-1])
+            expand_count = reversed_input_tensor_1_shape.index(squeezed_input_tensor_2_shape[0])
             for _ in range(expand_count):
-                input_tensor_1 = tf.expand_dims(
-                    input=input_tensor_1,
+                input_tensor_2 = tf.expand_dims(
+                    input=input_tensor_2,
                     axis=-1,
                 )
         else:
-            input_tensor_2_shape = input_tensor_2.shape
-            squeezed_input_tensor_2_shape = [idx for idx in input_tensor_2_shape if idx != 1]
-            squeezed_input_tensor_2_shape_rank = len(squeezed_input_tensor_2_shape)
             input_tensor_1_shape = input_tensor_1.shape
-            if squeezed_input_tensor_2_shape_rank == 1 \
-                and squeezed_input_tensor_2_shape[0] in input_tensor_1_shape:
-                input_tensor_2 = tf.squeeze(input_tensor_2)
-                reversed_input_tensor_1_shape = []
-                if isinstance(input_tensor_1_shape, list):
-                    reversed_input_tensor_1_shape = input_tensor_1_shape.reverse()
-                elif isinstance(input_tensor_1_shape, tuple):
-                    reversed_input_tensor_1_shape = list(input_tensor_1_shape[::-1])
-                elif isinstance(input_tensor_1_shape, np.ndarray):
-                    reversed_input_tensor_1_shape = input_tensor_1_shape[::-1].tolist()
-                elif isinstance(input_tensor_1_shape, tf.TensorShape):
-                    reversed_input_tensor_1_shape = list(input_tensor_1_shape[::-1])
-                expand_count = reversed_input_tensor_1_shape.index(squeezed_input_tensor_2_shape[0])
+            squeezed_input_tensor_1_shape = [idx for idx in input_tensor_1_shape if idx != 1]
+            squeezed_input_tensor_1_shape_rank = len(squeezed_input_tensor_1_shape)
+            input_tensor_2_shape = input_tensor_2.shape
+            if squeezed_input_tensor_1_shape_rank == 1 \
+                and squeezed_input_tensor_1_shape[0] in input_tensor_2_shape:
+                input_tensor_1 = tf.squeeze(input_tensor_1)
+                reversed_input_tensor_2_shape = []
+                if isinstance(input_tensor_2_shape, list):
+                    reversed_input_tensor_2_shape = input_tensor_2_shape.reverse()
+                elif isinstance(input_tensor_2_shape, tuple):
+                    reversed_input_tensor_2_shape = list(input_tensor_2_shape[::-1])
+                elif isinstance(input_tensor_2_shape, np.ndarray):
+                    reversed_input_tensor_2_shape = input_tensor_2_shape[::-1].tolist()
+                elif isinstance(input_tensor_2_shape, tf.TensorShape):
+                    reversed_input_tensor_2_shape = list(input_tensor_2_shape[::-1])
+                expand_count = reversed_input_tensor_2_shape.index(squeezed_input_tensor_1_shape[0])
                 for _ in range(expand_count):
-                    input_tensor_2 = tf.expand_dims(
-                        input=input_tensor_2,
+                    input_tensor_1 = tf.expand_dims(
+                        input=input_tensor_1,
                         axis=-1,
                     )
     return input_tensor_1, input_tensor_2


### PR DESCRIPTION
### 1. Content and background
- Fixed a bug in `pre_explicit_broadcast` that caused the order of operations to be reversed for `Sub`, `Div`, and `Mod`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
