### PR TITLE
Added a process to suppress the creation of `FlexTranspose` for extrapolation of the `Transpose` immediately before the `Reshape`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.0
+  ghcr.io/pinto0309/onnx2tf:1.7.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -16,6 +16,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     make_tf_partial_model_inputs,
     dummy_tf_inference,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 
@@ -98,10 +99,13 @@ def make_node(
     ]
 
     # NHWC -> HCHW
-    transposed_tensor = tf.transpose(
-        a=input_tensor,
-        perm=list(perm) if perm is not None else None,
-    )
+    transposed_tensor = transpose_with_flexing_deterrence(
+            input_tensor=input_tensor,
+            perm=list(perm) if perm is not None else None,
+            output_shape=output_shape,
+            name=graph_node.name,
+            **kwargs,
+        )
     test_data = None
     if not isinstance(input_tensor, np.ndarray):
         if not isinstance(graph_node_input_1, np.ndarray) \

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2438,6 +2438,8 @@ def transpose_with_flexing_deterrence(
         kwargs['disable_suppression_flextranspose']
     number_of_dimensions_after_flextranspose_compression: int = \
         kwargs['number_of_dimensions_after_flextranspose_compression']
+    COMPRESSION_DEFAULT_VALUE = 6
+
     tensor_after_transposition = input_tensor
 
     if disable_suppression_flextranspose:
@@ -2465,8 +2467,8 @@ def transpose_with_flexing_deterrence(
         # Obtain a shape with the dimension with 1 element removed
         squeezed_original_shapes = squeezed_original_x.shape
 
-        if input_tensor_rank >= 7 \
-            and len(squeezed_original_shapes) <= 6 \
+        if input_tensor_rank >= (COMPRESSION_DEFAULT_VALUE + 1) \
+            and len(squeezed_original_shapes) <= COMPRESSION_DEFAULT_VALUE \
             and x_shape_none_dims_count < 2 \
             and output_shape is not None:
             # Special Transpose.1
@@ -2494,7 +2496,8 @@ def transpose_with_flexing_deterrence(
                         dim if not isinstance(dim, str) else -1 for dim in output_shape
                     ],
                 )
-        elif input_tensor_rank >= 7 and x_shape_none_dims_count == 0:
+        elif input_tensor_rank >= (COMPRESSION_DEFAULT_VALUE + 1) and x_shape_none_dims_count == 0 \
+            or number_of_dimensions_after_flextranspose_compression < COMPRESSION_DEFAULT_VALUE and x_shape_none_dims_count == 0:
             # Special Transpose.2
             #   Suppresses as much as possible the conversion of transposes
             #   of 6 or more dimensions into FlexTransposes.

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2497,7 +2497,9 @@ def transpose_with_flexing_deterrence(
                     ],
                 )
         elif input_tensor_rank >= (COMPRESSION_DEFAULT_VALUE + 1) and x_shape_none_dims_count == 0 \
-            or number_of_dimensions_after_flextranspose_compression < COMPRESSION_DEFAULT_VALUE and x_shape_none_dims_count == 0:
+            or number_of_dimensions_after_flextranspose_compression < COMPRESSION_DEFAULT_VALUE \
+                and number_of_dimensions_after_flextranspose_compression >= 2 \
+                and x_shape_none_dims_count == 0:
             # Special Transpose.2
             #   Suppresses as much as possible the conversion of transposes
             #   of 6 or more dimensions into FlexTransposes.


### PR DESCRIPTION
### 1. Content and background
- Added a process to suppress the creation of `FlexTranspose` for extrapolation of the `Transpose` immediately before the `Reshape`
- If the `-nodafc` option has a value less than `6`, compress `Transpose` to the specified numeric dimension.
- If `-nodafc` option is set to `2`, `Transpose` is completely lost.
- [model_2.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/10769390/model_2.onnx.zip)


```
onnx2tf -i model_2.onnx -nodafc 2
```
![image](https://user-images.githubusercontent.com/33194443/219726183-07e14e0c-106e-464c-8097-23936771c1ad.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Remove transpose before reshape #193](https://github.com/PINTO0309/onnx2tf/issues/193)