### PR TITLE
Added `--no_large_tensor` option for onnxsim

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.5.45
+  ghcr.io/pinto0309/onnx2tf:1.6.0
 
   or
 
@@ -134,6 +134,7 @@ usage: onnx2tf
 [-nuonag]
 [-b BATCH_SIZE]
 [-ois OVERWRITE_INPUT_SHAPE [OVERWRITE_INPUT_SHAPE ...]]
+[-nlt]
 [-onwdt]
 [-k KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES [KEEP_NCW_OR_NCHW_OR_NCDHW_INPUT_NAMES ...]]
 [-kt KEEP_NWC_OR_NHWC_OR_NDHWC_INPUT_NAMES [KEEP_NWC_OR_NHWC_OR_NDHWC_INPUT_NAMES ...]]
@@ -266,6 +267,10 @@ optional arguments:
     A value of 1 or more must be specified.
     Numerical values other than dynamic dimensions are ignored.
     Ignores --batch_size if specified at the same time as --batch_size.
+
+  -nlt, --no_large_tensor
+    Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim.
+    See: https://github.com/daquexian/onnx-simplifier/issues/178
 
   -onwdt, --output_nms_with_dynamic_tensor
     The number of bounding boxes in the NMS output results is
@@ -511,6 +516,7 @@ convert(
   not_use_opname_auto_generate: Optional[bool] = False,
   batch_size: Union[int, NoneType] = None,
   overwrite_input_shape: Union[List[str], NoneType] = None,
+  no_large_tensor: Optional[bool] = False,
   output_nms_with_dynamic_tensor: Optional[bool] = False,
   keep_ncw_or_nchw_or_ncdhw_input_names: Union[List[str], NoneType] = None,
   keep_nwc_or_nhwc_or_ndhwc_input_names: Union[List[str], NoneType] = None,
@@ -653,6 +659,10 @@ convert(
       A value of 1 or more must be specified.
       Numerical values other than dynamic dimensions are ignored.
       Ignores batch_size if specified at the same time as batch_size.
+
+    no_large_tensor: Optional[bool]
+        Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim.
+        See: https://github.com/daquexian/onnx-simplifier/issues/178
 
     output_nms_with_dynamic_tensor: Optional[bool]
         The number of bounding boxes in the NMS output results is

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.5.45'
+__version__ = '1.6.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -66,6 +66,7 @@ def convert(
     not_use_opname_auto_generate: Optional[bool] = False,
     batch_size: Optional[int] = None,
     overwrite_input_shape: Optional[List[str]] = None,
+    no_large_tensor: Optional[bool] = False,
     output_nms_with_dynamic_tensor: Optional[bool] = False,
     keep_ncw_or_nchw_or_ncdhw_input_names: Optional[List[str]] = None,
     keep_nwc_or_nhwc_or_ndhwc_input_names: Optional[List[str]] = None,
@@ -208,6 +209,10 @@ def convert(
         A value of 1 or more must be specified.\n
         Numerical values other than dynamic dimensions are ignored.\n
         Ignores batch_size if specified at the same time as batch_size.
+
+    no_large_tensor: Optional[bool]
+        Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim.\n
+        See: https://github.com/daquexian/onnx-simplifier/issues/178
 
     output_nms_with_dynamic_tensor: Optional[bool]
         The number of bounding boxes in the NMS output results is\n
@@ -504,6 +509,8 @@ def convert(
             for _ in range(3):
                 append_param = list(['--overwrite-input-shape'] + overwrite_input_shape) \
                     if overwrite_input_shape is not None else []
+                append_param = append_param + ['--no-large-tensor'] \
+                    if no_large_tensor else append_param
                 result = subprocess.check_output(
                     [
                         'onnxsim',
@@ -1413,6 +1420,14 @@ def main():
             'Ignores --batch_size if specified at the same time as --batch_size.'
     )
     parser.add_argument(
+        '-nlt',
+        '--no_large_tensor',
+        action='store_true',
+        help=\
+            'Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim. \n' +
+            'See: https://github.com/daquexian/onnx-simplifier/issues/178'
+    )
+    parser.add_argument(
         '-onwdt',
         '--output_nms_with_dynamic_tensor',
         action='store_true',
@@ -1731,6 +1746,7 @@ def main():
         not_use_opname_auto_generate=args.not_use_opname_auto_generate,
         batch_size=args.batch_size,
         overwrite_input_shape=args.overwrite_input_shape,
+        no_large_tensor=args.no_large_tensor,
         output_nms_with_dynamic_tensor=args.output_nms_with_dynamic_tensor,
         keep_ncw_or_nchw_or_ncdhw_input_names=args.keep_ncw_or_nchw_or_ncdhw_input_names,
         keep_nwc_or_nhwc_or_ndhwc_input_names=args.keep_nwc_or_nhwc_or_ndhwc_input_names,


### PR DESCRIPTION
### 1. Content and background
- Added `--no_large_tensor`, `-nlt` option for onnxsim
    ```
    no_large_tensor: Optional[bool]
        Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim.\n
        See: https://github.com/daquexian/onnx-simplifier/issues/178
    ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Support additional parameters to onnxsim #175](https://github.com/PINTO0309/onnx2tf/issues/175)