### PR TITLE
[BugFix] Clip op: Convert tf.Tensor min/max values to numpy arrays

### DIFF
--- a/onnx2tf/ops/Clip.py
+++ b/onnx2tf/ops/Clip.py
@@ -115,9 +115,9 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
-    if min_value is not None and isinstance(min_value, float):
+    if min_value is not None and (isinstance(min_value, float) or isinstance(min_value, tf.Tensor)):
         min_value = np.asarray([min_value])
-    if max_value is not None and isinstance(max_value, float):
+    if max_value is not None and (isinstance(max_value, float) or isinstance(max_value, tf.Tensor)):
         max_value = np.asarray([max_value])
 
     tf_op_type = None


### PR DESCRIPTION
### 1. Content and background

Clip op raises an exception, when min/max values are tf.Tensors:

```
INFO: onnx_op_type: Clip onnx_op_name: /layers.0/layers.0.2/Clip
INFO:  input_name.1: /layers.0/layers.0.0/Conv_output_0 shape: [1, 32, 128, 72] dtype: float32
INFO:  input_name.2: /layers.0/layers.0.2/Constant_output_0 shape: [] dtype: float32
INFO:  input_name.3: /layers.0/layers.0.2/Constant_1_output_0 shape: [] dtype: float32
INFO:  output_name.1: /layers.0/layers.0.2/Clip_output_0 shape: [1, 32, 128, 72] dtype: float32
ERROR: The trace log is below.
Traceback (most recent call last):
  File "onnx2tf/utils/common_functions.py", line 275, in print_wrapper_func
    result = func(*args, **kwargs)
  File "onnx2tf/utils/common_functions.py", line 338, in inverted_operation_enable_disable_wrapper_func
    result = func(*args, **kwargs)
  File "onnx2tf/utils/common_functions.py", line 45, in get_replacement_parameter_wrapper_func
    func(*args, **kwargs)
  File "onnx2tf/ops/Clip.py", line 172, in make_node
    before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape
KeyError: 'tf_node'
ERROR: Read this and deal with it. https://github.com/PINTO0309/onnx2tf#parameter-replacement
ERROR: Alternatively, if the input OP has a dynamic dimension, use the -b or -ois option to rewrite it to a static shape and try again.
ERROR: If the input OP of ONNX before conversion is NHWC or an irregular channel arrangement other than NCHW, use the -kt or -kat option.
```

### 2. Summary of corrections

The fix is pretty simple - convert tf.Tensors to numpy arrays.

### 3. Before/After (If there is an operating log that can be used as a reference)

n/a

### 4. Issue number (only if there is a related issue)

n/a
