### PR TITLE
`MaxPool` and `AveragePool` fix for `ceil_mode`

### DIFF
--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -106,8 +106,7 @@ def make_node(
     tf_pads = calc_tf_pooling_pads(
         input_shape=input_tensor_shape,
         kernel=dilated_kernel_shape,
-        strides=strides,
-        func=func,
+        strides=strides
     )
 
     # onnx padding value is ignored if auto_pad is not 'NOTSET'

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -167,12 +167,12 @@ def make_node(
             [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
             [[0, 0]]
 
-        # explicit padding value should be negative infinite since this is max pooling
+        # use minimum limit value of data type for explicit padding value since this is max pooling
         padded_tensor = tf.pad(
             tensor=input_tensor,
             paddings=tf_pads,
             mode='CONSTANT',
-            constant_values=-np.inf
+            constant_values=input_tensor.dtype.min
         )
 
     else:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3410,6 +3410,7 @@ def calc_extra_padding_with_ceil(
         strides: Union[np.ndarray, List]
 ) -> List:
     """
+    Calculate extra padding for ceil_mode enabled pooling layer
 
     Parameters
     ----------

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1,3 +1,4 @@
+import math
 import os
 import io
 import sys
@@ -3358,7 +3359,7 @@ def broadcast_for_gpu_delegate(
     return input_tensor_1, input_tensor_2
 
 
-def calc_tf_pooling_pads(input_shape, kernel, strides, func):
+def calc_tf_pooling_pads(input_shape, kernel, strides):
     """Calculate how much padding is needed for tensorflow mode 'SAME'.
 
     Parameters
@@ -3369,8 +3370,6 @@ def calc_tf_pooling_pads(input_shape, kernel, strides, func):
         kernel shape from onnx
     strides: List
         strides from onnx
-    func: Callable
-        function for ceil or floor, depends on onnx option ceil_mode
 
     Returns
     -------
@@ -3383,10 +3382,10 @@ def calc_tf_pooling_pads(input_shape, kernel, strides, func):
 
     # calculate how much padding is needed except batch and channel dimension
     for i, k, s in zip(input_shape[1:-1], kernel, strides):
-        same_output_shape = func((i - 1) / s) + 1
+        same_output_shape = math.floor((i - 1) / s) + 1
         axis_pads = np.max((same_output_shape - 1) * s + k - i, 0)
 
-        padded_valid_output_shape = func((i + axis_pads - k) / s) + 1
+        padded_valid_output_shape = math.floor((i + axis_pads - k) / s) + 1
         error_msg = f'{Color.RED}ERROR:{Color.RESET} ' + \
                     f'Wrong padding calculation.'
         assert same_output_shape == padded_valid_output_shape, error_msg


### PR DESCRIPTION
### 1. Content and background

### 2. Summary of corrections
Padding calculation is fixed for the case when `ceil_mode` is used.
Now extra padding value is added to match the output shape of tensorflow to ONNX. This extra padding is added to right, bottom side of feature map if needed.
However, `ceil_mode` caused bug in `AveragePool`. I guess it can be solved by using `average_multiplier` in this case, but couldn't fixed yet.

### 3. Before/After (If there is an operating log that can be used as a reference)

isnet convert result | isnet structure
---- | ----
<img src="https://user-images.githubusercontent.com/34959032/221738099-7a5d5b59-caf4-400e-bedd-8b4af4cab1c7.png" height="100"> | <img src="https://user-images.githubusercontent.com/34959032/221737693-cd9e4d59-a277-427e-afc9-ad1bb20ce344.png" width="300">

Right, bottom side value difference in AveragePool when `ceil_mode` is True |
---- |
![Screenshot from 2023-02-28 11-15-29](https://user-images.githubusercontent.com/34959032/221737701-12fcd45b-941e-4392-9471-0a1cc9553d99.png)


### 4. Issue number (only if there is a related issue)
#207