### PR TITLE
Improve processing of `Gather` to eliminate `tf.where`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.22
+  ghcr.io/pinto0309/onnx2tf:1.5.23
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.22'
+__version__ = '1.5.23'

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -69,8 +69,16 @@ def make_node(
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
 
+    optimization_for_gpu_delegate: bool = \
+        kwargs['optimization_for_gpu_delegate']
+
     # tensorflow gather supports only positive indices
-    indices = tf.cast(indices, tf.int64) + tf.cast(tf.where(indices < 0, 1, 0) * tf.shape(input_tensor)[axis], tf.int64)
+    if not optimization_for_gpu_delegate:
+        cond = tf.cast(indices < 0, dtype=indices.dtype)
+        indices = indices + tf.cast(cond * tf.shape(input_tensor)[axis], dtype=indices.dtype)
+    else:
+        cond = indices < 0
+        indices = indices + tf.cast(tf.where(cond, 1, 0) * tf.shape(input_tensor)[axis], dtype=indices.dtype)
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -75,10 +75,10 @@ def make_node(
     # tensorflow gather supports only positive indices
     if not optimization_for_gpu_delegate:
         cond = tf.cast(indices < 0, dtype=indices.dtype)
-        indices = tf.cast(indices + cond * tf.shape(input_tensor)[axis], dtype=tf.int64)
+        indices = tf.cast(indices + cond * tf.shape(input_tensor, out_type=indices.dtype)[axis], dtype=indices.dtype)
     else:
         cond = indices < 0
-        indices = indices + tf.cast(tf.where(cond, 1, 0) * tf.shape(input_tensor)[axis], dtype=indices.dtype)
+        indices = indices + tf.cast(tf.where(cond, 1, 0) * tf.shape(input_tensor, out_type=indices.dtype)[axis], dtype=indices.dtype)
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -75,7 +75,7 @@ def make_node(
     # tensorflow gather supports only positive indices
     if not optimization_for_gpu_delegate:
         cond = tf.cast(indices < 0, dtype=indices.dtype)
-        indices = indices + tf.cast(cond * tf.shape(input_tensor)[axis], dtype=indices.dtype)
+        indices = tf.cast(indices + cond * tf.shape(input_tensor)[axis], dtype=tf.int64)
     else:
         cond = indices < 0
         indices = indices + tf.cast(tf.where(cond, 1, 0) * tf.shape(input_tensor)[axis], dtype=indices.dtype)


### PR DESCRIPTION
### 1. Content and background
- Improve processing of `Gather` to eliminate `tf.where`

- Before
  ![image](https://user-images.githubusercontent.com/33194443/213472641-69624e23-bc36-442b-bcb6-8f14e7154625.png)
- After
  ![image](https://user-images.githubusercontent.com/33194443/213472313-cd6f9b4b-ff14-4b9d-8a76-c4c73bf59762.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[MobileBERT] Add --optimization_for_gpu_delegate option #132](https://github.com/PINTO0309/onnx2tf/issues/132)
[I cannot run a transformer model with token-level output on accelerated hardware in TF Lite #59232](https://github.com/tensorflow/tensorflow/issues/59232)