### PR TITLE
Fixed `Transpose`->`Softmax`->`Transpose` pattern to take over `Transpose` enable/disable status when `Transpose`->`Softmax`->`Transpose` pattern is used to remove useless `Transpose` from the graph and optimize it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
         nano python3-pip python3-mock libpython3-dev \
-        libpython3-all-dev python-is-python3 wget \
+        libpython3-all-dev python-is-python3 wget curl \
         software-properties-common sudo flatbuffers-compiler \
     && sed -i 's/# set linenumbers/set linenumbers/g' /etc/nanorc \
     && apt clean \

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.6.2
+  ghcr.io/pinto0309/onnx2tf:1.6.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.6.2'
+__version__ = '1.6.3'

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -3,7 +3,6 @@ import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
-import onnx
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -16,12 +15,11 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    dummy_onnx_inference,
     dummy_tf_inference,
     get_tf_model_inputs,
     onnx_tf_tensor_validation,
 )
-from typing import List, Any, Dict
+from typing import Any, Dict
 
 
 @print_node_info
@@ -74,7 +72,10 @@ def make_node(
         'dtype': dtype,
         'nhwc': tf_layers_dict[graph_node_input.name]['nhwc'] \
             if isinstance(graph_node_input, gs.Variable) \
-                and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
+                and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False,
+        'nwc_nhwc_ndhwc_keep': tf_layers_dict[graph_node_input.name]['nwc_nhwc_ndhwc_keep'] \
+            if isinstance(graph_node_input, gs.Variable) \
+                and 'nwc_nhwc_ndhwc_keep' in tf_layers_dict[graph_node_input.name].keys() else False,
     }
 
     # Param replacement

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -58,12 +58,14 @@ def make_node(
         and tf_layers_dict[graph_node_input.name]['nwc_nhwc_ndhwc_keep'] == True:
         perm = [i for i in range(tensor_rank)]
 
+    nwc_nhwc_ndhwc_keep = False
     if isinstance(perm, list) or (isinstance(perm, np.ndarray) and len(perm.shape) > 0):
         if perm[0] == 0:
             try:
                 if graph_node.o().op == 'Softmax' \
                     and graph_node.o().inputs[0].shape == input_tensor_shape:
                     perm = [idx for idx in range(tensor_rank)]
+                    nwc_nhwc_ndhwc_keep = True
                 else:
                     perm = [
                         convert_axis(
@@ -153,6 +155,7 @@ def make_node(
         'optype': graph_node.op,
         'shape': output_shape,
         'dtype': dtype,
+        'nwc_nhwc_ndhwc_keep': nwc_nhwc_ndhwc_keep,
     }
 
     perm = list(perm) if perm is not None else None


### PR DESCRIPTION
### 1. Content and background
- Fixed `Transpose`->`Softmax`->`Transpose` pattern to take over `Transpose` enable/disable status when Transpose->Softmax->Transpose pattern is used to remove useless `Transpose` from the graph and optimize it.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)
- Before
  ![image](https://user-images.githubusercontent.com/33194443/217759939-7f75b7d6-abbc-48a8-bf84-554966fca146.png)
  ONNX | TF
  :-: | :-:
  <img src="https://user-images.githubusercontent.com/34959032/217731925-bae71fee-257a-47c9-a245-a9b7b555f66c.png" width="150">|  <img src="https://user-images.githubusercontent.com/34959032/217731953-09e75533-ef33-476e-8da1-e9e28a6140c4.png" width="150">

- After
  ![image](https://user-images.githubusercontent.com/33194443/217760618-35809f57-80e2-485e-8fb4-5612c2769306.png)
  ONNX | TF
  :-: | :-:
  <img src="https://user-images.githubusercontent.com/34959032/217731925-bae71fee-257a-47c9-a245-a9b7b555f66c.png" width="150">|  <img src="https://user-images.githubusercontent.com/33194443/217760365-b1f000fb-34ab-493b-9acc-1a6e406abbf8.png">



### 4. Issue number (only if there is a related issue)
[[FastestDet] height and width axes are switched before last concatenation #180](https://github.com/PINTO0309/onnx2tf/issues/180)