### PR TITLE
Added ability to output only model weights in hdf5 format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN pip install pip -U \
     && pip install -U simple_onnx_processing_tools \
     && pip install tensorflow==2.10.0 \
     && pip install protobuf==3.20.3 \
+    && pip install h5py==3.7.0 \
     && python -m pip cache purge
 
 ENV USERNAME=user

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.4
+  ghcr.io/pinto0309/onnx2tf:1.5.5
 
   or
 
@@ -98,7 +98,8 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U onnx-graphsurgeon \
   && pip install -U onnxsim \
   && pip install -U simple_onnx_processing_tools \
-  && pip install -U onnx2tf
+  && pip install -U onnx2tf \
+  && pip install -U h5py==3.7.0
 
   or
 
@@ -127,7 +128,8 @@ or
     && python3.9 -m pip install -U onnxsim \
     && python3.9 -m pip install -U simple_onnx_processing_tools \
     && python3.9 -m pip install -U onnx2tf \
-    && python3.9 -m pip install -U protobuf==3.20.3
+    && python3.9 -m pip install -U protobuf==3.20.3 \
+    && python3.9 -m pip install -U h5py==3.7.0
   ```
 
 Run test.
@@ -176,6 +178,7 @@ usage: onnx2tf
 [-o OUTPUT_FOLDER_PATH]
 [-osd]
 [-oh5]
+[-ow]
 [-oiqt]
 [-qt {per-channel,per-tensor}]
 [-qcind INPUT_NAME NUMPY_FILE_PATH MEAN STD]
@@ -230,7 +233,10 @@ optional arguments:
     of model conversion and significant increase the size of the model.
 
   -oh5, --output_h5
-    Output in Keras H5 format.
+    Output model in Keras (hdf5) format.
+
+  -ow, --output_weights
+    Output weights in hdf5 format.
 
   -oiqt, --output_integer_quantized_tflite
     Output of integer quantized tflite.
@@ -500,8 +506,11 @@ optional arguments:
     """
 
   -coto, --check_onnx_tf_outputs_elementwise_close
-    Returns true if the two arrays, the output of onnx and the output of TF,
-    are elementwise close within an acceptable range.
+    Returns "Matches" if the output of onnx and the output of TF are
+    within acceptable proximity element by element.
+    Returns Unmatched if the output of onnx and the output of TF are
+    not within acceptable proximity element by element.
+    Only the output content of the models final output OP is checked.
 
   -cotof, --check_onnx_tf_outputs_elementwise_close_full
     Returns "Matches" if the output of onnx and the output of TF are
@@ -541,6 +550,7 @@ convert(
   output_folder_path: Union[str, NoneType] = 'saved_model',
   output_signaturedefs: Optional[bool] = False,
   output_h5: Optional[bool] = False,
+  output_weights: Optional[bool] = False,
   output_integer_quantized_tflite: Optional[bool] = False,
   quant_type: Optional[str] = 'per-channel',
   quant_calib_input_op_name_np_data_path: Optional[List] = None,
@@ -604,7 +614,10 @@ convert(
       of model conversion and significant increase the size of the model.
 
     output_h5: Optional[bool]
-      Output in Keras H5 format.
+      Output model in Keras H5 format.
+
+    output_weights: Optional[bool]
+        Output weights in hdf5 format.
 
     output_integer_quantized_tflite: Optional[bool]
       Output of integer quantized tflite.
@@ -876,8 +889,11 @@ convert(
       """
 
     check_onnx_tf_outputs_elementwise_close: Optional[bool]
-        Returns true if the two arrays, the output of onnx and the output of TF,
-        are elementwise close within an acceptable range.
+        Returns "Matches" if the output of onnx and the output of TF are
+        within acceptable proximity element by element.
+        Returns Unmatched if the output of onnx and the output of TF are
+        not within acceptable proximity element by element.
+        Only the output content of the models final output OP is checked.
 
     check_onnx_tf_outputs_elementwise_close_full: Optional[bool]
         Returns "Matches" if the output of onnx and the output of TF are

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.4'
+__version__ = '1.5.5'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -43,6 +43,7 @@ from onnx2tf.utils.common_functions import (
     dummy_onnx_inference,
     dummy_tf_inference,
     onnx_tf_tensor_validation,
+    weights_export,
 )
 from onnx2tf.utils.colors import Color
 from sng4onnx import generate as op_name_auto_generate
@@ -54,6 +55,7 @@ def convert(
     output_folder_path: Optional[str] = 'saved_model',
     output_signaturedefs: Optional[bool] = False,
     output_h5: Optional[bool] = False,
+    output_weights: Optional[bool] = False,
     output_integer_quantized_tflite: Optional[bool] = False,
     quant_type: Optional[str] = 'per-channel',
     quant_calib_input_op_name_np_data_path: Optional[List] = None,
@@ -116,7 +118,10 @@ def convert(
         of model conversion and significant increase the size of the model.
 
     output_h5: Optional[bool]
-        Output in Keras H5 format.
+        Output model in Keras (hdf5) format.
+
+    output_weights: Optional[bool]
+        Output weights in hdf5 format.
 
     output_integer_quantized_tflite: Optional[bool]
         Output of integer quantized tflite.
@@ -759,6 +764,11 @@ def convert(
         tflite_model = converter.convert()
         with open(f'{output_folder_path}/model_float32.tflite', 'wb') as w:
             w.write(tflite_model)
+        if output_weights:
+            weights_export(
+                extract_target_tflite_file_path=f'{output_folder_path}/model_float32.tflite',
+                output_weights_file_path=f'{output_folder_path}/model_float32_weights.h5',
+            )
         if not non_verbose:
             print(f'{Color.GREEN}Float32 tflite output complete!{Color.RESET}')
 
@@ -771,6 +781,11 @@ def convert(
         tflite_model = converter.convert()
         with open(f'{output_folder_path}/model_float16.tflite', 'wb') as w:
             w.write(tflite_model)
+        if output_weights:
+            weights_export(
+                extract_target_tflite_file_path=f'{output_folder_path}/model_float16.tflite',
+                output_weights_file_path=f'{output_folder_path}/model_float16_weights.h5',
+            )
         if not non_verbose:
             print(f'{Color.GREEN}Float16 tflite output complete!{Color.RESET}')
 
@@ -807,6 +822,11 @@ def convert(
                 tflite_model = converter.convert()
                 with open(f'{output_folder_path}/model_dynamic_range_quant.tflite', 'wb') as w:
                     w.write(tflite_model)
+                if output_weights:
+                    weights_export(
+                        extract_target_tflite_file_path=f'{output_folder_path}/model_dynamic_range_quant.tflite',
+                        output_weights_file_path=f'{output_folder_path}/model_dynamic_range_quant_weights.h5',
+                    )
                 if not non_verbose:
                     print(f'{Color.GREEN}Dynamic Range Quantization tflite output complete!{Color.RESET}')
             except RuntimeError as ex:
@@ -890,6 +910,11 @@ def convert(
                 tflite_model = converter.convert()
                 with open(f'{output_folder_path}/model_integer_quant.tflite', 'wb') as w:
                     w.write(tflite_model)
+                if output_weights:
+                    weights_export(
+                        extract_target_tflite_file_path=f'{output_folder_path}/model_integer_quant.tflite',
+                        output_weights_file_path=f'{output_folder_path}/model_integer_quant_weights.h5',
+                    )
                 if not non_verbose:
                     print(f'{Color.GREEN}INT8 Quantization tflite output complete!{Color.RESET}')
 
@@ -914,6 +939,11 @@ def convert(
                 tflite_model = converter.convert()
                 with open(f'{output_folder_path}/model_full_integer_quant.tflite', 'wb') as w:
                     w.write(tflite_model)
+                if output_weights:
+                    weights_export(
+                        extract_target_tflite_file_path=f'{output_folder_path}/model_full_integer_quant.tflite',
+                        output_weights_file_path=f'{output_folder_path}/model_full_integer_quant_weights.h5',
+                    )
                 if not non_verbose:
                     print(f'{Color.GREEN}Full INT8 Quantization tflite output complete!{Color.RESET}')
             except RuntimeError as ex:
@@ -1146,7 +1176,14 @@ def main():
         '--output_h5',
         action='store_true',
         help=\
-            'Output in Keras H5 format.'
+            'Output model in Keras (hdf5) format.'
+    )
+    parser.add_argument(
+        '-ow',
+        '--output_weights',
+        action='store_true',
+        help=\
+            'Output weights in hdf5 format.'
     )
     parser.add_argument(
         '-oiqt',
@@ -1571,6 +1608,7 @@ def main():
         output_folder_path=args.output_folder_path,
         output_signaturedefs=args.output_signaturedefs,
         output_h5=args.output_h5,
+        output_weights=args.output_weights,
         output_integer_quantized_tflite=args.output_integer_quantized_tflite,
         quant_type=args.quant_type,
         quant_calib_input_op_name_np_data_path=calib_params,


### PR DESCRIPTION
### 1. Content and background
- Added ability to output only model weights in hdf5 format
  - Note that the INT16 format is not supported
    ![image](https://user-images.githubusercontent.com/33194443/212021310-18b26cbf-1020-4627-b9f8-4022af63aafa.png)
    ![image](https://user-images.githubusercontent.com/33194443/212021451-32249b7c-28b1-4f30-b3f3-0c66327b4f73.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[MobileFormer]Converted model outputs values mismatch with original ones. #105](https://github.com/PINTO0309/onnx2tf/issues/105)