### PR TITLE
Fixed the number of NMS outputs to be fixed outputs in `max_output_boxes_per_class`. `-onwdt` option to generate a dynamic tensor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.38
+  ghcr.io/pinto0309/onnx2tf:1.5.39
 
   or
 
@@ -191,6 +191,7 @@ usage: onnx2tf
 [-nuonag]
 [-b BATCH_SIZE]
 [-ois OVERWRITE_INPUT_SHAPE [OVERWRITE_INPUT_SHAPE ...]]
+[-onwdt]
 [-k KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES [KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES ...]]
 [-kt KEEP_NWC_OR_NHWC_OR_NDHWC_INPUT_NAMES [KEEP_NWC_OR_NHWC_OR_NDHWC_INPUT_NAMES ...]]
 [-kat KEEP_SHAPE_ABSOLUTELY_INPUT_NAMES [KEEP_SHAPE_ABSOLUTELY_INPUT_NAMES ...]]
@@ -331,6 +332,18 @@ optional arguments:
     A value of 1 or more must be specified.
     Numerical values other than dynamic dimensions are ignored.
     Ignores --batch_size if specified at the same time as --batch_size.
+
+  -onwdt, --output_nms_with_dynamic_tensor
+    The number of bounding boxes in the NMS output results is
+    not fixed at the maximum number of max_output_boxes_per_class,
+    but rather at the smallest possible number of dynamic tensors.
+    If this option is disabled, NMS output is padded to the number
+    set in the max_output_boxes_per_class attribute.
+    e.g.
+    disable --output_nms_with_dynamic_tensor:
+        output_tensor_shape: [100, 7]
+    enable --output_nms_with_dynamic_tensor:
+        output_tensor_shape: [N, 7]
 
   -k KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES [KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES ...], \
       --keep_ncw_or_nchw_or_ncdhw_input_names KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES \
