### PR TITLE
1. Support for `PReLU` special patterns. 2. Move workaround processing of shape mismatch errors to before padding is performed. `Conv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.5
+  ghcr.io/pinto0309/onnx2tf:1.7.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.5'
+__version__ = '1.7.6'

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -219,11 +219,12 @@ def make_node(
     # tensorflow average pooling needs extra process to get same output with onnx
     # https://github.com/PINTO0309/onnx2tf/issues/124
     if average_multiplier != [1] * spatial_size * 2:
-        warning_msg = f'{Color.YELLOW}WARNING:{Color.RESET} ' \
-                      f'Tensorflow incompatible action detected. ' \
-                      f'Some additional layers are inserted to reproduce same output. ' \
-                      f'Please refer to the following link for more information: ' \
-                      f'https://github.com/PINTO0309/onnx2tf/issues/124'
+        warning_msg = \
+            f'{Color.YELLOW}WARNING:{Color.RESET} ' \
+            f'Tensorflow incompatible action detected. ' \
+            f'Some additional layers are inserted to reproduce same output. ' \
+            f'Please refer to the following link for more information: ' \
+            f'https://github.com/PINTO0309/onnx2tf/issues/124'
         print(warning_msg)
 
         if pooled_tensor.shape[1] >= 2:

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -64,11 +64,12 @@ def make_node(
     )
 
     if len(graph_node.outputs) > 1:
-        error_msg = f'{Color.RED}ERROR:{Color.RESET} ' \
-                    f'MaxPoolWithArgmax is not yet implemented. ' \
-                    f'Pull requests are welcome. \n' \
-                    f'https://github.com/onnx/onnx-tensorflow/blob/f9ebc35dba8a9555112a8d0b84f5a3d51278cca9/onnx_tf/handlers/backend/dilated_pooling.py#L544 \n' \
-                    f'graph_node.name: {graph_node.name}'
+        error_msg = \
+            f'{Color.RED}ERROR:{Color.RESET} ' \
+            f'MaxPoolWithArgmax is not yet implemented. ' \
+            f'Pull requests are welcome. \n' \
+            f'https://github.com/onnx/onnx-tensorflow/blob/f9ebc35dba8a9555112a8d0b84f5a3d51278cca9/onnx_tf/handlers/backend/dilated_pooling.py#L544 \n' \
+            f'graph_node.name: {graph_node.name}'
         print(error_msg)
         raise NotImplementedError(error_msg)
 
@@ -102,10 +103,12 @@ def make_node(
     if dilations != [1] * spatial_size:
         dilated_kernel_shape = [(k - 1) * d for k, d in zip(kernel_shape, dilations)]
 
-    tf_pads = calc_tf_pooling_pads(input_shape=input_tensor_shape,
-                                   kernel=dilated_kernel_shape,
-                                   strides=strides,
-                                   func=func)
+    tf_pads = calc_tf_pooling_pads(
+        input_shape=input_tensor_shape,
+        kernel=dilated_kernel_shape,
+        strides=strides,
+        func=func,
+    )
 
     # onnx padding value is ignored if auto_pad is not 'NOTSET'
     if auto_pad == 'NOTSET':
@@ -137,9 +140,10 @@ def make_node(
 
     # add extra pad layer if needed
     if is_explicit_padding and tf_pads != [0] * spatial_size * 2:
-        warning_msg = f'{Color.YELLOW}WARNING:{Color.RESET} ' \
-                      f'Tensorflow incompatible padding detected. ' \
-                      f'Extra pad layer is inserted automatically. '
+        warning_msg = \
+            f'{Color.YELLOW}WARNING:{Color.RESET} ' \
+            f'Tensorflow incompatible padding detected. ' \
+            f'Extra pad layer is inserted automatically. '
         print(warning_msg)
 
         if auto_pad == 'SAME_LOWER':
@@ -147,9 +151,10 @@ def make_node(
             tf_pads = [i for tup in zip(tf_pads[len(tf_pads) // 2:], tf_pads[:len(tf_pads) // 2]) for i in tup]
 
         # convert to tensorflow padding format
-        tf_pads = [[0, 0]] + \
-                  [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
-                  [[0, 0]]
+        tf_pads = \
+            [[0, 0]] + \
+            [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
+            [[0, 0]]
 
         # explicit padding value should be negative infinite since this is max pooling
         padded_tensor = tf.pad(

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -106,7 +106,12 @@ def make_node(
         neg = (input_tensor - abs(input_tensor)) * (slope * 0.5)
         tf_layers_dict[graph_node_output.name]['tf_node'] = pos + neg
     else:
-        shared_axes = [val + 1 for val in range(len(input_tensor.shape) - 2)]
+        if slope.shape is not None \
+            and len(slope.shape) > 0 \
+            and sum([1 if dim is not None and dim == 1 else 0 for dim in slope.shape]) == len(slope.shape):
+            shared_axes = [val + 1 for val in range(len(input_tensor.shape) - 1)]
+        else:
+            shared_axes = [val + 1 for val in range(len(input_tensor.shape) - 2)]
         tf_layers_dict[graph_node_output.name]['tf_node'] = PReLU(
             weights=slope,
             shared_axes=shared_axes,

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -689,6 +689,14 @@ def pre_explicit_broadcast(
     # output:
     #   input_tensor_1: [1,2,3,4]
     #   input_tensor_2: [3,1]
+    #
+    # e.g.3
+    # input:
+    #   input_tensor_1: [1,2,3,4]
+    #   input_tensor_2: [1,1,1]
+    # output:
+    #   input_tensor_1: [1,2,3,4]
+    #   input_tensor_2: [1,1,1,1]
     if input_tensor_1.shape is not None \
         and input_tensor_2.shape is not None \
         and None not in input_tensor_1.shape \
@@ -740,6 +748,19 @@ def pre_explicit_broadcast(
                         input=input_tensor_1,
                         axis=-1,
                     )
+    elif input_tensor_1.shape is not None \
+        and input_tensor_2.shape is not None \
+        and None not in input_tensor_1.shape \
+        and None not in input_tensor_2.shape \
+        and len(input_tensor_1.shape) > len(input_tensor_2.shape) \
+        and sum([1 if not isinstance(dim, str) and dim == 1 else 0 for dim in input_tensor_2.shape]) == len(input_tensor_2.shape):
+        expand_count = len(input_tensor_1.shape) - len(input_tensor_2.shape)
+        for _ in range(expand_count):
+            input_tensor_2 = tf.expand_dims(
+                input=input_tensor_2,
+                axis=-1,
+            )
+
     return input_tensor_1, input_tensor_2
 
 


### PR DESCRIPTION
### 1. Content and background
- Fixed a problem with `broadcast` and `shared_axes` calculations aborting when the following pattern `PReLU` is used.
    ```
    input_tensor.shape: [1,2,3,4]
    slope.shape: [1,1,1]
    shared_axes: [1,2,3]
    ```
- `Conv`
  - Move workaround processing of shape mismatch errors to before padding is performed.
- https://github.com/PINTO0309/PINTO_model_zoo/tree/main/353_ShadowFormer

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
