### PR TITLE
Fixed a fatal bug that disabled parameter substitution when ONNX OP name starts with "/".

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.6.0
+  ghcr.io/pinto0309/onnx2tf:1.6.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -488,6 +488,10 @@ def convert(
         try:
             with open(param_replacement_file, 'r') as f:
                 replacement_parameters = json.load(f)['operations']
+                for operations in replacement_parameters:
+                    operations['op_name'] = operations['op_name'].replace(':','_')
+                    if output_signaturedefs:
+                        operations['op_name'] = re.sub('^/', 'wa/', operations['op_name'])
         except json.decoder.JSONDecodeError as ex:
             print(
                 f'{Color.RED}ERROR:{Color.RESET} ' +


### PR DESCRIPTION
### 1. Content and background
- Fixed a fatal bug that disabled parameter substitution when ONNX OP name starts with `/`.
- The problem occurred only when the `-osd` option was specified.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[[DDNM] Support additional parameters to onnxsim #175](https://github.com/PINTO0309/onnx2tf/issues/175)