### PR TITLE
Faster output compare & ONNX Runtime ReduceXX operator inference error fixed

### DIFF
--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1056,7 +1056,7 @@ def convert(
                         ops_output_names_sub.append(graph_node_output.name)
                     ops_output_names.extend(ops_output_names_sub)
             else:
-                ops_output_names = [output_names]
+                ops_output_names = output_names
 
             # download test data
             all_four_dim = sum(

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1082,7 +1082,6 @@ def convert(
             if all_four_dim and same_batch_dim:
                 test_data: np.ndarray = download_test_image_data()
                 test_data_nhwc = test_data[:inputs[0].shape[0], ...]
-                test_data_nhwc = test_data_nhwc * 255.0
                 if check_onnx_tf_outputs_sample_data_normalization == "norm":
                     pass
                 elif check_onnx_tf_outputs_sample_data_normalization == "denorm":

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1054,7 +1054,7 @@ def convert(
                     ops_output_names_sub = []
                     for graph_node_output in graph_node.outputs:
                         ops_output_names_sub.append(graph_node_output.name)
-                    ops_output_names.append(ops_output_names_sub)
+                    ops_output_names.extend(ops_output_names_sub)
             else:
                 ops_output_names = [output_names]
 
@@ -1080,79 +1080,75 @@ def convert(
                 test_data: np.ndarray = download_test_image_data()
                 test_data_nhwc = test_data[:inputs[0].shape[0], ...]
                 test_data_nhwc = test_data_nhwc * 255.0
-            for output_names in ops_output_names:
-                # ONNX dummy inference
-                dummy_onnx_outputs: List[np.ndarray] = dummy_onnx_inference(
-                    onnx_graph=onnx_graph,
-                    output_names=output_names,
-                    test_data_nhwc=test_data_nhwc,
-                )
-                # TF dummy inference
-                del model
-                outputs = [
-                    layer_info['tf_node'] \
-                        for opname, layer_info in tf_layers_dict.items() \
-                            if opname in output_names
-                ]
-                model = tf.keras.Model(inputs=inputs, outputs=outputs)
-                dummy_tf_outputs: List[Any] = dummy_tf_inference(
-                    model=model,
-                    inputs=inputs,
-                    test_data_nhwc=test_data_nhwc,
-                )
-                if not isinstance(dummy_tf_outputs, list):
-                    dummy_tf_outputs = [dummy_tf_outputs]
-                dummy_tf_outputs = [
-                    dummy_tf_output.numpy() \
-                        for dummy_tf_output in dummy_tf_outputs
-                ]
-                # Validation
-                onnx_tensor_infos = {
-                    output_name: dummy_onnx_output \
-                        for output_name, dummy_onnx_output in zip(output_names, dummy_onnx_outputs)
-                }
-                """
-                np.allclose(
-                    dummy_onnx_outputs,
-                    dummy_tf_outputs,
-                    rtol=0.0,
-                    atol=1e-04,
-                    equal_nan=True,
-                )
 
-                check_results: Dict[str, List[np.ndarray, bool]]
-                    {
-                        onnx_output_name: [
-                            onnx_tensor,
-                            matched_flg, <--- True: Matched, False: Unmatched
-                        ]
-                    }
-                """
-                check_results = onnx_tf_tensor_validation(
-                    onnx_tensor_infos=onnx_tensor_infos,
-                    tf_tensors=dummy_tf_outputs,
-                    rtol=check_onnx_tf_outputs_elementwise_close_rtol,
-                    atol=check_onnx_tf_outputs_elementwise_close_atol,
+            # ONNX dummy inference
+            dummy_onnx_outputs: List[np.ndarray] = dummy_onnx_inference(
+                onnx_graph=onnx_graph,
+                output_names=ops_output_names,
+                test_data_nhwc=test_data_nhwc,
+            )
+            # TF dummy inference
+            del model
+            outputs = [
+                layer_info['tf_node'] \
+                    for opname, layer_info in tf_layers_dict.items() \
+                        if opname in ops_output_names
+            ]
+            model = tf.keras.Model(inputs=inputs, outputs=outputs)
+            dummy_tf_outputs: List[Any] = dummy_tf_inference(
+                model=model,
+                inputs=inputs,
+                test_data_nhwc=test_data_nhwc,
+            )
+            if not isinstance(dummy_tf_outputs, list):
+                dummy_tf_outputs = [dummy_tf_outputs]
+            dummy_tf_outputs = [
+                dummy_tf_output.numpy() \
+                    for dummy_tf_output in dummy_tf_outputs
+            ]
+            # Validation
+            onnx_tensor_infos = {
+                output_name: dummy_onnx_output \
+                    for output_name, dummy_onnx_output in zip(ops_output_names, dummy_onnx_outputs)
+            }
+            """
+            np.allclose(
+                dummy_onnx_outputs,
+                dummy_tf_outputs,
+                rtol=0.0,
+                atol=1e-04,
+                equal_nan=True,
+            )
+
+            check_results: Dict[str, List[np.ndarray, bool]]
+                {
+                    onnx_output_name: [
+                        onnx_tensor,
+                        matched_flg, <--- True: Matched, False: Unmatched
+                    ]
+                }
+            """
+            check_results = onnx_tf_tensor_validation(
+                onnx_tensor_infos=onnx_tensor_infos,
+                tf_tensors=dummy_tf_outputs,
+                rtol=check_onnx_tf_outputs_elementwise_close_rtol,
+                atol=check_onnx_tf_outputs_elementwise_close_atol,
+            )
+            for onnx_output_name, checked_value in check_results.items():
+                validated_onnx_tensor: np.ndarray = checked_value[0]
+                matched_flg: bool = checked_value[1]
+                message = ''
+                if matched_flg:
+                    message = f'{Color.GREEN}validate_result{Color.RESET}: {Color.REVERCE}{Color.GREEN} Matches {Color.RESET}'
+                else:
+                    message = f'{Color.GREEN}validate_result{Color.RESET}: {Color.REVERCE}{Color.YELLOW} Unmatched {Color.RESET}'
+                print(
+                    f'{Color.GREEN}INFO:{Color.RESET} '+
+                    f'{Color.GREEN}onnx_output_name{Color.RESET}: {onnx_output_name} '+
+                    f'{Color.GREEN}shape{Color.RESET}: {validated_onnx_tensor.shape} '+
+                    f'{Color.GREEN}dtype{Color.RESET}: {validated_onnx_tensor.dtype} '+
+                    f'{message}'
                 )
-                total_matched_flg = True
-                for onnx_output_name, checked_value in check_results.items():
-                    validated_onnx_tensor: np.ndarray = checked_value[0]
-                    matched_flg: bool = checked_value[1]
-                    message = ''
-                    if matched_flg:
-                        message = f'{Color.GREEN}validate_result{Color.RESET}: {Color.REVERCE}{Color.GREEN} Matches {Color.RESET}'
-                    else:
-                        message = f'{Color.GREEN}validate_result{Color.RESET}: {Color.REVERCE}{Color.YELLOW} Unmatched {Color.RESET}'
-                    print(
-                        f'{Color.GREEN}INFO:{Color.RESET} '+
-                        f'{Color.GREEN}onnx_output_name{Color.RESET}: {onnx_output_name} '+
-                        f'{Color.GREEN}shape{Color.RESET}: {validated_onnx_tensor.shape} '+
-                        f'{Color.GREEN}dtype{Color.RESET}: {validated_onnx_tensor.dtype} '+
-                        f'{message}'
-                    )
-                    total_matched_flg = total_matched_flg & matched_flg
-                if not total_matched_flg:
-                    break
 
         return model
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2795,16 +2795,39 @@ def dummy_onnx_inference(
     """
     # Separate onnx at specified output_names position
     gs_graph = gs.import_onnx(onnx_graph)
-    extracted_graph = extraction(
-        onnx_graph=onnx_graph,
-        input_op_names=[graph_input.name for graph_input in gs_graph.inputs],
-        output_op_names=output_names,
-        non_verbose=True,
-    )
+    for i, node in enumerate(gs_graph.nodes):
+        if "Reduce" in gs_graph.nodes[i].op and 'axes' not in node.attrs:
+            # reduce all axes except batch axis
+            gs_graph.nodes[i].attrs['axes'] = [i for i in range(1, len(gs_graph.nodes[i].inputs[0].shape))]
+
+    # CAUTION: these lines are commented due to error in shape inference when ReduceXX operators are used
+    # extracted_graph = extraction(
+    #     onnx_graph=onnx_graph,
+    #     input_op_names=[graph_input.name for graph_input in gs_graph.inputs],
+    #     output_op_names=output_names,
+    #     non_verbose=True,
+    # )
+
+    # instead, modify onnx graph manually
+    graph_node_outputs = [
+        graph_nodes \
+        for graph_nodes in gs_graph.nodes \
+        for graph_nodes_output in graph_nodes.outputs \
+        if graph_nodes_output.name in output_names
+    ]
+
+    gs_graph.outputs = [
+        graph_node_output \
+        for graph_node in graph_node_outputs \
+        for graph_node_output in graph_node.outputs
+    ]
+
+    new_onnx_graph = gs.export_onnx(gs_graph)
+
     ### debug
-    onnx.save(extracted_graph, 'test.onnx')
+    onnx.save(new_onnx_graph, 'test.onnx')
     ### debug
-    serialized_graph = onnx._serialize(extracted_graph)
+    serialized_graph = onnx._serialize(new_onnx_graph)
     onnx_session = ort.InferenceSession(
         path_or_bytes=serialized_graph,
         providers=['CPUExecutionProvider'],

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2809,18 +2809,11 @@ def dummy_onnx_inference(
     # )
 
     # instead, modify onnx graph manually
-    graph_node_outputs = [
-        graph_nodes \
-        for graph_nodes in gs_graph.nodes \
-        for graph_nodes_output in graph_nodes.outputs \
-        if graph_nodes_output.name in output_names
-    ]
-
-    gs_graph.outputs = [
-        graph_node_output \
-        for graph_node in graph_node_outputs \
-        for graph_node_output in graph_node.outputs
-    ]
+    gs_graph.outputs = []
+    for graph_node in gs_graph.nodes:
+        for node_output in graph_node.outputs:
+            if node_output.name in output_names:
+                gs_graph.outputs.append(node_output)
 
     new_onnx_graph = gs.export_onnx(gs_graph)
 


### PR DESCRIPTION
### 1. Content and background

### 2. Summary of corrections
1. Speed improvement in dummy output compare between onnx, tensorflow
In previous version, new onnx graph and new tensorflow model were generated to get dummy output of intermediate layers. I modified `dummy_onnx_inference` in `common_functions.py` to generate single onnx graph which have all intermediate output as graph output. After that, tensorflow model also is created once.
This reduced output comparing time significantly. For YOLOX-X, output comparing took more than 15 minutes in my environment. After this fix, it took less than 3 minutes.

2. ONNX Runtime ReduceXX operator inference error fixed
This error happens because `axes` is not specified for some ReduceXX operators. I fixed `dummy_onnx_inference` in `common_functions.py` to assign proper `axes` value. If the value is not given, axes value except batch dimension is assigned.


### 3. Before/After (If there is an operating log that can be used as a reference)
<img src="https://user-images.githubusercontent.com/34959032/212209657-eb67b655-31be-4466-ba93-5d9e5f0e9280.png" width="700">


### 4. Issue number (only if there is a related issue)
#107 #108