### PR TITLE
Add `--optimization_for_gpu_delegate` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.18
+  ghcr.io/pinto0309/onnx2tf:1.5.19
 
   or
 
@@ -196,6 +196,7 @@ usage: onnx2tf
 [-ebu]
 [-dsft]
 [-nodafc]
+[-ofgd]
 [-rari64 | -rarf32 | -rafi64 | -raff32]
 [-fasr FUSED_ARGMAX_SCALE_RATIO]
 [-rasin]
@@ -373,6 +374,10 @@ optional arguments:
   -nodafc, --number_of_dimensions_after_flextranspose_compression
     Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
     Default: 5
+
+  -ofgd, --optimization_for_gpu_delegate
+    Replace operations that do not support gpu delegate with those
+    that do as much as possible.
 
   -rari64, --replace_argmax_to_reducemax_and_indicies_is_int64
     Replace ArgMax with a ReduceMax. The returned indicies are int64.
@@ -588,6 +593,7 @@ convert(
   enaable_batchmatmul_unfold: Optional[bool] = False,
   disable_suppression_flextranspose: Optional[bool] = False,
   number_of_dimensions_after_flextranspose_compression: Optional[int] = 5,
+  optimization_for_gpu_delegate: Optional[bool] = False,
   replace_argmax_to_reducemax_and_indicies_is_int64: Union[bool, NoneType] = False,
   replace_argmax_to_reducemax_and_indicies_is_float32: Union[bool, NoneType] = False,
   replace_argmax_to_fused_argmax_and_indicies_is_int64: Union[bool, NoneType] = False,
@@ -772,6 +778,10 @@ convert(
     number_of_dimensions_after_flextranspose_compression: Optional[int]
       Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
       Default: 5
+
+    optimization_for_gpu_delegate: Optional[bool]
+        Replace operations that do not support gpu delegate with those
+        that do as much as possible.
 
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool]
       Replace ArgMax with a ReduceMax. The returned indicies are int64.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.18'
+__version__ = '1.5.19'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -73,6 +73,7 @@ def convert(
     enable_batchmatmul_unfold: Optional[bool] = False,
     disable_suppression_flextranspose: Optional[bool] = False,
     number_of_dimensions_after_flextranspose_compression: Optional[int] = 5,
+    optimization_for_gpu_delegate: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_float32: Optional[bool] = False,
     replace_argmax_to_fused_argmax_and_indicies_is_int64: Optional[bool] = False,
@@ -257,6 +258,10 @@ def convert(
     number_of_dimensions_after_flextranspose_compression: Optional[int]
         Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.\n
         Default: 5
+
+    optimization_for_gpu_delegate: Optional[bool]
+        Replace operations that do not support gpu delegate with those\n
+        that do as much as possible.
 
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool]
         Replace ArgMax with a ReduceMax. The returned indicies are int64.\n
@@ -610,6 +615,7 @@ def convert(
         'disable_group_convolution': disable_group_convolution,
         'disable_suppression_flextranspose': disable_suppression_flextranspose,
         'number_of_dimensions_after_flextranspose_compression': number_of_dimensions_after_flextranspose_compression,
+        'optimization_for_gpu_delegate': optimization_for_gpu_delegate,
         'replace_argmax_to_reducemax_and_indicies_is_int64': replace_argmax_to_reducemax_and_indicies_is_int64,
         'replace_argmax_to_reducemax_and_indicies_is_float32': replace_argmax_to_reducemax_and_indicies_is_float32,
         'replace_argmax_to_fused_argmax_and_indicies_is_int64': replace_argmax_to_fused_argmax_and_indicies_is_int64,
@@ -1450,6 +1456,14 @@ def main():
             'Number of Transpose OP dimensions generated after avoiding FlexTranspose generation. \n' +
             'Default: 5'
     )
+    parser.add_argument(
+        '-ofgd',
+        '--optimization_for_gpu_delegate',
+        action='store_true',
+        help=\
+            'Replace operations that do not support gpu delegate with those \n' +
+            'that do as much as possible.'
+    )
     rar_group = parser.add_mutually_exclusive_group()
     rar_group.add_argument(
         '-rari64',
@@ -1718,6 +1732,7 @@ def main():
         enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
         disable_suppression_flextranspose=args.disable_suppression_flextranspose,
         number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
+        optimization_for_gpu_delegate=args.optimization_for_gpu_delegate,
         replace_argmax_to_reducemax_and_indicies_is_int64=args.replace_argmax_to_reducemax_and_indicies_is_int64,
         replace_argmax_to_reducemax_and_indicies_is_float32=args.replace_argmax_to_reducemax_and_indicies_is_float32,
         replace_argmax_to_fused_argmax_and_indicies_is_int64=args.replace_argmax_to_fused_argmax_and_indicies_is_int64,

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -102,6 +102,9 @@ def make_node(
     alpha = graph_node.attrs.get('alpha', 1.0)
     beta = graph_node.attrs.get('beta', 1.0)
 
+    optimization_for_gpu_delegate: bool = \
+        kwargs['optimization_for_gpu_delegate']
+
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
@@ -170,7 +173,10 @@ def make_node(
         x = tf.cast(x, tf.float32)
         y = tf.cast(y, tf.float32)
         z = tf.cast(z, tf.float32)
-        result = alpha * tf.matmul(x, y) + beta * z
+        if not optimization_for_gpu_delegate:
+            result = alpha * tf.matmul(x, y) + beta * z
+        else:
+            result = alpha * tf.matmul(x, y) - (beta * z) * -1
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.cast(result, input_tensor_x_dtype)
 


### PR DESCRIPTION
### 1. Content and background
- Add `--optimization_for_gpu_delegate` option
- https://tfhub.dev/tensorflow/lite-model/mobilebert/1/metadata/1?lite-format=tflite
- GPU COMPATIBILITY WARNING: FullyConnected doesn't support more than 2 runtime inputs. 

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[I cannot run a transformer model with token-level output on accelerated hardware in TF Lite #59232](https://github.com/tensorflow/tensorflow/issues/59232)
[[MobileBERT] Add --optimization_for_gpu_delegate option #132](https://github.com/PINTO0309/onnx2tf/issues/132)