### PR TITLE
Fixed Abort problem on Keras (.h5) output when using `np.dtype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.29
+  ghcr.io/pinto0309/onnx2tf:1.5.30
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.29'
+__version__ = '1.5.30'

--- a/onnx2tf/ops/ArgMax.py
+++ b/onnx2tf/ops/ArgMax.py
@@ -16,6 +16,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -114,7 +115,8 @@ def make_node(
         argmaxed_tensor = tf.math.argmax(
             input=reversed_tensor,
             axis=axis,
-            output_type=dtype,
+            output_type=NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+                if isinstance(dtype, np.dtype) else dtype,
             name=f'{graph_node.name}_argmax',
         )
         if keepdims:
@@ -146,7 +148,8 @@ def make_node(
             input_tensor=reversed_tensor,
             original_shape=graph_node.inputs[0].shape,
             axis=axis,
-            output_type=dtype,
+            output_type=NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+                if isinstance(dtype, np.dtype) else dtype,
             keepdims=keepdims,
             replace_argmax_to_fused_argmax_and_indicies_is_int64=replace_argmax_to_fused_argmax_and_indicies_is_int64,
             replace_argmax_to_fused_argmax_and_indicies_is_float32=replace_argmax_to_fused_argmax_and_indicies_is_float32,
@@ -156,7 +159,8 @@ def make_node(
         argmaxed_tensor = tf.math.argmax(
             input=reversed_tensor,
             axis=axis,
-            output_type=dtype,
+            output_type=NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+                if isinstance(dtype, np.dtype) else dtype,
             name=f'{graph_node.name}_argmax',
         )
         if keepdims:

--- a/onnx2tf/ops/ArgMin.py
+++ b/onnx2tf/ops/ArgMin.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -96,7 +97,8 @@ def make_node(
     argmined_tensor = tf.math.argmin(
         input=reversed_tensor,
         axis=axis,
-        output_type=dtype,
+        output_type=NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+            if isinstance(dtype, np.dtype) else dtype,
         name=f'{graph_node.name}_argmin',
     )
     if keepdims:

--- a/onnx2tf/ops/Clip.py
+++ b/onnx2tf/ops/Clip.py
@@ -136,8 +136,8 @@ def make_node(
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.clip_by_value(
                     t=features,
-                    clip_value_min=min_value,
-                    clip_value_max=max_value,
+                    clip_value_min=tf.convert_to_tensor(min_value),
+                    clip_value_max=tf.convert_to_tensor(max_value),
                 )
             tf_op_type = tf.clip_by_value
         elif (isinstance(min_value, np.ndarray) and min_value.shape is not None) \
@@ -145,7 +145,7 @@ def make_node(
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.maximum(
                     x=features,
-                    y=min_value,
+                    y=tf.convert_to_tensor(min_value),
                 )
             tf_op_type = tf.maximum
         elif (min_value is None or min_value.shape is None) \
@@ -153,7 +153,7 @@ def make_node(
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.minimum(
                     x=features,
-                    y=max_value,
+                    y=tf.convert_to_tensor(max_value),
                 )
             tf_op_type = tf.minimum
 

--- a/onnx2tf/ops/Clip.py
+++ b/onnx2tf/ops/Clip.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -120,6 +121,8 @@ def make_node(
         max_value = np.asarray([max_value])
 
     tf_op_type = None
+    features_dtype = NUMPY_DTYPES_TO_TF_DTYPES[features.dtype] \
+        if isinstance(features.dtype, np.dtype) else features.dtype
     if (isinstance(min_value, np.ndarray) or isinstance(min_value, float)) and min_value == 0.0 \
         and (isinstance(max_value, np.ndarray)  or isinstance(max_value, float)) and max_value == 6.0:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -136,8 +139,10 @@ def make_node(
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.clip_by_value(
                     t=features,
-                    clip_value_min=tf.convert_to_tensor(min_value),
-                    clip_value_max=tf.convert_to_tensor(max_value),
+                    clip_value_min=tf.convert_to_tensor(min_value, dtype=features_dtype) \
+                        if isinstance(min_value, np.ndarray) else min_value,
+                    clip_value_max=tf.convert_to_tensor(max_value, dtype=features_dtype) \
+                        if isinstance(max_value, np.ndarray) else max_value,
                 )
             tf_op_type = tf.clip_by_value
         elif (isinstance(min_value, np.ndarray) and min_value.shape is not None) \
@@ -145,7 +150,8 @@ def make_node(
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.maximum(
                     x=features,
-                    y=tf.convert_to_tensor(min_value),
+                    y=tf.convert_to_tensor(min_value, dtype=features_dtype) \
+                        if isinstance(min_value, np.ndarray) else min_value,
                 )
             tf_op_type = tf.maximum
         elif (min_value is None or min_value.shape is None) \
@@ -153,7 +159,8 @@ def make_node(
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.minimum(
                     x=features,
-                    y=tf.convert_to_tensor(max_value),
+                    y=tf.convert_to_tensor(max_value, dtype=features_dtype) \
+                        if isinstance(max_value, np.ndarray) else max_value,
                 )
             tf_op_type = tf.minimum
 

--- a/onnx2tf/ops/Constant.py
+++ b/onnx2tf/ops/Constant.py
@@ -5,10 +5,7 @@ np.random.seed(0)
 import tensorflow as tf
 from onnx import numpy_helper
 import onnx_graphsurgeon as gs
-from onnx2tf.utils.enums import (
-    ONNX_DTYPES_TO_TF_DTYPES,
-    NUMPY_DTYPES_TO_TF_DTYPES,
-)
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 from onnx2tf.utils.common_functions import (
     print_node_info,
     make_tf_node_info,

--- a/onnx2tf/ops/EyeLike.py
+++ b/onnx2tf/ops/EyeLike.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -71,6 +72,9 @@ def make_node(
         'dtype': dtype,
     }
 
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+        if isinstance(dtype, np.dtype) else dtype
+
     # Generation of TF OP
     if None not in input_tensor_shape:
         max_eye_shape_ub = input_tensor_shape[1] \
@@ -84,7 +88,7 @@ def make_node(
         tensor = tf.eye(
             eye_shape,
             num_columns=eye_shape,
-            dtype=dtype,
+            dtype=output_dtype,
         )
         if offset > 0:
             tb_paddings = [
@@ -129,7 +133,7 @@ def make_node(
             tensor = tf.eye(
                 eye_shape,
                 num_columns=eye_shape,
-                dtype=dtype,
+                dtype=output_dtype,
             )
             if offset > 0:
                 tb_paddings = [

--- a/onnx2tf/ops/GatherND.py
+++ b/onnx2tf/ops/GatherND.py
@@ -17,6 +17,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
 )
 from onnx2tf.utils.colors import Color
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -134,7 +135,11 @@ def make_node(
         )
         mul = tf.math.multiply(
             indices_tensor,
-            tf.cast(axis_step, dtype=indices_tensor.dtype),
+            tf.cast(
+                axis_step,
+                dtype= NUMPY_DTYPES_TO_TF_DTYPES[indices_tensor.dtype] \
+                    if isinstance(indices_tensor.dtype, np.dtype) else indices_tensor.dtype,
+            ),
         )
         indices_flat = tf.reduce_sum(
             mul,

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -87,7 +88,8 @@ def make_node(
         **kwargs,
     )
 
-    input_tensor_x_dtype = x.dtype
+    input_tensor_x_dtype = NUMPY_DTYPES_TO_TF_DTYPES[x.dtype] \
+        if isinstance(x.dtype, np.dtype) else x.dtype
     x = tf.keras.layers.Flatten()(x)
     # The Flatten API changes data type from tf.float64 to tf.float32
     # so we need the following line to get the original type back

--- a/onnx2tf/ops/Hardmax.py
+++ b/onnx2tf/ops/Hardmax.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -121,7 +122,8 @@ def make_node(
             axis=-1,
         ),
         depth=depth,
-        dtype=x.dtype,
+        dtype=NUMPY_DTYPES_TO_TF_DTYPES[x.dtype] \
+            if isinstance(x.dtype, np.dtype) else x.dtype,
         name=graph_node.name,
     )
 

--- a/onnx2tf/ops/If.py
+++ b/onnx2tf/ops/If.py
@@ -86,7 +86,8 @@ def make_node(
             tf_layers_dict[output.name]['tf_node'] = \
                 tf.constant(
                     output.values,
-                    dtype=NUMPY_DTYPES_TO_TF_DTYPES[output.values.dtype],
+                    dtype=NUMPY_DTYPES_TO_TF_DTYPES[output.values.dtype] \
+                        if isinstance(output.values.dtype, np.dtype) else output.values.dtype,
                 )
     then_branch_ops = []
     for then_branch_graph_output in then_branch_graph_outputs:
@@ -127,7 +128,8 @@ def make_node(
             tf_layers_dict[output.name]['tf_node'] = \
                 tf.constant(
                     output.values,
-                    dtype=NUMPY_DTYPES_TO_TF_DTYPES[output.values.dtype],
+                    dtype=NUMPY_DTYPES_TO_TF_DTYPES[output.values.dtype] \
+                        if isinstance(output.values.dtype, np.dtype) else output.values.dtype,
                 )
     else_branch_ops = []
     for else_branch_graph_output in else_branch_graph_outputs:

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -82,12 +83,15 @@ def make_node(
         **kwargs,
     )
 
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+        if isinstance(dtype, np.dtype) else dtype
+
     try:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.matmul(
                 a=input_tensor_1,
                 b=input_tensor_2,
-                output_type=dtype,
+                output_type=output_dtype,
                 name=graph_node.name,
             )
     except Exception as ex1:
@@ -102,7 +106,7 @@ def make_node(
                         tf.matmul(
                             a=tf.transpose(a=input_tensor_1, perm=tensor_1_candidate_for_transposition),
                             b=tf.transpose(a=input_tensor_2, perm=tensor_2_candidate_for_transposition),
-                            output_type=dtype,
+                            output_type=output_dtype,
                             name=graph_node.name,
                         )
                     break

--- a/onnx2tf/ops/MatMulInteger.py
+++ b/onnx2tf/ops/MatMulInteger.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -125,11 +126,14 @@ def make_node(
         b_zero_point = tf.cast(b_zero_point, tf.int32)
         casted_input_tensor_2 = tf.subtract(casted_input_tensor_2, b_zero_point)
 
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+        if isinstance(dtype, np.dtype) else dtype
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.matmul(
             a=casted_input_tensor_1,
             b=casted_input_tensor_2,
-            output_type=dtype,
+            output_type=output_dtype,
             name=graph_node.name,
         )
 

--- a/onnx2tf/ops/Neg.py
+++ b/onnx2tf/ops/Neg.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -88,7 +89,11 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.math.multiply(
                 x=input_tensor,
-                y=tf.cast(-1, dtype=input_tensor.dtype),
+                y=tf.cast(
+                    -1,
+                    dtype=NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
+                ),
                 name=graph_node.name,
             )
 

--- a/onnx2tf/ops/NonMaxSuppression.py
+++ b/onnx2tf/ops/NonMaxSuppression.py
@@ -34,15 +34,27 @@ def non_max_suppression(
     name=None,
 ):
     with ops.name_scope(name, 'non_max_suppression'):
-        iou_threshold = ops.convert_to_tensor(iou_threshold, name='iou_threshold')
-        score_threshold = ops.convert_to_tensor(
-            score_threshold, name='score_threshold')
         selected_indices, num_valid = gen_image_ops.non_max_suppression_v4(
             boxes=boxes,
             scores=scores,
-            max_output_size=max_output_size,
-            iou_threshold=iou_threshold,
-            score_threshold=score_threshold,
+            max_output_size=max_output_size \
+                if not isinstance(max_output_size, np.ndarray) \
+                    else tf.convert_to_tensor(
+                        value=max_output_size,
+                        name='max_output_size'
+                    ),
+            iou_threshold=iou_threshold \
+                if not isinstance(iou_threshold, np.ndarray) \
+                    else tf.convert_to_tensor(
+                        value=iou_threshold,
+                        name='iou_threshold',
+                    ),
+            score_threshold=score_threshold \
+                if not isinstance(score_threshold, np.ndarray) \
+                    else tf.convert_to_tensor(
+                        value=score_threshold,
+                        name='score_threshold',
+                    ),
             pad_to_max_output_size=False,
         )
         return selected_indices[:num_valid]

--- a/onnx2tf/ops/Pad.py
+++ b/onnx2tf/ops/Pad.py
@@ -154,6 +154,8 @@ def make_node(
                 for new_idx, idx in enumerate(convertion_table):
                     new_values[new_idx] = paddings[idx]
                 paddings = np.asarray(new_values, dtype=paddings.dtype)
+            paddings = tf.convert_to_tensor(paddings) \
+                if isinstance(paddings, np.ndarray) else paddings
 
     mode = graph_node.attrs.get('mode', 'constant')
 

--- a/onnx2tf/ops/Range.py
+++ b/onnx2tf/ops/Range.py
@@ -10,6 +10,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -73,12 +74,15 @@ def make_node(
     input_tensor_3 = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
         if isinstance(graph_node_input_3, gs.Variable) else graph_node_input_3
 
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+        if isinstance(dtype, np.dtype) else dtype
+
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.range(
             start=input_tensor_1,
             limit=input_tensor_2,
             delta=input_tensor_3,
-            dtype=dtype,
+            dtype=output_dtype,
             name=graph_node.name,
         )
 

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -23,6 +23,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
 )
 from onnx2tf.utils.colors import Color
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 INF_INDEX_VALUE: int = 4294967296
 
@@ -213,11 +214,25 @@ def make_node(
             else:
                 h_w_scale = scales[1:input_tensor_rank-1]
                 h_w_shape = input_tensor_shape[1:input_tensor_rank-1]
-                new_size = tf.cast(h_w_scale * tf.cast(h_w_shape, scales.dtype), tf.int32)
+                new_size = tf.cast(
+                    h_w_scale * tf.cast(
+                        h_w_shape,
+                        NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
+                            if isinstance(scales.dtype, np.dtype) else scales.dtype,
+                    ),
+                    tf.int32,
+                )
         else:
             h_w_scale = scales[1:input_tensor_rank-1]
             h_w_shape = input_tensor_shape[1:input_tensor_rank-1]
-            new_size = tf.cast(h_w_scale * tf.cast(h_w_shape, scales.dtype), tf.int32)
+            new_size = tf.cast(
+                h_w_scale * tf.cast(
+                    h_w_shape,
+                    NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
+                        if isinstance(scales.dtype, np.dtype) else scales.dtype,
+                ),
+                tf.int32,
+            )
 
     if hasattr(new_size, '_inferred_value'):
         new_size_values = new_size._inferred_value

--- a/onnx2tf/ops/ScatterElements.py
+++ b/onnx2tf/ops/ScatterElements.py
@@ -17,6 +17,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
 )
 from onnx2tf.utils.colors import Color
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -177,7 +178,9 @@ def make_node(
         indices=indices,
         updates=updates,
     )
-    output = tf.cast(output, input_tensor.dtype)
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype
+    output = tf.cast(output, output_dtype)
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = output
 

--- a/onnx2tf/ops/SequenceConstruct.py
+++ b/onnx2tf/ops/SequenceConstruct.py
@@ -10,6 +10,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -35,7 +36,11 @@ def make_node(
     before_op_output_shape_trans = \
         before_op_output_shape_trans_1
 
-    input_sequence = tf.ragged.constant([], dtype=graph_node.inputs[0].dtype)
+    input_sequence = tf.ragged.constant(
+        [],
+        dtype=NUMPY_DTYPES_TO_TF_DTYPES[graph_node.inputs[0].dtype] \
+            if isinstance(graph_node.inputs[0].dtype, np.dtype) else graph_node.inputs[0].dtype
+    )
 
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape

--- a/onnx2tf/ops/Shape.py
+++ b/onnx2tf/ops/Shape.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -94,12 +95,14 @@ def make_node(
             # Clip if end is still < 0
             end = 0 if end < 0 else end
 
+    out_dtype = NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+        if isinstance(dtype, np.dtype) else dtype
     if start is not None and end is not None:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.slice(
                 tf.shape(
                     input=input_tensor,
-                    out_type=dtype,
+                    out_type=out_dtype,
                     name=graph_node.name,
                 ),
                 [start],
@@ -109,7 +112,7 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.shape(
                 input=input_tensor,
-                out_type=dtype,
+                out_type=out_dtype,
                 name=graph_node.name,
             )
 

--- a/onnx2tf/ops/Shrink.py
+++ b/onnx2tf/ops/Shrink.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -71,21 +72,23 @@ def make_node(
     }
 
     # Generation of TF OP
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype
     lambd_tensor = tf.fill(
         dims=input_tensor_shape,
-        value=tf.constant(lambd, input_tensor.dtype),
+        value=tf.constant(lambd, output_dtype),
     )
     lambd_neg_tensor = tf.fill(
         dims=input_tensor_shape,
-        value=tf.constant(lambd * -1, input_tensor.dtype),
+        value=tf.constant(lambd * -1, output_dtype),
     )
     bias_tensor = tf.fill(
         dims=input_tensor_shape,
-        value=tf.constant(bias, input_tensor.dtype),
+        value=tf.constant(bias, output_dtype),
     )
     zeros_tensor = tf.zeros(
         shape=input_tensor_shape,
-        dtype=input_tensor.dtype,
+        dtype=output_dtype,
     )
 
     # prepare return values and conditions

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -108,15 +108,18 @@ def make_node(
         )
     axes = tf_layers_dict[axes.name]['tf_node'] \
         if isinstance(axes, gs.Variable) else axes
+
+    ends_dtype = NUMPY_DTYPES_TO_TF_DTYPES[ends.dtype] \
+        if isinstance(ends.dtype, np.dtype) else ends.dtype
     if isinstance(axes, np.ndarray):
         axes = axes \
-            if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends.dtype)
+            if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends_dtype)
     elif isinstance(axes, list):
-        axes = np.asarray(axes, dtype=ends.dtype) \
-            if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends.dtype)
+        axes = np.asarray(axes, dtype=ends_dtype) \
+            if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends_dtype)
     elif axes is not None:
         axes = axes \
-            if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends.dtype)
+            if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends_dtype)
 
     steps = None
     if len(graph_node.inputs) >= 5:
@@ -126,8 +129,10 @@ def make_node(
         )
     steps = tf_layers_dict[steps.name]['tf_node'] \
         if isinstance(steps, gs.Variable) else steps
+    steps_dtype = NUMPY_DTYPES_TO_TF_DTYPES[steps.dtype] \
+        if isinstance(steps.dtype, np.dtype) else steps.dtype
     if isinstance(steps, np.ndarray):
-        steps = tf.constant(steps, dtype=NUMPY_DTYPES_TO_TF_DTYPES[steps.dtype])
+        steps = tf.constant(steps, dtype=steps_dtype)
 
     axes = graph_node.attrs.get('axes', axes)
 

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -115,7 +115,7 @@ def make_node(
         axes = axes \
             if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends_dtype)
     elif isinstance(axes, list):
-        axes = np.asarray(axes, dtype=ends_dtype) \
+        axes = np.asarray(axes, dtype=ends.dtype) \
             if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends_dtype)
     elif axes is not None:
         axes = axes \
@@ -129,9 +129,9 @@ def make_node(
         )
     steps = tf_layers_dict[steps.name]['tf_node'] \
         if isinstance(steps, gs.Variable) else steps
-    steps_dtype = NUMPY_DTYPES_TO_TF_DTYPES[steps.dtype] \
-        if isinstance(steps.dtype, np.dtype) else steps.dtype
     if isinstance(steps, np.ndarray):
+        steps_dtype = NUMPY_DTYPES_TO_TF_DTYPES[steps.dtype] \
+            if isinstance(steps.dtype, np.dtype) else steps.dtype
         steps = tf.constant(steps, dtype=steps_dtype)
 
     axes = graph_node.attrs.get('axes', axes)
@@ -151,14 +151,14 @@ def make_node(
             before_op_output_shape_trans=before_op_output_shape_trans,
         )
     if isinstance(axes, list):
-        axes = np.asarray(axes)
+        axes = tf.convert_to_tensor(np.asarray(axes))
 
     starts = graph_node.attrs.get('starts', starts)
     if isinstance(starts, list):
-        starts = np.asarray(starts)
+        starts = tf.convert_to_tensor(np.asarray(starts))
     ends = graph_node.attrs.get('ends', ends)
     if isinstance(ends, list):
-        ends = np.asarray(ends)
+        ends = tf.convert_to_tensor(np.asarray(ends))
 
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -100,6 +100,15 @@ def make_node(
         ends = tf_layers_dict[ends.name]['tf_node'] \
             if isinstance(ends, gs.Variable) else ends
 
+    starts = graph_node.attrs.get('starts', starts)
+    if isinstance(starts, list):
+        starts = tf.convert_to_tensor(np.asarray(starts))
+    ends = graph_node.attrs.get('ends', ends)
+    if isinstance(ends, list):
+        ends = tf.convert_to_tensor(np.asarray(ends))
+    ends_dtype = NUMPY_DTYPES_TO_TF_DTYPES[ends.dtype] \
+        if isinstance(ends.dtype, np.dtype) else ends.dtype
+
     axes = None
     if len(graph_node.inputs) >= 4:
         axes = get_constant_or_variable(
@@ -109,8 +118,6 @@ def make_node(
     axes = tf_layers_dict[axes.name]['tf_node'] \
         if isinstance(axes, gs.Variable) else axes
 
-    ends_dtype = NUMPY_DTYPES_TO_TF_DTYPES[ends.dtype] \
-        if isinstance(ends.dtype, np.dtype) else ends.dtype
     if isinstance(axes, np.ndarray):
         axes = axes \
             if len(graph_node.inputs) >= 4 else tf.range(tf.shape(starts)[0], dtype=ends_dtype)
@@ -152,13 +159,6 @@ def make_node(
         )
     if isinstance(axes, list):
         axes = tf.convert_to_tensor(np.asarray(axes))
-
-    starts = graph_node.attrs.get('starts', starts)
-    if isinstance(starts, list):
-        starts = tf.convert_to_tensor(np.asarray(starts))
-    ends = graph_node.attrs.get('ends', ends)
-    if isinstance(ends, list):
-        ends = tf.convert_to_tensor(np.asarray(ends))
 
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape

--- a/onnx2tf/ops/SplitToSequence.py
+++ b/onnx2tf/ops/SplitToSequence.py
@@ -16,6 +16,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
 )
 from onnx2tf.utils.colors import Color
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -121,8 +122,11 @@ def make_node(
                 tf.squeeze(split_input) for split_input in split_inputs
             ]
 
+    output_dtype = NUMPY_DTYPES_TO_TF_DTYPES[dtype] \
+        if isinstance(dtype, np.dtype) else dtype
+
     # create an empty sequence next
-    input_sequence = tf.ragged.constant([], dtype=dtype)
+    input_sequence = tf.ragged.constant([], dtype=output_dtype)
 
     # insert tensors at the end of sequence
     for i in range(len(split_inputs)):

--- a/onnx2tf/ops/TopK.py
+++ b/onnx2tf/ops/TopK.py
@@ -56,9 +56,11 @@ def make_node(
     Values: gs.Variable = graph_node.outputs[0]
     Indices: gs.Variable = graph_node.outputs[1]
     Values_shape = Values.shape
-    Values_dtype = Values.dtype
+    Values_dtype = NUMPY_DTYPES_TO_TF_DTYPES[Values.dtype] \
+        if isinstance(Values.dtype, np.dtype) else Values.dtype
     Indices_shape = Indices.shape
-    Indices_dtype = Indices.dtype
+    Indices_dtype = NUMPY_DTYPES_TO_TF_DTYPES[Indices.dtype] \
+        if isinstance(Indices.dtype, np.dtype) else Indices.dtype
 
     input_tensor = tf_layers_dict[X.name]['tf_node'] \
         if isinstance(X, gs.Variable) else X
@@ -135,7 +137,7 @@ def make_node(
         topked_values = tf.negative(topked_values)
     topked_indices = tf.cast(
         x=topked_indices,
-        dtype=NUMPY_DTYPES_TO_TF_DTYPES[Indices_dtype],
+        dtype=Indices_dtype,
     )
 
     if axis != (tensor_rank-1):

--- a/onnx2tf/ops/Trilu.py
+++ b/onnx2tf/ops/Trilu.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
 )
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -72,7 +73,9 @@ def make_node(
             k = 0 - tensor_shape[-2]
     else:
         k = tf.constant(0, dtype=tf.int64)
-    keep_triangle = tf.constant(-1, dtype=k.dtype)
+    k_dtype = NUMPY_DTYPES_TO_TF_DTYPES[k.dtype] \
+        if isinstance(k.dtype, np.dtype) else k.dtype
+    keep_triangle = tf.constant(-1, dtype=k_dtype)
 
     upper = bool(graph_node.attrs.get('upper', 1))
 


### PR DESCRIPTION
### 1. Content and background
- Fixed Abort problem on Keras (.h5) output when using `np.dtype`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[YOLOX-X] Error when outputting to h5 file. AttributeError: 'numpy.dtype[int64]' object has no attribute 'item' #146](https://github.com/PINTO0309/onnx2tf/issues/146)
[[MobileFormer] Converted model outputs values mismatch with original ones. #105](https://github.com/PINTO0309/onnx2tf/issues/105)
[[MobileFormer]Dimensions must be equal [Add Layer] #103](https://github.com/PINTO0309/onnx2tf/issues/103)