### PR TITLE
[Experimental] Fixed a problem in which the transposition flag was wrongly determined when the shapes of all parts of the tensor except the batch size after `MatMul` had the same numerical value

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.12
+  ghcr.io/pinto0309/onnx2tf:1.5.13
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.12'
+__version__ = '1.5.13'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -372,7 +372,8 @@ def inverted_operation_enable_disable(func):
                 and len(tf_node_output_shape) >= 3:
                 base_shape = tf_node_output_shape[1]
                 if len(tf_node_output_shape)-1 == sum([1 if base_shape == s else 0 for s in tf_node_output_shape[1:]]) \
-                    and (onnx_node_output_shape == tf_node_output_shape):
+                    and (onnx_node_output_shape == tf_node_output_shape) \
+                    and graph_node.op != 'MatMul':
                     trans_judge = True
             output_shape_trans = output_shape_trans or trans_judge
             tf_layers_dict[onnx_node_output.name]['before_op_output_shape_trans'] = output_shape_trans


### PR DESCRIPTION
### 1. Content and background
- [Experimental] Fixed a problem in which the transposition flag was wrongly determined when the shapes of all parts of the tensor except the batch size after `MatMul` had the same numerical value
- https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/detr_demo.onnx
  ![image](https://user-images.githubusercontent.com/33194443/212529012-1a02c768-da48-40be-8f31-dc3fc2a6f593.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
