### PR TITLE
MaxPool padding insertion logic update

### DIFF
--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -123,23 +123,27 @@ def make_node(
 
         if auto_pad == 'SAME_LOWER':
             # switch the order of pads
-            tf_pads = [i for tup in zip(tf_pads[1::2], tf_pads[::2]) for i in tup]
+            tf_pads = [i for tup in zip(tf_pads[len(tf_pads) // 2:], tf_pads[:len(tf_pads) // 2]) for i in tup]
 
         if not count_include_pad:
             # if last step is smaller than kernel, it will be dropped
             last_step = [
                 (tensor_shape + p_begin + p_end - k) % s
                 for tensor_shape, p_begin, p_end, k, s
-                in zip(input_tensor_shape[1:-1], tf_pads[::2], tf_pads[1::2], kernel_shape, strides)
+                in zip(input_tensor_shape[1:-1],
+                       tf_pads[:len(tf_pads) // 2],
+                       tf_pads[len(tf_pads) // 2:],
+                       kernel_shape,
+                       strides)
             ]
-            average_multiplier_begin = [k / (k - p) for p, k in zip(tf_pads[::2], kernel_shape)]
+            average_multiplier_begin = [k / (k - p) for p, k in zip(tf_pads[:len(tf_pads) // 2], kernel_shape)]
             average_multiplier_end = [k / (k - (p - l)) if l < p else 1
-                                      for p, k, l in zip(tf_pads[1::2], kernel_shape, last_step)]
+                                      for p, k, l in zip(tf_pads[len(tf_pads) // 2:], kernel_shape, last_step)]
             average_multiplier = [i for tup in zip(average_multiplier_begin, average_multiplier_end) for i in tup]
 
         # convert to tensorflow padding format
         tf_pads = [[0, 0]] + \
-                  [list(i) for i in zip(tf_pads[::2], tf_pads[1::2])] + \
+                  [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
                   [[0, 0]]
 
         padded_tensor = tf.pad(
@@ -156,11 +160,15 @@ def make_node(
             last_step = [
                 (tensor_shape + p_begin + p_end - k) % s
                 for tensor_shape, p_begin, p_end, k, s
-                in zip(input_tensor_shape[1:-1], tf_pads[::2], tf_pads[1::2], kernel_shape, strides)
+                in zip(input_tensor_shape[1:-1],
+                       tf_pads[:len(tf_pads) // 2],
+                       tf_pads[len(tf_pads) // 2:],
+                       kernel_shape,
+                       strides)
             ]
-            average_multiplier_begin = [(k - p) / k for p, k in zip(tf_pads[::2], kernel_shape)]
+            average_multiplier_begin = [(k - p) / k for p, k in zip(tf_pads[:len(tf_pads) // 2], kernel_shape)]
             average_multiplier_end = [(k - (p - l)) / k if l < p else 1
-                                      for p, k, l in zip(tf_pads[1::2], kernel_shape, last_step)]
+                                      for p, k, l in zip(tf_pads[len(tf_pads) // 2:], kernel_shape, last_step)]
             average_multiplier = [i for tup in zip(average_multiplier_begin, average_multiplier_end) for i in tup]
 
     # Preserving Graph Structure (Dict)

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -222,19 +222,23 @@ def make_node(
                       f'https://github.com/PINTO0309/onnx2tf/issues/124'
         print(warning_msg)
 
-        padded_slice_begin = pooled_tensor[:, 0:1, ...] * average_multiplier[0]
-        padded_slice_end = pooled_tensor[:, -1:, ...] * average_multiplier[1]
-        pooled_tensor = tf.concat([padded_slice_begin, pooled_tensor[:, 1:-1, ...], padded_slice_end], axis=1)
+        if pooled_tensor.shape[1] >= 3:
+            padded_slice_begin = pooled_tensor[:, 0:1, ...] * average_multiplier[0]
+            padded_slice_body = pooled_tensor[:, 1:-1, ...]
+            padded_slice_end = pooled_tensor[:, -1:, ...] * average_multiplier[1]
+            pooled_tensor = tf.concat([padded_slice_begin, padded_slice_body, padded_slice_end], axis=1)
 
-        if len(kernel_shape) >= 2:
+        if len(kernel_shape) >= 2 and pooled_tensor.shape[2] >= 3:
             padded_slice_begin = pooled_tensor[:, :, 0:1, ...] * average_multiplier[2]
+            padded_slice_body = pooled_tensor[:, :, 1:-1, ...]
             padded_slice_end = pooled_tensor[:, :, -1:, ...] * average_multiplier[3]
-            pooled_tensor = tf.concat([padded_slice_begin, pooled_tensor[:, :, 1:-1, ...], padded_slice_end], axis=2)
+            pooled_tensor = tf.concat([padded_slice_begin, padded_slice_body, padded_slice_end], axis=2)
 
-        if len(kernel_shape) >= 3:
+        if len(kernel_shape) >= 3 and pooled_tensor.shape[3] >= 3:
             padded_slice_begin = pooled_tensor[:, :, :, 0:1, ...] * average_multiplier[4]
+            padded_slice_body = pooled_tensor[:, :, :, 1:-1, ...]
             padded_slice_end = pooled_tensor[:, :, :, -1:, ...] * average_multiplier[5]
-            pooled_tensor = tf.concat([padded_slice_begin, pooled_tensor[:, :, :, 1:-1, ...], padded_slice_end], axis=3)
+            pooled_tensor = tf.concat([padded_slice_begin, padded_slice_body, padded_slice_end], axis=3)
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = pooled_tensor
 

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -144,11 +144,11 @@ def make_node(
 
         if auto_pad == 'SAME_LOWER':
             # switch the order of pads
-            tf_pads = [i for tup in zip(tf_pads[1::2], tf_pads[::2]) for i in tup]
+            tf_pads = [i for tup in zip(tf_pads[len(tf_pads) // 2:], tf_pads[:len(tf_pads) // 2]) for i in tup]
 
         # convert to tensorflow padding format
         tf_pads = [[0, 0]] + \
-                  [list(i) for i in zip(tf_pads[::2], tf_pads[1::2])] + \
+                  [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
                   [[0, 0]]
 
         # explicit padding value should be negative infinite since this is max pooling

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -220,7 +220,13 @@ def make_node(
     # applying the strides and dilations. Then use tf.nn.pool with
     # strides = kernel_shape and no dilations
     else:
-        # TODO: dilated pool need fixed
+        # TODO: Dilated MaxPool with strides is broken for 3D and above, need to be fixed
+        if spatial_size >= 3:
+            error_msg = f'{Color.RED}ERROR:{Color.RESET} ' \
+                        f'Dilated MaxPool with strides is not supported for 3D and above for now. '
+            print(error_msg)
+            raise NotImplementedError(error_msg)
+
         input_tensor = remove_dilations(
             input_tensor=padded_tensor,
             kernel_shape=kernel_shape,

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -98,8 +98,12 @@ def make_node(
     tf_pad_mode = 'VALID'
     is_explicit_padding = False
     func = math.ceil if ceil_mode else math.floor
+    dilated_kernel_shape = kernel_shape
+    if dilations != [1] * spatial_size:
+        dilated_kernel_shape = [(k - 1) * d for k, d in zip(kernel_shape, dilations)]
+
     tf_pads = calc_tf_pooling_pads(input_shape=input_tensor_shape,
-                                   kernel=kernel_shape,
+                                   kernel=dilated_kernel_shape,
                                    strides=strides,
                                    func=func)
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1901,7 +1901,7 @@ def remove_dilations(
     strides,
     dilations,
 ):
-    input_shape = tf_shape(input_tensor)
+    input_shape = tf_shape(input_tensor=input_tensor)
     in_spatial_shape = input_shape[1:len(kernel_shape)+1]
     channels_count = input_shape[-1]
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3296,10 +3296,11 @@ def calc_tf_pooling_pads(input_shape, kernel, strides, func):
     Returns
     -------
     same_pads: List
-        onnx formatted padding, [x1_begin, x1_end, ... xn_begin, xn_end]
+        onnx formatted padding, [x1_begin, x2_begin, ..., xn_begin, x1_end, x2_end, ..., xn_end]
     """
 
     same_pads = []
+    same_pads_end = []
 
     # calculate how much padding is needed except batch and channel dimension
     for i, k, s in zip(input_shape[1:-1], kernel, strides):
@@ -3314,8 +3315,10 @@ def calc_tf_pooling_pads(input_shape, kernel, strides, func):
         same_pads.append(axis_pads // 2)
         # pads to end more for odd number padding
         if axis_pads % 2:
-            same_pads.append(axis_pads // 2 + 1)
+            same_pads_end.append(axis_pads // 2 + 1)
         else:
-            same_pads.append(axis_pads // 2)
+            same_pads_end.append(axis_pads // 2)
+
+    same_pads.extend(same_pads_end)
 
     return same_pads

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1916,7 +1916,7 @@ def remove_dilations(
         output_size = (
             ((in_spatial_shape[dim] - filter_size) // strides[dim]) + 1
         ) * kernel_shape[dim]
-        output_shape[dim + 2] = output_size
+        output_shape[dim + 1] = output_size
 
         # initialize the output dimension index with the range of the
         # dimension output size (e.g. 4): [0, 1, 2, 3]
@@ -1934,7 +1934,7 @@ def remove_dilations(
         # convert to column vector
         dim_ind = tf.expand_dims(dim_ind, 1)
 
-        if (dim == spatial_size - 1):
+        if dim == spatial_size - 1:
             gather_ind = dim_ind
         else:
             # "combine" current dimension indices with the previous dimensions
@@ -1949,15 +1949,15 @@ def remove_dilations(
     # m is the width.
 
     # set the channels count in the output_shape
-    output_shape[1] = channels_count
+    output_shape[-1] = channels_count
     # create the channel indices
     channel_ind = tf.range(channels_count, dtype=tf.int64)
     # convert to column vector
     channel_ind = tf.expand_dims(channel_ind, 1)
     # "combine" channel indices with the result from the loop
     gather_ind = tf_product(
-        a=channel_ind,
-        b=gather_ind,
+        a=gather_ind,
+        b=channel_ind,
     )
 
     # expand the dimensions to match the input dimensions + 1


### PR DESCRIPTION
### 1. Content and background

I used code below for validity test.
```python
import os
import shutil

import onnxruntime
import tensorflow as tf
import torch
import torchvision
from einops import rearrange
from torch import nn
import numpy as np
from onnx2tf import convert
import onnx_graphsurgeon as gs
import onnx


class dummy_network(nn.Module):

    def __init__(self, kernel=3, pad=1, dilation=1, stride=1):
        super(dummy_network, self).__init__()
        self.kernel = kernel
        self.pad = pad
        self.dilation = dilation
        self.stride = stride

    def forward(self, x):

        if len(x.shape) == 3:
            result = torch.nn.MaxPool1d(self.kernel, self.stride, self.pad, self.dilation)(x)

        elif len(x.shape) == 4:
            result = torch.nn.MaxPool2d(self.kernel, self.stride, self.pad, self.dilation)(x)

        else:
            result = torch.nn.MaxPool3d(self.kernel, self.stride, self.pad, self.dilation)(x)

        return result


def main():
    os.makedirs("tflite", exist_ok=True)

    dummy_name = "dummy_maxpool"
    onnx_save_path = f"tflite/{dummy_name}.onnx"
    temp_tflite = "tflite/model_float32.tflite"
    tflite_save_path = f"tflite/{dummy_name}.tflite"

    dummy_x = torch.randn(1, 32, 36, 24, dtype=torch.float32)
    np.random.seed(12)
    kernels = [np.random.randint(3, 8) for _ in range(30)]
    strides = [np.random.randint(2, k) for k in kernels]
    dilations = [np.random.randint(1, k / 2 + 1) for k in kernels]
    # dilations = [1 for k in kernels]
    paddings = [np.random.randint(0, k / 2) for k in kernels]

    for k, s, d, p in zip(kernels, strides, dilations, paddings):
        print("kernel, stride, dilation, padding : ", k, s, d, p)
        model = dummy_network(kernel=k, stride=s, dilation=d, pad=p)
        model.eval()

        torch.onnx.export(model,
                          args=(dummy_x, ),
                          f=onnx_save_path,
                          input_names=["x"],
                          output_names=["result"],
                          opset_version=11)

        # get onnx output
        # -----------------------------------------------------------------------------------------------
        onnx_session = onnxruntime.InferenceSession(onnx_save_path, providers=['CPUExecutionProvider'])
        onnx_inputs = dict(x=dummy_x.numpy())
        onnx_output = onnx_session.run(None, onnx_inputs)[0]

        convert(onnx_save_path, output_folder_path="tflite", check_onnx_tf_outputs_elementwise_close_full=True)
        shutil.move(temp_tflite, tflite_save_path)

        # get tflite output
        # -----------------------------------------------------------------------------------------------
        tflite_onnx2tf = tf.lite.Interpreter(model_path=tflite_save_path)
        tflite_onnx2tf.allocate_tensors()

        if len(dummy_x.shape) == 3:
            tflite_onnx2tf.set_tensor(tflite_onnx2tf.get_input_details()[0]['index'],
                                      rearrange(dummy_x.numpy(), "n c h -> n h c"))
        elif len(dummy_x.shape) == 4:
            tflite_onnx2tf.set_tensor(tflite_onnx2tf.get_input_details()[0]['index'],
                                      rearrange(dummy_x.numpy(), "n c h w -> n h w c"))
        elif len(dummy_x.shape) == 5:
            tflite_onnx2tf.set_tensor(tflite_onnx2tf.get_input_details()[0]['index'],
                                      rearrange(dummy_x.numpy(), "n c d h w -> n d h w c"))

        tflite_onnx2tf.invoke()
        tflite_output = [tflite_onnx2tf.get_tensor(i['index']) for i in tflite_onnx2tf.get_output_details()][0]

        if len(dummy_x.shape) == 3:
            tflite_output = rearrange(tflite_output, "n h c -> n c h")
        elif len(dummy_x.shape) == 4:
            tflite_output = rearrange(tflite_output, "n h w c -> n c h w")
        elif len(dummy_x.shape) == 5:
            tflite_output = rearrange(tflite_output, "n d h w c -> n c d h w")

        np.testing.assert_allclose(tflite_output, onnx_output, rtol=0.1, atol=1e-3)
        print("convert done")

    return


if __name__ == "__main__":
    main()

```


### 2. Summary of corrections

1. MaxPool padding insertion logic is updated same as AveragePool.
MaxPool has `dilation` option, which does not exist in AveragePool. This may occur some unexpected problem. At least error didn't occur in my test cases.

2. Dilated MaxPool 1D with strided fixed, 3D and above is disabled.
https://github.com/PINTO0309/onnx2tf/blob/794bd8699b55ea74c09411fd1d077448e02954aa/onnx2tf/ops/MaxPool.py#L229-L258
Dilated MaxPool with strided is processed in line number 229-258. I found out this logic is broken when I tried to convert corresponding onnx file as below.
![Screenshot from 2023-01-20 11-25-27](https://user-images.githubusercontent.com/34959032/213624323-a955f5cb-96dd-4e73-9530-bfa808cc2896.png)
For 1D MaxPool, it was able to fix easily. However, it didn't work well for 3D and above. So I disabled this part by raising `NotImplementedError` when 3D and above input is used.

3. ~~AveragePool count_include_pad logic fixed.~~
~~When the `count_include_pad` option was applied, the part that corrects the input was modified to form a cleaner graph.~~
This change is reverted to save memory since `tf.split` allocate extra memory to new sub tensors.

### 3. Before/After (If there is an operating log that can be used as a reference)

~~AveragePool Before~~ | ~~AveragePool After~~
----|----
<img src="https://user-images.githubusercontent.com/34959032/213624959-bc9d032c-79f9-49e2-b4d0-5f9f8050c80b.png" height="400"> | <img src="https://user-images.githubusercontent.com/34959032/213624969-e7bbb66f-cd0d-4c33-bc8b-e71be2774a8b.png" height="400">


### 4. Issue number (only if there is a related issue)
#124 