### PR TITLE
Re-release `flatc` with some customizations of our own to address the lack of arithmetic precision of the quantization parameters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get install -y \
         nano python3-pip python3-mock libpython3-dev \
         libpython3-all-dev python-is-python3 wget curl \
-        software-properties-common sudo flatbuffers-compiler \
+        software-properties-common sudo \
     && sed -i 's/# set linenumbers/set linenumbers/g' /etc/nanorc \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
@@ -23,6 +23,14 @@ RUN pip install pip -U \
     && pip install h5py==3.7.0 \
     && pip install -U onnxruntime==1.13.1 \
     && python -m pip cache purge
+
+# Re-release flatc with some customizations of our own to address
+# the lack of arithmetic precision of the quantization parameters
+# https://github.com/PINTO0309/onnx2tf/issues/196
+RUN wget https://github.com/PINTO0309/onnx2tf/releases/download/1.7.3/flatc.tar.gz \
+    && tar -zxvf flatc.tar.gz \
+    && chmod +x flatc \
+    && mv flatc /usr/bin/
 
 ENV USERNAME=user
 RUN echo "root:root" | chpasswd \

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - simple_onnx_processing_tools
 - tensorflow==2.12.0rc0
 - flatbuffers-compiler (Optional, Only when using the `-coion` option. Executable file named `flatc`.)
-  ```
-  Debian/Ubuntu: sudo apt-get install -y flatbuffers-compiler
-  Other than Debian/Ubuntu: https://github.com/google/flatbuffers/releases
+  ```bash
+  # Custom flatc binary for Ubuntu 20.04+
+  # https://github.com/PINTO0309/onnx2tf/issues/196
+  wget https://github.com/PINTO0309/onnx2tf/releases/download/1.7.3/flatc.tar.gz \
+    && tar -zxvf flatc.tar.gz \
+    && chmod +x flatc \
+    && mv flatc /usr/bin/
   ```
 
 ## Sample Usage
@@ -35,7 +39,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.3
+  ghcr.io/pinto0309/onnx2tf:1.7.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.3'
+__version__ = '1.7.4'


### PR DESCRIPTION
### 1. Content and background
- Re-release `flatc` with some customizations of our own to address the lack of arithmetic precision of the quantization parameters.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Re-release flatc with some customizations of our own to address the lack of arithmetic precision of the quantization parameters](https://github.com/PINTO0309/onnx2tf/issues/196)
- [tflite to JSON to tflite quantization error #1](https://github.com/PINTO0309/tflite2json2tflite/issues/1)