### PR TITLE
[YOLOv8 FP16] TensorFlow's Resize operation casts to Float32 on its own, so we have to change it back to the original type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.15
+  ghcr.io/pinto0309/onnx2tf:1.5.16
 
   or
 
@@ -1359,12 +1359,14 @@ ONNX file for testing. https://github.com/PINTO0309/onnx2tf/releases/tag/1.1.28
 |70|yolact_regnetx_800mf_20classes_512x512.onnx|:heavy_check_mark:|
 |71|yolo_free_nano_crowdhuman_192x320_post.onnx|:heavy_check_mark:|
 |72|yolov7_tiny_head_0.768_post_480x640.onnx|:heavy_check_mark:|
-|73|yolox_nano_192x192.onnx|:heavy_check_mark:|
-|74|yolox_nano_416x416.onnx|:heavy_check_mark:|
-|75|yolox_s.onnx|:heavy_check_mark:|
-|76|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
-|77|zero_dce_640_dele.onnx|:heavy_check_mark:|
-|78|zfnet512-12.onnx|:heavy_check_mark:|
+|73|yolov8n.onnx|:heavy_check_mark:|
+|74|yolov8n-seg.onnx|:heavy_check_mark:|
+|75|yolox_nano_192x192.onnx|:heavy_check_mark:|
+|76|yolox_nano_416x416.onnx|:heavy_check_mark:|
+|77|yolox_s.onnx|:heavy_check_mark:|
+|78|yolox_x_crowdhuman_mot17_bytetrack.onnx|:heavy_check_mark:|
+|79|zero_dce_640_dele.onnx|:heavy_check_mark:|
+|80|zfnet512-12.onnx|:heavy_check_mark:|
 
 ## Related tools
 1. [tflite2tensorflow](https://github.com/PINTO0309/tflite2tensorflow)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.15'
+__version__ = '1.5.16'

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -301,6 +301,7 @@ def make_node(
     tf_op_type = None
     align_corners = None
     half_pixel_centers = None
+    org_dtype = input_tensor.dtype
     if coordinate_transformation_mode == "tf_crop_and_resize":
         # get boxes for crop
         indices = [1,2,5,6]
@@ -365,6 +366,14 @@ def make_node(
             name=graph_node.name,
         )
         tf_op_type = tf.image.resize
+
+    # TensorFlow's Resize operation casts to Float32 on its own,
+    # so we have to change it back to the original type.
+    if org_dtype != resized_tensor.dtype:
+        resized_tensor = tf.cast(
+            x=resized_tensor,
+            dtype=org_dtype,
+        )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = resized_tensor
 


### PR DESCRIPTION
### 1. Content and background
- `Resize`
  - [YOLOv8 FP16] TensorFlow's `Resize` operation casts to Float32 on its own, so we have to change it back to the original type.
  - Support for YOLOv8
    - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/yolov8n.onnx
    - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/yolov8n-seg.onnx
- Validation (Float32)
![image](https://user-images.githubusercontent.com/33194443/212796087-49683cd4-8846-4ab8-8a7a-d266eb29f581.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
