### PR TITLE
Fixed an error with EagerTensor (np.ndarray). `-cotof`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.34
+  ghcr.io/pinto0309/onnx2tf:1.5.35
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.34'
+__version__ = '1.5.35'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1210,8 +1210,10 @@ def convert(
                 }
             """
             input_names = [k.name for k in inputs]
-            onnx_tf_output_pairs = {(k, v['tf_node'].name): (onnx_tensor_infos[k], tf_tensor_infos[v['tf_node'].name])
-                                    for k, v in tf_layers_dict.items() if k not in input_names}
+            onnx_tf_output_pairs = {
+                (k, v['tf_node'].name): (onnx_tensor_infos[k], tf_tensor_infos[v['tf_node'].name])
+                    for k, v in tf_layers_dict.items() if k not in input_names and not hasattr(v['tf_node'], 'numpy')
+            }
 
             check_results = onnx_tf_tensor_validation(
                 output_pairs=onnx_tf_output_pairs,


### PR DESCRIPTION
### 1. Content and background
- Fixed an error with EagerTensor (np.ndarray). `-cotof`
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.27/human_segmentation_pphumanseg_2021oct.onnx
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.27/replace.json
  ```
  onnx2tf -i human_segmentation_pphumanseg_2021oct.onnx -prf replace.json -cotof
  ```
  ```
    File "/home/xxxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 1808, in <module>
      main()
    File "/home/xxxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 1757, in main
      model = convert(
    File "/home/xxxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 1217, in convert
      onnx_tf_output_pairs = {
    File "/home/xxxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 1218, in <dictcomp>
      (k, v['tf_node'].name): (onnx_tensor_infos[k], tf_tensor_infos[v['tf_node'].name])
    File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/framework/ops.py", line 446, in __getattr__
      self.__getattribute__(name)
    File "/usr/local/lib/python3.8/dist-packages/tensorflow/python/framework/ops.py", line 1317, in name
      raise AttributeError(
  AttributeError: Tensor.name is undefined when eager execution is enabled.
  ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
