### PR TITLE
Work around a bug in TensorFlow's model optimizer. `Reducemax` -> `Subtract` -> `Softmax`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.6.3
+  ghcr.io/pinto0309/onnx2tf:1.6.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.6.3'
+__version__ = '1.6.4'

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -182,9 +182,9 @@ def make_node(
                     tf.math.subtract(
                         x=tf.math.add(
                             x=input_tensor,
-                            y=tf.constant(1e-7, dtype=tf.float32)
+                            y=tf.constant(1e-7, dtype=input_tensor.dtype)
                         ),
-                        y=tf.constant(1e-7, dtype=tf.float32)
+                        y=tf.constant(1e-7, dtype=input_tensor.dtype)
                     )
     except Exception as ex:
         pass


### PR DESCRIPTION
### 1. Content and background
- Work around a bug in TensorFlow's model optimizer. `Reducemax` -> `Subtract` -> `Softmax`
- There seems to be a rather critical bug in TensorFlow's `Softmax`.
- Fatal bug where `Reducemax` and `Subtract` are ignored 

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)
- Before
  |onnx|Left: Keras .h5, Right: tflite|
  |:-:|:-:|
  |![image](https://user-images.githubusercontent.com/33194443/218233243-523a7f64-982d-44fd-b67b-03ca350e8913.png)|![image](https://user-images.githubusercontent.com/33194443/218233231-fc7b8fd7-507b-43b4-95d6-9bae8f53cf40.png)|

- After
  ![image](https://user-images.githubusercontent.com/33194443/218233371-231a3e82-87a6-4bff-a866-95d27173b506.png)

### 4. Issue number (only if there is a related issue)
[ReduceMax before Softmax ignored during conversion #182](https://github.com/PINTO0309/onnx2tf/issues/182)