### PR TITLE
To support GPU Delegate, replace all `Gather` processing part of NMS with `strided_slice`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.37
+  ghcr.io/pinto0309/onnx2tf:1.5.38
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.37'
+__version__ = '1.5.38'

--- a/onnx2tf/ops/NonMaxSuppression.py
+++ b/onnx2tf/ops/NonMaxSuppression.py
@@ -269,14 +269,56 @@ def make_node(
 
     for batch_i in tf.range(num_batches):
         # get boxes in batch_i only
-        tf_boxes = tf.squeeze(tf.gather(boxes, [batch_i]), axis=0)
+        begin_ = [0 if idx != 0 else batch_i for idx in range(len(boxes.shape))]
+        end_ = [0 if idx != 0 else batch_i + 1 for idx in range(len(boxes.shape))]
+        begin_mask_ = sum([2**idx if idx != 0 else 0 for idx in range(len(boxes.shape))])
+        end_mask_ = begin_mask_
+        tf_boxes = \
+            tf.squeeze(
+                input=tf.strided_slice(
+                    input_=boxes,
+                    begin=begin_,
+                    end=end_,
+                    begin_mask=begin_mask_,
+                    end_mask=end_mask_,
+                ),
+                axis=0,
+            )
         # get scores of all classes in batch_i only
-        batch_i_scores = tf.squeeze(tf.gather(scores, [batch_i]), axis=0)
+        begin_ = [0 if idx != 0 else batch_i for idx in range(len(scores.shape))]
+        end_ = [0 if idx != 0 else batch_i + 1 for idx in range(len(scores.shape))]
+        begin_mask_ = sum([2**idx if idx != 0 else 0 for idx in range(len(scores.shape))])
+        end_mask_ = begin_mask_
+        batch_i_scores = \
+            tf.squeeze(
+                input=tf.strided_slice(
+                    input_=scores,
+                    begin=begin_,
+                    end=end_,
+                    begin_mask=begin_mask_,
+                    end_mask=end_mask_,
+                ),
+                axis=0,
+            )
         # get number of classess in batch_i only
         num_classes = batch_i_scores.shape[0]
         for class_j in tf.range(num_classes):
             # get scores in class_j for batch_i only
-            tf_scores = tf.squeeze(tf.gather(batch_i_scores, [class_j]), axis=0)
+            begin_ = [0 if idx != 0 else class_j for idx in range(len(batch_i_scores.shape))]
+            end_ = [0 if idx != 0 else class_j + 1 for idx in range(len(batch_i_scores.shape))]
+            begin_mask_ = sum([2**idx if idx != 0 else 0 for idx in range(len(batch_i_scores.shape))])
+            end_mask_ = begin_mask_
+            tf_scores = \
+                tf.squeeze(
+                    input=tf.strided_slice(
+                        input_=batch_i_scores,
+                        begin=begin_,
+                        end=end_,
+                        begin_mask=begin_mask_,
+                        end_mask=end_mask_,
+                    ),
+                    axis=0,
+                )
             # get the selected boxes indices
             nms = NMSLayer()
             selected_indices = nms(


### PR DESCRIPTION
### 1. Content and background
To support GPU Delegate, replace all `Gather` processing part of NMS with `strided_slice`.
![image](https://user-images.githubusercontent.com/33194443/216209814-26edd9a8-a5a9-4989-8034-f37c46de7e93.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Yolov7-tiny to TensorflowLite comversion results in a dynamic output model incompatible with TfLite Java API #159](https://github.com/PINTO0309/onnx2tf/issues/159)