### PR TITLE
Corrected a mistake in the decision statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.10
+  ghcr.io/pinto0309/onnx2tf:1.7.11
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.10'
+__version__ = '1.7.11'

--- a/onnx2tf/ops/Squeeze.py
+++ b/onnx2tf/ops/Squeeze.py
@@ -110,7 +110,7 @@ def make_node(
             workaround_exec_flg = True
         if workaround_exec_flg \
             and graph_node.o().op == 'Unsqueeze' \
-            and (hasattr(graph_node.o(), 'attrs') and 'axes' in graph_node.o().attrs) or len(graph_node.o().inputs) >= 2:
+            and ((hasattr(graph_node.o(), 'attrs') and 'axes' in graph_node.o().attrs) or len(graph_node.o().inputs) >= 2):
             # Remove useless squeeze/unsqueeze combinations
             #   Only when squeeze and unsqueeze are consecutive
             #   and each is performing a useless process of


### PR DESCRIPTION
### 1. Content and background
- `Squeeze`
  - Corrected a mistake in the decision statement

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Cannot reshape a tensor with 41835024 elements to shape [3234,4] (12936 elements) #217](https://github.com/PINTO0309/onnx2tf/issues/217)