### PR TITLE
Simplifying operation replacement procedure to pseudo operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,35 +435,11 @@ optional arguments:
     0.0 < fused_argmax_scale_ratio <= 1.0
     Default: 0.5
 
-  -rasin, --replace_asin_to_pseudo_asin
-    Replace Asin with a pseudo Asin.
-
-  -racos, --replace_acos_to_pseudo_acos
-    Replace Acos with a pseudo Acos.
-
-  -rabs, --replace_abs_to_pseudo_abs
-    Replace Abs with a pseudo Abs.
-
-  -rpr, --replace_prelu_to_pseudo_prelu
-    Replace PReLU with a pseudo PReLU.
-
-  -rlr, --replace_leakyrelu_to_pseudo_leakyrelu
-    Replace LeakyReLU with a pseudo LeakyReLU.
-
-  -rpw, --replace_power_to_pseudo_power
-    Replace Power with a pseudo Power.
-
-  -rgn, --replace_gathernd_to_pseudo_gathernd
-    Replace GatherND with a pseudo GatherND.
-
-  -rng, --replace_neg_to_pseudo_neg
-    Replace Neg with a pseudo Neg.
-
-  -rhs, --replace_hardswish_to_pseudo_hardswish
-    Replace HardSwish with a pseudo HardSwish.
-
-  -rerf, --replace_erf_to_pseudo_erf
-    Replace Erf with a pseudo Erf.
+  -rtpo, --replace_to_pseudo_operators
+    Replace list of operators to pseudo operators.
+    Full name of the target operators should be given.
+    Currently supported operators :
+    Asin, Acos, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf
 
   -me, --mvn_epsilon
     For MeanVarianceNormalization.
