### PR TITLE
[Experimental / WIP] Generate a miniscule model for each OP only, retain the results of test inference, and propagate to all OPs. STEP.1,2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.6.4
+  ghcr.io/pinto0309/onnx2tf:1.7.0
 
   or
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   -w /workdir \
   ghcr.io/pinto0309/onnx2tf:1.7.0
 
-
   or
 
   $ pip install -U onnx \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.6.4'
+__version__ = '1.7.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -662,6 +662,7 @@ def convert(
 
     # Define additional parameters
     additional_parameters = {
+        'input_onnx_file_path': input_onnx_file_path if input_onnx_file_path is not None else None,
         'onnx_graph': onnx_graph,
         'opset': graph.opset,
         'batch_size': batch_size,

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -163,7 +163,7 @@ def make_node(
             )
 
     # Generation of TF OP
-    # Overall model
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.add(
             x=input_tensor_1,

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -70,11 +70,26 @@ def make_node(
         'dtype': dtype,
     }
 
-    # Generation of TF OP
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+
+    # Acquisition of test data for validation
+    if not isinstance(graph_node_input_1, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    elif isinstance(graph_node_input_1, np.ndarray):
+        test_data1: np.ndarray = graph_node_input_1
+    else:
+        test_data1 = None
+    if not isinstance(graph_node_input_2, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+    elif isinstance(graph_node_input_2, np.ndarray):
+        test_data2: np.ndarray = graph_node_input_2
+    else:
+        test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -170,20 +185,10 @@ def make_node(
             outputs=tf_partial_model_outputs,
         )
         test_data1 = None
-        if not isinstance(input_tensor_1, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-            else:
-                test_data1 = None
-        else:
+        if isinstance(input_tensor_1, np.ndarray):
             test_data1 = input_tensor_1
         test_data2 = None
-        if not isinstance(input_tensor_2, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-                test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-            else:
-                test_data2 = None
-        else:
+        if isinstance(input_tensor_2, np.ndarray):
             test_data2 = input_tensor_2
         tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
             model=tf_partial_model,

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -170,21 +170,21 @@ def make_node(
             outputs=tf_partial_model_outputs,
         )
         test_data1 = None
-        if not isinstance(graph_node_input_1, np.ndarray):
+        if not isinstance(input_tensor_1, np.ndarray):
             if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                test_data1 = tf_layers_dict[graph_node_input_1.name]['verification_data']
+                test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
             else:
                 test_data1 = None
         else:
-            test_data1 = graph_node_input_1
+            test_data1 = input_tensor_1
         test_data2 = None
-        if not isinstance(graph_node_input_2, np.ndarray):
+        if not isinstance(input_tensor_2, np.ndarray):
             if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-                test_data2 = tf_layers_dict[graph_node_input_2.name]['verification_data']
+                test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
             else:
                 test_data2 = None
         else:
-            test_data2 = graph_node_input_2
+            test_data2 = input_tensor_2
         tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -20,8 +20,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
-
 
 
 @print_node_info

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -144,23 +144,14 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
-    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape_1,
-                    tf_partial_model_input_shape_2,
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[
+                input_tensor_1,
+                input_tensor_2,
+            ]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -171,8 +162,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.add(

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -250,7 +250,8 @@ def make_node(
             and isinstance(test_data, np.ndarray) \
             and tf_input_shape != list(test_data.shape):
             test_data = test_data.transpose(test_data_transposed_perm)
-        if padded:
+        if padded \
+            and isinstance(test_data, np.ndarray):
             test_data = get_padding_as_op(
                 x=test_data,
                 pads=pads,

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -219,7 +219,8 @@ def make_node(
                 input_tensor,
             ]
         )
-    tf_partial_model_tensors = tf_partial_model_inputs[0]
+    tf_partial_model_tensors = tf_partial_model_inputs[0] \
+        if tf_partial_model_inputs is not None else None
     tf_partial_model_outputs = None
 
     def tf_partial_model_inference(

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -119,7 +119,7 @@ def make_node(
                 and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
                 test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
             elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = input_tensor
+                test_data: np.ndarray = graph_node_input
             else:
                 test_data = None
         else:

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -106,7 +106,7 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.cos(
-                    x=input_tensor,
+                    x=tf_partial_model_inputs[0],
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -16,7 +16,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -120,8 +120,7 @@ def make_node(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,
             verification_datas=[
-                tf_layers_dict[graph_node_input.name]['verification_data'] \
-                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+                test_data
             ]
         )
         tf_layers_dict[graph_node_output.name]['verification_data'] = \

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -81,18 +81,11 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -102,7 +95,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.cos(

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -12,7 +12,11 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -75,11 +79,65 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
+                ],
+            )
+
+    # Generation of TF OP
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.cos(
             x=input_tensor,
             name=graph_node.name,
         )
+    ### Partial model
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_outputs = \
+            [
+                tf.math.cos(
+                    x=input_tensor,
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data = None
+        if not isinstance(input_tensor, np.ndarray):
+            if not isinstance(graph_node_input, np.ndarray) \
+                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+            elif isinstance(graph_node_input, np.ndarray):
+                test_data: np.ndarray = input_tensor
+            else:
+                test_data = None
+        else:
+            test_data = input_tensor
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                tf_layers_dict[graph_node_input.name]['verification_data'] \
+                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+            ]
+        )
+        tf_layers_dict[graph_node_output.name]['verification_data'] = \
+            list(tf_partial_model_result_infos.values())[0]
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -178,23 +178,14 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
-    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape_1,
-                    tf_partial_model_input_shape_2,
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[
+                input_tensor_1,
+                input_tensor_2,
+            ]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -204,8 +195,7 @@ def make_node(
         name=graph_node.name,
     )
     ### Partial model
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.divide(

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -21,10 +21,7 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import (
-    NUMPY_DTYPES_TO_TF_DTYPES,
-    TF_DTYPES_TO_NUMPY_DTYPES,
-)
+from onnx2tf.utils.enums import TF_DTYPES_TO_NUMPY_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -234,7 +234,7 @@ def make_node(
         tf_partial_model_result: np.ndarray = list(tf_partial_model_result_infos.values())[0]
         if xy_is_integer and dtype in target_cast_dtype:
             cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[dtype] \
-                if isinstance(dtype, tf.dtypes) else dtype
+                if isinstance(dtype, tf.dtypes.DType) else dtype
             tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
         tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
         del tf_partial_model

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -17,6 +17,13 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
+)
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import (
+    NUMPY_DTYPES_TO_TF_DTYPES,
+    TF_DTYPES_TO_NUMPY_DTYPES,
 )
 
 
@@ -70,6 +77,22 @@ def make_node(
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+
+    # Acquisition of test data for validation
+    if not isinstance(graph_node_input_1, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    elif isinstance(graph_node_input_1, np.ndarray):
+        test_data1: np.ndarray = graph_node_input_1
+    else:
+        test_data1 = None
+    if not isinstance(graph_node_input_2, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+    elif isinstance(graph_node_input_2, np.ndarray):
+        test_data2: np.ndarray = graph_node_input_2
+    else:
+        test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -148,12 +171,77 @@ def make_node(
     x_is_integer = input_tensor_1.dtype in target_cast_dtype
     y_is_integer = input_tensor_2.dtype in target_cast_dtype
     xy_is_integer = x_is_integer and y_is_integer
+    input_tensor_1 = input_tensor_1 \
+        if not xy_is_integer else tf.cast(input_tensor_1, dtype=tf.float32)
+    input_tensor_2 = input_tensor_2 \
+        if not xy_is_integer else tf.cast(input_tensor_2, dtype=tf.float32)
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
+    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape_1,
+                    tf_partial_model_input_shape_2,
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
+                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
+                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
+                ],
+            )
+
+    # Generation of TF OP
+    ### Overall model
     divided_tensor = tf.math.divide(
-        x=input_tensor_1 if not xy_is_integer else tf.cast(input_tensor_1, dtype=tf.float32),
-        y=input_tensor_2 if not xy_is_integer else tf.cast(input_tensor_2, dtype=tf.float32),
+        x=input_tensor_1,
+        y=input_tensor_2,
         name=graph_node.name,
     )
+    ### Partial model
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_outputs = \
+            [
+                tf.math.divide(
+                    x=tf_partial_model_inputs[0],
+                    y=tf_partial_model_inputs[1],
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data1 = None
+        if isinstance(input_tensor_1, np.ndarray):
+            test_data1 = input_tensor_1
+        test_data2 = None
+        if isinstance(input_tensor_2, np.ndarray):
+            test_data2 = input_tensor_2
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                test_data1,
+                test_data2,
+            ]
+        )
+        tf_partial_model_result: np.ndarray = list(tf_partial_model_result_infos.values())[0]
+        if xy_is_integer and dtype in target_cast_dtype:
+            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[dtype] \
+                if isinstance(dtype, tf.dtypes) else dtype
+            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+        tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data1
+        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -212,9 +212,12 @@ def make_node(
                 z,
             ]
         )
-    tf_partial_x = tf_partial_model_inputs[0]
-    tf_partial_y = tf_partial_model_inputs[1]
-    tf_partial_z = tf_partial_model_inputs[2]
+    tf_partial_x = tf_partial_model_inputs[0] \
+        if tf_partial_model_inputs is not None else None
+    tf_partial_y = tf_partial_model_inputs[1] \
+        if tf_partial_model_inputs is not None else None
+    tf_partial_z = tf_partial_model_inputs[2] \
+        if tf_partial_model_inputs is not None else None
     if isinstance(test_data3, np.ndarray) and len(test_data3.shape) == 1 and len(tf_partial_z.shape) == 2:
         test_data3 = np.expand_dims(test_data3, 0)
     tf_partial_model_outputs = None

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -13,8 +13,14 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import (
+    TF_DTYPES_TO_NUMPY_DTYPES,
+    NUMPY_DTYPES_TO_TF_DTYPES,
+)
 
 
 @print_node_info
@@ -68,6 +74,29 @@ def make_node(
     z = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
         if isinstance(graph_node_input_3, gs.Variable) else graph_node_input_3
 
+    # Acquisition of test data for validation
+    if not isinstance(graph_node_input_1, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    elif isinstance(graph_node_input_1, np.ndarray):
+        test_data1: np.ndarray = graph_node_input_1
+    else:
+        test_data1 = None
+    if not isinstance(graph_node_input_2, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+    elif isinstance(graph_node_input_2, np.ndarray):
+        test_data2: np.ndarray = graph_node_input_2
+    else:
+        test_data2 = None
+    if not isinstance(graph_node_input_3, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_3.name].keys():
+        test_data3: np.ndarray = tf_layers_dict[graph_node_input_3.name]['verification_data']
+    elif isinstance(graph_node_input_3, np.ndarray):
+        test_data3: np.ndarray = graph_node_input_3
+    else:
+        test_data3 = None
+
     # Pre-process transpose
     x = pre_process_transpose(
         value_before_transpose=x,
@@ -91,10 +120,15 @@ def make_node(
     input_tensor_x_dtype = NUMPY_DTYPES_TO_TF_DTYPES[x.dtype] \
         if isinstance(x.dtype, np.dtype) else x.dtype
     x = tf.keras.layers.Flatten()(x)
+    if test_data1 is not None and isinstance(test_data1, np.ndarray):
+        test_data1 = tf.keras.layers.Flatten()(test_data1).numpy()
     # The Flatten API changes data type from tf.float64 to tf.float32
     # so we need the following line to get the original type back
     x = tf.cast(x, input_tensor_x_dtype) \
         if input_tensor_x_dtype is tf.float64 else x
+    if test_data1 is not None and isinstance(test_data1, np.ndarray):
+        test_data1 = test_data1.astype(TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_x_dtype]) \
+            if input_tensor_x_dtype is tf.float64 else test_data1
 
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
@@ -161,26 +195,146 @@ def make_node(
     # Generation of TF OP
     if transA == True:
         x = tf.transpose(x)
+        if test_data1 is not None:
+            test_data1 = tf.transpose(test_data1)
     if transB == True:
         y = tf.transpose(y)
+        if test_data2 is not None:
+            test_data2 = tf.transpose(test_data2)
+
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[
+                x,
+                y,
+                z,
+            ]
+        )
+    tf_partial_x = tf_partial_model_inputs[0]
+    tf_partial_y = tf_partial_model_inputs[1]
+    tf_partial_z = tf_partial_model_inputs[2]
+    if isinstance(test_data3, np.ndarray) and len(test_data3.shape) == 1 and len(tf_partial_z.shape) == 2:
+        test_data3 = np.expand_dims(test_data3, 0)
+    tf_partial_model_outputs = None
+
     # We cast to either input or attribute data type to preserve precision
     if input_tensor_x_dtype in [tf.float64]:
         # cast to input data type
         alpha = tf.cast(alpha, input_tensor_x_dtype)
         beta = tf.cast(beta, input_tensor_x_dtype)
+        ### Overall model
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             alpha * tf.matmul(x, y) + beta * z
+        ### Partial model
+        if tf_partial_model_inputs is not None:
+            tf_partial_model_outputs = \
+                [
+                    alpha * tf.matmul(tf_partial_x, tf_partial_y) + beta * tf_partial_z
+                ]
+            tf_partial_model = tf.keras.Model(
+                inputs=tf_partial_model_inputs,
+                outputs=tf_partial_model_outputs,
+            )
+            tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+                model=tf_partial_model,
+                inputs=tf_partial_model_inputs,
+                verification_datas=[
+                    test_data1,
+                    test_data2,
+                    test_data3,
+                ]
+            )
+            tf_layers_dict[graph_node_output.name]['verification_data'] = \
+                list(tf_partial_model_result_infos.values())[0]
+            del tf_partial_model
+            del tf_partial_model_inputs
+            del tf_partial_model_outputs
+            del test_data1
+            del test_data2
+            del test_data3
+
     else:
         # cast to attribute data type
         x = tf.cast(x, tf.float32)
+        if test_data1 is not None:
+            test_data1 = tf.cast(test_data1, tf.float32)
         y = tf.cast(y, tf.float32)
+        if test_data2 is not None:
+            test_data2 = tf.cast(test_data2, tf.float32)
         z = tf.cast(z, tf.float32)
+        if test_data3 is not None:
+            test_data3 = tf.cast(test_data3, tf.float32)
         if not optimization_for_gpu_delegate:
+            ### Overall model
             result = alpha * tf.matmul(x, y) + beta * z
+            ### Partial model
+            if tf_partial_model_inputs is not None:
+                tf_partial_model_outputs = \
+                    [
+                        alpha * tf.matmul(tf_partial_x, tf_partial_y) + beta * tf_partial_z
+                    ]
+                tf_partial_model = tf.keras.Model(
+                    inputs=tf_partial_model_inputs,
+                    outputs=tf_partial_model_outputs,
+                )
+                tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+                    model=tf_partial_model,
+                    inputs=tf_partial_model_inputs,
+                    verification_datas=[
+                        test_data1,
+                        test_data2,
+                        test_data3,
+                    ]
+                )
+                tf_layers_dict[graph_node_output.name]['verification_data'] = \
+                    list(tf_partial_model_result_infos.values())[0]
+                del tf_partial_model
+                del tf_partial_model_inputs
+                del tf_partial_model_outputs
+                del test_data1
+                del test_data2
+                del test_data3
+
         else:
+            ### Overall model
             result = alpha * tf.matmul(x, y) - (beta * z) * -1
+            ### Partial model
+            if tf_partial_model_inputs is not None:
+                tf_partial_model_outputs = \
+                    [
+                        alpha * tf.matmul(tf_partial_x, tf_partial_y) - (beta * tf_partial_z) * -1
+                    ]
+                tf_partial_model = tf.keras.Model(
+                    inputs=tf_partial_model_inputs,
+                    outputs=tf_partial_model_outputs,
+                )
+                tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+                    model=tf_partial_model,
+                    inputs=tf_partial_model_inputs,
+                    verification_datas=[
+                        test_data1,
+                        test_data2,
+                        test_data3,
+                    ]
+                )
+                tf_layers_dict[graph_node_output.name]['verification_data'] = \
+                    list(tf_partial_model_result_infos.values())[0]
+                del tf_partial_model
+                del tf_partial_model_inputs
+                del tf_partial_model_outputs
+                del test_data1
+                del test_data2
+                del test_data3
+
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.cast(result, input_tensor_x_dtype)
+        if 'verification_data' in tf_layers_dict[graph_node_output.name].keys():
+            tf_layers_dict[graph_node_output.name]['verification_data'] = \
+                tf_layers_dict[graph_node_output.name]['verification_data'].astype(
+                    TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_x_dtype]
+                )
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -219,7 +219,9 @@ def make_node(
     tf_partial_z = tf_partial_model_inputs[2] \
         if tf_partial_model_inputs is not None else None
     if tf_partial_model_inputs is not None:
-        if isinstance(test_data3, np.ndarray) and len(test_data3.shape) == 1 and len(tf_partial_z.shape) == 2:
+        if isinstance(test_data3, np.ndarray) \
+            and len(test_data3.shape) == 1 \
+            and len(tf_partial_z.shape) == 2:
             test_data3 = np.expand_dims(test_data3, 0)
     tf_partial_model_outputs = None
 

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -218,8 +218,9 @@ def make_node(
         if tf_partial_model_inputs is not None else None
     tf_partial_z = tf_partial_model_inputs[2] \
         if tf_partial_model_inputs is not None else None
-    if isinstance(test_data3, np.ndarray) and len(test_data3.shape) == 1 and len(tf_partial_z.shape) == 2:
-        test_data3 = np.expand_dims(test_data3, 0)
+    if tf_partial_model_inputs is not None:
+        if isinstance(test_data3, np.ndarray) and len(test_data3.shape) == 1 and len(tf_partial_z.shape) == 2:
+            test_data3 = np.expand_dims(test_data3, 0)
     tf_partial_model_outputs = None
 
     # We cast to either input or attribute data type to preserve precision

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -92,23 +92,13 @@ def make_node(
     try:
         # Generate input OPs for TensorFlow subgraphs
         # For inference testing on OP stand-alone
-        tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
-        tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
-        if None not in tf_partial_model_input_shape_1 \
-            and None not in tf_partial_model_input_shape_2:
-            tf_partial_model_inputs: List[tf.keras.Input] = \
-                make_tf_partial_model_inputs(
-                    input_shapes=[
-                        tf_partial_model_input_shape_1,
-                        tf_partial_model_input_shape_2,
-                    ],
-                    input_dtypes=[
-                        NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                            if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                        NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                            if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                    ],
-                )
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor_1,
+                    input_tensor_2,
+                ]
+            )
         tf_partial_model_outputs = None
         ### Overall model
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -119,8 +109,7 @@ def make_node(
                 name=graph_node.name,
             )
         ### Partial model
-        if None not in tf_partial_model_input_shape_1 \
-            and None not in tf_partial_model_input_shape_2:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.matmul(
@@ -165,22 +154,12 @@ def make_node(
                 try:
                     # Generate input OPs for TensorFlow subgraphs
                     # For inference testing on OP stand-alone
-                    tf_partial_model_input_shape_1 = [dim for dim in np.asarray(input_tensor_1.shape)[tensor_1_candidate_for_transposition]]
-                    tf_partial_model_input_shape_2 = [dim for dim in np.asarray(input_tensor_2.shape)[tensor_2_candidate_for_transposition]]
-                    if None not in tf_partial_model_input_shape_1 \
-                        and None not in tf_partial_model_input_shape_2:
-                        tf_partial_model_inputs: List[tf.keras.Input] = \
+                    tf_partial_model_inputs: List[tf.keras.Input] = \
                             make_tf_partial_model_inputs(
-                                input_shapes=[
-                                    tf_partial_model_input_shape_1,
-                                    tf_partial_model_input_shape_2,
-                                ],
-                                input_dtypes=[
-                                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                                ],
+                                input_tensors=[
+                                    np.asarray(input_tensor_1.shape)[tensor_1_candidate_for_transposition],
+                                    np.asarray(input_tensor_2.shape)[tensor_2_candidate_for_transposition],
+                                ]
                             )
                     tf_partial_model_outputs = None
                     ### Overall model
@@ -192,8 +171,7 @@ def make_node(
                             name=graph_node.name,
                         )
                     ### Partial model
-                    if None not in tf_partial_model_input_shape_1 \
-                        and None not in tf_partial_model_input_shape_2:
+                    if tf_partial_model_inputs is not None:
                         tf_partial_model_outputs = \
                             [
                                 tf.matmul(

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -16,7 +16,11 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -71,6 +75,22 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    # Acquisition of test data for validation
+    if not isinstance(graph_node_input_1, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    elif isinstance(graph_node_input_1, np.ndarray):
+        test_data1: np.ndarray = graph_node_input_1
+    else:
+        test_data1 = None
+    if not isinstance(graph_node_input_2, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+    elif isinstance(graph_node_input_2, np.ndarray):
+        test_data2: np.ndarray = graph_node_input_2
+    else:
+        test_data2 = None
+
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
     #   2. If only one of the two is the output of Transpose
@@ -122,12 +142,69 @@ def make_node(
         **kwargs,
     )
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
+    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape_1,
+                    tf_partial_model_input_shape_2,
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
+                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
+                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
+                ],
+            )
+
+    # Generation of TF OP
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.mod(
             x=input_tensor_1,
             y=input_tensor_2,
             name=graph_node.name,
         )
+    ### Partial model
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_outputs = \
+            [
+                tf.math.mod(
+                    x=tf_partial_model_inputs[0],
+                    y=tf_partial_model_inputs[1],
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data1 = None
+        if isinstance(input_tensor_1, np.ndarray):
+            test_data1 = input_tensor_1
+        test_data2 = None
+        if isinstance(input_tensor_2, np.ndarray):
+            test_data2 = input_tensor_2
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                test_data1,
+                test_data2,
+            ]
+        )
+        tf_layers_dict[graph_node_output.name]['verification_data'] = \
+            list(tf_partial_model_result_infos.values())[0]
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data1
+        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -144,23 +144,14 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
-    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape_1,
-                    tf_partial_model_input_shape_2,
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[
+                input_tensor_1,
+                input_tensor_2,
+            ]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -171,8 +162,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.mod(

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -20,7 +20,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -166,23 +166,14 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
-    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape_1,
-                    tf_partial_model_input_shape_2,
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[
+                input_tensor_1,
+                input_tensor_2,
+            ]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -193,8 +184,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.multiply(

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -18,7 +18,11 @@ from onnx2tf.utils.common_functions import (
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
     broadcast_for_gpu_delegate,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -71,6 +75,22 @@ def make_node(
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+
+    # Acquisition of test data for validation
+    if not isinstance(graph_node_input_1, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    elif isinstance(graph_node_input_1, np.ndarray):
+        test_data1: np.ndarray = graph_node_input_1
+    else:
+        test_data1 = None
+    if not isinstance(graph_node_input_2, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+    elif isinstance(graph_node_input_2, np.ndarray):
+        test_data2: np.ndarray = graph_node_input_2
+    else:
+        test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -144,13 +164,69 @@ def make_node(
         **kwargs,
     )
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
+    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape_1,
+                    tf_partial_model_input_shape_2,
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
+                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
+                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
+                ],
+            )
+
     # Generation of TF OP
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.multiply(
             x=input_tensor_1,
             y=input_tensor_2,
             name=graph_node.name,
         )
+    ### Partial model
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_outputs = \
+            [
+                tf.math.multiply(
+                    x=tf_partial_model_inputs[0],
+                    y=tf_partial_model_inputs[1],
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data1 = None
+        if isinstance(input_tensor_1, np.ndarray):
+            test_data1 = input_tensor_1
+        test_data2 = None
+        if isinstance(input_tensor_2, np.ndarray):
+            test_data2 = input_tensor_2
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                test_data1,
+                test_data2,
+            ]
+        )
+        tf_layers_dict[graph_node_output.name]['verification_data'] = \
+            list(tf_partial_model_result_infos.values())[0]
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data1
+        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -22,7 +22,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -172,7 +172,7 @@ def make_node(
                 and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
                 test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
             elif isinstance(graph_node_input_1, np.ndarray):
-                test_data: np.ndarray = input_tensor
+                test_data: np.ndarray = graph_node_input_1
             else:
                 test_data = None
         else:

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -17,8 +17,9 @@ from onnx2tf.utils.common_functions import (
     make_tf_partial_model_inputs,
     dummy_tf_inference,
 )
-from onnx2tf.utils.colors import Color
 from typing import Any, Dict, List
+from onnx2tf.utils.colors import Color
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -135,7 +136,8 @@ def make_node(
                 [dim for dim in input_tensor.shape]
             ],
             input_dtypes=[
-                input_tensor.dtype
+                NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                    if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
             ],
         )
 

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -173,8 +173,7 @@ def make_node(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,
             verification_datas=[
-                tf_layers_dict[graph_node_input_1.name]['verification_data'] \
-                    if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys() else None
+                test_data
             ]
         )
         tf_layers_dict[graph_node_output.name]['verification_data'] = \

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -145,9 +145,8 @@ def make_node(
 
     # Generation of TF OP
     ### Overall model
-    reducemaxed_tensor = input_tensor
     reducemaxed_tensor = tf.math.reduce_max(
-        input_tensor=reducemaxed_tensor,
+        input_tensor=input_tensor,
         axis=axes,
         keepdims=keepdims,
         name=f'{graph_node.name}',
@@ -168,13 +167,13 @@ def make_node(
             outputs=tf_partial_model_outputs,
         )
         test_data = None
-        if not isinstance(graph_node_input_1, np.ndarray):
+        if not isinstance(input_tensor, np.ndarray):
             if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                test_data = tf_layers_dict[graph_node_input_1.name]['verification_data']
+                test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
             else:
                 test_data = None
         else:
-            test_data = graph_node_input_1
+            test_data = input_tensor
         tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -130,18 +130,11 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -153,7 +146,7 @@ def make_node(
     )
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemaxed_tensor
     ### Partial model
-    if None not in tf_partial_model_input_shape:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.reduce_max(

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -19,7 +19,6 @@ from onnx2tf.utils.common_functions import (
 )
 from typing import Any, Dict, List
 from onnx2tf.utils.colors import Color
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -168,8 +168,11 @@ def make_node(
         )
         test_data = None
         if not isinstance(input_tensor, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            if not isinstance(graph_node_input_1, np.ndarray) \
+                and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
                 test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+            elif isinstance(graph_node_input_1, np.ndarray):
+                test_data: np.ndarray = input_tensor
             else:
                 test_data = None
         else:

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -197,6 +197,9 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['verification_data'] = \
         list(tf_partial_model_result_infos.values())[0]
     del tf_partial_model
+    del tf_partial_model_inputs
+    del tf_partial_model_outputs
+    del test_data
 
     # Special support for ShuffleNet patterns
     # 5D Reshape -> 5D Transpose -> 4D Reshape

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -106,12 +106,12 @@ def make_node(
     test_data = None
     if not isinstance(input_tensor, np.ndarray):
         if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data = tf_layers_dict[graph_node_input_1.name]['verification_data']
+            test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
             test_data = test_data.transpose(list(perm) if perm is not None else None)
         else:
             test_data = None
     else:
-        test_data = graph_node_input_1.transpose(list(perm) if perm is not None else None)
+        test_data = input_tensor.transpose(list(perm) if perm is not None else None)
 
     if isinstance(reshape_shape, np.ndarray):
         perm_shape = [

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -157,18 +157,11 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in transposed_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[transposed_tensor.dtype] \
-                        if isinstance(transposed_tensor.dtype, np.dtype) else transposed_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[transposed_tensor]
+        )
+    tf_partial_model_outputs = None
 
     # Reshape
     has_undefined_outputshape = output_shape is None
@@ -185,7 +178,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.reshape(
@@ -242,7 +235,7 @@ def make_node(
                         perm=[0,2,3,1],
                     )
                 ### Partial model
-                if None not in tf_partial_model_input_shape:
+                if tf_partial_model_inputs is not None:
                     tf_layers_dict[graph_node_output.name]['verification_data'] = \
                         tf_layers_dict[graph_node_output.name]['verification_data'].transpose([0,2,3,1])
             else:

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -18,7 +18,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -105,8 +105,12 @@ def make_node(
     )
     test_data = None
     if not isinstance(input_tensor, np.ndarray):
-        if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        if not isinstance(graph_node_input_1, np.ndarray) \
+            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
             test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+            test_data = test_data.transpose(list(perm) if perm is not None else None)
+        elif isinstance(graph_node_input_1, np.ndarray):
+            test_data: np.ndarray = input_tensor
             test_data = test_data.transpose(list(perm) if perm is not None else None)
         else:
             test_data = None

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -97,10 +97,22 @@ def make_node(
             before_op_output_shape_trans=before_op_output_shape_trans,
         ) for idx in range(tensor_rank)
     ]
+
+    # NHWC -> HCHW
     transposed_tensor = tf.transpose(
         a=input_tensor,
         perm=list(perm) if perm is not None else None,
     )
+    test_data = None
+    if not isinstance(input_tensor, np.ndarray):
+        if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            test_data = tf_layers_dict[graph_node_input_1.name]['verification_data']
+            test_data = test_data.transpose(list(perm) if perm is not None else None)
+        else:
+            test_data = None
+    else:
+        test_data = graph_node_input_1.transpose(list(perm) if perm is not None else None)
+
     if isinstance(reshape_shape, np.ndarray):
         perm_shape = [
             convert_axis(
@@ -182,14 +194,6 @@ def make_node(
             inputs=tf_partial_model_inputs,
             outputs=tf_partial_model_outputs,
         )
-        test_data = None
-        if not isinstance(graph_node_input_1, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                test_data = tf_layers_dict[graph_node_input_1.name]['verification_data']
-            else:
-                test_data = None
-        else:
-            test_data = graph_node_input_1
         tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -347,6 +347,22 @@ def make_node(
         **kwargs,
     )
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
+                ],
+            )
+    tf_partial_model_outputs = None
+
     resized_tensor = None
     boxes = None
     box_indices = None
@@ -386,35 +402,6 @@ def make_node(
                         extrapolation_value=extrapolation_value,
                     )
                 ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            test_data = None
-            if not isinstance(input_tensor, np.ndarray):
-                if not isinstance(graph_node_input, np.ndarray) \
-                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-                elif isinstance(graph_node_input, np.ndarray):
-                    test_data: np.ndarray = graph_node_input
-                else:
-                    test_data = None
-            else:
-                test_data = input_tensor
-            # TF dummy inference
-            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data
-                ]
-            )
-            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
-            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
-                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
-            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
-            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
-            del tf_partial_model
 
     elif coordinate_transformation_mode == "align_corners":
         align_corners = True
@@ -446,35 +433,6 @@ def make_node(
                         if tf_partial_model_tensors is not None else tf_partial_model_inputs[0]
                     )
                 ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            test_data = None
-            if not isinstance(input_tensor, np.ndarray):
-                if not isinstance(graph_node_input, np.ndarray) \
-                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-                elif isinstance(graph_node_input, np.ndarray):
-                    test_data: np.ndarray = graph_node_input
-                else:
-                    test_data = None
-            else:
-                test_data = input_tensor
-            # TF dummy inference
-            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data
-                ]
-            )
-            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
-            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
-                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
-            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
-            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
-            del tf_partial_model
 
     elif coordinate_transformation_mode == "asymmetric":
         align_corners = False
@@ -506,35 +464,6 @@ def make_node(
                         if tf_partial_model_tensors is not None else tf_partial_model_inputs[0]
                     )
                 ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            test_data = None
-            if not isinstance(input_tensor, np.ndarray):
-                if not isinstance(graph_node_input, np.ndarray) \
-                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-                elif isinstance(graph_node_input, np.ndarray):
-                    test_data: np.ndarray = graph_node_input
-                else:
-                    test_data = None
-            else:
-                test_data = input_tensor
-            # TF dummy inference
-            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data
-                ]
-            )
-            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
-            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
-                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
-            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
-            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
-            del tf_partial_model
 
     elif coordinate_transformation_mode == "half_pixel":
         align_corners = False
@@ -566,35 +495,6 @@ def make_node(
                         if tf_partial_model_tensors is not None else tf_partial_model_inputs[0]
                     )
                 ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            test_data = None
-            if not isinstance(input_tensor, np.ndarray):
-                if not isinstance(graph_node_input, np.ndarray) \
-                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-                elif isinstance(graph_node_input, np.ndarray):
-                    test_data: np.ndarray = graph_node_input
-                else:
-                    test_data = None
-            else:
-                test_data = input_tensor
-            # TF dummy inference
-            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data
-                ]
-            )
-            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
-            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
-                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
-            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
-            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
-            del tf_partial_model
 
     else:
         ### Overall model
@@ -614,38 +514,43 @@ def make_node(
                             if tf_partial_model_tensors is not None else tf_partial_model_inputs[0],
                         size=new_size,
                         method=mode,
-                        name=graph_node.name,
                     )
                 ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            test_data = None
-            if not isinstance(input_tensor, np.ndarray):
-                if not isinstance(graph_node_input, np.ndarray) \
-                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-                elif isinstance(graph_node_input, np.ndarray):
-                    test_data: np.ndarray = graph_node_input
-                else:
-                    test_data = None
+
+    ### Partial model
+    if tf_partial_model_outputs is not None:
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data = None
+        if not isinstance(input_tensor, np.ndarray):
+            if not isinstance(graph_node_input, np.ndarray) \
+                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+            elif isinstance(graph_node_input, np.ndarray):
+                test_data: np.ndarray = graph_node_input
             else:
-                test_data = input_tensor
-            # TF dummy inference
-            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data
-                ]
-            )
-            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
-            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
-                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
-            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
-            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
-            del tf_partial_model
+                test_data = None
+        else:
+            test_data = input_tensor
+        # TF dummy inference
+        tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                test_data
+            ]
+        )
+        tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
+        cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
+            if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
+        tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+        tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data
 
     # TensorFlow's Resize operation casts to Float32 on its own,
     # so we have to change it back to the original type.

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -71,19 +71,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
     tf_partial_model_tensors = None
+    tf_partial_model_outputs = None
 
     # Workaround to avoid as many Resize failures as possible
     # for models with useless Transpose immediately before them.
@@ -112,7 +105,7 @@ def make_node(
                 )
                 before_op_output_shape_trans = True
                 # 2D - Partial model
-                if None not in tf_partial_model_input_shape:
+                if tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
                         tf.transpose(
                             a=tf_partial_model_inputs[0],
@@ -126,7 +119,7 @@ def make_node(
                 )
                 before_op_output_shape_trans = True
                 # 3D - Partial model
-                if None not in tf_partial_model_input_shape:
+                if tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
                         tf.transpose(
                             a=tf_partial_model_inputs[0],
@@ -347,22 +340,6 @@ def make_node(
         **kwargs,
     )
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
-    tf_partial_model_outputs = None
-
     resized_tensor = None
     boxes = None
     box_indices = None
@@ -389,7 +366,7 @@ def make_node(
         )
         tf_op_type = tf.image.crop_and_resize
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.image.crop_and_resize(
@@ -418,7 +395,7 @@ def make_node(
         )(input_tensor)
         tf_op_type = tf_resize
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     Lambda(
@@ -449,7 +426,7 @@ def make_node(
         )(input_tensor)
         tf_op_type = tf_resize
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     Lambda(
@@ -480,7 +457,7 @@ def make_node(
         )(input_tensor)
         tf_op_type = tf_resize
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     Lambda(
@@ -506,7 +483,7 @@ def make_node(
         )
         tf_op_type = tf.image.resize
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.image.resize(
@@ -518,7 +495,7 @@ def make_node(
                 ]
 
     ### Partial model
-    if tf_partial_model_outputs is not None:
+    if tf_partial_model_inputs is not None:
         tf_partial_model = tf.keras.Model(
             inputs=tf_partial_model_inputs,
             outputs=tf_partial_model_outputs,

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -21,9 +21,15 @@ from onnx2tf.utils.common_functions import (
     upsampling3d_nearest,
     pre_process_transpose,
     post_process_transpose,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
 from onnx2tf.utils.colors import Color
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
+from onnx2tf.utils.enums import (
+    NUMPY_DTYPES_TO_TF_DTYPES,
+    TF_DTYPES_TO_NUMPY_DTYPES,
+)
 
 INF_INDEX_VALUE: int = 4294967296
 
@@ -54,14 +60,31 @@ def make_node(
 
     opset = kwargs['opset']
 
-    input_tensor = get_constant_or_variable(
+    graph_node_input = get_constant_or_variable(
         graph_node.inputs[0],
         before_op_output_shape_trans,
     )
-    input_tensor = tf_layers_dict[input_tensor.name]['tf_node'] \
-        if isinstance(input_tensor, gs.Variable) else input_tensor
+    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
+        if isinstance(graph_node_input, gs.Variable) else graph_node_input
     input_tensor_shape = input_tensor.shape
     input_tensor_rank = len(input_tensor_shape)
+
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
+                ],
+            )
+    tf_partial_model_tensors = None
+
     # Workaround to avoid as many Resize failures as possible
     # for models with useless Transpose immediately before them.
     # If the input geometry of the ONNX and the input geometry of the TF model match,
@@ -82,19 +105,33 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 4:
-                # 2D
+                # 2D - Overall model
                 input_tensor = tf.transpose(
                     a=input_tensor,
                     perm=[0,2,3,1],
                 )
                 before_op_output_shape_trans = True
+                # 2D - Partial model
+                if None not in tf_partial_model_input_shape:
+                    tf_partial_model_tensors = \
+                        tf.transpose(
+                            a=tf_partial_model_inputs[0],
+                            perm=[0,2,3,1],
+                        )
             elif len(onnx_input_shape) == 5:
-                # 3D
+                # 3D - Overall model
                 input_tensor = tf.transpose(
                     a=input_tensor,
                     perm=[0,2,3,4,1],
                 )
                 before_op_output_shape_trans = True
+                # 3D - Partial model
+                if None not in tf_partial_model_input_shape:
+                    tf_partial_model_tensors = \
+                        tf.transpose(
+                            a=tf_partial_model_inputs[0],
+                            perm=[0,2,3,4,1],
+                        )
 
     roi = None
     scales = None
@@ -323,6 +360,7 @@ def make_node(
         boxes = tf.expand_dims(tf.gather(roi, indices, axis=0), 0)
         # get box_indices for crop
         box_indices = tf.cast(tf.range(0, input_tensor_shape[0]), dtype=tf.int32)
+        ### Overall model
         # run crop and resize
         resized_tensor = tf.image.crop_and_resize(
             images=input_tensor,
@@ -334,9 +372,54 @@ def make_node(
             name=graph_node.name,
         )
         tf_op_type = tf.image.crop_and_resize
+        ### Partial model
+        if None not in tf_partial_model_input_shape:
+            tf_partial_model_outputs = \
+                [
+                    tf.image.crop_and_resize(
+                        images=tf_partial_model_tensors \
+                            if tf_partial_model_tensors is not None else tf_partial_model_inputs[0],
+                        boxes=boxes,
+                        box_indices=box_indices,
+                        crop_size=new_size,
+                        method=mode,
+                        extrapolation_value=extrapolation_value,
+                    )
+                ]
+            tf_partial_model = tf.keras.Model(
+                inputs=tf_partial_model_inputs,
+                outputs=tf_partial_model_outputs,
+            )
+            test_data = None
+            if not isinstance(input_tensor, np.ndarray):
+                if not isinstance(graph_node_input, np.ndarray) \
+                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+                elif isinstance(graph_node_input, np.ndarray):
+                    test_data: np.ndarray = graph_node_input
+                else:
+                    test_data = None
+            else:
+                test_data = input_tensor
+            # TF dummy inference
+            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                model=tf_partial_model,
+                inputs=tf_partial_model_inputs,
+                verification_datas=[
+                    test_data
+                ]
+            )
+            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
+            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
+                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
+            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+            del tf_partial_model
+
     elif coordinate_transformation_mode == "align_corners":
         align_corners = True
         half_pixel_centers = False
+        ### Overall model
         resized_tensor = Lambda(
             tf_resize,
             arguments={
@@ -347,9 +430,56 @@ def make_node(
             }
         )(input_tensor)
         tf_op_type = tf_resize
+        ### Partial model
+        if None not in tf_partial_model_input_shape:
+            tf_partial_model_outputs = \
+                [
+                    Lambda(
+                        tf_resize,
+                        arguments={
+                            'new_size': new_size,
+                            'align_corners': align_corners,
+                            'half_pixel_centers': half_pixel_centers,
+                            'name': graph_node.name,
+                        }
+                    )(tf_partial_model_tensors \
+                        if tf_partial_model_tensors is not None else tf_partial_model_inputs[0]
+                    )
+                ]
+            tf_partial_model = tf.keras.Model(
+                inputs=tf_partial_model_inputs,
+                outputs=tf_partial_model_outputs,
+            )
+            test_data = None
+            if not isinstance(input_tensor, np.ndarray):
+                if not isinstance(graph_node_input, np.ndarray) \
+                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+                elif isinstance(graph_node_input, np.ndarray):
+                    test_data: np.ndarray = graph_node_input
+                else:
+                    test_data = None
+            else:
+                test_data = input_tensor
+            # TF dummy inference
+            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                model=tf_partial_model,
+                inputs=tf_partial_model_inputs,
+                verification_datas=[
+                    test_data
+                ]
+            )
+            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
+            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
+                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
+            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+            del tf_partial_model
+
     elif coordinate_transformation_mode == "asymmetric":
         align_corners = False
         half_pixel_centers = False
+        ### Overall model
         resized_tensor = Lambda(
             tf_resize,
             arguments={
@@ -360,9 +490,56 @@ def make_node(
             }
         )(input_tensor)
         tf_op_type = tf_resize
+        ### Partial model
+        if None not in tf_partial_model_input_shape:
+            tf_partial_model_outputs = \
+                [
+                    Lambda(
+                        tf_resize,
+                        arguments={
+                            'new_size': new_size,
+                            'align_corners': align_corners,
+                            'half_pixel_centers': half_pixel_centers,
+                            'name': graph_node.name,
+                        }
+                    )(tf_partial_model_tensors \
+                        if tf_partial_model_tensors is not None else tf_partial_model_inputs[0]
+                    )
+                ]
+            tf_partial_model = tf.keras.Model(
+                inputs=tf_partial_model_inputs,
+                outputs=tf_partial_model_outputs,
+            )
+            test_data = None
+            if not isinstance(input_tensor, np.ndarray):
+                if not isinstance(graph_node_input, np.ndarray) \
+                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+                elif isinstance(graph_node_input, np.ndarray):
+                    test_data: np.ndarray = graph_node_input
+                else:
+                    test_data = None
+            else:
+                test_data = input_tensor
+            # TF dummy inference
+            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                model=tf_partial_model,
+                inputs=tf_partial_model_inputs,
+                verification_datas=[
+                    test_data
+                ]
+            )
+            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
+            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
+                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
+            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+            del tf_partial_model
+
     elif coordinate_transformation_mode == "half_pixel":
         align_corners = False
         half_pixel_centers = True
+        ### Overall model
         resized_tensor = Lambda(
             tf_resize,
             arguments={
@@ -373,7 +550,54 @@ def make_node(
             }
         )(input_tensor)
         tf_op_type = tf_resize
+        ### Partial model
+        if None not in tf_partial_model_input_shape:
+            tf_partial_model_outputs = \
+                [
+                    Lambda(
+                        tf_resize,
+                        arguments={
+                            'new_size': new_size,
+                            'align_corners': align_corners,
+                            'half_pixel_centers': half_pixel_centers,
+                            'name': graph_node.name,
+                        }
+                    )(tf_partial_model_tensors \
+                        if tf_partial_model_tensors is not None else tf_partial_model_inputs[0]
+                    )
+                ]
+            tf_partial_model = tf.keras.Model(
+                inputs=tf_partial_model_inputs,
+                outputs=tf_partial_model_outputs,
+            )
+            test_data = None
+            if not isinstance(input_tensor, np.ndarray):
+                if not isinstance(graph_node_input, np.ndarray) \
+                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+                elif isinstance(graph_node_input, np.ndarray):
+                    test_data: np.ndarray = graph_node_input
+                else:
+                    test_data = None
+            else:
+                test_data = input_tensor
+            # TF dummy inference
+            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                model=tf_partial_model,
+                inputs=tf_partial_model_inputs,
+                verification_datas=[
+                    test_data
+                ]
+            )
+            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
+            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
+                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
+            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+            del tf_partial_model
+
     else:
+        ### Overall model
         resized_tensor = tf.image.resize(
             images=input_tensor,
             size=new_size,
@@ -381,6 +605,47 @@ def make_node(
             name=graph_node.name,
         )
         tf_op_type = tf.image.resize
+        ### Partial model
+        if None not in tf_partial_model_input_shape:
+            tf_partial_model_outputs = \
+                [
+                    tf.image.resize(
+                        images=tf_partial_model_tensors \
+                            if tf_partial_model_tensors is not None else tf_partial_model_inputs[0],
+                        size=new_size,
+                        method=mode,
+                        name=graph_node.name,
+                    )
+                ]
+            tf_partial_model = tf.keras.Model(
+                inputs=tf_partial_model_inputs,
+                outputs=tf_partial_model_outputs,
+            )
+            test_data = None
+            if not isinstance(input_tensor, np.ndarray):
+                if not isinstance(graph_node_input, np.ndarray) \
+                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+                elif isinstance(graph_node_input, np.ndarray):
+                    test_data: np.ndarray = graph_node_input
+                else:
+                    test_data = None
+            else:
+                test_data = input_tensor
+            # TF dummy inference
+            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                model=tf_partial_model,
+                inputs=tf_partial_model_inputs,
+                verification_datas=[
+                    test_data
+                ]
+            )
+            tf_partial_model_result: np.ndarray = list(tf_tensor_infos.values())[0]
+            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[org_dtype] \
+                if isinstance(org_dtype, tf.dtypes.DType) else org_dtype
+            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
+            tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
+            del tf_partial_model
 
     # TensorFlow's Resize operation casts to Float32 on its own,
     # so we have to change it back to the original type.

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -121,8 +121,7 @@ def make_node(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,
             verification_datas=[
-                tf_layers_dict[graph_node_input.name]['verification_data'] \
-                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+                test_data
             ]
         )
         tf_layers_dict[graph_node_output.name]['verification_data'] = \

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -12,7 +12,11 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -76,11 +80,65 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
+                ],
+            )
+
+    # Generation of TF OP
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.nn.sigmoid(
             x=input_tensor,
             name=graph_node.name,
         )
+    ### Partial model
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_outputs = \
+            [
+                tf.nn.sigmoid(
+                    x=input_tensor,
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data = None
+        if not isinstance(input_tensor, np.ndarray):
+            if not isinstance(graph_node_input, np.ndarray) \
+                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+            elif isinstance(graph_node_input, np.ndarray):
+                test_data: np.ndarray = input_tensor
+            else:
+                test_data = None
+        else:
+            test_data = input_tensor
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                tf_layers_dict[graph_node_input.name]['verification_data'] \
+                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+            ]
+        )
+        tf_layers_dict[graph_node_output.name]['verification_data'] = \
+            list(tf_partial_model_result_infos.values())[0]
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -82,18 +82,11 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -103,7 +96,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.nn.sigmoid(

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -16,7 +16,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -107,7 +107,7 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.nn.sigmoid(
-                    x=input_tensor,
+                    x=tf_partial_model_inputs[0],
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -120,7 +120,7 @@ def make_node(
                 and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
                 test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
             elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = input_tensor
+                test_data: np.ndarray = graph_node_input
             else:
                 test_data = None
         else:

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -119,7 +119,7 @@ def make_node(
                 and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
                 test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
             elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = input_tensor
+                test_data: np.ndarray = graph_node_input
             else:
                 test_data = None
         else:

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -16,7 +16,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -120,8 +120,7 @@ def make_node(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,
             verification_datas=[
-                tf_layers_dict[graph_node_input.name]['verification_data'] \
-                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+                test_data
             ]
         )
         tf_layers_dict[graph_node_output.name]['verification_data'] = \

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -12,7 +12,11 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
+from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info
@@ -75,11 +79,65 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
+                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
+                ],
+            )
+
+    # Generation of TF OP
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.sin(
             x=input_tensor,
             name=graph_node.name,
         )
+    ### Partial model
+    if None not in tf_partial_model_input_shape:
+        tf_partial_model_outputs = \
+            [
+                tf.math.sin(
+                    x=input_tensor,
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data = None
+        if not isinstance(input_tensor, np.ndarray):
+            if not isinstance(graph_node_input, np.ndarray) \
+                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
+            elif isinstance(graph_node_input, np.ndarray):
+                test_data: np.ndarray = input_tensor
+            else:
+                test_data = None
+        else:
+            test_data = input_tensor
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                tf_layers_dict[graph_node_input.name]['verification_data'] \
+                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+            ]
+        )
+        tf_layers_dict[graph_node_output.name]['verification_data'] = \
+            list(tf_partial_model_result_infos.values())[0]
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -81,18 +81,11 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -102,7 +95,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.sin(

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -106,7 +106,7 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.sin(
-                    x=input_tensor,
+                    x=tf_partial_model_inputs[0],
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -171,9 +171,9 @@ def make_node(
         tf_model_inputs = get_tf_model_inputs(
             tf_layers_dict=tf_layers_dict,
         )
-        try:
-            for check_axis in check_axes:
-                # Search for the axis with the smallest error
+        # Search for the axis with the smallest error
+        for check_axis in check_axes:
+            try:
                 if None not in tf_partial_model_input_shape:
                     ### Partial model check
                     tf_partial_model_outputs = \
@@ -253,8 +253,8 @@ def make_node(
                     min_abs_err_axis = check_axis
                     if min_abs_err < 1e-3:
                         break
-        except tf.errors.InvalidArgumentError as ex:
-            pass
+            except tf.errors.InvalidArgumentError as ex:
+                pass
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -111,19 +111,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
     tf_partial_model_tensors = None
+    tf_partial_model_outputs = None
 
     # It seems that TensorFlow only behaves incorrectly when processing
     # Reducemax() -> Subtract() -> Softmax() in that order.
@@ -144,7 +137,7 @@ def make_node(
                         y=tf.constant(1e-7, dtype=input_tensor.dtype)
                     )
                 # Partial model
-                if None not in tf_partial_model_input_shape:
+                if tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
                         tf.math.subtract(
                             x=tf.math.add(
@@ -174,7 +167,7 @@ def make_node(
         # Search for the axis with the smallest error
         for check_axis in check_axes:
             try:
-                if None not in tf_partial_model_input_shape:
+                if tf_partial_model_inputs is not None:
                     ### Partial model check
                     tf_partial_model_outputs = \
                         [

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -126,7 +126,7 @@ def make_node(
             sub_op: gs.Node = graph_node.i()
             if sub_op.i(tensor_idx=0).op == 'ReduceMax' \
                 or sub_op.i(tensor_idx=1).op == 'ReduceMax':
-                # Overall model
+                ### Overall model
                 input_tensor = \
                     tf.math.subtract(
                         x=tf.math.add(
@@ -135,7 +135,7 @@ def make_node(
                         ),
                         y=tf.constant(1e-7, dtype=input_tensor.dtype)
                     )
-                # Partial model
+                ### Partial model
                 if tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
                         tf.math.subtract(

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -225,7 +225,8 @@ def make_node(
     tf_partial_model_outputs = \
         [
             tf.nn.softmax(
-                logits=tf_partial_model_tensors,
+                logits=tf_partial_model_tensors \
+                    if tf_partial_model_tensors is not None else tf_partial_model_inputs[0],
                 axis=min_abs_err_axis,
             )
         ]

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -190,8 +190,11 @@ def make_node(
                     )
                     test_data = None
                     if not isinstance(graph_node_input, np.ndarray):
-                        if 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                        if not isinstance(graph_node_input, np.ndarray) \
+                            and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
                             test_data = tf_layers_dict[graph_node_input.name]['verification_data']
+                        elif isinstance(graph_node_input, np.ndarray):
+                            test_data: np.ndarray = graph_node_input
                         else:
                             test_data = None
                     else:

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -22,7 +22,6 @@ from onnx2tf.utils.common_functions import (
     make_tf_partial_model_inputs,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -189,16 +189,11 @@ def make_node(
                         outputs=tf_partial_model_outputs,
                     )
                     test_data = None
-                    if not isinstance(graph_node_input, np.ndarray):
-                        if not isinstance(graph_node_input, np.ndarray) \
-                            and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    if not isinstance(graph_node_input, np.ndarray) \
+                        and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
                             test_data = tf_layers_dict[graph_node_input.name]['verification_data']
-                        elif isinstance(graph_node_input, np.ndarray):
-                            test_data: np.ndarray = graph_node_input
-                        else:
-                            test_data = None
                     else:
-                        test_data = graph_node_input
+                        test_data: np.ndarray = graph_node_input
                     # TF dummy inference
                     tf_tensor_infos: Dict[Any] = dummy_tf_inference(
                         model=tf_partial_model,

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -189,9 +189,14 @@ def make_node(
                         outputs=tf_partial_model_outputs,
                     )
                     test_data = None
-                    if not isinstance(graph_node_input, np.ndarray) \
-                        and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                    if not isinstance(graph_node_input, np.ndarray):
+                        if not isinstance(graph_node_input, np.ndarray) \
+                            and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
                             test_data = tf_layers_dict[graph_node_input.name]['verification_data']
+                        elif isinstance(graph_node_input, np.ndarray):
+                            test_data: np.ndarray = graph_node_input
+                        else:
+                            test_data = None
                     else:
                         test_data: np.ndarray = graph_node_input
                     # TF dummy inference

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -1,4 +1,5 @@
 import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
@@ -124,69 +125,6 @@ def make_node(
             )
     tf_partial_model_tensors = None
 
-    # Detect conversion errors in axis and identify the axis
-    # with the smallest possible error and replace it.
-    min_abs_err = sys.maxsize
-    min_abs_err_axis: int = axis
-    try:
-        onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = \
-            kwargs['onnx_tensor_infos_for_validation']
-        if onnx_tensor_infos_for_validation is not None:
-            onnx_tensor_infos = {
-                graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
-            }
-            del onnx_tensor_infos_for_validation
-            check_axes = reversed([idx for idx in range(tensor_rank)])
-            # Search for the axis with the smallest error
-            tf_model_inputs = get_tf_model_inputs(
-                tf_layers_dict=tf_layers_dict,
-            )
-            for check_axis in check_axes:
-                # TF dummy inference
-                val_model = tf.keras.Model(
-                    inputs=tf_model_inputs,
-                    outputs=[
-                        tf.nn.softmax(
-                            logits=input_tensor,
-                            axis=check_axis,
-                            name=graph_node.name,
-                        )
-                    ],
-                )
-                tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                    model=val_model,
-                    inputs=tf_model_inputs,
-                )
-                del val_model
-                # Validation
-                onnx_tf_output_pairs = {
-                    (oi[0], ti[0]): (oi[1], ti[1]) \
-                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
-                }
-                """
-                check_results: Dict[str, List[np.ndarray, int, float|int]]
-                    {
-                        onnx_output_name: [
-                            onnx_tensor,
-                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
-                            max_abs_err,
-                        ]
-                    }
-                """
-                check_results = onnx_tf_tensor_validation(
-                    output_pairs=onnx_tf_output_pairs,
-                    rtol=0.0,
-                    atol=0.0,
-                )
-                result_err = sum([val[2] for val in check_results.values()])
-                if result_err < min_abs_err:
-                    min_abs_err = result_err
-                    min_abs_err_axis = check_axis
-                    if min_abs_err < 1e-3:
-                        break
-    except tf.errors.InvalidArgumentError as ex:
-        pass
-
     # It seems that TensorFlow only behaves incorrectly when processing
     # Reducemax() -> Subtract() -> Softmax() in that order.
     # Work around a bug in TensorFlow's model optimizer.
@@ -218,49 +156,113 @@ def make_node(
     except Exception as ex:
         pass
 
+    # Detect conversion errors in axis and identify the axis
+    # with the smallest possible error and replace it.
+    min_abs_err = sys.maxsize
+    min_abs_err_axis: int = axis
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = \
+        kwargs['onnx_tensor_infos_for_validation']
+    if onnx_tensor_infos_for_validation is not None:
+        onnx_tensor_infos = {
+            graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+        }
+        del onnx_tensor_infos_for_validation
+        check_axes = reversed([idx for idx in range(tensor_rank)])
+        tf_model_inputs = get_tf_model_inputs(
+            tf_layers_dict=tf_layers_dict,
+        )
+        try:
+            for check_axis in check_axes:
+                # Search for the axis with the smallest error
+                if None not in tf_partial_model_input_shape:
+                    ### Partial model check
+                    tf_partial_model_outputs = \
+                        [
+                            tf.nn.softmax(
+                                logits=tf_partial_model_tensors \
+                                    if tf_partial_model_tensors is not None else tf_partial_model_inputs[0],
+                                axis=check_axis,
+                            )
+                        ]
+                    tf_partial_model = tf.keras.Model(
+                        inputs=tf_partial_model_inputs,
+                        outputs=tf_partial_model_outputs,
+                    )
+                    test_data = None
+                    if not isinstance(graph_node_input, np.ndarray):
+                        if 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
+                            test_data = tf_layers_dict[graph_node_input.name]['verification_data']
+                        else:
+                            test_data = None
+                    else:
+                        test_data = graph_node_input
+                    # TF dummy inference
+                    tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                        model=tf_partial_model,
+                        inputs=tf_partial_model_inputs,
+                        verification_datas=[
+                            test_data
+                        ]
+                    )
+                    tf_layers_dict[graph_node_output.name]['verification_data'] = \
+                        list(tf_tensor_infos.values())[0]
+                    del tf_partial_model
+
+                else:
+                    ### Overall model check
+                    val_model = tf.keras.Model(
+                        inputs=tf_model_inputs,
+                        outputs=[
+                            tf.nn.softmax(
+                                logits=input_tensor,
+                                axis=check_axis,
+                                name=graph_node.name,
+                            )
+                        ],
+                    )
+                    # TF dummy inference
+                    tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                    )
+                    del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axis = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+        except tf.errors.InvalidArgumentError as ex:
+            pass
+
     # Generation of TF OP
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.nn.softmax(
             logits=input_tensor,
             axis=min_abs_err_axis,
             name=graph_node.name,
         )
-    ### Partial model
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_outputs = \
-            [
-                tf.nn.softmax(
-                    logits=tf_partial_model_tensors \
-                        if tf_partial_model_tensors is not None else tf_partial_model_inputs[0],
-                    axis=min_abs_err_axis,
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data = None
-        if not isinstance(graph_node_input, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                test_data = tf_layers_dict[graph_node_input.name]['verification_data']
-            else:
-                test_data = None
-        else:
-            test_data = graph_node_input
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -183,21 +183,21 @@ def make_node(
             outputs=tf_partial_model_outputs,
         )
         test_data1 = None
-        if not isinstance(graph_node_input_1, np.ndarray):
+        if not isinstance(input_tensor_1, np.ndarray):
             if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                test_data1 = tf_layers_dict[graph_node_input_1.name]['verification_data']
+                test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
             else:
                 test_data1 = None
         else:
-            test_data1 = graph_node_input_1
+            test_data1 = input_tensor_1
         test_data2 = None
-        if not isinstance(graph_node_input_2, np.ndarray):
+        if not isinstance(input_tensor_2, np.ndarray):
             if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-                test_data2 = tf_layers_dict[graph_node_input_2.name]['verification_data']
+                test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
             else:
                 test_data2 = None
         else:
-            test_data2 = graph_node_input_2
+            test_data2 = input_tensor_2
         tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -142,19 +142,23 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_shapes=[
-                [dim for dim in input_tensor_1.shape],
-                [dim for dim in input_tensor_2.shape],
-            ],
-            input_dtypes=[
-                NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                    if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                    if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-            ],
-        )
+    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
+    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_shapes=[
+                    tf_partial_model_input_shape_1,
+                    tf_partial_model_input_shape_2,
+                ],
+                input_dtypes=[
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
+                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
+                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
+                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
+                ],
+            )
 
     # Generation of TF OP
     # Overall model
@@ -165,44 +169,50 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    tf_partial_model_outputs = \
-        [
-            tf.math.subtract(
-                x=tf_partial_model_inputs[0],
-                y=tf_partial_model_inputs[1],
-            )
-        ]
-    tf_partial_model = tf.keras.Model(
-        inputs=tf_partial_model_inputs,
-        outputs=tf_partial_model_outputs,
-    )
-    test_data1 = None
-    if not isinstance(graph_node_input_1, np.ndarray):
-        if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data1 = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    if None not in tf_partial_model_input_shape_1 \
+        and None not in tf_partial_model_input_shape_2:
+        tf_partial_model_outputs = \
+            [
+                tf.math.subtract(
+                    x=tf_partial_model_inputs[0],
+                    y=tf_partial_model_inputs[1],
+                )
+            ]
+        tf_partial_model = tf.keras.Model(
+            inputs=tf_partial_model_inputs,
+            outputs=tf_partial_model_outputs,
+        )
+        test_data1 = None
+        if not isinstance(graph_node_input_1, np.ndarray):
+            if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+                test_data1 = tf_layers_dict[graph_node_input_1.name]['verification_data']
+            else:
+                test_data1 = None
         else:
-            test_data1 = None
-    else:
-        test_data1 = graph_node_input_1
-    test_data2 = None
-    if not isinstance(graph_node_input_2, np.ndarray):
-        if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-            test_data2 = tf_layers_dict[graph_node_input_2.name]['verification_data']
+            test_data1 = graph_node_input_1
+        test_data2 = None
+        if not isinstance(graph_node_input_2, np.ndarray):
+            if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+                test_data2 = tf_layers_dict[graph_node_input_2.name]['verification_data']
+            else:
+                test_data2 = None
         else:
-            test_data2 = None
-    else:
-        test_data2 = graph_node_input_2
-    tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-        model=tf_partial_model,
-        inputs=tf_partial_model_inputs,
-        verification_datas=[
-            test_data1,
-            test_data2,
-        ]
-    )
-    tf_layers_dict[graph_node_output.name]['verification_data'] = \
-        list(tf_partial_model_result_infos.values())[0]
-    del tf_partial_model
+            test_data2 = graph_node_input_2
+        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+            model=tf_partial_model,
+            inputs=tf_partial_model_inputs,
+            verification_datas=[
+                test_data1,
+                test_data2,
+            ]
+        )
+        tf_layers_dict[graph_node_output.name]['verification_data'] = \
+            list(tf_partial_model_result_infos.values())[0]
+        del tf_partial_model
+        del tf_partial_model_inputs
+        del tf_partial_model_outputs
+        del test_data1
+        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -177,7 +177,7 @@ def make_node(
             )
 
     # Generation of TF OP
-    # Overall model
+    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.subtract(
             x=input_tensor_1,

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -75,6 +75,22 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    # Acquisition of test data for validation
+    if not isinstance(graph_node_input_1, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+    elif isinstance(graph_node_input_1, np.ndarray):
+        test_data1: np.ndarray = graph_node_input_1
+    else:
+        test_data1 = None
+    if not isinstance(graph_node_input_2, np.ndarray) \
+        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+    elif isinstance(graph_node_input_2, np.ndarray):
+        test_data2: np.ndarray = graph_node_input_2
+    else:
+        test_data2 = None
+
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
     #   2. If only one of the two is the output of Transpose
@@ -183,20 +199,10 @@ def make_node(
             outputs=tf_partial_model_outputs,
         )
         test_data1 = None
-        if not isinstance(input_tensor_1, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-            else:
-                test_data1 = None
-        else:
+        if isinstance(input_tensor_1, np.ndarray):
             test_data1 = input_tensor_1
         test_data2 = None
-        if not isinstance(input_tensor_2, np.ndarray):
-            if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-                test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-            else:
-                test_data2 = None
-        else:
+        if isinstance(input_tensor_2, np.ndarray):
             test_data2 = input_tensor_2
         tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
             model=tf_partial_model,

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -158,23 +158,14 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape_1 = [dim for dim in input_tensor_1.shape]
-    tf_partial_model_input_shape_2 = [dim for dim in input_tensor_2.shape]
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape_1,
-                    tf_partial_model_input_shape_2,
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_1.dtype] \
-                        if isinstance(input_tensor_1.dtype, np.dtype) else input_tensor_1.dtype,
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor_2.dtype] \
-                        if isinstance(input_tensor_2.dtype, np.dtype) else input_tensor_2.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[
+                input_tensor_1,
+                input_tensor_2,
+            ]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -185,8 +176,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape_1 \
-        and None not in tf_partial_model_input_shape_2:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.subtract(

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -21,7 +21,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -17,7 +17,10 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
+    make_tf_partial_model_inputs,
+    dummy_tf_inference,
 )
+from typing import Any, Dict, List
 
 
 @print_node_info
@@ -136,13 +139,53 @@ def make_node(
         **kwargs,
     )
 
+    # Generate input OPs for TensorFlow subgraphs
+    # For inference testing on OP stand-alone
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_shapes=[
+                [dim for dim in input_tensor_1.shape],
+                [dim for dim in input_tensor_2.shape],
+            ],
+            input_dtypes=[
+                input_tensor_1.dtype,
+                input_tensor_2.dtype,
+            ],
+        )
+
     # Generation of TF OP
+    # Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.subtract(
             x=input_tensor_1,
             y=input_tensor_2,
             name=graph_node.name,
         )
+    ### Partial model
+    tf_partial_model_outputs = \
+        [
+            tf.math.subtract(
+                x=tf_partial_model_inputs[0],
+                y=tf_partial_model_inputs[1],
+            )
+        ]
+    tf_partial_model = tf.keras.Model(
+        inputs=tf_partial_model_inputs,
+        outputs=tf_partial_model_outputs,
+    )
+    tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
+        model=tf_partial_model,
+        inputs=tf_partial_model_inputs,
+        verification_datas=[
+            tf_layers_dict[graph_node_input_1.name]['verification_data'] \
+                if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys() else None,
+            tf_layers_dict[graph_node_input_2.name]['verification_data'] \
+                if 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys() else None,
+        ]
+    )
+    tf_layers_dict[graph_node_output.name]['verification_data'] = \
+        list(tf_partial_model_result_infos.values())[0]
+    del tf_partial_model
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -17,7 +17,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -225,8 +225,7 @@ def make_node(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,
             verification_datas=[
-                tf_layers_dict[graph_node_input.name]['verification_data'] \
-                    if 'verification_data' in tf_layers_dict[graph_node_input.name].keys() else None
+                test_data
             ]
         )
         tf_layers_dict[graph_node_output.name]['verification_data'] = \

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -180,18 +180,11 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
+    tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -204,7 +197,7 @@ def make_node(
             **kwargs,
         )
     ### Partial model
-    if None not in tf_partial_model_input_shape:
+    if tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 transpose_with_flexing_deterrence(

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -238,8 +238,7 @@ def make_node(
             model=tf_partial_model,
             inputs=tf_partial_model_inputs,
             verification_datas=[
-                tf_layers_dict[graph_node_input_1.name]['verification_data'] \
-                    if 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys() else None
+                test_data
             ]
         )
         tf_layers_dict[graph_node_output.name]['verification_data'] = \

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -128,18 +128,10 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_input_shape = [dim for dim in input_tensor.shape]
-    if None not in tf_partial_model_input_shape:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_shapes=[
-                    tf_partial_model_input_shape
-                ],
-                input_dtypes=[
-                    NUMPY_DTYPES_TO_TF_DTYPES[input_tensor.dtype] \
-                        if isinstance(input_tensor.dtype, np.dtype) else input_tensor.dtype,
-                ],
-            )
+    tf_partial_model_inputs: List[tf.keras.Input] = \
+        make_tf_partial_model_inputs(
+            input_tensors=[input_tensor]
+        )
     tf_partial_model_outputs = None
 
     # Generation of TF OP
@@ -167,7 +159,7 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.identity(input=input_tensor)
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.identity(
@@ -181,7 +173,7 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.identity(input=input_tensor)
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.identity(
@@ -200,7 +192,7 @@ def make_node(
                 name=graph_node.name,
             )
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.expand_dims(
@@ -217,7 +209,7 @@ def make_node(
                 name=graph_node.name,
             )
         ### Partial model
-        if None not in tf_partial_model_input_shape:
+        if tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.reshape(
@@ -227,7 +219,7 @@ def make_node(
                 ]
 
     ### Partial model
-    if tf_partial_model_outputs is not None:
+    if tf_partial_model_inputs is not None:
         tf_partial_model = tf.keras.Model(
             inputs=tf_partial_model_inputs,
             outputs=tf_partial_model_outputs,

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -18,7 +18,6 @@ from onnx2tf.utils.common_functions import (
     dummy_tf_inference,
 )
 from typing import Any, Dict, List
-from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 
 @print_node_info

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -323,6 +323,11 @@ def print_node_info(func):
                     f'{Color.RED}ERROR:{Color.RESET} ' +
                     f'{input_onnx_file_path}'
                 )
+            if graph_node is not None:
+                print(
+                    f'{Color.RED}ERROR:{Color.RESET} ' +
+                    f'onnx_op_name: {graph_node.name}'
+                )
             print(
                 f'{Color.RED}ERROR:{Color.RESET} ' +
                 f'Read this and deal with it. https://github.com/PINTO0309/onnx2tf#parameter-replacement'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2948,7 +2948,10 @@ def dummy_tf_inference(
 
             if verification_data is not None:
                 if len(input_size) != len(verification_data.shape):
-                    dummy_datas[input_name] = verification_data.reshape(input_size)
+                    if len(verification_data.shape) == 0:
+                        dummy_datas[input_name] = verification_data
+                    else:
+                        dummy_datas[input_name] = verification_data.reshape(input_size)
                 else:
                     dummy_datas[input_name] = verification_data
             else:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2948,7 +2948,7 @@ def dummy_tf_inference(
 
             if verification_data is not None:
                 if len(input_size) != len(verification_data.shape):
-                    if len(verification_data.shape) == 0:
+                    if len(verification_data.shape) <= 1:
                         dummy_datas[input_name] = verification_data
                     else:
                         dummy_datas[input_name] = verification_data.reshape(input_size)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -243,6 +243,7 @@ def make_tf_node_info(**kwargs):
 def print_node_info(func):
     @wraps(func)
     def print_wrapper_func(*args, **kwargs):
+        input_onnx_file_path: str = kwargs.get('input_onnx_file_path', None)
         graph_input: gs.Variable = kwargs.get('graph_input', None)
         graph_node: gs.Variable = kwargs.get('graph_node', None)
         tf_layers_dict: dict = kwargs.get('tf_layers_dict', None)
@@ -317,6 +318,11 @@ def print_node_info(func):
         except:
             print(f'{Color.RED}ERROR:{Color.RESET} The trace log is below.')
             traceback.print_exc()
+            if input_onnx_file_path is not None:
+                print(
+                    f'{Color.RED}ERROR:{Color.RESET} ' +
+                    f'{input_onnx_file_path}'
+                )
             print(
                 f'{Color.RED}ERROR:{Color.RESET} ' +
                 f'Read this and deal with it. https://github.com/PINTO0309/onnx2tf#parameter-replacement'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2943,9 +2943,14 @@ def dummy_tf_inference(
                         size=[input_size[1],input_size[2]],
                     ).numpy().astype(TF_DTYPES_TO_NUMPY_DTYPES[input_dtype])
     else:
-        for input_name, input_size, input_dtype, verification_data in zip(input_names, input_sizes, input_dtypes, verification_datas):
+        for input_name, input_size, input_dtype, verification_data \
+            in zip(input_names, input_sizes, input_dtypes, verification_datas):
+
             if verification_data is not None:
-                dummy_datas[input_name] = verification_data
+                if len(input_size) != len(verification_data.shape):
+                    dummy_datas[input_name] = verification_data.reshape(input_size)
+                else:
+                    dummy_datas[input_name] = verification_data
             else:
                 dummy_datas[input_name] = np.ones(
                     input_size,

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3564,6 +3564,7 @@ def make_tf_partial_model_inputs(
         if len(input_shape) == 1:
             input = tf.keras.Input(
                 shape=input_shape[0] if isinstance(input_shape[0], int) else None,
+                batch_size=1,
                 dtype=input_dtype,
             )
         elif len(input_shape) >= 2:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3557,11 +3557,3 @@ def make_tf_partial_model_inputs(
             )
         inputs.append(input)
     return inputs
-
-
-def tf_single_op_inference(
-    *,
-    input_data: np.ndarray,
-    tf_op,
-):
-    pass

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3566,7 +3566,7 @@ def make_tf_partial_model_inputs(
                 shape=input_shape[0] if isinstance(input_shape[0], int) else None,
                 dtype=input_dtype,
             )
-        elif len(input_shape) >= 1:
+        elif len(input_shape) >= 2:
             input = tf.keras.Input(
                 shape=[
                     inp if isinstance(inp, int) else None for inp in input_shape[1:]

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3534,18 +3534,14 @@ def make_tf_partial_model_inputs(
     """
     inputs: List[tf.keras.Input] = []
     input = None
+    for idx, input_shape in enumerate(input_shapes):
+        if isinstance(input_shape, list) and len(input_shape) == 0:
+            input_shapes[idx] = [1]
     for input_shape, input_dtype in zip(input_shapes, input_dtypes):
-        if not isinstance(input_shape, list):
-            input_shape = [input_shape]
         if len(input_shape) == 1:
             input = tf.keras.Input(
-                shape=[1],
-                batch_size=input_shape[0] if isinstance(input_shape[0], int) else None,
+                shape=input_shape[0] if isinstance(input_shape[0], int) else None,
                 dtype=input_dtype,
-            )
-            input = tf.squeeze(
-                input=input,
-                axis=1,
             )
         elif len(input_shape) >= 1:
             input = tf.keras.Input(

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -321,7 +321,7 @@ def print_node_info(func):
             if input_onnx_file_path is not None:
                 print(
                     f'{Color.RED}ERROR:{Color.RESET} ' +
-                    f'{input_onnx_file_path}'
+                    f'input_onnx_file_path: {input_onnx_file_path}'
                 )
             if graph_node is not None:
                 print(


### PR DESCRIPTION
### 1. Content and background
- [Experimental / WIP] Generate a miniscule model for each OP only, retain the results of test inference, and propagate to all OPs.
  - [x] First step
    - [x] `Softmax`
    - [x] `Sub`
    - [x] `ReduceMax`
    - [x] `Reshape`
      In the figure below, the output from the first `Reshape` only model is propagated to `ReduceMax` and `Sub`. Next, a `ReduceMax` only model is generated and test inference is performed based on the inference values propagated from the `Reshape` model.
    - In other words, it generates models for only one OP each and stores all test inference results for each OP alone.
    - By using a method that sequentially stores inference results in a model with only one OP, it becomes easy to backward from the point where an inference accuracy error is detected and rerun the inference test from the OP where the problem is assumed to have occurred.
      ![image](https://user-images.githubusercontent.com/33194443/218247294-0ae9ab82-e676-44d2-be90-b78866ef6cfb.png)
  - [x] Second step
    - To attempt to speed up the inference checks in [ddnm.onnx](https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_175/ddnm.onnx), the OPs in the following list will be addressed.
    - Eliminate `Softmax`'s redundant multiple inference accuracy correction process.
    - Implement on a trial basis in the following OPs for verification.
      - [x] `Add`
      - [x] `Concat`
      - [x] `Conv`
      - [x] `Cos`
      - [x] `Gemm`
      - [x] `InstanceNormalization`
      - [x] `MatMul`
      - [x] `Mul`
      - [x] `Div`
      - [x] `Mod`
      - [x] `ReduceMax`
      - [x] `Reshape`
      - [x] `Resize`
      - [x] `Sigmoid`
      - [x] `Sin`
      - [x] `Softmax`
      - [x] `Sub`
      - [x] `Transpose`
      - [x] `Unsqueeze`
      ```
      ssc4onnx -if ddnm.onnx
      ┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
      ┃ OP Type                ┃ OPs        ┃
      ┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
      │ Add                    │ 141        │
      │ Concat                 │ 19         │
      │ Conv                   │ 120        │
      │ Cos                    │ 1          │
      │ Gemm                   │ 34         │
      │ InstanceNormalization  │ 71         │
      │ MatMul                 │ 12         │
      │ Mul                    │ 145        │
      │ Reshape                │ 166        │
      │ Resize                 │ 5          │
      │ Sigmoid                │ 67         │
      │ Sin                    │ 1          │
      │ Softmax                │ 6          │
      │ Transpose              │ 12         │
      │ Unsqueeze              │ 65         │
      │ ---------------------- │ ---------- │
      │ Total number of OPs    │ 865        │
      │ ====================== │ ========== │
      │ Model Size             │ 433.8MiB   │
      └────────────────────────┴────────────┘
      ```
  - [ ] Third step - Will be separated into separate pull requests
    - Add a process to perform the calculation of the maximum absolute error on the inference results of all OPs.
  - [ ] Fourth step - Will be separated into separate pull requests
    - Implement propagation of inference results for all operations other than the above. 
  - [ ] Fifth step - Will be separated into separate pull requests
    - Instead of a processing format for inferring TensorFlow models, primitive operations are replaced with Numpy operations to make the process as fast as possible.
  - [ ] Sixth step - Will be separated into separate pull requests
    - Seek ways to eliminate accuracy errors without creating JSON files.
    - https://github.com/PINTO0309/onnx2tf/issues/175


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Implementation of strict mode #145](https://github.com/PINTO0309/onnx2tf/issues/145)
[[DDNM] Support additional parameters to onnxsim #175](https://github.com/PINTO0309/onnx2tf/issues/175)