### PR TITLE
`FlexTranspose` generation suppression and `Transpose` dimensionality reduction applied to almost all `Transpose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,8 @@ optional arguments:
 
   -nodafc, --number_of_dimensions_after_flextranspose_compression
     Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
-    Default: 5
+    Also suppress the creation of the Transpose itself by specifying 2.
+    Default: 6
 
   -ofgd, --optimization_for_gpu_delegate
     Replace operations that do not support gpu delegate with those
@@ -756,7 +757,8 @@ convert(
 
     number_of_dimensions_after_flextranspose_compression: Optional[int]
       Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
-      Default: 5
+      Also suppress the creation of the Transpose itself by specifying 2.
+      Default: 6
 
     optimization_for_gpu_delegate: Optional[bool]
         Replace operations that do not support gpu delegate with those

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -283,6 +283,7 @@ def convert(
 
     number_of_dimensions_after_flextranspose_compression: Optional[int]
         Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.\n
+        Also suppress the creation of the Transpose itself by specifying 2.\n
         Default: 6
 
     optimization_for_gpu_delegate: Optional[bool]
@@ -1634,6 +1635,7 @@ def main():
         default=6,
         help=\
             'Number of Transpose OP dimensions generated after avoiding FlexTranspose generation. \n' +
+            'Also suppress the creation of the Transpose itself by specifying 2. \n' +
             'Default: 6'
     )
     parser.add_argument(

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -100,6 +100,7 @@ def make_node(
             graph_node_input_2=graph_node_input_2,
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
+            **kwargs,
         )
 
     input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
@@ -124,6 +125,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/And.py
+++ b/onnx2tf/ops/And.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -16,6 +16,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     make_tf_partial_model_inputs,
     dummy_tf_inference,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 
@@ -82,11 +83,11 @@ def make_node(
         for same_input_shape_as_onnx, nhwc_flag, value in zip(same_input_shape_as_onnxs, nhwc_flags, values):
             if same_input_shape_as_onnx and not nhwc_flag:
                 if len(value.shape) == 3:
-                    new_values.append(tf.transpose(a=value, perm=[0,2,1]))
+                    new_values.append(transpose_with_flexing_deterrence(input_tensor=value, perm=[0,2,1]))
                 elif len(value.shape) == 4:
-                    new_values.append(tf.transpose(a=value, perm=[0,2,3,1]))
+                    new_values.append(transpose_with_flexing_deterrence(input_tensor=value, perm=[0,2,3,1]))
                 elif len(value.shape) == 5:
-                    new_values.append(tf.transpose(a=value, perm=[0,2,3,4,1]))
+                    new_values.append(transpose_with_flexing_deterrence(input_tensor=value, perm=[0,2,3,4,1]))
                 else:
                     new_values.append(value)
             else:

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -83,11 +83,29 @@ def make_node(
         for same_input_shape_as_onnx, nhwc_flag, value in zip(same_input_shape_as_onnxs, nhwc_flags, values):
             if same_input_shape_as_onnx and not nhwc_flag:
                 if len(value.shape) == 3:
-                    new_values.append(transpose_with_flexing_deterrence(input_tensor=value, perm=[0,2,1]))
+                    new_values.append(
+                        transpose_with_flexing_deterrence(
+                            input_tensor=value,
+                            perm=[0,2,1],
+                            **kwargs,
+                        )
+                    )
                 elif len(value.shape) == 4:
-                    new_values.append(transpose_with_flexing_deterrence(input_tensor=value, perm=[0,2,3,1]))
+                    new_values.append(
+                        transpose_with_flexing_deterrence(
+                            input_tensor=value,
+                            perm=[0,2,3,1],
+                            **kwargs,
+                        )
+                    )
                 elif len(value.shape) == 5:
-                    new_values.append(transpose_with_flexing_deterrence(input_tensor=value, perm=[0,2,3,4,1]))
+                    new_values.append(
+                        transpose_with_flexing_deterrence(
+                            input_tensor=value,
+                            perm=[0,2,3,4,1],
+                            **kwargs,
+                        )
+                    )
                 else:
                     new_values.append(value)
             else:

--- a/onnx2tf/ops/Constant.py
+++ b/onnx2tf/ops/Constant.py
@@ -19,6 +19,7 @@ def _make_tf_constant(
     value,
     dtype,
     name,
+    kwargs,
 ):
     constant_tensor = tf.constant(
         value=value,
@@ -32,6 +33,7 @@ def _make_tf_constant(
                 input_tensor=constant_tensor,
                 perm=[0,2,1],
                 name=name,
+                **kwargs,
             )
     elif len(value.shape) == 4:
         transposed_tensor = \
@@ -39,6 +41,7 @@ def _make_tf_constant(
                 input_tensor=constant_tensor,
                 perm=[0,2,3,1],
                 name=name,
+                **kwargs,
             )
     elif len(value.shape) == 5:
         transposed_tensor = \
@@ -46,6 +49,7 @@ def _make_tf_constant(
                 input_tensor=constant_tensor,
                 perm=[0,2,3,4,1],
                 name=name,
+                **kwargs,
             )
     else:
         transposed_tensor = constant_tensor
@@ -140,6 +144,7 @@ def make_node(
                     value=value,
                     dtype=const_dtype,
                     name=graph_node.name,
+                    kwargs=kwargs,
                 )
             # Generation of Debug Info
             tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
@@ -202,6 +207,7 @@ def make_node(
                         value=value,
                         dtype=const_dtype,
                         name=graph_node.name,
+                        kwargs=kwargs,
                     )
                 # Generation of Debug Info
                 tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
@@ -273,6 +279,7 @@ def make_node(
                 value=value,
                 dtype=const_dtype,
                 name=graph_node.name,
+                kwargs=kwargs,
             )
         # Generation of Debug Info
         tf_layers_dict[graph_node_output.name]['tf_node_info'] = \

--- a/onnx2tf/ops/Constant.py
+++ b/onnx2tf/ops/Constant.py
@@ -9,6 +9,7 @@ from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 from onnx2tf.utils.common_functions import (
     print_node_info,
     make_tf_node_info,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -27,22 +28,22 @@ def _make_tf_constant(
     transposed_tensor = None
     if len(value.shape) == 3:
         transposed_tensor = \
-            tf.transpose(
-                a=constant_tensor,
+            transpose_with_flexing_deterrence(
+                input_tensor=constant_tensor,
                 perm=[0,2,1],
                 name=name,
             )
     elif len(value.shape) == 4:
         transposed_tensor = \
-            tf.transpose(
-                a=constant_tensor,
+            transpose_with_flexing_deterrence(
+                input_tensor=constant_tensor,
                 perm=[0,2,3,1],
                 name=name,
             )
     elif len(value.shape) == 5:
         transposed_tensor = \
-            tf.transpose(
-                a=constant_tensor,
+            transpose_with_flexing_deterrence(
+                input_tensor=constant_tensor,
                 perm=[0,2,3,4,1],
                 name=name,
             )

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -18,6 +18,7 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     make_tf_partial_model_inputs,
     dummy_tf_inference,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 from onnx2tf.utils.colors import Color
@@ -184,22 +185,22 @@ def make_node(
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
                 # 1D - Overall model
-                input_tensor = tf.transpose(
-                    a=input_tensor,
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
                     perm=[0,2,1],
                 )
                 tf_transposed_perm = [0,2,1]
             elif len(onnx_input_shape) == 4:
                 # 2D - Overall model
-                input_tensor = tf.transpose(
-                    a=input_tensor,
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
                     perm=[0,2,3,1],
                 )
                 tf_transposed_perm = [0,2,3,1]
             elif len(onnx_input_shape) == 5:
                 # 3D - Overall model
-                input_tensor = tf.transpose(
-                    a=input_tensor,
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
                     perm=[0,2,3,4,1],
                 )
                 tf_transposed_perm = [0,2,3,4,1]

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -188,6 +188,7 @@ def make_node(
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,1],
+                    **kwargs,
                 )
                 tf_transposed_perm = [0,2,1]
             elif len(onnx_input_shape) == 4:
@@ -195,6 +196,7 @@ def make_node(
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
+                    **kwargs,
                 )
                 tf_transposed_perm = [0,2,3,1]
             elif len(onnx_input_shape) == 5:
@@ -202,6 +204,7 @@ def make_node(
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],
+                    **kwargs,
                 )
                 tf_transposed_perm = [0,2,3,4,1]
     else:

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -16,6 +16,7 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     calc_output_shape_conv_transpose,
     dummy_onnx_inference,
+    transpose_with_flexing_deterrence,
 )
 from onnx2tf.utils.colors import Color
 
@@ -244,8 +245,8 @@ def make_node(
                     for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
                         try:
                             conv_rs = conv_func(
-                                input=tf.transpose(a=input_tensor_split, perm=tensor_1_candidate_for_transposition),
-                                filters=tf.transpose(a=weight_split, perm=tensor_2_candidate_for_transposition),
+                                input=transpose_with_flexing_deterrence(input_tensor=input_tensor_split, perm=tensor_1_candidate_for_transposition),
+                                filters=transpose_with_flexing_deterrence(input_tensor=weight_split, perm=tensor_2_candidate_for_transposition),
                                 output_shape=split_conv_output_shape,
                                 strides=strides,
                                 padding=pad_mode,

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -245,8 +245,16 @@ def make_node(
                     for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
                         try:
                             conv_rs = conv_func(
-                                input=transpose_with_flexing_deterrence(input_tensor=input_tensor_split, perm=tensor_1_candidate_for_transposition),
-                                filters=transpose_with_flexing_deterrence(input_tensor=weight_split, perm=tensor_2_candidate_for_transposition),
+                                input=transpose_with_flexing_deterrence(
+                                    input_tensor=input_tensor_split,
+                                    perm=tensor_1_candidate_for_transposition,
+                                    **kwargs,
+                                ),
+                                filters=transpose_with_flexing_deterrence(
+                                    input_tensor=weight_split,
+                                    perm=tensor_2_candidate_for_transposition,
+                                    **kwargs,
+                                ),
                                 output_shape=split_conv_output_shape,
                                 strides=strides,
                                 padding=pad_mode,

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -102,6 +102,7 @@ def make_node(
             graph_node_input_2=graph_node_input_2,
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
+            **kwargs,
         )
 
     input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
@@ -126,6 +127,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Param replacement

--- a/onnx2tf/ops/Equal.py
+++ b/onnx2tf/ops/Equal.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -136,6 +136,7 @@ def make_node(
     input_tensor = transpose_with_flexing_deterrence(
         input_tensor=input_tensor,
         perm=list(perm) if perm is not None else None,
+        **kwargs,
     )
 
     if cal_shape is not None:

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -132,8 +133,8 @@ def make_node(
             before_op_output_shape_trans=before_op_output_shape_trans,
         ) for idx in range(input_tensor_rank)
     ]
-    input_tensor = tf.transpose(
-        a=input_tensor,
+    input_tensor = transpose_with_flexing_deterrence(
+        input_tensor=input_tensor,
         perm=list(perm) if perm is not None else None,
     )
 

--- a/onnx2tf/ops/GatherElements.py
+++ b/onnx2tf/ops/GatherElements.py
@@ -112,10 +112,12 @@ def make_node(
         data_swaped = transpose_with_flexing_deterrence(
             input_tensor=input_tensor,
             perm=axis_perm,
+            **kwargs,
         )
         index_swaped = transpose_with_flexing_deterrence(
             input_tensor=indices_tensor,
             perm=axis_perm,
+            **kwargs,
         )
 
     idx_tensors_per_axis = [
@@ -140,6 +142,7 @@ def make_node(
         transpose_with_flexing_deterrence(
             input_tensor=gathered,
             perm=axis_perm,
+            **kwargs,
         )
 
     # Post-process transpose

--- a/onnx2tf/ops/GatherElements.py
+++ b/onnx2tf/ops/GatherElements.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 
 
@@ -108,8 +109,14 @@ def make_node(
             tf.constant([[0], [axis]]),
             tf.constant([axis, 0])
         )
-        data_swaped = tf.transpose(input_tensor, perm=axis_perm)
-        index_swaped = tf.transpose(indices_tensor, perm=axis_perm)
+        data_swaped = transpose_with_flexing_deterrence(
+            input_tensor=input_tensor,
+            perm=axis_perm,
+        )
+        index_swaped = transpose_with_flexing_deterrence(
+            input_tensor=indices_tensor,
+            perm=axis_perm,
+        )
 
     idx_tensors_per_axis = [
         tf.range(tf.shape(index_swaped, index_swaped.dtype)[i]) \
@@ -130,7 +137,10 @@ def make_node(
     gathered = tf.gather_nd(data_swaped, index_expanded)
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.transpose(gathered, perm=axis_perm)
+        transpose_with_flexing_deterrence(
+            input_tensor=gathered,
+            perm=axis_perm,
+        )
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Greater.py
+++ b/onnx2tf/ops/Greater.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/GreaterOrEqual.py
+++ b/onnx2tf/ops/GreaterOrEqual.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -144,18 +144,22 @@ def make_node(
     wa = transpose_with_flexing_deterrence(
         input_tensor=(x1 - xgrid) * (y1 - ygrid),
         perm=[3, 0, 1, 2],
+        **kwargs,
     )
     wb = transpose_with_flexing_deterrence(
         input_tensor=(x1 - xgrid) * (ygrid - y0),
         perm=[3, 0, 1, 2],
+        **kwargs,
     )
     wc = transpose_with_flexing_deterrence(
         input_tensor=(xgrid - x0) * (y1 - ygrid),
         perm=[3, 0, 1, 2],
+        **kwargs,
     )
     wd = transpose_with_flexing_deterrence(
         input_tensor=(xgrid - x0) * (ygrid - y0),
         perm=[3, 0, 1, 2],
+        **kwargs,
     )
 
     x0 = tf.cast(
@@ -215,6 +219,7 @@ def make_node(
     temp_traspose_wa = transpose_with_flexing_deterrence(
         input_tensor=temp_reshape1_wa,
         perm=[1,0],
+        **kwargs,
     )
     temp_reshape2_wa = tf.reshape(
         tensor=temp_traspose_wa,
@@ -241,6 +246,7 @@ def make_node(
     temp_traspose_wb = transpose_with_flexing_deterrence(
         input_tensor=temp_reshape1_wb,
         perm=[1,0],
+        **kwargs,
     )
     temp_reshape2_wb = tf.reshape(
         tensor=temp_traspose_wb,
@@ -267,6 +273,7 @@ def make_node(
     temp_traspose_wc = transpose_with_flexing_deterrence(
         input_tensor=temp_reshape1_wc,
         perm=[1,0],
+        **kwargs,
     )
     temp_reshape2_wc = tf.reshape(
         tensor=temp_traspose_wc,
@@ -293,6 +300,7 @@ def make_node(
     temp_traspose_wd = transpose_with_flexing_deterrence(
         input_tensor=temp_reshape1_wd,
         perm=[1,0],
+        **kwargs,
     )
     temp_reshape2_wd = tf.reshape(
         tensor=temp_traspose_wd,
@@ -310,6 +318,7 @@ def make_node(
     output_tensor = transpose_with_flexing_deterrence(
         input_tensor=output_tensor,
         perm=[1,2,3,0],
+        **kwargs,
     )
     mask = tf.tile(
         input=mask,

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 from onnx2tf.utils.colors import Color
 
@@ -140,20 +141,20 @@ def make_node(
     y0 = tf.math.floor(ygrid)
     y1 = y0 + 1
 
-    wa = tf.transpose(
-        a=(x1 - xgrid) * (y1 - ygrid),
+    wa = transpose_with_flexing_deterrence(
+        input_tensor=(x1 - xgrid) * (y1 - ygrid),
         perm=[3, 0, 1, 2],
     )
-    wb = tf.transpose(
-        a=(x1 - xgrid) * (ygrid - y0),
+    wb = transpose_with_flexing_deterrence(
+        input_tensor=(x1 - xgrid) * (ygrid - y0),
         perm=[3, 0, 1, 2],
     )
-    wc = tf.transpose(
-        a=(xgrid - x0) * (y1 - ygrid),
+    wc = transpose_with_flexing_deterrence(
+        input_tensor=(xgrid - x0) * (y1 - ygrid),
         perm=[3, 0, 1, 2],
     )
-    wd = tf.transpose(
-        a=(xgrid - x0) * (ygrid - y0),
+    wd = transpose_with_flexing_deterrence(
+        input_tensor=(xgrid - x0) * (ygrid - y0),
         perm=[3, 0, 1, 2],
     )
 
@@ -211,8 +212,8 @@ def make_node(
         tensor=temp_gather_wa,
         shape=[-1, temp_gather_wa.shape[3]],
     )
-    temp_traspose_wa = tf.transpose(
-        a=temp_reshape1_wa,
+    temp_traspose_wa = transpose_with_flexing_deterrence(
+        input_tensor=temp_reshape1_wa,
         perm=[1,0],
     )
     temp_reshape2_wa = tf.reshape(
@@ -237,8 +238,8 @@ def make_node(
         tensor=temp_gather_wb,
         shape=[-1, temp_gather_wb.shape[3]],
     )
-    temp_traspose_wb = tf.transpose(
-        a=temp_reshape1_wb,
+    temp_traspose_wb = transpose_with_flexing_deterrence(
+        input_tensor=temp_reshape1_wb,
         perm=[1,0],
     )
     temp_reshape2_wb = tf.reshape(
@@ -263,8 +264,8 @@ def make_node(
         tensor=temp_gather_wc,
         shape=[-1, temp_gather_wc.shape[3]],
     )
-    temp_traspose_wc = tf.transpose(
-        a=temp_reshape1_wc,
+    temp_traspose_wc = transpose_with_flexing_deterrence(
+        input_tensor=temp_reshape1_wc,
         perm=[1,0],
     )
     temp_reshape2_wc = tf.reshape(
@@ -289,8 +290,8 @@ def make_node(
         tensor=temp_gather_wd,
         shape=[-1, temp_gather_wd.shape[3]],
     )
-    temp_traspose_wd = tf.transpose(
-        a=temp_reshape1_wd,
+    temp_traspose_wd = transpose_with_flexing_deterrence(
+        input_tensor=temp_reshape1_wd,
         perm=[1,0],
     )
     temp_reshape2_wd = tf.reshape(
@@ -306,8 +307,8 @@ def make_node(
     ### wa + wb + wc + wd
     output_tensor = temp_wa + temp_wb + temp_wc + temp_wd
 
-    output_tensor = tf.transpose(
-        a=output_tensor,
+    output_tensor = transpose_with_flexing_deterrence(
+        input_tensor=output_tensor,
         perm=[1,2,3,0],
     )
     mask = tf.tile(

--- a/onnx2tf/ops/Hardmax.py
+++ b/onnx2tf/ops/Hardmax.py
@@ -104,6 +104,7 @@ def make_node(
             x = transpose_with_flexing_deterrence(
                 input_tensor=input_tensor,
                 perm=perm,
+                **kwargs,
             )
         else:
             cal_shape = (

--- a/onnx2tf/ops/Hardmax.py
+++ b/onnx2tf/ops/Hardmax.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
@@ -100,8 +101,8 @@ def make_node(
                 values=[perm1, [tensor_rank - 1], perm2, [axis]],
                 axis=-1,
             )
-            x = tf.transpose(
-                a=input_tensor,
+            x = transpose_with_flexing_deterrence(
+                input_tensor=input_tensor,
                 perm=perm,
             )
         else:

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     make_tf_partial_model_inputs,
     dummy_tf_inference,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
@@ -125,15 +126,15 @@ def make_node(
                 if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
                     if len(onnx_input_shape) == 3:
                         # 1D
-                        input_tensor = tf.transpose(
-                            a=input_tensor,
+                        input_tensor = transpose_with_flexing_deterrence(
+                            input_tensor=input_tensor,
                             perm=[0,2,1],
                         )
                         tf_transposed_perm = [0,2,1]
                     elif len(onnx_input_shape) == 4:
                         # 2D
-                        input_tensor = tf.transpose(
-                            a=input_tensor,
+                        input_tensor = transpose_with_flexing_deterrence(
+                            input_tensor=input_tensor,
                             perm=[0,2,3,1],
                         )
                         tf_transposed_perm = [0,2,3,1]

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -129,6 +129,7 @@ def make_node(
                         input_tensor = transpose_with_flexing_deterrence(
                             input_tensor=input_tensor,
                             perm=[0,2,1],
+                            **kwargs,
                         )
                         tf_transposed_perm = [0,2,1]
                     elif len(onnx_input_shape) == 4:
@@ -136,6 +137,7 @@ def make_node(
                         input_tensor = transpose_with_flexing_deterrence(
                             input_tensor=input_tensor,
                             perm=[0,2,3,1],
+                            **kwargs,
                         )
                         tf_transposed_perm = [0,2,3,1]
                 else:

--- a/onnx2tf/ops/Less.py
+++ b/onnx2tf/ops/Less.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/LessOrEqual.py
+++ b/onnx2tf/ops/LessOrEqual.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -169,10 +169,12 @@ def make_node(
                             a=transpose_with_flexing_deterrence(
                                 input_tensor=input_tensor_1,
                                 perm=tensor_1_candidate_for_transposition,
+                                **kwargs,
                             ),
                             b=transpose_with_flexing_deterrence(
                                 input_tensor=input_tensor_2,
                                 perm=tensor_2_candidate_for_transposition,
+                                **kwargs,
                             ),
                             output_type=output_dtype,
                             name=graph_node.name,
@@ -184,11 +186,13 @@ def make_node(
                                 tf.matmul(
                                     a=transpose_with_flexing_deterrence(
                                         input_tensor=tf_partial_model_inputs[0],
-                                        perm=tensor_1_candidate_for_transposition
+                                        perm=tensor_1_candidate_for_transposition,
+                                        **kwargs,
                                     ),
                                     b=transpose_with_flexing_deterrence(
                                         input_tensor=tf_partial_model_inputs[1],
-                                        perm=tensor_2_candidate_for_transposition
+                                        perm=tensor_2_candidate_for_transposition,
+                                        **kwargs,
                                     ),
                                     output_type=output_dtype,
                                 )

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -15,6 +15,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     make_tf_partial_model_inputs,
     dummy_tf_inference,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
@@ -165,8 +166,14 @@ def make_node(
                     ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.matmul(
-                            a=tf.transpose(a=input_tensor_1, perm=tensor_1_candidate_for_transposition),
-                            b=tf.transpose(a=input_tensor_2, perm=tensor_2_candidate_for_transposition),
+                            a=transpose_with_flexing_deterrence(
+                                input_tensor=input_tensor_1,
+                                perm=tensor_1_candidate_for_transposition,
+                            ),
+                            b=transpose_with_flexing_deterrence(
+                                input_tensor=input_tensor_2,
+                                perm=tensor_2_candidate_for_transposition,
+                            ),
                             output_type=output_dtype,
                             name=graph_node.name,
                         )
@@ -175,8 +182,14 @@ def make_node(
                         tf_partial_model_outputs = \
                             [
                                 tf.matmul(
-                                    a=tf.transpose(tf_partial_model_inputs[0], perm=tensor_1_candidate_for_transposition),
-                                    b=tf.transpose(tf_partial_model_inputs[1], perm=tensor_2_candidate_for_transposition),
+                                    a=transpose_with_flexing_deterrence(
+                                        input_tensor=tf_partial_model_inputs[0],
+                                        perm=tensor_1_candidate_for_transposition
+                                    ),
+                                    b=transpose_with_flexing_deterrence(
+                                        input_tensor=tf_partial_model_inputs[1],
+                                        perm=tensor_2_candidate_for_transposition
+                                    ),
                                     output_type=output_dtype,
                                 )
                             ]

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -101,6 +101,7 @@ def make_node(
             graph_node_input_2=graph_node_input_2,
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
+            **kwargs,
         )
 
     input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
@@ -125,6 +126,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -102,6 +102,7 @@ def make_node(
             graph_node_input_2=graph_node_input_2,
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
+            **kwargs,
         )
 
     input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
@@ -126,6 +127,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # broadcast_for_gpu_delegate

--- a/onnx2tf/ops/NonMaxSuppression.py
+++ b/onnx2tf/ops/NonMaxSuppression.py
@@ -254,7 +254,11 @@ def make_node(
 
     # Generation of TF OP
     if center_point_box == 1:
-        boxes_t = transpose_with_flexing_deterrence(input_tensor=boxes, perm=[0, 2, 1])
+        boxes_t = transpose_with_flexing_deterrence(
+            input_tensor=boxes,
+            perm=[0, 2, 1],
+            **kwargs,
+        )
         x_centers = tf.slice(boxes_t, [0, 0, 0], [-1, 1, -1])
         y_centers = tf.slice(boxes_t, [0, 1, 0], [-1, 1, -1])
         widths = tf.slice(boxes_t, [0, 2, 0], [-1, 1, -1])
@@ -264,7 +268,11 @@ def make_node(
         y2 = tf.add(y_centers, tf.divide(heights, 2))
         x2 = tf.add(x_centers, tf.divide(widths, 2))
         boxes_t = tf.concat([y1, x1, y2, x2], 1)
-        boxes = transpose_with_flexing_deterrence(input_tensor=boxes_t, perm=[0, 2, 1])
+        boxes = transpose_with_flexing_deterrence(
+            input_tensor=boxes_t,
+            perm=[0, 2, 1],
+            **kwargs,
+        )
 
     num_batches = boxes.shape[0]
 

--- a/onnx2tf/ops/NonMaxSuppression.py
+++ b/onnx2tf/ops/NonMaxSuppression.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 from onnx2tf.utils.colors import Color
 
@@ -253,7 +254,7 @@ def make_node(
 
     # Generation of TF OP
     if center_point_box == 1:
-        boxes_t = tf.transpose(boxes, perm=[0, 2, 1])
+        boxes_t = transpose_with_flexing_deterrence(input_tensor=boxes, perm=[0, 2, 1])
         x_centers = tf.slice(boxes_t, [0, 0, 0], [-1, 1, -1])
         y_centers = tf.slice(boxes_t, [0, 1, 0], [-1, 1, -1])
         widths = tf.slice(boxes_t, [0, 2, 0], [-1, 1, -1])
@@ -263,7 +264,7 @@ def make_node(
         y2 = tf.add(y_centers, tf.divide(heights, 2))
         x2 = tf.add(x_centers, tf.divide(widths, 2))
         boxes_t = tf.concat([y1, x1, y2, x2], 1)
-        boxes = tf.transpose(boxes_t, perm=[0, 2, 1])
+        boxes = transpose_with_flexing_deterrence(input_tensor=boxes_t, perm=[0, 2, 1])
 
     num_batches = boxes.shape[0]
 

--- a/onnx2tf/ops/Or.py
+++ b/onnx2tf/ops/Or.py
@@ -78,6 +78,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -233,8 +233,8 @@ def make_node(
                 # ShuffleNet patterns - 4D only
                 ### Overall model
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                    tf.transpose(
-                        a=tf_layers_dict[graph_node_output.name]['tf_node'],
+                    transpose_with_flexing_deterrence(
+                        input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
                         perm=[0,2,3,1],
                     )
                 ### Partial model

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -236,6 +236,7 @@ def make_node(
                     transpose_with_flexing_deterrence(
                         input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
                         perm=[0,2,3,1],
+                        **kwargs,
                     )
                 ### Partial model
                 if tf_partial_model_inputs is not None:

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -103,6 +103,7 @@ def make_node(
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
+                    **kwargs,
                 )
                 before_op_output_shape_trans = True
                 # 2D - Partial model
@@ -111,12 +112,14 @@ def make_node(
                         transpose_with_flexing_deterrence(
                             input_tensor=tf_partial_model_inputs[0],
                             perm=[0,2,3,1],
+                            **kwargs,
                         )
             elif len(onnx_input_shape) == 5:
                 # 3D - Overall model
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],
+                    **kwargs,
                 )
                 before_op_output_shape_trans = True
                 # 3D - Partial model
@@ -125,6 +128,7 @@ def make_node(
                         transpose_with_flexing_deterrence(
                             input_tensor=tf_partial_model_inputs[0],
                             perm=[0,2,3,4,1],
+                            **kwargs,
                         )
 
     roi = None

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -23,6 +23,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     make_tf_partial_model_inputs,
     dummy_tf_inference,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 from onnx2tf.utils.colors import Color
@@ -99,30 +100,30 @@ def make_node(
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 4:
                 # 2D - Overall model
-                input_tensor = tf.transpose(
-                    a=input_tensor,
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
                     perm=[0,2,3,1],
                 )
                 before_op_output_shape_trans = True
                 # 2D - Partial model
                 if tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
-                        tf.transpose(
-                            a=tf_partial_model_inputs[0],
+                        transpose_with_flexing_deterrence(
+                            input_tensor=tf_partial_model_inputs[0],
                             perm=[0,2,3,1],
                         )
             elif len(onnx_input_shape) == 5:
                 # 3D - Overall model
-                input_tensor = tf.transpose(
-                    a=input_tensor,
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
                     perm=[0,2,3,4,1],
                 )
                 before_op_output_shape_trans = True
                 # 3D - Partial model
                 if tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
-                        tf.transpose(
-                            a=tf_partial_model_inputs[0],
+                        transpose_with_flexing_deterrence(
+                            input_tensor=tf_partial_model_inputs[0],
                             perm=[0,2,3,4,1],
                         )
 

--- a/onnx2tf/ops/ScatterElements.py
+++ b/onnx2tf/ops/ScatterElements.py
@@ -15,6 +15,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
 )
 from onnx2tf.utils.colors import Color
 from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
@@ -160,7 +161,7 @@ def make_node(
     for dim in dim_expanded_idx_tensors_per_axis:
         if dim is not None and len([i for i in dim.shape if i is None]) == len(dim.shape)-1 and dim.shape[-1] == 1 and len(dim.shape) == 5:
             new_dim_expanded_idx_tensors_per_axis.append(
-                tf.transpose(a=dim, perm=[0,2,3,1,4])
+                transpose_with_flexing_deterrence(input_tensor=dim, perm=[0,2,3,1,4])
             )
         else:
             new_dim_expanded_idx_tensors_per_axis.append(dim)

--- a/onnx2tf/ops/ScatterElements.py
+++ b/onnx2tf/ops/ScatterElements.py
@@ -161,7 +161,11 @@ def make_node(
     for dim in dim_expanded_idx_tensors_per_axis:
         if dim is not None and len([i for i in dim.shape if i is None]) == len(dim.shape)-1 and dim.shape[-1] == 1 and len(dim.shape) == 5:
             new_dim_expanded_idx_tensors_per_axis.append(
-                transpose_with_flexing_deterrence(input_tensor=dim, perm=[0,2,3,1,4])
+                transpose_with_flexing_deterrence(
+                    input_tensor=dim,
+                    perm=[0,2,3,1,4],
+                    **kwargs,
+                )
             )
         else:
             new_dim_expanded_idx_tensors_per_axis.append(dim)

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -101,6 +101,7 @@ def make_node(
             graph_node_input_2=graph_node_input_2,
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
+            **kwargs,
         )
 
     input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
@@ -125,6 +126,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Param replacement

--- a/onnx2tf/ops/Xor.py
+++ b/onnx2tf/ops/Xor.py
@@ -79,6 +79,7 @@ def make_node(
         input_tensor_1=input_tensor_1,
         input_tensor_2=input_tensor_2,
         tf_layers_dict=tf_layers_dict,
+        **kwargs,
     )
 
     # Pre-process transpose

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2146,8 +2146,8 @@ def disable_unnecessary_transpose(
                             unmatch = True
                             break
                 if unmatch:
-                    input_tensor_2 = tf.transpose(
-                        a=input_tensor_2,
+                    input_tensor_2 = transpose_with_flexing_deterrence(
+                        input_tensor=input_tensor_2,
                         perm=reverse_perm,
                     )
     return graph_node_input_1, graph_node_input_2, input_tensor_1, input_tensor_2
@@ -2243,11 +2243,11 @@ def shape_unmatched_special_avoidance_workaround(
         for idx, (same_input_shape_as_onnx, nhwc_flag) in enumerate(zip(same_input_shape_as_onnxs, nhwc_flags)):
             if same_input_shape_as_onnx and not nhwc_flag:
                 if len(values[idx].shape) == 3:
-                    values[idx] = tf.transpose(a=values[idx], perm=[0,2,1])
+                    values[idx] = transpose_with_flexing_deterrence(input_tensor=values[idx], perm=[0,2,1])
                 elif len(values[idx].shape) == 4:
-                    values[idx] = tf.transpose(a=values[idx], perm=[0,2,3,1])
+                    values[idx] = transpose_with_flexing_deterrence(input_tensor=values[idx], perm=[0,2,3,1])
                 elif len(values[idx].shape) == 5:
-                    values[idx] = tf.transpose(a=values[idx], perm=[0,2,3,4,1])
+                    values[idx] = transpose_with_flexing_deterrence(input_tensor=values[idx], perm=[0,2,3,4,1])
         input_tensor_1 = values[0]
         input_tensor_2 = values[1]
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2059,6 +2059,7 @@ def disable_unnecessary_transpose(
     graph_node_input_2: Any,
     input_tensor_1: Any,
     input_tensor_2: Any,
+    **kwargs: dict,
 ) -> Tuple[Any, Any, Any, Any]:
     """Remove unnecessary Transpose to NHWC.
 
@@ -2149,6 +2150,7 @@ def disable_unnecessary_transpose(
                     input_tensor_2 = transpose_with_flexing_deterrence(
                         input_tensor=input_tensor_2,
                         perm=reverse_perm,
+                        **kwargs,
                     )
     return graph_node_input_1, graph_node_input_2, input_tensor_1, input_tensor_2
 
@@ -2160,6 +2162,7 @@ def shape_unmatched_special_avoidance_workaround(
     input_tensor_1: Any,
     input_tensor_2: Any,
     tf_layers_dict: dict,
+    **kwargs: dict,
 ) -> Tuple[Any, Any]:
     """Force correction of the shape mismatch between input X and input Y to NHWC format
     only if the output of the immediately preceding OP is definitively NHWC.
@@ -2243,11 +2246,23 @@ def shape_unmatched_special_avoidance_workaround(
         for idx, (same_input_shape_as_onnx, nhwc_flag) in enumerate(zip(same_input_shape_as_onnxs, nhwc_flags)):
             if same_input_shape_as_onnx and not nhwc_flag:
                 if len(values[idx].shape) == 3:
-                    values[idx] = transpose_with_flexing_deterrence(input_tensor=values[idx], perm=[0,2,1])
+                    values[idx] = transpose_with_flexing_deterrence(
+                        input_tensor=values[idx],
+                        perm=[0,2,1],
+                        **kwargs,
+                    )
                 elif len(values[idx].shape) == 4:
-                    values[idx] = transpose_with_flexing_deterrence(input_tensor=values[idx], perm=[0,2,3,1])
+                    values[idx] = transpose_with_flexing_deterrence(
+                        input_tensor=values[idx],
+                        perm=[0,2,3,1],
+                        **kwargs,
+                    )
                 elif len(values[idx].shape) == 5:
-                    values[idx] = transpose_with_flexing_deterrence(input_tensor=values[idx], perm=[0,2,3,4,1])
+                    values[idx] = transpose_with_flexing_deterrence(
+                        input_tensor=values[idx],
+                        perm=[0,2,3,4,1],
+                        **kwargs,
+                    )
         input_tensor_1 = values[0]
         input_tensor_2 = values[1]
 


### PR DESCRIPTION
### 1. Content and background
- `FlexTranspose` generation suppression and `Transpose` dimensionality reduction applied to almost all `Transpose`
  - `Concat`
  - `Constant`
  - `Conv`
  - `ConvTranspose`
  - `Flatten`
  - `GatherElements`
  - `GridSample`
  - `Hardmax`
  - `InstanceNormalization`
  - `MatMul`
  - `NonMaxSuppression`
  - `Reshape`
  - `Resize`
  - `ScatterElements`
  - `common_functions`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
[Remove transpose before reshape #193](https://github.com/PINTO0309/onnx2tf/issues/193)