### PR TITLE
Improved full validation algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.26
+  ghcr.io/pinto0309/onnx2tf:1.5.27
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.26'
+__version__ = '1.5.27'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1182,7 +1182,7 @@ def convert(
                 {
                     onnx_output_name: [
                         onnx_tensor,
-                        matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped
+                        matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
                         max_abs_err,
                     ]
                 }
@@ -1210,7 +1210,7 @@ def convert(
                 elif matched_flg == 2:
                     message = \
                         f'{Color.GREEN}validate_result{Color.RESET}: ' +\
-                        f'{Color.REVERCE}{Color.BLUE} Skipped {Color.RESET}'
+                        f'{Color.REVERCE}{Color.BLUE} Skipped (Deleted or Shape Unmatched) {Color.RESET}'
                 print(
                     f'{Color.GREEN}INFO:{Color.RESET} '+
                     f'{Color.GREEN}onnx_output_name{Color.RESET}: {onnx_output_name} '+

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2937,7 +2937,7 @@ def dummy_tf_inference(
 def onnx_tf_tensor_validation(
     *,
     onnx_tensor_infos: Dict[str, np.ndarray],
-    tf_tensors: List[np.ndarray],
+    tf_tensor_infos:  Dict[str, np.ndarray],
     rtol: float=1e-05,
     atol: float=1e-05,
 ) -> Dict[str, List]:
@@ -2983,75 +2983,71 @@ def onnx_tf_tensor_validation(
         onnx_output_name: [onnx_tensor, False, 0.0] \
             for onnx_output_name, onnx_tensor in onnx_tensor_infos.items()
     }
-    tf_check_skip_flag = [False] * len(tf_tensors)
+
     for onnx_output_name, onnx_check_info in check_results.items():
         onnx_tensor: np.ndarray = onnx_check_info[0] # onnx_tensor
+        tf_tensor: np.ndarray = tf_tensor_infos[onnx_output_name] # tf_tensor
         onnx_tensor_shape = onnx_tensor.shape
         max_abs_err = ONNX_INF_INDEX_VALUE
-        validate_result = False
-        for tf_idx, tf_tensor in enumerate(tf_tensors):
-            """
-            onnx_dummy_data: np.random.random_sample([1,3,224,224])
-            tf_dummy_data  : onnx_dummy_data.transpose([0,2,3,1]), len(tf_tensor.shape) == 4
+        """
+        onnx_dummy_data: np.random.random_sample([1,3,224,224])
+        tf_dummy_data  : onnx_dummy_data.transpose([0,2,3,1]), len(tf_tensor.shape) == 4
 
-            tf_shape_transpose_perms:
+        tf_shape_transpose_perms:
+            [
+                (0, 1, 2, 3), (0, 1, 3, 2), (0, 2, 1, 3), (0, 2, 3, 1), (0, 3, 1, 2),
+                (0, 3, 2, 1), (1, 0, 2, 3), (1, 0, 3, 2), (1, 2, 0, 3), (1, 2, 3, 0),
+                (1, 3, 0, 2), (1, 3, 2, 0), (2, 0, 1, 3), (2, 0, 3, 1), (2, 1, 0, 3),
+                (2, 1, 3, 0), (2, 3, 0, 1), (2, 3, 1, 0), (3, 0, 1, 2), (3, 0, 2, 1),
+                (3, 1, 0, 2), (3, 1, 2, 0), (3, 2, 0, 1), (3, 2, 1, 0)
+            ]
+
+        tf_target_transpose_perms:
+            [(0, 3, 1, 2), (0, 3, 2, 1)]
+        """
+        tf_shape_transpose_perms = list(itertools.permutations(range(len(tf_tensor.shape))))
+        tf_target_transpose_perms = [
+            tf_shape_transpose_perm \
+                for tf_shape_transpose_perm in tf_shape_transpose_perms \
+                    if tf_tensor.transpose(tf_shape_transpose_perm).shape == onnx_tensor_shape
+        ]
+        # Validation
+        """
+        tf_check_infos:
+            {
                 [
-                    (0, 1, 2, 3), (0, 1, 3, 2), (0, 2, 1, 3), (0, 2, 3, 1), (0, 3, 1, 2),
-                    (0, 3, 2, 1), (1, 0, 2, 3), (1, 0, 3, 2), (1, 2, 0, 3), (1, 2, 3, 0),
-                    (1, 3, 0, 2), (1, 3, 2, 0), (2, 0, 1, 3), (2, 0, 3, 1), (2, 1, 0, 3),
-                    (2, 1, 3, 0), (2, 3, 0, 1), (2, 3, 1, 0), (3, 0, 1, 2), (3, 0, 2, 1),
-                    (3, 1, 0, 2), (3, 1, 2, 0), (3, 2, 0, 1), (3, 2, 1, 0)
+                    tf_target_transpose_perm, <--- tf_target_transpose_perms[idx]
+                    matched_flg, <--- True: Matched, False: Unmatched
                 ]
-
-            tf_target_transpose_perms:
-                [(0, 3, 1, 2), (0, 3, 2, 1)]
-            """
-            if not tf_check_skip_flag[tf_idx]:
-                tf_shape_transpose_perms = list(itertools.permutations(range(len(tf_tensor.shape))))
-                tf_target_transpose_perms = [
-                    tf_shape_transpose_perm \
-                        for tf_shape_transpose_perm in tf_shape_transpose_perms \
-                            if tf_tensor.transpose(tf_shape_transpose_perm).shape == onnx_tensor_shape
-                ]
-                # Validation
-                """
-                tf_check_infos:
-                    {
-                        [
-                            tf_target_transpose_perm, <--- tf_target_transpose_perms[idx]
-                            matched_flg, <--- True: Matched, False: Unmatched
-                        ]
-                    }
-                """
-                tf_check_infos = [
-                    [tf_target_transpose_perm, 0] for tf_target_transpose_perm in tf_target_transpose_perms
-                ]
-                for tf_check_info in tf_check_infos:
-                    if len(onnx_tensor_shape) > 1:
-                        tf_transposed_tensor = tf_tensor.transpose(tf_check_info[0])
-                        if np.allclose(a=onnx_tensor, b=tf_transposed_tensor, rtol=rtol, atol=atol, equal_nan=True):
-                            # Matched
-                            tf_check_info[1] = 1
-                            tf_check_skip_flag[tf_idx] = True
-                            max_abs_err = 0.0
-                            break
-                        else:
-                            # Unmatched
-                            if onnx_tensor.shape == tf_transposed_tensor.shape:
-                                error_value = np.max(np.abs(onnx_tensor - tf_transposed_tensor))
-                                max_abs_err = error_value if error_value < max_abs_err else max_abs_err
-                    else:
-                        tf_check_info[1] = 2
-                        max_abs_err = 0.0
-
-                # Validation results check
-                for tf_check_info in tf_check_infos:
-                    if tf_check_info[1]:
-                        validate_result = tf_check_info[1]
-                        break
+            }
+        """
+        validate_result = False
+        tf_check_infos = [
+            [tf_target_transpose_perm, 0] for tf_target_transpose_perm in tf_target_transpose_perms
+        ]
+        for tf_check_info in tf_check_infos:
+            if len(onnx_tensor_shape) > 1:
+                tf_transposed_tensor = tf_tensor.transpose(tf_check_info[0])
+                if np.allclose(a=onnx_tensor, b=tf_transposed_tensor, rtol=rtol, atol=atol, equal_nan=True):
+                    # Matched
+                    tf_check_info[1] = 1
+                    max_abs_err = 0.0
+                    break
                 else:
-                    continue
+                    # Unmatched
+                    if onnx_tensor.shape == tf_transposed_tensor.shape:
+                        error_value = np.max(np.abs(onnx_tensor - tf_transposed_tensor))
+                        max_abs_err = error_value if error_value < max_abs_err else max_abs_err
+            else:
+                tf_check_info[1] = 2
+                max_abs_err = 0.0
+
+        # Validation results check
+        for tf_check_info in tf_check_infos:
+            if tf_check_info[1]:
+                validate_result = tf_check_info[1]
                 break
+
         if not validate_result and max_abs_err == ONNX_INF_INDEX_VALUE:
             # Tensors deleted from the TensorFlow model structure during
             # the model optimization process are not comparable,
@@ -3061,6 +3057,7 @@ def onnx_tf_tensor_validation(
         else:
             check_results[onnx_output_name][1] = validate_result
             check_results[onnx_output_name][2] = max_abs_err
+
     return check_results
 
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2974,7 +2974,7 @@ def onnx_tf_tensor_validation(
         {
             onnx_output_name: [
                 onnx_tensor,
-                matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped,
+                matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched),
                 max_abs_err,
             ]
         }
@@ -3052,6 +3052,7 @@ def onnx_tf_tensor_validation(
             # Tensors deleted from the TensorFlow model structure during
             # the model optimization process are not comparable,
             # so the status is rewritten to Skip.
+            # If there was no match between ONNX and TensorFlow output shapes.
             check_results[onnx_output_name][1] = 2
             check_results[onnx_output_name][2] = max_abs_err
         else:


### PR DESCRIPTION
### 1. Content and background
1. Improved full validation algorithm
2. Problem solved where validation could fail for a sequence of tensors of the same shape.
3. Validation speed is now approximately five times faster. 
4. The more complex the structure of the model, the greater the improvement in validation speed.
5. When converting `pidnet_S_cityscapes_192x320.onnx`, I noticed that the output size of `AveragePool` is different between ONNX and TensorFlow, but I will separate the correspondence from this pull request. Maybe this pull request will improve it. [MaxPool padding insertion logic update #138](https://github.com/PINTO0309/onnx2tf/pull/138)
```
INFO: onnx_op_type: AveragePool onnx_op_name: /spp/scale2/scale2.0/AveragePool
INFO:  input_name.1: /layer5/layer5.1/Add_output_0 shape: [1, 512, 3, 5] dtype: float32
INFO:  output_name.1: /spp/scale2/scale2.0/AveragePool_output_0 shape: [1, 512, 1, 2] dtype: float32
INFO: tf_op_type: AveragePooling2D
INFO:  input.1.x: name: tf.math.add_81/Add:0 shape: (1, 3, 5, 512) dtype: <dtype: 'float32'> 
INFO:  input.2.pool_size: val: [9, 9] 
INFO:  input.3.strides: val: [4, 4] 
INFO:  input.4.padding: val: [[0, 0], [4, 4], [4, 4], [0, 0]] 
INFO:  output.1.output: name: tf.concat_1/concat:0 shape: (1, 2, 2, 512) dtype: <dtype: 'float32'> 
```
6. Changed `Skipped` indication to `Skipped (Deleted or Shape Unmatched)`.
  ![image](https://user-images.githubusercontent.com/33194443/213901853-45ca42aa-5513-4876-891e-711f93b492fa.png)

- sample
  ```
  onnx2tf -i pidnet_S_cityscapes_192x320.onnx -cotof -cotoa 1e-4
  ```
- Before
  ![image](https://user-images.githubusercontent.com/33194443/213900647-2fb3c0a2-d3f2-44ee-b715-a562e5ca34f9.png)
- After
  ![image](https://user-images.githubusercontent.com/33194443/213901953-4f40897b-81e4-43e0-8d11-898d7f92b6f6.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Bug in onnx_tf_tensor_validation #139](https://github.com/PINTO0309/onnx2tf/issues/139)