### PR TITLE
Fix `np.ndarray` of weights to be converted to tensor with `tf.convert_to_tensor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.24
+  ghcr.io/pinto0309/onnx2tf:1.5.25
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.24'
+__version__ = '1.5.25'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -458,7 +458,7 @@ def get_weights_constant_or_variable(
         """
         convertion_table = [i for i in range(2, kernel_size + 2)] + [1, 0]
         values = values.transpose(convertion_table)
-        return values
+        return tf.convert_to_tensor(values)
     elif hasattr(const_or_var, 'inputs') \
         and hasattr(const_or_var.inputs[0], 'attrs') \
         and 'value' in const_or_var.inputs[0].attrs \
@@ -482,7 +482,7 @@ def get_weights_constant_or_variable(
         values = values.transpose(convertion_table).astype(np.float32)
         if isinstance(values, np.ndarray) and values.dtype in (tf.int8, tf.uint8):
             values = values.astype(np.float32)
-        return values
+        return tf.convert_to_tensor(values)
     elif isinstance(const_or_var.i(), gs.Constant) \
         and hasattr(const_or_var.i(), 'values'):
         values = const_or_var.i().values
@@ -504,7 +504,7 @@ def get_weights_constant_or_variable(
         values = values.transpose(convertion_table).astype(np.float32)
         if isinstance(values, np.ndarray) and values.dtype in (tf.int8, tf.uint8):
             values = values.astype(np.float32)
-        return values
+        return tf.convert_to_tensor(values)
     else:
         return const_or_var
 


### PR DESCRIPTION
### 1. Content and background
- Fix `np.ndarray` of weights to be converted to tensor with `tf.convert_to_tensor`
  - This modification significantly reduces the size bloat of the generated `saved_model` Protocol Buffer file.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
