### PR TITLE
Allow selection of whether to use normalized or denormalized data during validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.6
+  ghcr.io/pinto0309/onnx2tf:1.5.7
 
   or
 
@@ -210,6 +210,7 @@ usage: onnx2tf
 [-prf PARAM_REPLACEMENT_FILE]
 [-cgdc]
 [-coto | -cotof]
+[-coton]
 [-cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL]
 [-cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL]
 [-n]
@@ -523,6 +524,13 @@ optional arguments:
     It is very time consuming because it performs as many inferences as
     there are operations.
 
+  -coton, --check_onnx_tf_outputs_sample_data_normalization
+    norm: Validate using random data normalized to the range 0.0 to 1.0
+    denorm: Validate using random data in the range 0.0 to 255.0
+    If there is a normalization layer at the model's entry point, or
+    if the model was trained on denormalized data, "denorm" must be specified.
+    Default: "norm"
+
   -cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL,\
     --check_onnx_tf_outputs_elementwise_close_rtol CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL
     The relative tolerance parameter.
@@ -586,6 +594,7 @@ convert(
   check_gpu_delegate_compatibility: Optional[bool] = False,
   check_onnx_tf_outputs_elementwise_close: Optional[bool] = False,
   check_onnx_tf_outputs_elementwise_close_full: Optional[bool] = False,
+  check_onnx_tf_outputs_sample_data_normalization: Optional[str] = 'norm',
   check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
   check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
   non_verbose: Union[bool, NoneType] = False
@@ -905,6 +914,13 @@ convert(
         not within acceptable proximity element by element.
         It is very time consuming because it performs as many inferences as
         there are operations.
+
+    check_onnx_tf_outputs_sample_data_normalization: Optional[str]
+        norm: Validate using random data normalized to the range 0.0 to 1.0
+        denorm: Validate using random data in the range 0.0 to 255.0
+        If there is a normalization layer at the models entry point, or
+        if the model was trained on denormalized data, "denorm" must be specified.
+        Default: "norm"
 
     check_onnx_tf_outputs_elementwise_close_rtol: Optional[float]
         The relative tolerance parameter.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.6'
+__version__ = '1.5.7'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -90,6 +90,7 @@ def convert(
     check_gpu_delegate_compatibility: Optional[bool] = False,
     check_onnx_tf_outputs_elementwise_close: Optional[bool] = False,
     check_onnx_tf_outputs_elementwise_close_full: Optional[bool] = False,
+    check_onnx_tf_outputs_sample_data_normalization: Optional[str] = 'norm',
     check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
     check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
     mvn_epsilon: Optional[float] = 0.0000000001,
@@ -355,6 +356,13 @@ def convert(
         not within acceptable proximity element by element.\n
         It is very time consuming because it performs as many inferences as\n
         there are operations.
+
+    check_onnx_tf_outputs_sample_data_normalization: Optional[str]
+        norm: Validate using random data normalized to the range 0.0 to 1.0\n
+        denorm: Validate using random data in the range 0.0 to 255.0\n
+        If there is a normalization layer at the model's entry point,\n
+        or if the model was trained on denormalized data, "denorm" must be specified.\n
+        Default: "norm"
 
     check_onnx_tf_outputs_elementwise_close_rtol: Optional[float]
         The relative tolerance parameter.\n
@@ -1079,7 +1087,10 @@ def convert(
             if all_four_dim and same_batch_dim:
                 test_data: np.ndarray = download_test_image_data()
                 test_data_nhwc = test_data[:inputs[0].shape[0], ...]
-                test_data_nhwc = test_data_nhwc * 255.0
+                if check_onnx_tf_outputs_sample_data_normalization == "norm":
+                    pass
+                elif check_onnx_tf_outputs_sample_data_normalization == "denorm":
+                    test_data_nhwc = test_data_nhwc * 255.0
             for output_names in ops_output_names:
                 # ONNX dummy inference
                 dummy_onnx_outputs: List[np.ndarray] = dummy_onnx_inference(
@@ -1571,6 +1582,19 @@ def main():
             'there are operations.'
     )
     parser.add_argument(
+        '-coton',
+        '--check_onnx_tf_outputs_sample_data_normalization',
+        type=str,
+        choices=['norm', 'denorm'],
+        default='norm',
+        help=\
+            'norm: Validate using random data normalized to the range 0.0 to 1.0 ' +
+            'denorm: Validate using random data in the range 0.0 to 255.0 ' +
+            'If there is a normalization layer at the models entry point, ' +
+            'or if the model was trained on denormalized data, "denorm" must be specified. ' +
+            'Default: "norm"'
+    )
+    parser.add_argument(
         '-cotor',
         '--check_onnx_tf_outputs_elementwise_close_rtol',
         type=float,
@@ -1661,6 +1685,7 @@ def main():
         check_gpu_delegate_compatibility=args.check_gpu_delegate_compatibility,
         check_onnx_tf_outputs_elementwise_close=args.check_onnx_tf_outputs_elementwise_close,
         check_onnx_tf_outputs_elementwise_close_full=args.check_onnx_tf_outputs_elementwise_close_full,
+        check_onnx_tf_outputs_sample_data_normalization=args.check_onnx_tf_outputs_sample_data_normalization,
         check_onnx_tf_outputs_elementwise_close_rtol=args.check_onnx_tf_outputs_elementwise_close_rtol,
         check_onnx_tf_outputs_elementwise_close_atol=args.check_onnx_tf_outputs_elementwise_close_atol,
         mvn_epsilon=args.mvn_epsilon,


### PR DESCRIPTION
### 1. Content and background
- Allow selection of whether to use normalized or denormalized data during validation
- [[YoloX] output differs between onnx and tflite #107](https://github.com/PINTO0309/onnx2tf/issues/107)
  ```
  -coton, --check_onnx_tf_outputs_sample_data_normalization
    norm: Validate using random data normalized to the range 0.0 to 1.0
    denorm: Validate using random data in the range 0.0 to 255.0
    If there is a normalization layer at the model's entry point, or
    if the model was trained on denormalized data, "denorm" must be specified.
    Default: "norm"
  ```
### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
