### PR TITLE
Change initial values for relative and absolute tolerances

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.1
+  ghcr.io/pinto0309/onnx2tf:1.5.2
 
   or
 
@@ -500,12 +500,12 @@ optional arguments:
   -cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL,\
     --check_onnx_tf_outputs_elementwise_close_rtol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL
     The relative tolerance parameter.
-    Default: 1e-5
+    Default: 0.0
 
   -cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL,\
     --check_onnx_tf_outputs_elementwise_close_atol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL
     The absolute tolerance parameter.
-    Default: 1e-5
+    Default: 1e-4
 
   -n, --non_verbose
     Do not show all information logs. Only error logs are displayed.
@@ -558,8 +558,8 @@ convert(
   param_replacement_file: Optional[str] = '',
   check_gpu_delegate_compatibility: Optional[bool] = False,
   check_onnx_tf_outputs_elementwise_close: Optional[bool] = False,
-  check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 1e-5,
-  check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-5,
+  check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
+  check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
   non_verbose: Union[bool, NoneType] = False
 ) -> keras.engine.training.Model
 
@@ -863,11 +863,11 @@ convert(
 
     check_onnx_tf_outputs_elementwise_close_rtol: Optional[float]
         The relative tolerance parameter.
-        Default: 1e-5
+        Default: 0.0
 
     check_onnx_tf_outputs_elementwise_close_atol: Optional[float]
         The absolute tolerance parameter.
-        Default: 1e-5
+        Default: 1e-4
 
     non_verbose: Optional[bool]
         Do not show all information logs. Only error logs are displayed.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -87,8 +87,8 @@ def convert(
     param_replacement_file: Optional[str] = '',
     check_gpu_delegate_compatibility: Optional[bool] = False,
     check_onnx_tf_outputs_elementwise_close: Optional[bool] = False,
-    check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 1e-5,
-    check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-5,
+    check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
+    check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
     mvn_epsilon: Optional[float] = 0.0000000001,
     non_verbose: Optional[bool] = False,
 ) -> tf.keras.Model:
@@ -338,11 +338,11 @@ def convert(
 
     check_onnx_tf_outputs_elementwise_close_rtol: Optional[float]
         The relative tolerance parameter.\n
-        Default: 1e-5
+        Default: 0.0
 
     check_onnx_tf_outputs_elementwise_close_atol: Optional[float]
         The absolute tolerance parameter.\n
-        Default: 1e-5
+        Default: 1e-4
 
     non_verbose: Optional[bool]
         Do not show all information logs. Only error logs are displayed.\n
@@ -1012,8 +1012,8 @@ def convert(
             check_results = onnx_tf_tensor_validation(
                 onnx_tensor_infos=onnx_tensor_infos,
                 tf_tensors=dummy_tf_outputs,
-                rtol=1e-05,
-                atol=1e-05,
+                rtol=check_onnx_tf_outputs_elementwise_close_rtol,
+                atol=check_onnx_tf_outputs_elementwise_close_atol,
             )
             for onnx_output_name, checked_value in check_results.items():
                 validated_onnx_tensor: np.ndarray = checked_value[0]
@@ -1425,19 +1425,19 @@ def main():
         '-cotor',
         '--check_onnx_tf_outputs_elementwise_close_rtol',
         type=float,
-        default=1e-5,
+        default=0.0,
         help=\
             'The relative tolerance parameter \n' +
-            'Default: 1e-5'
+            'Default: 0.0'
     )
     parser.add_argument(
         '-cotoa',
         '--check_onnx_tf_outputs_elementwise_close_atol',
         type=float,
-        default=1e-5,
+        default=1e-4,
         help=\
             'The absolute tolerance parameter \n' +
-            'Default: 1e-5'
+            'Default: 1e-4'
     )
     parser.add_argument(
         '-n',


### PR DESCRIPTION
### 1. Content and background
- `--check_onnx_tf_outputs_elementwise_close`
  - Change initial values for relative and absolute tolerances
    - `rtol`
      - `1e-5` -> `0.0`
    - `atol`
      - `1e-5` -> `1e-4`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[YoloX] output differs between onnx and tflite #107](https://github.com/PINTO0309/onnx2tf/issues/107)