### PR TITLE
Support for substitution of `Gather` attribute parameter `axis`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.8
+  ghcr.io/pinto0309/onnx2tf:1.7.9
 
   or
 
@@ -1163,7 +1163,7 @@ Do not submit an issue that only contains an amount of information that cannot b
   |6|Expand|1. "param_target": "inputs"<br>`values`: Value of `shape`<br>`pre_process_transpose_perm`: Transpose is applied to the tensor before the Expand operation with the perm specified as pre-processing.<br>2. "param_target": "outputs"<br>`post_process_transpose_perm`: Transpose is applied to the tensor after the Expand operation with the perm specified as post-processing.|
   |7|Flatten|1. "param_target": "attributes"<br>`axis`: Value of `axis`<br>2. "param_target": "inputs"<br>`pre_process_transpose_perm`: Transpose is applied to the tensor before the Flatten operation with the perm specified as pre-processing.<br>3. "param_target": "outputs"<br>`post_process_transpose_perm`: Transpose is applied to the tensor after the Flatten operation with the perm specified as post-processing.|
   |8|Gemm||
-  |9|Gather|1. "param_target": "inputs"<br>`values`: Value of `indices`<br>`pre_process_transpose_perm`: Transpose is applied to the tensor before the Gather operation with the perm specified as pre-processing.<br>2. "param_target": "outputs"<br>`post_process_transpose_perm`: Transpose is applied to the tensor after the Gather operation with the perm specified as post-processing.|
+  |9|Gather|1. "param_target": "attributes"<br>`axis`: Value of `axis`<br>2. "param_target": "inputs"<br>`values`: Value of `indices`<br>`pre_process_transpose_perm`: Transpose is applied to the tensor before the Gather operation with the perm specified as pre-processing.<br>3. "param_target": "outputs"<br>`post_process_transpose_perm`: Transpose is applied to the tensor after the Gather operation with the perm specified as post-processing.|
   |10|MatMul|1. "param_target": "inputs"<br>`pre_process_transpose_perm`: Transpose is applied to the tensor before the MatMul operation with the perm specified as pre-processing.<br>2. "param_target": "outputs"<br>`post_process_transpose_perm`: Transpose is applied to the tensor after the MatMul operation with the perm specified as post-processing.|
   |11|Mul|1. "param_target": "inputs"<br>`values`: Value of `input`<br>`pre_process_transpose_perm`: Transpose is applied to the tensor before the Mul operation with the perm specified as pre-processing.<br>2. "param_target": "outputs"<br>`post_process_transpose_perm`: Transpose is applied to the tensor after the Mul operation with the perm specified as post-processing.|
   |12|NonMaxSuppression||

--- a/json_samples/replace_rtmdet_tiny.json
+++ b/json_samples/replace_rtmdet_tiny.json
@@ -24,6 +24,12 @@
       "param_target": "attributes",
       "param_name": "axis",
       "values": 1
+    },
+    {
+      "op_name": "/Gather_14",
+      "param_target": "attributes",
+      "param_name": "axis",
+      "values": 2
     }
   ]
 }

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.8'
+__version__ = '1.7.9'

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -80,6 +80,14 @@ def make_node(
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
 
+    # Param replacement - axis
+    axis = replace_parameter(
+        value_before_replacement=axis,
+        param_target='attributes',
+        param_name='axis',
+        **kwargs,
+    )
+
     optimization_for_gpu_delegate: bool = \
         kwargs['optimization_for_gpu_delegate']
 


### PR DESCRIPTION
### 1. Content and background
- `Gather`
  - Support for substitution of `Gather` attribute parameter `axis`
    ![image](https://user-images.githubusercontent.com/33194443/221851421-06da5e80-4a68-4a23-b357-a86c5ff0f608.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Converting an ONNX model with static output to TfLite leads to a model that is not supported by the TfLite Java API #210](https://github.com/PINTO0309/onnx2tf/issues/210)