### PR TITLE
Fixed to generate a tflite file with the same name as the input onnx file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.28
+  ghcr.io/pinto0309/onnx2tf:1.5.29
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.28'
+__version__ = '1.5.29'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -425,6 +425,15 @@ def convert(
         )
         sys.exit(1)
 
+    # Extracting onnx filenames
+    output_file_name = ''
+    if input_onnx_file_path:
+        output_file_name = os.path.splitext(
+            os.path.basename(input_onnx_file_path)
+        )[0]
+    else:
+        output_file_name = 'model'
+
     # batch_size
     if batch_size is not None and batch_size <= 0:
         print(
@@ -732,7 +741,7 @@ def convert(
         if output_h5:
             if not non_verbose:
                 print(f'{Color.REVERCE}h5 output started{Color.RESET}', '=' * 67)
-            model.save(f'{output_folder_path}/model_float32.h5')
+            model.save(f'{output_folder_path}/{output_file_name}_float32.h5')
             if not non_verbose:
                 print(f'{Color.GREEN}h5 output complete!{Color.RESET}')
 
@@ -801,12 +810,12 @@ def convert(
         ]
         converter._experimental_disable_batchmatmul_unfold = not enable_batchmatmul_unfold
         tflite_model = converter.convert()
-        with open(f'{output_folder_path}/model_float32.tflite', 'wb') as w:
+        with open(f'{output_folder_path}/{output_file_name}_float32.tflite', 'wb') as w:
             w.write(tflite_model)
         if output_weights:
             weights_export(
-                extract_target_tflite_file_path=f'{output_folder_path}/model_float32.tflite',
-                output_weights_file_path=f'{output_folder_path}/model_float32_weights.h5',
+                extract_target_tflite_file_path=f'{output_folder_path}/{output_file_name}_float32.tflite',
+                output_weights_file_path=f'{output_folder_path}/{output_file_name}_float32_weights.h5',
             )
         if not non_verbose:
             print(f'{Color.GREEN}Float32 tflite output complete!{Color.RESET}')
@@ -818,12 +827,12 @@ def convert(
             tf.lite.OpsSet.SELECT_TF_OPS,
         ]
         tflite_model = converter.convert()
-        with open(f'{output_folder_path}/model_float16.tflite', 'wb') as w:
+        with open(f'{output_folder_path}/{output_file_name}_float16.tflite', 'wb') as w:
             w.write(tflite_model)
         if output_weights:
             weights_export(
-                extract_target_tflite_file_path=f'{output_folder_path}/model_float16.tflite',
-                output_weights_file_path=f'{output_folder_path}/model_float16_weights.h5',
+                extract_target_tflite_file_path=f'{output_folder_path}/{output_file_name}_float16.tflite',
+                output_weights_file_path=f'{output_folder_path}/{output_file_name}_float16_weights.h5',
             )
         if not non_verbose:
             print(f'{Color.GREEN}Float16 tflite output complete!{Color.RESET}')
@@ -861,12 +870,12 @@ def convert(
                 converter._experimental_disable_per_channel = disable_per_channel
                 converter._experimental_disable_batchmatmul_unfold = not enable_batchmatmul_unfold
                 tflite_model = converter.convert()
-                with open(f'{output_folder_path}/model_dynamic_range_quant.tflite', 'wb') as w:
+                with open(f'{output_folder_path}/{output_file_name}_dynamic_range_quant.tflite', 'wb') as w:
                     w.write(tflite_model)
                 if output_weights:
                     weights_export(
-                        extract_target_tflite_file_path=f'{output_folder_path}/model_dynamic_range_quant.tflite',
-                        output_weights_file_path=f'{output_folder_path}/model_dynamic_range_quant_weights.h5',
+                        extract_target_tflite_file_path=f'{output_folder_path}/{output_file_name}_dynamic_range_quant.tflite',
+                        output_weights_file_path=f'{output_folder_path}/{output_file_name}_dynamic_range_quant_weights.h5',
                     )
                 if not non_verbose:
                     print(f'{Color.GREEN}Dynamic Range Quantization tflite output complete!{Color.RESET}')
@@ -942,12 +951,12 @@ def convert(
                 converter._experimental_disable_batchmatmul_unfold = not enable_batchmatmul_unfold
                 converter.representative_dataset = representative_dataset_gen
                 tflite_model = converter.convert()
-                with open(f'{output_folder_path}/model_integer_quant.tflite', 'wb') as w:
+                with open(f'{output_folder_path}/{output_file_name}_integer_quant.tflite', 'wb') as w:
                     w.write(tflite_model)
                 if output_weights:
                     weights_export(
-                        extract_target_tflite_file_path=f'{output_folder_path}/model_integer_quant.tflite',
-                        output_weights_file_path=f'{output_folder_path}/model_integer_quant_weights.h5',
+                        extract_target_tflite_file_path=f'{output_folder_path}/{output_file_name}_integer_quant.tflite',
+                        output_weights_file_path=f'{output_folder_path}/{output_file_name}_integer_quant_weights.h5',
                     )
                 if not non_verbose:
                     print(f'{Color.GREEN}INT8 Quantization tflite output complete!{Color.RESET}')
@@ -971,12 +980,12 @@ def convert(
                 converter.inference_input_type = inf_type
                 converter.inference_output_type = inf_type
                 tflite_model = converter.convert()
-                with open(f'{output_folder_path}/model_full_integer_quant.tflite', 'wb') as w:
+                with open(f'{output_folder_path}/{output_file_name}_full_integer_quant.tflite', 'wb') as w:
                     w.write(tflite_model)
                 if output_weights:
                     weights_export(
-                        extract_target_tflite_file_path=f'{output_folder_path}/model_full_integer_quant.tflite',
-                        output_weights_file_path=f'{output_folder_path}/model_full_integer_quant_weights.h5',
+                        extract_target_tflite_file_path=f'{output_folder_path}/{output_file_name}_full_integer_quant.tflite',
+                        output_weights_file_path=f'{output_folder_path}/{output_file_name}_full_integer_quant_weights.h5',
                     )
                 if not non_verbose:
                     print(f'{Color.GREEN}Full INT8 Quantization tflite output complete!{Color.RESET}')
@@ -1003,7 +1012,7 @@ def convert(
                 converter.inference_input_type = tf.float32
                 converter.inference_output_type = tf.float32
                 tflite_model = converter.convert()
-                with open(f'{output_folder_path}/model_integer_quant_with_int16_act.tflite', 'wb') as w:
+                with open(f'{output_folder_path}/{output_file_name}_integer_quant_with_int16_act.tflite', 'wb') as w:
                     w.write(tflite_model)
                 if not non_verbose:
                     print(f'{Color.GREEN}INT8 Quantization with int16 activations tflite output complete!{Color.RESET}')
@@ -1030,7 +1039,7 @@ def convert(
                 converter.inference_input_type = tf.int16
                 converter.inference_output_type = tf.int16
                 tflite_model = converter.convert()
-                with open(f'{output_folder_path}/model_full_integer_quant_with_int16_act.tflite', 'wb') as w:
+                with open(f'{output_folder_path}/{output_file_name}_full_integer_quant_with_int16_act.tflite', 'wb') as w:
                     w.write(tflite_model)
                 if not non_verbose:
                     print(f'{Color.GREEN}Full INT8 Quantization with int16 activations tflite output complete!{Color.RESET}')


### PR DESCRIPTION
### 1. Content and background
- Fixed to generate a tflite file with the same name as the input onnx file
  ![image](https://user-images.githubusercontent.com/33194443/213948279-d620fa86-ef5f-4709-83e8-492931a0a37c.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
