### PR TITLE
Added the ability to overwrite ONNX input/output names with tflite input/output names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
         nano python3-pip python3-mock libpython3-dev \
         libpython3-all-dev python-is-python3 wget \
-        software-properties-common sudo \
+        software-properties-common sudo flatbuffers-compiler \
     && sed -i 's/# set linenumbers/set linenumbers/g' /etc/nanorc \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
 - tensorflow==2.10.0
+- flatbuffers-compiler
 
 ## Sample Usage
 - HostPC
@@ -29,7 +30,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.6.1
+  ghcr.io/pinto0309/onnx2tf:1.6.2
 
   or
 
@@ -58,6 +59,7 @@ or
   !sudo apt-get -y install python3.9-dev
   !sudo apt-get -y install python3-pip
   !sudo apt-get -y install python3.9-distutils
+  !sudo apt-get -y install flatbuffers-compiler
   !python3.9 -m pip install -U setuptools \
     && python3.9 -m pip install -U pip \
     && python3.9 -m pip install -U distlib
@@ -126,6 +128,7 @@ usage: onnx2tf
 [-osd]
 [-oh5]
 [-ow]
+[-coion]
 [-oiqt]
 [-qt {per-channel,per-tensor}]
 [-qcind INPUT_NAME NUMPY_FILE_PATH MEAN STD]
@@ -180,6 +183,17 @@ optional arguments:
 
   -ow, --output_weights
     Output weights in hdf5 format.
+
+  -coion, --copy_onnx_input_output_names_to_tflite
+    Copy the input/output OP name of ONNX to the input/output OP name of tflite.
+    Due to Tensorflow internal operating specifications,
+    the input/output order of ONNX does not necessarily match
+    the input/output order of tflite.
+    Be sure to check that the input/output OP names in the generated
+    tflite file have been converted as expected.
+    Also, this option generates a huge JSON file as a temporary file for processing.
+    Therefore, it is strongly discouraged to use it on large models of hundreds
+    of megabytes or more.
 
   -oiqt, --output_integer_quantized_tflite
     Output of integer quantized tflite.
@@ -508,6 +522,7 @@ convert(
   output_signaturedefs: Optional[bool] = False,
   output_h5: Optional[bool] = False,
   output_weights: Optional[bool] = False,
+  copy_onnx_input_output_names_to_tflite: Optional[bool] = False,
   output_integer_quantized_tflite: Optional[bool] = False,
   quant_type: Optional[str] = 'per-channel',
   quant_calib_input_op_name_np_data_path: Optional[List] = None,
@@ -571,6 +586,17 @@ convert(
 
     output_weights: Optional[bool]
         Output weights in hdf5 format.
+
+    copy_onnx_input_output_names_to_tflite: Optional[bool]
+      Copy the input/output OP name of ONNX to the input/output OP name of tflite.
+      Due to Tensorflow internal operating specifications,
+      the input/output order of ONNX does not necessarily match
+      the input/output order of tflite.
+      Be sure to check that the input/output OP names in the generated
+      tflite file have been converted as expected.
+      Also, this option generates a huge JSON file as a temporary file for processing.
+      Therefore, it is strongly discouraged to use it on large models of hundreds
+      of megabytes or more.
 
     output_integer_quantized_tflite: Optional[bool]
       Output of integer quantized tflite.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'


### PR DESCRIPTION
### 1. Content and background
- Added the ability to override tflite input/output names with ONNX input/output names. `-coion`
```
-coion, --copy_onnx_input_output_names_to_tflite
  Copy the input/output OP name of ONNX to the input/output OP name of tflite.
  Due to Tensorflow internal operating specifications,
  the input/output order of ONNX does not necessarily match
  the input/output order of tflite.
  Be sure to check that the input/output OP names in the generated
  tflite file have been converted as expected.
  Also, this option generates a huge JSON file as a temporary file for processing.
  Therefore, it is strongly discouraged to use it on large models of hundreds
  of megabytes or more.
```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)
![image](https://user-images.githubusercontent.com/33194443/217706803-4201ad6f-83e1-48fe-aff0-a59f0c8858ad.png)

### 4. Issue number (only if there is a related issue)
[ONNX model input & output names are not preserved in TensorFlow & TensorFlow Lite models #178](https://github.com/PINTO0309/onnx2tf/issues/178)