### PR TITLE
Exclude `Constant` and `ConstantOfShape` from validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.7
+  ghcr.io/pinto0309/onnx2tf:1.5.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.7'
+__version__ = '1.5.8'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1101,6 +1101,12 @@ def convert(
                         if opname in ops_output_names \
                             and not hasattr(layer_info['tf_node'], 'numpy')
             ]
+            exclude_output_names = [
+                opname \
+                    for opname, layer_info in tf_layers_dict.items() \
+                        if opname in ops_output_names \
+                            and hasattr(layer_info['tf_node'], 'numpy')
+            ]
             model = tf.keras.Model(inputs=inputs, outputs=outputs)
             dummy_tf_outputs: List[Any] = dummy_tf_inference(
                 model=model,
@@ -1116,7 +1122,8 @@ def convert(
             # Validation
             onnx_tensor_infos = {
                 output_name: dummy_onnx_output \
-                    for output_name, dummy_onnx_output in zip(ops_output_names, dummy_onnx_outputs)
+                    for output_name, dummy_onnx_output in zip(ops_output_names, dummy_onnx_outputs) \
+                        if output_name not in exclude_output_names
             }
             """
             np.allclose(

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1098,7 +1098,8 @@ def convert(
             outputs = [
                 layer_info['tf_node'] \
                     for opname, layer_info in tf_layers_dict.items() \
-                        if opname in ops_output_names
+                        if opname in ops_output_names \
+                            and not hasattr(layer_info['tf_node'], 'numpy')
             ]
             model = tf.keras.Model(inputs=inputs, outputs=outputs)
             dummy_tf_outputs: List[Any] = dummy_tf_inference(


### PR DESCRIPTION
### 1. Content and background
- Exclude `Constant` and `ConstantOfShape` from validation

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[human_segmentation_pphumanseg_2021oct] -cotof option is used, ValueError: Output tensors of a Functional model must be the output of a TensorFlow Layer #117](https://github.com/PINTO0309/onnx2tf/issues/117)