### PR TITLE
TF v2.12.0rc0 - 1. `Transpose` now supports 6D tensors. 2. Support for `Atan2`.

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -26,7 +26,7 @@ jobs:
         pip install pip -U
         pip install cmake==3.22.5
         pip install onnx==1.12.0
-        pip install tensorflow==2.10.0
+        pip install tensorflow==2.12.0rc0
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon
         pip install protobuf==3.20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install pip -U \
     && pip install -U onnx2tf \
     && pip install -U onnx2tf \
     && pip install -U simple_onnx_processing_tools \
-    && pip install tensorflow==2.10.0 \
+    && pip install tensorflow==2.12.0rc0 \
     && pip install protobuf==3.20.3 \
     && pip install h5py==3.7.0 \
     && pip install -U onnxruntime==1.13.1 \

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -76,7 +76,7 @@ def convert(
     disable_group_convolution: Optional[bool] = False,
     enable_batchmatmul_unfold: Optional[bool] = False,
     disable_suppression_flextranspose: Optional[bool] = False,
-    number_of_dimensions_after_flextranspose_compression: Optional[int] = 5,
+    number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
     optimization_for_gpu_delegate: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_float32: Optional[bool] = False,
@@ -279,7 +279,7 @@ def convert(
 
     number_of_dimensions_after_flextranspose_compression: Optional[int]
         Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.\n
-        Default: 5
+        Default: 6
 
     optimization_for_gpu_delegate: Optional[bool]
         Replace operations that do not support gpu delegate with those\n
@@ -1612,10 +1612,10 @@ def main():
         '-nodafc',
         '--number_of_dimensions_after_flextranspose_compression',
         type=int,
-        default=5,
+        default=6,
         help=\
             'Number of Transpose OP dimensions generated after avoiding FlexTranspose generation. \n' +
-            'Default: 5'
+            'Default: 6'
     )
     parser.add_argument(
         '-ofgd',


### PR DESCRIPTION
### 1. Content and background
- TF v2.12.0rc0
  1. `Transpose` now supports 6D tensors.
  2. Support for `Atan2`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Avoid creating FlexTranspose for DepthToSpace #93](https://github.com/PINTO0309/onnx2tf/issues/93)
- [Native support for StridedSlice in 6D and Transpose in 7D #53702](https://github.com/tensorflow/tensorflow/issues/53702)