### PR TITLE
Fixed dtype conversion error when outputting `Gather` for GPU Delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.41
+  ghcr.io/pinto0309/onnx2tf:1.5.42
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.41'
+__version__ = '1.5.42'

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -95,7 +95,11 @@ def make_node(
     else:
         cond = indices < 0
         indices = indices + tf.cast(
-            tf.where(cond, 1, 0) * tf.shape(input_tensor, out_type=out_dtype)[axis],
+            tf.where(
+                cond,
+                tf.convert_to_tensor(1, dtype=out_dtype),
+                tf.convert_to_tensor(0, dtype=out_dtype)
+            ) * tf.shape(input_tensor, out_type=out_dtype)[axis],
             dtype=out_dtype,
         )
 


### PR DESCRIPTION
### 1. Content and background
- Fixed dtype conversion error when outputting `Gather` for GPU Delegate

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