@@ -588,6 +601,7 @@ convert(
   not_use_opname_auto_generate: Optional[bool] = False,
   batch_size: Union[int, NoneType] = None,
   overwrite_input_shape: Union[List[str], NoneType] = None,
+  output_nms_with_dynamic_tensor: Optional[bool] = False,
   keep_ncw_or_nchw_or_ncdhw_input_names: Union[List[str], NoneType] = None,
   keep_nwc_or_nhwc_or_ndhwc_input_names: Union[List[str], NoneType] = None,
   keep_shape_absolutely_input_names: Optional[List[str]] = None,
@@ -738,6 +752,18 @@ convert(
       A value of 1 or more must be specified.
       Numerical values other than dynamic dimensions are ignored.
       Ignores batch_size if specified at the same time as batch_size.
+
+    output_nms_with_dynamic_tensor: Optional[bool]
+        The number of bounding boxes in the NMS output results is
+        not fixed at the maximum number of max_output_boxes_per_class,
+        but rather at the smallest possible number of dynamic tensors.
+        If this option is disabled, NMS output is padded to the number
+        set in the max_output_boxes_per_class attribute.
+        e.g.
+        disable --output_nms_with_dynamic_tensor:
+            output_tensor_shape: [100, 7]
+        enable --output_nms_with_dynamic_tensor:
+            output_tensor_shape: [N, 7]
 
     keep_ncw_or_nchw_or_ncdhw_input_names: Optional[List[str]]
       Holds the NCW or NCHW or NCDHW of the input shape for the specified INPUT OP names.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.38'
+__version__ = '1.5.39'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -66,6 +66,7 @@ def convert(
     not_use_opname_auto_generate: Optional[bool] = False,
     batch_size: Optional[int] = None,
     overwrite_input_shape: Optional[List[str]] = None,
+    output_nms_with_dynamic_tensor: Optional[bool] = False,
     keep_ncw_or_nchw_or_ncdhw_input_names: Optional[List[str]] = None,
     keep_nwc_or_nhwc_or_ndhwc_input_names: Optional[List[str]] = None,
     keep_shape_absolutely_input_names: Optional[List[str]] = None,
@@ -216,6 +217,18 @@ def convert(
         A value of 1 or more must be specified.\n
         Numerical values other than dynamic dimensions are ignored.\n
         Ignores batch_size if specified at the same time as batch_size.
+
+    output_nms_with_dynamic_tensor: Optional[bool]
+        The number of bounding boxes in the NMS output results is\n
+        not fixed at the maximum number of max_output_boxes_per_class,\n
+        but rather at the smallest possible number of dynamic tensors.\n
+        If this option is disabled, NMS output is padded to the number\n
+        set in the max_output_boxes_per_class attribute.\n
+        e.g.\n
+        disable --output_nms_with_dynamic_tensor:\n
+            output_tensor_shape: [100, 7]\n
+        enable --output_nms_with_dynamic_tensor:\n
+            output_tensor_shape: [N, 7]
 
     keep_ncw_or_nchw_or_ncdhw_input_names: Optional[List[str]]
         Holds the NCW or NCHW or NCDHW of the input shape for the specified INPUT OP names.\n
@@ -683,6 +696,7 @@ def convert(
         'mvn_epsilon': mvn_epsilon,
         'output_signaturedefs': output_signaturedefs,
         'onnx_tensor_infos_for_validation': onnx_tensor_infos_for_validation,
+        'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
     }
 
     tf_layers_dict = {}
@@ -1438,6 +1452,22 @@ def main():
             'Ignores --batch_size if specified at the same time as --batch_size.'
     )
     parser.add_argument(
+        '-onwdt',
+        '--output_nms_with_dynamic_tensor',
+        action='store_true',
+        help=\
+            'The number of bounding boxes in the NMS output results is \n' +
+            'not fixed at the maximum number of max_output_boxes_per_class, \n' +
+            'but rather at the smallest possible number of dynamic tensors. \n' +
+            'If this option is disabled, NMS output is padded to the number \n' +
+            'set in the max_output_boxes_per_class attribute. \n' +
+            'e.g. \n' +
+            'disable --output_nms_with_dynamic_tensor: \n' +
+            '    output_tensor_shape: [100, 7] \n' +
+            'enable --output_nms_with_dynamic_tensor: \n' +
+            '    output_tensor_shape: [N, 7]'
+    )
+    parser.add_argument(
         '-k',
         '--keep_ncw_or_nchw_or_ncdhw_input_names',
         type=str,
@@ -1785,6 +1815,7 @@ def main():
         not_use_opname_auto_generate=args.not_use_opname_auto_generate,
         batch_size=args.batch_size,
         overwrite_input_shape=args.overwrite_input_shape,
+        output_nms_with_dynamic_tensor=args.output_nms_with_dynamic_tensor,
         keep_ncw_or_nchw_or_ncdhw_input_names=args.keep_ncw_or_nchw_or_ncdhw_input_names,
         keep_nwc_or_nhwc_or_ndhwc_input_names=args.keep_nwc_or_nhwc_or_ndhwc_input_names,
         keep_shape_absolutely_input_names=args.keep_shape_absolutely_input_names,

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -88,24 +88,28 @@ def make_node(
             onnx_output_shape = [s if not isinstance(s, str) else None for s in output_shape]
             onnx_output_shape_none_count = onnx_output_shape.count(None)
             tf_input_shape = input_tensor_shape
+            tf_input_shape_none_count = [s for s in tf_input_shape].count(None)
             new_perm = [-1] * len(onnx_output_shape)
-            for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
-                matched_idxs = [
-                    idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
-                        if onnx_shape_value == tf_shape_value
-                ]
-                if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
-                    new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
-                elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
-                    new_perm = perm
-                elif len(matched_idxs) == 1:
-                    new_perm[matched_idxs[0]] = tf_shape_idx
-                else:
-                    for matched_idx in matched_idxs:
-                        if new_perm[matched_idx] == -1:
-                            new_perm[matched_idx] = tf_shape_idx
-                            break
-            perm = new_perm
+            if onnx_output_shape_none_count > 0 and tf_input_shape_none_count == 0:
+                pass
+            else:
+                for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
+                    matched_idxs = [
+                        idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
+                            if onnx_shape_value == tf_shape_value
+                    ]
+                    if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
+                        new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
+                    elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
+                        new_perm = perm
+                    elif len(matched_idxs) == 1:
+                        new_perm[matched_idxs[0]] = tf_shape_idx
+                    else:
+                        for matched_idx in matched_idxs:
+                            if new_perm[matched_idx] == -1:
+                                new_perm[matched_idx] = tf_shape_idx
+                                break
+                perm = new_perm
 
     elif perm is not None and isinstance(perm, np.ndarray) and len(perm.shape) == 0:
         if perm[0] == 0:
@@ -121,24 +125,28 @@ def make_node(
             onnx_output_shape = [s if not isinstance(s, str) else None for s in output_shape]
             onnx_output_shape_none_count = onnx_output_shape.count(None)
             tf_input_shape = input_tensor_shape
+            tf_input_shape_none_count = [s for s in tf_input_shape].count(None)
             new_perm = [-1] * len(onnx_output_shape)
-            for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
-                matched_idxs = [
-                    idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
-                        if onnx_shape_value == tf_shape_value
-                ]
-                if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
-                    new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
-                elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
-                    new_perm = perm
-                elif len(matched_idxs) == 1:
-                    new_perm[matched_idxs[0]] = tf_shape_idx
-                else:
-                    for matched_idx in matched_idxs:
-                        if new_perm[matched_idx] == -1:
-                            new_perm[matched_idx] = tf_shape_idx
-                            break
-            perm = new_perm
+            if onnx_output_shape_none_count > 0 and tf_input_shape_none_count == 0:
+                pass
+            else:
+                for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
+                    matched_idxs = [
+                        idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
+                            if onnx_shape_value == tf_shape_value
+                    ]
+                    if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
+                        new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
+                    elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
+                        new_perm = perm
+                    elif len(matched_idxs) == 1:
+                        new_perm[matched_idxs[0]] = tf_shape_idx
+                    else:
+                        for matched_idx in matched_idxs:
+                            if new_perm[matched_idx] == -1:
+                                new_perm[matched_idx] = tf_shape_idx
+                                break
+                perm = new_perm
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -328,6 +328,11 @@ def print_node_info(func):
                 f'If the input OP of ONNX before conversion is NHWC or ' +
                 f'an irregular channel arrangement other than NCHW, use the -kt or -kat option.'
             )
+            print(
+                f'{Color.RED}ERROR:{Color.RESET} ' +
+                f'Also, for models that include NonMaxSuppression in the post-processing, ' +
+                f'try the -onwdt option.'
+            )
             sys.exit(1)
     return print_wrapper_func
 

--- a/tests/test_model_convert.py
+++ b/tests/test_model_convert.py
@@ -112,6 +112,7 @@ def _report_convert_model(file_path):
         onnx2tf.convert(
             input_onnx_file_path=file_path,
             output_folder_path=_CFG['output_directory'],
+            output_nms_with_dynamic_tensor=True,
             non_verbose=True,
         )
         os.remove(file_path)


### PR DESCRIPTION
### 1. Content and background
- Fixed the number of NMS outputs to be fixed outputs in `max_output_boxes_per_class`. `-onwdt` option to generate a dynamic tensor. Taking into account that tflite's primary use is for Android, change the behavior so that it is replaced with a fixed output shape by default.
  ```python
  -onwdt, --output_nms_with_dynamic_tensor
    The number of bounding boxes in the NMS output results is
    not fixed at the maximum number of max_output_boxes_per_class,
    but rather at the smallest possible number of dynamic tensors.
    If this option is disabled, NMS output is padded to the number
    set in the max_output_boxes_per_class attribute.
    e.g.
    disable --output_nms_with_dynamic_tensor:
        output_tensor_shape: [100, 7]
    enable --output_nms_with_dynamic_tensor:
        output_tensor_shape: [N, 7]
  ```

  - disable `-onwdt`
    ![image](https://user-images.githubusercontent.com/33194443/216482120-3d10e4c8-6c3e-4307-9ab5-42d999b572c7.png)

  - enable `-onwdt`
    ![image](https://user-images.githubusercontent.com/33194443/216482248-8d81f6cd-e1c6-4464-a53d-706c3b2c2c45.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Yolov7-tiny to TensorflowLite comversion results in a dynamic output model incompatible with TfLite Java API #159](https://github.com/PINTO0309/onnx2tf/issues/159)