### PR TITLE
Padding in `SYMMETRIC` mode will cause an error if the padding size is larger than the input size, so replace `CONSTANT` with `SYMMETRIC`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.14
+  ghcr.io/pinto0309/onnx2tf:1.5.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.14'
+__version__ = '1.5.15'

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -141,6 +141,8 @@ def make_node(
                     for pad_begin, pad_end in zip(calc_pads[0:spatial_size], calc_pads[spatial_size:len(calc_pads)])
             ] + \
             [[0,0]]
+        # Padding in `SYMMETRIC` mode will cause an error if the padding size is larger than the input size,
+        # so replace `CONSTANT` with `SYMMETRIC`
         symmetric_enable_check = [
             True if pad_size[0] <= input_tensor.shape[dim+1] and pad_size[1] <= input_tensor.shape[dim+1] else False \
                 for dim, pad_size in enumerate(tmp_pad[1:spatial_size])

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -142,7 +142,7 @@ def make_node(
             ] + \
             [[0,0]]
         symmetric_enable_check = [
-            True if pad_size[0] <= input_tensor.shape[dim+1] else False \
+            True if pad_size[0] <= input_tensor.shape[dim+1] and pad_size[1] <= input_tensor.shape[dim+1] else False \
                 for dim, pad_size in enumerate(tmp_pad[1:spatial_size])
         ]
         padded_tensor = tf.pad(

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -141,10 +141,14 @@ def make_node(
                     for pad_begin, pad_end in zip(calc_pads[0:spatial_size], calc_pads[spatial_size:len(calc_pads)])
             ] + \
             [[0,0]]
+        symmetric_enable_check = [
+            True if pad_size[0] <= input_tensor.shape[dim+1] else False \
+                for dim, pad_size in enumerate(tmp_pad[1:spatial_size])
+        ]
         padded_tensor = tf.pad(
             tensor=input_tensor,
             paddings=tmp_pad,
-            mode='SYMMETRIC',
+            mode='SYMMETRIC' if False not in symmetric_enable_check else 'CONSTANT',
         )
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/ops/GlobalAveragePool.py
+++ b/onnx2tf/ops/GlobalAveragePool.py
@@ -4,6 +4,11 @@ import numpy as np
 np.random.seed(0)
 import tensorflow as tf
 import onnx_graphsurgeon as gs
+from tensorflow.python.keras.layers import (
+    GlobalAveragePooling1D,
+    GlobalAveragePooling2D,
+    GlobalAveragePooling3D,
+)
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
     print_node_info,
@@ -69,13 +74,29 @@ def make_node(
 
     # Generation of TF OP
     axis = [dim for dim in range(1, input_tensor_rank - 1)]
-    tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.reduce_mean(
-            input_tensor=input_tensor,
-            axis=axis,
-            keepdims=True,
-            name=graph_node.name,
-        )
+    if len(axis) == 1:
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            GlobalAveragePooling1D(
+                keepdims=True,
+            )(input_tensor)
+    elif len(axis) == 2:
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            GlobalAveragePooling2D(
+                keepdims=True,
+            )(input_tensor)
+    elif len(axis) == 3:
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            GlobalAveragePooling3D(
+                keepdims=True,
+            )(input_tensor)
+    else:
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.reduce_mean(
+                input_tensor=input_tensor,
+                axis=axis,
+                keepdims=True,
+                name=graph_node.name,
+            )
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -158,7 +158,7 @@ def make_node(
             ] + \
             [[0,0]]
         symmetric_enable_check = [
-            True if pad_size[0] <= input_tensor.shape[dim+1] else False \
+            True if pad_size[0] <= input_tensor.shape[dim+1] and pad_size[1] <= input_tensor.shape[dim+1] else False \
                 for dim, pad_size in enumerate(tmp_pad[1:spatial_size])
         ]
         padded_tensor = tf.pad(

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -157,6 +157,8 @@ def make_node(
                     for pad_begin, pad_end in zip(calc_pads[0:spatial_size], calc_pads[spatial_size:len(calc_pads)])
             ] + \
             [[0,0]]
+        # Padding in `SYMMETRIC` mode will cause an error if the padding size is larger than the input size,
+        # so replace `CONSTANT` with `SYMMETRIC`
         symmetric_enable_check = [
             True if pad_size[0] <= input_tensor.shape[dim+1] and pad_size[1] <= input_tensor.shape[dim+1] else False \
                 for dim, pad_size in enumerate(tmp_pad[1:spatial_size])

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -157,10 +157,14 @@ def make_node(
                     for pad_begin, pad_end in zip(calc_pads[0:spatial_size], calc_pads[spatial_size:len(calc_pads)])
             ] + \
             [[0,0]]
+        symmetric_enable_check = [
+            True if pad_size[0] <= input_tensor.shape[dim+1] else False \
+                for dim, pad_size in enumerate(tmp_pad[1:spatial_size])
+        ]
         padded_tensor = tf.pad(
             tensor=input_tensor,
             paddings=tmp_pad,
-            mode='SYMMETRIC',
+            mode='SYMMETRIC' if False not in symmetric_enable_check else 'CONSTANT',
         )
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2825,7 +2825,8 @@ def dummy_onnx_inference(
     for graph_node in gs_graph.nodes:
         for node_output in graph_node.outputs:
             if node_output.name in output_names:
-                gs_graph.outputs.append(node_output)
+                if node_output.dtype is not None:
+                    gs_graph.outputs.append(node_output)
 
     new_onnx_graph = gs.export_onnx(gs_graph)
 


### PR DESCRIPTION
### 1. Content and background
- Padding in `SYMMETRIC` mode will cause an error if the padding size is larger than the input size, so replace `CONSTANT` with `SYMMETRIC`
- Replace `tf.reduce_mean` with `GlobalAveragePoolingxD` to reduce inference error

However, the phenomenon where the error between `AveragePool` and `GlobalAveragePool` becomes unusually large has not been corrected.
![image](https://user-images.githubusercontent.com/33194443/212544002-6699d4db-0a0c-4468-b95d-6f84674aa917.png)

- Workaround issue with onnx_graphsurgeon aborting when using output with dtype unknown
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/rcnn-ilsvrc13-9.onnx

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[FastestDet] The absolute error of AveragePool is quite large #124](https://github.com/PINTO0309/onnx2tf/issues/124)