@@ -616,16 +592,7 @@ convert(
   replace_argmax_to_fused_argmax_and_indicies_is_int64: Union[bool, NoneType] = False,
   replace_argmax_to_fused_argmax_and_indicies_is_float32: Union[bool, NoneType] = False,
   fused_argmax_scale_ratio: Union[float, NoneType] = 0.5,
-  replace_asin_to_pseudo_asin: Union[bool, NoneType] = False,
-  replace_acos_to_pseudo_acos: Union[bool, NoneType] = False,
-  replace_abs_to_pseudo_abs: Union[bool, NoneType] = False,
-  replace_prelu_to_pseudo_prelu: Union[bool, NoneType] = False,
-  replace_leakyrelu_to_pseudo_leakyrelu: Union[bool, NoneType] = False,
-  replace_power_to_pseudo_power: Optional[bool] = False,
-  replace_gathernd_to_pseudo_gathernd: Optional[bool] = False,
-  replace_neg_to_pseudo_neg: Optional[bool] = False,
-  replace_hardswish_to_pseudo_hardswish: Optional[bool] = False,
-  replace_erf_to_pseudo_erf: Optional[bool] = False,
+  replace_to_pseudo_operators: List[str] = None,
   mvn_epsilon: Union[float, NoneType] = 0.0000000001,
   param_replacement_file: Optional[str] = '',
   check_gpu_delegate_compatibility: Optional[bool] = False,
@@ -856,35 +823,11 @@ convert(
       0.0 < fused_argmax_scale_ratio <= 1.0
       Default: 0.5
 
-    replace_asin_to_pseudo_asin: Optional[bool]
-      Replace Asin with a pseudo Asin.
-
-    replace_acos_to_pseudo_acos: Optional[bool]
-      Replace Acos with a pseudo Acos.
-
-    replace_acbs_to_pseudo_abs: Optional[bool]
-      Replace Abs with a pseudo Abs.
-
-    replace_prelu_to_pseudo_prelu: Optional[bool]
-      Replace PReLU with a pseudo PReLU.
-
-    replace_leakyrelu_to_pseudo_leakyrelu: Optional[bool]
-      Replace LeakyReLU with a pseudo LeakyReLU.
-
-    replace_power_to_pseudo_power: Optional[bool]
-      Replace Power with a pseudo Power.
-
-    replace_gathernd_to_pseudo_gathernd: Optional[bool]
-      Replace GatherND with a pseudo GatherND.
-
-    replace_neg_to_pseudo_neg: Optional[bool]
-      Replace Neg with a pseudo Neg.
-
-    replace_hardswish_to_pseudo_hardswish: Optional[bool]
-      Replace HardSwish with a pseudo HardSwish.
-
-    replace_erf_to_pseudo_erf: Optional[bool]
-      Replace Erf with a pseudo Erf.
+    replace_to_pseudo_operators: List[str]
+      Replace list of operators to pseudo operators. \n
+      Full name of the target operators should be given. \n
+      Currently supported operators :
+      Asin, Acos, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf
 
     mvn_epsilon: Optional[float]
       For MeanVarianceNormalization.

--- a/onnx2tf/ops/Abs.py
+++ b/onnx2tf/ops/Abs.py
@@ -60,7 +60,7 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
-    replace_abs_to_pseudo_abs = kwargs['replace_abs_to_pseudo_abs']
+    replace_abs_to_pseudo_abs = "abs" in kwargs['replace_to_pseudo_operators']
 
     # Pre-process transpose
     before_trans_shape = input_tensor.shape

--- a/onnx2tf/ops/Acos.py
+++ b/onnx2tf/ops/Acos.py
@@ -48,7 +48,7 @@ def make_node(
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    replace_acos_to_pseudo_acos = kwargs['replace_acos_to_pseudo_acos']
+    replace_acos_to_pseudo_acos = "acos" in kwargs['replace_to_pseudo_operators']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/Asin.py
+++ b/onnx2tf/ops/Asin.py
@@ -48,7 +48,7 @@ def make_node(
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    replace_asin_to_pseudo_asin = kwargs['replace_asin_to_pseudo_asin']
+    replace_asin_to_pseudo_asin = "asin" in kwargs['replace_to_pseudo_operators']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/Erf.py
+++ b/onnx2tf/ops/Erf.py
@@ -58,7 +58,7 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
-    replace_erf_to_pseudo_erf = kwargs['replace_erf_to_pseudo_erf']
+    replace_erf_to_pseudo_erf = "erf" in kwargs['replace_to_pseudo_operators']
 
     # Generation of TF OP
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \

--- a/onnx2tf/ops/GatherND.py
+++ b/onnx2tf/ops/GatherND.py
@@ -87,7 +87,7 @@ def make_node(
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
 
-    replace_gathernd_to_pseudo_gathernd = kwargs['replace_gathernd_to_pseudo_gathernd']
+    replace_gathernd_to_pseudo_gathernd = "gathernd" in kwargs['replace_to_pseudo_operators']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/HardSwish.py
+++ b/onnx2tf/ops/HardSwish.py
@@ -50,8 +50,7 @@ def make_node(
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
-    replace_hardswish_to_pseudo_hardswish = \
-        kwargs['replace_hardswish_to_pseudo_hardswish']
+    replace_hardswish_to_pseudo_hardswish = "hardswish" in kwargs['replace_to_pseudo_operators']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/LeakyRelu.py
+++ b/onnx2tf/ops/LeakyRelu.py
@@ -48,8 +48,7 @@ def make_node(
     dtype = graph_node_output.dtype
 
     alpha = graph_node.attrs.get('alpha', 0.01)
-    replace_leakyrelu_to_pseudo_leakyrelu = \
-        kwargs['replace_leakyrelu_to_pseudo_leakyrelu']
+    replace_leakyrelu_to_pseudo_leakyrelu = "leakyrelu" in kwargs['replace_to_pseudo_operators']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {

--- a/onnx2tf/ops/Neg.py
+++ b/onnx2tf/ops/Neg.py
@@ -59,7 +59,7 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
-    replace_neg_to_pseudo_neg = kwargs['replace_neg_to_pseudo_neg']
+    replace_neg_to_pseudo_neg = "neg" in kwargs['replace_to_pseudo_operators']
 
     # Generation of TF OP
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -58,7 +58,7 @@ def make_node(
     slope = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
-    replace_prelu_to_pseudo_prelu = kwargs['replace_prelu_to_pseudo_prelu']
+    replace_prelu_to_pseudo_prelu = "prelu" in kwargs['replace_to_pseudo_operators']
 
     _, slope = pre_explicit_broadcast(
         input_tensor_1=input_tensor,

--- a/onnx2tf/ops/Pow.py
+++ b/onnx2tf/ops/Pow.py
@@ -93,7 +93,8 @@ def make_node(
         **kwargs,
     )
 
-    replace_power_to_pseudo_power = kwargs['replace_power_to_pseudo_power']
+    replace_power_to_pseudo_power = "power" in kwargs['replace_to_pseudo_operators'] \
+                                    or "pow" in kwargs['replace_to_pseudo_operators']
 
     if not replace_power_to_pseudo_power:
         powed_tensor = \

--- a/onnx2tf/ops/QLinearLeakyRelu.py
+++ b/onnx2tf/ops/QLinearLeakyRelu.py
@@ -60,8 +60,7 @@ def make_node(
     dtype = graph_node_output.dtype
 
     alpha = graph_node.attrs.get('alpha', 0.01)
-    replace_leakyrelu_to_pseudo_leakyrelu = \
-        kwargs['replace_leakyrelu_to_pseudo_leakyrelu']
+    replace_leakyrelu_to_pseudo_leakyrelu = "leakyrelu" in kwargs['replace_to_pseudo_operators']
 
     x = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1


### PR DESCRIPTION
### 1. Content and background

### 2. Summary of corrections
There is replacement options for some operations like `Asin` and `PReLU`. However, these options are separated in argument parsing and parameter passing, which make redundant and duplicated code parts.
In this PR, those lines are simplified by using single option `replace_to_pseudo_operators`. If user give the names of target operation as list like `["acos", "hardswish"]`, each operator is replaced to pseudo operators same as before. I didn't change the logic itself, just refactoring for future in case more pseudo operators are added.

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
