### PR TITLE
Corrected the decision condition to enable `DepthwiseConv2D`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.27
+  ghcr.io/pinto0309/onnx2tf:1.5.28
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.27'
+__version__ = '1.5.28'

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -137,7 +137,18 @@ def make_node(
         assert False, error_msg
 
 
-    depthwise = (input_tensor_rank == 4 and len(input_weights_shape) == 4 and group != 1 and not (None in input_weights_shape))
+    # DepthwiseConv2D
+    #   1. rank=4
+    #   2. group>1
+    #   3. No undefined dimension
+    #   4. All strides spatial shape are the same number
+    depthwise = (
+        input_tensor_rank == 4 \
+        and len(input_weights_shape) == 4 \
+        and group != 1 \
+        and not (None in input_weights_shape) \
+        and sum([1 if s == strides[0] else 0 for s in strides]) == len(strides)
+    )
     if depthwise and input_tensor_shape[-1] != None:
         depthwise = bool(group == input_tensor_shape[-1])
 


### PR DESCRIPTION
### 1. Content and background
- Corrected the decision condition to enable `DepthwiseConv2D`
- [[japan_PP-OCRv3] For min_value and max_value in Clip.py #14](https://github.com/PINTO0309/onnx2tf/issues/14)
- [japan_PP-OCRv3_rec_infer.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/10474146/japan_PP-OCRv3_rec_infer.onnx.zip)

Solves the problem of TensorFlow runtime abort during inference when `DepthwiseConv2D` is generated with different values of strides in the row and column directions, such as `[1,2]` or `[2,1]` strides. `DepthwiseConv2D` seems to work correctly only when all strides have the same value. In this case, `GroupConvolution` is generated. 
![image](https://user-images.githubusercontent.com/33194443/213910894-a8b96c83-c2dd-480d-bfe0-abacd7fd5cee.png)

- e.g. TensorFlow (Keras) - `DepthwiseConv2D` error message
```
Current implementation only supports equal length strides in the row and column dimensions. [Op:DepthwiseConv2dNative]

Call arguments received by layer "tf.compat.v1.nn.depthwise_conv2d_3" "                 f"(type TFOpLambda):
  • input=tf.Tensor(shape=(3, 18, 82, 64), dtype=float32)
  • filter=tf.Tensor(shape=(3, 3, 64, 1), dtype=float32)
  • strides=['1', '2', '1', '1']
  • padding='VALID'
  • rate=['1', '1']
  • name=None
  • data_format=None
  • dilations=None
```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
