### PR TITLE
Tensors deleted from the TensorFlow model structure during the model optimization process are not comparable, so the status is rewritten to `Skipped`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.21
+  ghcr.io/pinto0309/onnx2tf:1.5.22
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.21'
+__version__ = '1.5.22'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3051,8 +3051,15 @@ def onnx_tf_tensor_validation(
                 else:
                     continue
                 break
-        check_results[onnx_output_name][1] = validate_result
-        check_results[onnx_output_name][2] = max_abs_err
+        if not validate_result and max_abs_err == ONNX_INF_INDEX_VALUE:
+            # Tensors deleted from the TensorFlow model structure during
+            # the model optimization process are not comparable,
+            # so the status is rewritten to Skip.
+            check_results[onnx_output_name][1] = 2
+            check_results[onnx_output_name][2] = max_abs_err
+        else:
+            check_results[onnx_output_name][1] = validate_result
+            check_results[onnx_output_name][2] = max_abs_err
     return check_results
 
 


### PR DESCRIPTION
### 1. Content and background
- Tensors deleted from the TensorFlow model structure during the model optimization process are not comparable, so the status is rewritten to `Skipped`.

- Before
  ![image](https://user-images.githubusercontent.com/33194443/213432580-206053b2-8a2b-4d44-aaa5-3aeee3d75444.png)
- After
  ![image](https://user-images.githubusercontent.com/33194443/213432473-dfa3452c-1058-4686-9996-5998b08a4e0a.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
