### PR TITLE
[Experimental] Improved consistency check by downloading MS-COCO dummy data when model inputs appear to assume images

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.5
+  ghcr.io/pinto0309/onnx2tf:1.5.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.5'
+__version__ = '1.5.6'


### PR DESCRIPTION
### 1. Content and background
- [Experimental] Improved consistency check by downloading MS-COCO dummy data when model inputs appear to assume images

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[YOLOX] Abort onnxruntime when keepdims=False in ReduceXX and the final tensor dimension is reduced to zero #108](https://github.com/PINTO0309/onnx2tf/issues/108)
[[YoloX] output differs between onnx and tflite #107](https://github.com/PINTO0309/onnx2tf/issues/107)