### PR TITLE
Skip error check if onnx and tensorflow input geometry is an exact match and axis is exactly the same. Also, skip the process of forced replacement of axis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.6
+  ghcr.io/pinto0309/onnx2tf:1.7.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.6'
+__version__ = '1.7.7'


### PR DESCRIPTION
### 1. Content and background
- `Softmax`
  1. Skip error check if onnx and tensorflow input geometry is an exact match and `axis` is exactly the same.
  2. Also, skip the process of forced replacement of `axis`.
  3. This modification increases the speed of model conversion by skipping the unnecessary accuracy check process.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)
With this modification, the output of `ShadowFormer` matches perfectly.
![image](https://user-images.githubusercontent.com/33194443/221331496-51fe5c32-4abc-4356-935a-be4aa878e334.png)

### 4. Issue number (only if there is a related issue)
[[ShadowFormer] Unnecessary Transpose extrapolated immediately after Softmax #205](https://github.com/PINTO0309/onnx2tf/issues/205)