### PR TITLE
Disabling splits that do not make sense and preventing the generation of `FlexSplitV` were added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.11
+  ghcr.io/pinto0309/onnx2tf:1.7.12
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.11'
+__version__ = '1.7.12'


### PR DESCRIPTION
### 1. Content and background
- `Split`
  - Disabling splits that do not make sense and preventing the generation of `FlexSplitV` were added.
  - [ssdlite320_mobilenet_v3_large.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/10866464/ssdlite320_mobilenet_v3_large.onnx.zip)
  - `Split` that makes no sense
    ![image](https://user-images.githubusercontent.com/33194443/222298056-54cc78f8-f53a-4de8-b5eb-bb6a72d6fb33.png)
    ![image](https://user-images.githubusercontent.com/33194443/222298718-1894e141-8fa6-4273-ba49-b0f017cb063b.png)
  - `Split` converted to `FlexSplitV`.
    ![image](https://user-images.githubusercontent.com/33194443/222298147-b68e1dd3-6eae-48dd-a741-30b66666cefe.png)
    ![image](https://user-images.githubusercontent.com/33194443/222298778-73d9f72c-ae3f-4421-bccd-9687958d0a95.png)



### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Cannot reshape a tensor with 41835024 elements to shape [3234,4] (12936 elements) #217](https://github.com/PINTO0309/onnx2tf/issues/217)