### PR TITLE
Added option to compress `FlexTranspose` to any number of dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.10
+  ghcr.io/pinto0309/onnx2tf:1.5.11
 
   or
 
@@ -195,6 +195,7 @@ usage: onnx2tf
 [-dgc]
 [-ebu]
 [-dsft]
+[-nodafc]
 [-rari64 | -rarf32 | -rafi64 | -raff32]
 [-fasr FUSED_ARGMAX_SCALE_RATIO]
 [-rasin]
@@ -368,6 +369,11 @@ optional arguments:
 
   -dsft, --disable_suppression_flextranspose
     Disables FlexTranspose generation suppression.
+
+  -nodafc, --number_of_dimensions_after_flextranspose_compression
+    Number of Transpose OP dimensions generated after avoiding FlexTranspose
+    generation.
+    Default: 5
 
   -rari64, --replace_argmax_to_reducemax_and_indicies_is_int64
     Replace ArgMax with a ReduceMax. The returned indicies are int64.
@@ -582,6 +588,7 @@ convert(
   disable_group_convolution: Union[bool, NoneType] = False,
   enaable_batchmatmul_unfold: Optional[bool] = False,
   disable_suppression_flextranspose: Optional[bool] = False,
+  number_of_dimensions_after_flextranspose_compression: Optional[int] = 5,
   replace_argmax_to_reducemax_and_indicies_is_int64: Union[bool, NoneType] = False,
   replace_argmax_to_reducemax_and_indicies_is_float32: Union[bool, NoneType] = False,
   replace_argmax_to_fused_argmax_and_indicies_is_int64: Union[bool, NoneType] = False,
@@ -762,6 +769,11 @@ convert(
 
     disable_suppression_flextranspose: Optional[bool]
       Disables FlexTranspose generation suppression.
+
+    number_of_dimensions_after_flextranspose_compression: Optional[int]
+      Number of Transpose OP dimensions generated after avoiding FlexTranspose
+      generation.
+      Default: 5
 
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool]
       Replace ArgMax with a ReduceMax. The returned indicies are int64.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.10'
+__version__ = '1.5.11'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -71,6 +71,7 @@ def convert(
     disable_group_convolution: Optional[bool] = False,
     enable_batchmatmul_unfold: Optional[bool] = False,
     disable_suppression_flextranspose: Optional[bool] = False,
+    number_of_dimensions_after_flextranspose_compression: Optional[int] = 5,
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_float32: Optional[bool] = False,
     replace_argmax_to_fused_argmax_and_indicies_is_int64: Optional[bool] = False,
@@ -251,6 +252,10 @@ def convert(
 
     disable_suppression_flextranspose: Optional[bool]
         Disables FlexTranspose generation suppression.
+
+    number_of_dimensions_after_flextranspose_compression: Optional[int]
+        Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.\n
+        Default: 5
 
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool]
         Replace ArgMax with a ReduceMax. The returned indicies are int64.\n
@@ -592,6 +597,7 @@ def convert(
         'non_verbose': non_verbose,
         'disable_group_convolution': disable_group_convolution,
         'disable_suppression_flextranspose': disable_suppression_flextranspose,
+        'number_of_dimensions_after_flextranspose_compression': number_of_dimensions_after_flextranspose_compression,
         'replace_argmax_to_reducemax_and_indicies_is_int64': replace_argmax_to_reducemax_and_indicies_is_int64,
         'replace_argmax_to_reducemax_and_indicies_is_float32': replace_argmax_to_reducemax_and_indicies_is_float32,
         'replace_argmax_to_fused_argmax_and_indicies_is_int64': replace_argmax_to_fused_argmax_and_indicies_is_int64,
@@ -1414,6 +1420,15 @@ def main():
         help=\
             'Disables FlexTranspose generation suppression.'
     )
+    parser.add_argument(
+        '-nodafc',
+        '--number_of_dimensions_after_flextranspose_compression',
+        type=int,
+        default=5,
+        help=\
+            'Number of Transpose OP dimensions generated after avoiding FlexTranspose generation. \n' +
+            'Default: 5'
+    )
     rar_group = parser.add_mutually_exclusive_group()
     rar_group.add_argument(
         '-rari64',
@@ -1681,6 +1696,7 @@ def main():
         disable_group_convolution=args.disable_group_convolution,
         enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
         disable_suppression_flextranspose=args.disable_suppression_flextranspose,
+        number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
         replace_argmax_to_reducemax_and_indicies_is_int64=args.replace_argmax_to_reducemax_and_indicies_is_int64,
         replace_argmax_to_reducemax_and_indicies_is_float32=args.replace_argmax_to_reducemax_and_indicies_is_float32,
         replace_argmax_to_fused_argmax_and_indicies_is_int64=args.replace_argmax_to_fused_argmax_and_indicies_is_int64,

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -459,9 +459,20 @@ def convert(
     # fused_argmax_scale_ratio
     if ra_option_list.count(True) > 0 and not (0.0 < fused_argmax_scale_ratio <= 1.0):
         print(
+            f'{Color.RED}ERROR:{Color.RESET} ' +
             f'fused_argmax_scale_ratio must be specified in the range '+
             f'0.0 < fused_argmax_scale_ratio <= 1.0. '+
             f'fused_argmax_scale_ratio: {fused_argmax_scale_ratio}'
+        )
+        sys.exit(1)
+
+    # number_of_dimensions_after_flextranspose_compression
+    if number_of_dimensions_after_flextranspose_compression < 2:
+        print(
+            f'{Color.RED}ERROR:{Color.RESET} ' +
+            f'number_of_dimensions_after_flextranspose_compression must be at least 2. '+
+            f'number_of_dimensions_after_flextranspose_compression: ' +
+            f'{number_of_dimensions_after_flextranspose_compression}'
         )
         sys.exit(1)
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2442,6 +2442,8 @@ def transpose_with_flexing_deterrence(
     """
     disable_suppression_flextranspose: bool = \
         kwargs['disable_suppression_flextranspose']
+    number_of_dimensions_after_flextranspose_compression: int = \
+        kwargs['number_of_dimensions_after_flextranspose_compression']
     tensor_after_transposition = input_tensor
 
     if disable_suppression_flextranspose:
@@ -2525,7 +2527,8 @@ def transpose_with_flexing_deterrence(
             """
             # 1. Extract the dimension with the smallest number needed to be less than 5 dimensions
             np_input_tensor_shape = np.asarray(input_tensor_shape)
-            num_of_dim_requiring_compression = input_tensor_rank - 5
+            num_of_dim_requiring_compression = \
+                input_tensor_rank - number_of_dimensions_after_flextranspose_compression
             """
             np_input_tensor_shape:
                 Shape of input data before transposition


### PR DESCRIPTION
### 1. Content and background
- Added option to compress `FlexTranspose` to any number of dimensions
  ```
  -nodafc, --number_of_dimensions_after_flextranspose_compression
    Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
    Default: 5
  ``` 
  - `-nodafc 4`
  ![image](https://user-images.githubusercontent.com/33194443/212480251-7de52bd4-5375-47d6-8d57-a786148a9c90.png)

  - `-nodafc 2`
    ![image](https://user-images.githubusercontent.com/33194443/212482452-86ae6e55-b67a-4369-9108-6c1cc1b6022f.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Avoid creating FlexTranspose for DepthToSpace #93](https://github.com/PINTO0309/onnx2tf/issues/93)