### PR TITLE
[Experimental] Avoid `MUL requires one tensor that not less than second in all dimensions.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.19
+  ghcr.io/pinto0309/onnx2tf:1.5.20
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.19'
+__version__ = '1.5.20'

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -17,6 +17,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
+    broadcast_for_gpu_delegate,
 )
 
 
@@ -87,6 +88,13 @@ def make_node(
     input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
+    )
+
+    # broadcast_for_gpu_delegate
+    input_tensor_1, input_tensor_2 = broadcast_for_gpu_delegate(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        **kwargs,
     )
 
     input_tensor_1, input_tensor_2 = explicit_broadcast(

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -90,13 +90,6 @@ def make_node(
         input_tensor_2=input_tensor_2,
     )
 
-    # broadcast_for_gpu_delegate
-    input_tensor_1, input_tensor_2 = broadcast_for_gpu_delegate(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        **kwargs,
-    )
-
     input_tensor_1, input_tensor_2 = explicit_broadcast(
         const_or_var_1=input_tensor_1,
         const_or_var_2=input_tensor_2,
@@ -114,6 +107,13 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+    )
+
+    # broadcast_for_gpu_delegate
+    input_tensor_1, input_tensor_2 = broadcast_for_gpu_delegate(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        **kwargs,
     )
 
     # Param replacement

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3165,7 +3165,7 @@ def broadcast_for_gpu_delegate(
                 tile_counts_part_list = list(tile_counts[-yshapes_rank:])
                 xshape_part_list = list(xshapes[-yshapes_rank:])
                 for axis, (xshape, yshape) in enumerate(zip(xshape_part_list, yshape_list)):
-                    if xshape is not None and yshape is not None and xshape < yshape:
+                    if xshape is not None and yshape is not None and xshape < yshape and xshape == 1:
                         tile_counts_part_list[axis] = yshape
                 tile_counts[-yshapes_rank:] = tile_counts_part_list
                 tiled_x = tf.tile(input_tensor_1, list(tile_counts)) * -1 * -1
@@ -3185,7 +3185,7 @@ def broadcast_for_gpu_delegate(
                 tile_counts_part_list = list(tile_counts[-xshapes_rank:])
                 yshape_part_list = list(yshapes[-xshapes_rank:])
                 for axis, (xshape, yshape) in enumerate(zip(xshape_list, yshape_part_list)):
-                    if xshape is not None and yshape is not None and xshape > yshape:
+                    if xshape is not None and yshape is not None and xshape > yshape and yshape == 1:
                         tile_counts_part_list[axis] = xshape
                 tile_counts[-xshapes_rank:] = tile_counts_part_list
                 tiled_y = tf.tile(input_tensor_2, list(tile_counts)) * -1 * -1

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3147,32 +3147,125 @@ def broadcast_for_gpu_delegate(
     yshapes = input_tensor_2.shape
     yshape_list = [int(dim) for dim in input_tensor_2.shape]
     yshapes_rank = len(yshape_list)
-    xshape_part_list = []
-    if xshapes_rank > 0 and yshapes_rank > 0:
-        if xshapes_rank > yshapes_rank:
-            tile_counts = np.asarray([1] * xshapes_rank, dtype=np.int64)
-            tile_counts_part_list = list(tile_counts)
-            tile_counts_part_list = list(tile_counts[-yshapes_rank:])
-            xshape_part_list = list(xshapes[-yshapes_rank:])
-            for axis, (xshape, yshape) in enumerate(zip(xshape_part_list, yshape_list)):
-                if xshape is not None and yshape is not None and xshape < yshape:
-                    tile_counts_part_list[axis] = yshape
-            tile_counts[-yshapes_rank:] = tile_counts_part_list
-            tiled_x = tf.tile(input_tensor_1, list(tile_counts))
-            return tiled_x, input_tensor_2
 
-        elif xshapes_rank < yshapes_rank:
-            tile_counts = np.asarray([1] * yshapes_rank, dtype=np.int64)
-            tile_counts_part_list = list(tile_counts)
-            tile_counts_part_list = list(tile_counts[-xshapes_rank:])
-            yshape_part_list = list(yshapes[-xshapes_rank:])
-            for axis, (xshape, yshape) in enumerate(zip(xshape_list, yshape_part_list)):
-                if xshape is not None and yshape is not None and xshape > yshape:
-                    tile_counts_part_list[axis] = xshape
-            tile_counts[-xshapes_rank:] = tile_counts_part_list
-            tiled_y = tf.tile(input_tensor_2, list(tile_counts))
-            return input_tensor_1, tiled_y
+    try:
+        if xshapes_rank > 0 and yshapes_rank > 0:
 
-        elif xshapes_rank == yshapes_rank:
-            pass
+            def x_tile(
+                *,
+                input_tensor_1,
+                input_tensor_2,
+                xshapes,
+                xshapes_rank,
+                yshapes_rank,
+                yshape_list,
+            ):
+                tile_counts = np.asarray([1] * xshapes_rank, dtype=np.int64)
+                tile_counts_part_list = list(tile_counts)
+                tile_counts_part_list = list(tile_counts[-yshapes_rank:])
+                xshape_part_list = list(xshapes[-yshapes_rank:])
+                for axis, (xshape, yshape) in enumerate(zip(xshape_part_list, yshape_list)):
+                    if xshape is not None and yshape is not None and xshape < yshape:
+                        tile_counts_part_list[axis] = yshape
+                tile_counts[-yshapes_rank:] = tile_counts_part_list
+                tiled_x = tf.tile(input_tensor_1, list(tile_counts)) * -1 * -1
+                return tiled_x, input_tensor_2
+
+            def y_tile(
+                *,
+                input_tensor_1,
+                input_tensor_2,
+                yshapes,
+                yshapes_rank,
+                xshapes_rank,
+                xshape_list,
+            ):
+                tile_counts = np.asarray([1] * yshapes_rank, dtype=np.int64)
+                tile_counts_part_list = list(tile_counts)
+                tile_counts_part_list = list(tile_counts[-xshapes_rank:])
+                yshape_part_list = list(yshapes[-xshapes_rank:])
+                for axis, (xshape, yshape) in enumerate(zip(xshape_list, yshape_part_list)):
+                    if xshape is not None and yshape is not None and xshape > yshape:
+                        tile_counts_part_list[axis] = xshape
+                tile_counts[-xshapes_rank:] = tile_counts_part_list
+                tiled_y = tf.tile(input_tensor_2, list(tile_counts)) * -1 * -1
+                return input_tensor_1, tiled_y
+
+            if xshapes_rank > yshapes_rank:
+                tiled_x, input_tensor_2 = x_tile(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                    xshapes=xshapes,
+                    xshapes_rank=xshapes_rank,
+                    yshapes_rank=yshapes_rank,
+                    yshape_list=yshape_list,
+                )
+                return tiled_x, input_tensor_2
+
+            elif xshapes_rank < yshapes_rank:
+                input_tensor_1, tiled_y =  y_tile(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                    yshapes=yshapes,
+                    yshapes_rank=yshapes_rank,
+                    xshapes_rank=xshapes_rank,
+                    xshape_list=xshape_list,
+                )
+                return tiled_y, input_tensor_1
+
+            elif xshapes_rank == yshapes_rank:
+                # 1. Compare xshape_list from the end to get the position where [-(n-1)] > [-n].
+                # 2. Compare yshape_list from the end to get the position where [-(n-1)] > [-n].
+                # 3. Tile the dimension for which [-(n-1)] > [-n] first holds.
+                x_mn2_large_mn1_index = -1
+                y_mn2_large_mn1_index = -1
+                for axis, dim in reversed(list(enumerate(xshape_list))):
+                    if dim is not None and dim > x_mn2_large_mn1_index:
+                        x_mn2_large_mn1_index = axis
+                for axis, dim in reversed(list(enumerate(yshape_list))):
+                    if dim is not None and dim > y_mn2_large_mn1_index:
+                        y_mn2_large_mn1_index = axis
+
+                if x_mn2_large_mn1_index == xshapes_rank - 1 and y_mn2_large_mn1_index == yshapes_rank - 1:
+                    return input_tensor_1, input_tensor_2
+                elif x_mn2_large_mn1_index != xshapes_rank - 1 and y_mn2_large_mn1_index == yshapes_rank - 1:
+                    tiled_x, input_tensor_2 = x_tile(
+                        input_tensor_1=input_tensor_1,
+                        input_tensor_2=input_tensor_2,
+                        xshapes=xshapes,
+                        xshapes_rank=xshapes_rank,
+                        yshapes_rank=yshapes_rank,
+                        yshape_list=yshape_list,
+                    )
+                    return tiled_x, input_tensor_2
+                elif x_mn2_large_mn1_index == xshapes_rank - 1 and y_mn2_large_mn1_index != yshapes_rank - 1:
+                    input_tensor_1, tiled_y =  y_tile(
+                        input_tensor_1=input_tensor_1,
+                        input_tensor_2=input_tensor_2,
+                        yshapes=yshapes,
+                        yshapes_rank=yshapes_rank,
+                        xshapes_rank=xshapes_rank,
+                        xshape_list=xshape_list,
+                    )
+                    return tiled_y, input_tensor_1
+                elif x_mn2_large_mn1_index != xshapes_rank - 1 and y_mn2_large_mn1_index != yshapes_rank - 1:
+                    tiled_x, input_tensor_2 = x_tile(
+                        input_tensor_1=input_tensor_1,
+                        input_tensor_2=input_tensor_2,
+                        xshapes=xshapes,
+                        xshapes_rank=xshapes_rank,
+                        yshapes_rank=yshapes_rank,
+                        yshape_list=yshape_list,
+                    )
+                    tiled_x, tiled_y = y_tile(
+                        input_tensor_1=tiled_x,
+                        input_tensor_2=input_tensor_2,
+                        yshapes=yshapes,
+                        yshapes_rank=yshapes_rank,
+                        xshapes_rank=xshapes_rank,
+                        xshape_list=xshape_list,
+                    )
+                    return tiled_x, tiled_y
+    except Exception as ex:
+        pass
     return input_tensor_1, input_tensor_2


### PR DESCRIPTION
### 1. Content and background
- GPU Delegate
  - [Experimental] Avoid `MUL requires one tensor that not less than second in all dimensions.`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[MobileBERT] Add --optimization_for_gpu_delegate option #132](https://github.com/PINTO0309/onnx2tf/issues/132)
[I cannot run a transformer model with token-level output on accelerated hardware in TF Lite #59232](https://github.com/tensorflow/tensorflow/issues/59232)