### PR TITLE
1. Temporarily disabled accuracy check function added as a backend function. 2. Backward to v1.13.1 because I noticed a bug in `sigmoid` behavior in onnxruntime v1.14.0

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -32,7 +32,7 @@ jobs:
         pip install protobuf==3.20.3
         pip install onnxsim
         pip install sng4onnx
-        pip install onnxruntime==1.14.0
+        pip install onnxruntime==1.13.1
         pip install -e .
     - name: Download models
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install pip -U \
     && pip install tensorflow==2.12.0rc0 \
     && pip install protobuf==3.20.3 \
     && pip install h5py==3.7.0 \
-    && pip install -U onnxruntime==1.14.0 \
+    && pip install -U onnxruntime==1.13.1 \
     && python -m pip cache purge
 
 # Re-release flatc with some customizations of our own to address

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.12
+  ghcr.io/pinto0309/onnx2tf:1.7.13
 
   or
 
@@ -53,7 +53,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
   && pip install -U polygraphy \
-  && pip install -U onnxruntime \
+  && pip install -U onnxruntime==1.13.1 \
   && pip install -U onnxsim \
   && pip install -U simple_onnx_processing_tools \
   && pip install -U onnx2tf \
@@ -89,7 +89,7 @@ or
     && python3.9 -m pip install -U nvidia-pyindex \
     && python3.9 -m pip install -U onnx-graphsurgeon \
     && python3.9 -m pip install -U polygraphy \
-    && python3.9 -m pip install -U onnxruntime \
+    && python3.9 -m pip install -U onnxruntime==1.13.1 \
     && python3.9 -m pip install -U onnxsim \
     && python3.9 -m pip install -U simple_onnx_processing_tools \
     && python3.9 -m pip install -U onnx2tf \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.12'
+__version__ = '1.7.13'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -687,6 +687,7 @@ def convert(
         'output_signaturedefs': output_signaturedefs,
         'onnx_tensor_infos_for_validation': onnx_tensor_infos_for_validation,
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
+        'acc_check': False,
     }
 
     tf_layers_dict = {}

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -74,22 +74,23 @@ def make_node(
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
     # Acquisition of test data for validation
-    if not isinstance(graph_node_input_1, np.ndarray) \
-        and graph_node_input_1.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-    elif isinstance(graph_node_input_1, np.ndarray):
-        test_data1: np.ndarray = graph_node_input_1
-    else:
-        test_data1 = None
-    if not isinstance(graph_node_input_2, np.ndarray) \
-        and graph_node_input_2.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-    elif isinstance(graph_node_input_2, np.ndarray):
-        test_data2: np.ndarray = graph_node_input_2
-    else:
-        test_data2 = None
+    if kwargs['acc_check']:
+        if not isinstance(graph_node_input_1, np.ndarray) \
+            and graph_node_input_1.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+        elif isinstance(graph_node_input_1, np.ndarray):
+            test_data1: np.ndarray = graph_node_input_1
+        else:
+            test_data1 = None
+        if not isinstance(graph_node_input_2, np.ndarray) \
+            and graph_node_input_2.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+        elif isinstance(graph_node_input_2, np.ndarray):
+            test_data2: np.ndarray = graph_node_input_2
+        else:
+            test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -146,14 +147,15 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[
-                input_tensor_1,
-                input_tensor_2,
-            ]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor_1,
+                    input_tensor_2,
+                ]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -164,7 +166,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.add(

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -160,11 +160,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=values
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=values
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -175,7 +176,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         test_datas = []
         for graph_node_input, value in zip(graph_node.inputs, values):
             test_data = None

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -217,15 +217,16 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[
-                input_tensor,
-            ]
-        )
-    tf_partial_model_tensors = tf_partial_model_inputs[0] \
-        if tf_partial_model_inputs is not None else None
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor,
+                ]
+            )
+        tf_partial_model_tensors = tf_partial_model_inputs[0] \
+            if tf_partial_model_inputs is not None else None
+        tf_partial_model_outputs = None
 
     def tf_partial_model_inference(
         *,
@@ -296,7 +297,7 @@ def make_node(
                     )
                 tf_op_type = tf.nn.convolution
                 ### Partial model
-                if tf_partial_model_inputs is not None:
+                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                     tf_partial_model_outputs = \
                         [
                             tf.add(
@@ -344,7 +345,7 @@ def make_node(
                         )
                     tf_op_type = 'GroupedConvolution1D'
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         tf_partial_model_outputs = \
                             [
                                 tf.add(
@@ -387,7 +388,7 @@ def make_node(
                         )
                     tf_op_type = 'GroupedConvolution2D'
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         tf_partial_model_outputs = \
                             [
                                 tf.add(
@@ -432,7 +433,7 @@ def make_node(
                 #         )
                 #     tf_op_type = 'GroupedConvolution3D'
                 #     ### Partial model
-                #     if tf_partial_model_inputs is not None:
+                #     if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                 #         tf_partial_model_outputs = \
                 #             [
                 #                 tf.add(
@@ -479,7 +480,7 @@ def make_node(
                         )
                     tf_op_type = tf.nn.convolution
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         partial_input_tensor_splits = tf.split(tf_partial_model_tensors, num_or_size_splits=group, axis=-1)
                         partial_weight_splits = tf.split(input_weights, num_or_size_splits=group, axis=-1)
                         tf_partial_model_outputs = \
@@ -523,7 +524,7 @@ def make_node(
                 )
             tf_op_type = tf.nn.depthwise_conv2d
             ### Partial model
-            if tf_partial_model_inputs is not None:
+            if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                 tf_partial_model_outputs = \
                     [
                         tf.add(
@@ -558,7 +559,7 @@ def make_node(
                     )
                 tf_op_type = tf.nn.convolution
                 ### Partial model
-                if tf_partial_model_inputs is not None:
+                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                     tf_partial_model_outputs = \
                         [
                             tf.nn.convolution(
@@ -600,7 +601,7 @@ def make_node(
                         )(input_tensor)
                     tf_op_type = 'GroupedConvolution1D'
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         tf_partial_model_outputs = \
                             [
                                 Conv1D(
@@ -637,7 +638,7 @@ def make_node(
                         )(input_tensor)
                     tf_op_type = 'GroupedConvolution2D'
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         tf_partial_model_outputs = \
                             [
                                 Conv2D(
@@ -676,7 +677,7 @@ def make_node(
                 #         )(input_tensor)
                 #     tf_op_type = 'GroupedConvolution3D'
                 #     ### Partial model
-                #     if tf_partial_model_inputs is not None:
+                #     if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                 #         tf_partial_model_outputs = \
                 #             [
                 #                 Conv3D(
@@ -717,7 +718,7 @@ def make_node(
                         )
                     tf_op_type = tf.nn.convolution
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         partial_input_tensor_splits = tf.split(tf_partial_model_tensors, num_or_size_splits=group, axis=-1)
                         partial_weight_splits = tf.split(input_weights, num_or_size_splits=group, axis=-1)
                         tf_partial_model_outputs = \
@@ -755,7 +756,7 @@ def make_node(
                 )
             tf_op_type = tf.nn.depthwise_conv2d
             ### Partial model
-            if tf_partial_model_inputs is not None:
+            if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                 tf_partial_model_outputs = \
                     [
                         tf.nn.depthwise_conv2d(

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -80,11 +80,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -94,7 +95,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.cos(

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -76,22 +76,23 @@ def make_node(
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
     # Acquisition of test data for validation
-    if not isinstance(graph_node_input_1, np.ndarray) \
-        and graph_node_input_1.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-    elif isinstance(graph_node_input_1, np.ndarray):
-        test_data1: np.ndarray = graph_node_input_1
-    else:
-        test_data1 = None
-    if not isinstance(graph_node_input_2, np.ndarray) \
-        and graph_node_input_2.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-    elif isinstance(graph_node_input_2, np.ndarray):
-        test_data2: np.ndarray = graph_node_input_2
-    else:
-        test_data2 = None
+    if kwargs['acc_check']:
+        if not isinstance(graph_node_input_1, np.ndarray) \
+            and graph_node_input_1.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+        elif isinstance(graph_node_input_1, np.ndarray):
+            test_data1: np.ndarray = graph_node_input_1
+        else:
+            test_data1 = None
+        if not isinstance(graph_node_input_2, np.ndarray) \
+            and graph_node_input_2.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+        elif isinstance(graph_node_input_2, np.ndarray):
+            test_data2: np.ndarray = graph_node_input_2
+        else:
+            test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -179,14 +180,15 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[
-                input_tensor_1,
-                input_tensor_2,
-            ]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor_1,
+                    input_tensor_2,
+                ]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -196,7 +198,7 @@ def make_node(
         name=graph_node.name,
     )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.divide(

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -150,11 +150,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
 
     # Generation of TF OP
@@ -173,7 +174,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         (input_tensor - mean) / tf.math.sqrt(variance + epsilon) * scale + B
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         mean = tf.reduce_mean(
             input_tensor=tf_partial_model_inputs[0],
             axis=axes,

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -96,14 +96,15 @@ def make_node(
     try:
         # Generate input OPs for TensorFlow subgraphs
         # For inference testing on OP stand-alone
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[
-                    input_tensor_1,
-                    input_tensor_2,
-                ]
-            )
-        tf_partial_model_outputs = None
+        if kwargs['acc_check']:
+            tf_partial_model_inputs: List[tf.keras.Input] = \
+                make_tf_partial_model_inputs(
+                    input_tensors=[
+                        input_tensor_1,
+                        input_tensor_2,
+                    ]
+                )
+            tf_partial_model_outputs = None
         ### Overall model
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.matmul(
@@ -117,7 +118,7 @@ def make_node(
                 name=graph_node.name,
             )
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.matmul(
@@ -181,24 +182,25 @@ def make_node(
                 try:
                     # Generate input OPs for TensorFlow subgraphs
                     # For inference testing on OP stand-alone
-                    tf_partial_model_inputs: List[tf.keras.Input] = \
-                            make_tf_partial_model_inputs(
-                                input_tensors=[
-                                    np.zeros(
-                                        list(input_tensor_1.shape),
-                                        dtype=input_tensor_1.dtype \
-                                            if isinstance(input_tensor_1, np.ndarray) \
-                                                else TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_1.dtype],
-                                    ).transpose(tensor_1_candidate_for_transposition),
-                                    np.zeros(
-                                        list(input_tensor_2.shape),
-                                        dtype=input_tensor_2.dtype \
-                                            if isinstance(input_tensor_2, np.ndarray) \
-                                                else TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_2.dtype],
-                                    ).transpose(tensor_2_candidate_for_transposition),
-                                ]
-                            )
-                    tf_partial_model_outputs = None
+                    if kwargs['acc_check']:
+                        tf_partial_model_inputs: List[tf.keras.Input] = \
+                                make_tf_partial_model_inputs(
+                                    input_tensors=[
+                                        np.zeros(
+                                            list(input_tensor_1.shape),
+                                            dtype=input_tensor_1.dtype \
+                                                if isinstance(input_tensor_1, np.ndarray) \
+                                                    else TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_1.dtype],
+                                        ).transpose(tensor_1_candidate_for_transposition),
+                                        np.zeros(
+                                            list(input_tensor_2.shape),
+                                            dtype=input_tensor_2.dtype \
+                                                if isinstance(input_tensor_2, np.ndarray) \
+                                                    else TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_2.dtype],
+                                        ).transpose(tensor_2_candidate_for_transposition),
+                                    ]
+                                )
+                        tf_partial_model_outputs = None
                     ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.matmul(
@@ -220,7 +222,7 @@ def make_node(
                             name=graph_node.name,
                         )
                     ### Partial model
-                    if tf_partial_model_inputs is not None:
+                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                         tf_partial_model_outputs = \
                             [
                                 tf.matmul(

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -75,22 +75,23 @@ def make_node(
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
     # Acquisition of test data for validation
-    if not isinstance(graph_node_input_1, np.ndarray) \
-        and graph_node_input_1.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-    elif isinstance(graph_node_input_1, np.ndarray):
-        test_data1: np.ndarray = graph_node_input_1
-    else:
-        test_data1 = None
-    if not isinstance(graph_node_input_2, np.ndarray) \
-        and graph_node_input_2.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-    elif isinstance(graph_node_input_2, np.ndarray):
-        test_data2: np.ndarray = graph_node_input_2
-    else:
-        test_data2 = None
+    if kwargs['acc_check']:
+        if not isinstance(graph_node_input_1, np.ndarray) \
+            and graph_node_input_1.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+        elif isinstance(graph_node_input_1, np.ndarray):
+            test_data1: np.ndarray = graph_node_input_1
+        else:
+            test_data1 = None
+        if not isinstance(graph_node_input_2, np.ndarray) \
+            and graph_node_input_2.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+        elif isinstance(graph_node_input_2, np.ndarray):
+            test_data2: np.ndarray = graph_node_input_2
+        else:
+            test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -147,14 +148,15 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[
-                input_tensor_1,
-                input_tensor_2,
-            ]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor_1,
+                    input_tensor_2,
+                ]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -165,7 +167,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.mod(

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -76,22 +76,23 @@ def make_node(
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
     # Acquisition of test data for validation
-    if not isinstance(graph_node_input_1, np.ndarray) \
-        and graph_node_input_1.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-    elif isinstance(graph_node_input_1, np.ndarray):
-        test_data1: np.ndarray = graph_node_input_1
-    else:
-        test_data1 = None
-    if not isinstance(graph_node_input_2, np.ndarray) \
-        and graph_node_input_2.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-    elif isinstance(graph_node_input_2, np.ndarray):
-        test_data2: np.ndarray = graph_node_input_2
-    else:
-        test_data2 = None
+    if kwargs['acc_check']:
+        if not isinstance(graph_node_input_1, np.ndarray) \
+            and graph_node_input_1.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+        elif isinstance(graph_node_input_1, np.ndarray):
+            test_data1: np.ndarray = graph_node_input_1
+        else:
+            test_data1 = None
+        if not isinstance(graph_node_input_2, np.ndarray) \
+            and graph_node_input_2.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+        elif isinstance(graph_node_input_2, np.ndarray):
+            test_data2: np.ndarray = graph_node_input_2
+        else:
+            test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -169,14 +170,15 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[
-                input_tensor_1,
-                input_tensor_2,
-            ]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor_1,
+                    input_tensor_2,
+                ]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -187,7 +189,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.multiply(

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -129,11 +129,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -145,7 +146,7 @@ def make_node(
     )
     tf_layers_dict[graph_node_output.name]['tf_node'] = reducemaxed_tensor
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.reduce_max(

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -172,11 +172,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[transposed_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[transposed_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Reshape
     has_undefined_outputshape = output_shape is None
@@ -193,7 +194,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.reshape(
@@ -251,7 +252,7 @@ def make_node(
                         **kwargs,
                     )
                 ### Partial model
-                if tf_partial_model_inputs is not None:
+                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                     tf_layers_dict[graph_node_output.name]['verification_data'] = \
                         tf_layers_dict[graph_node_output.name]['verification_data'].transpose([0,2,3,1])
             else:

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -72,12 +72,13 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_tensors = None
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_tensors = None
+        tf_partial_model_outputs = None
 
     # Workaround to avoid as many Resize failures as possible
     # for models with useless Transpose immediately before them.
@@ -107,7 +108,7 @@ def make_node(
                 )
                 before_op_output_shape_trans = True
                 # 2D - Partial model
-                if tf_partial_model_inputs is not None:
+                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
                         transpose_with_flexing_deterrence(
                             input_tensor=tf_partial_model_inputs[0],
@@ -123,7 +124,7 @@ def make_node(
                 )
                 before_op_output_shape_trans = True
                 # 3D - Partial model
-                if tf_partial_model_inputs is not None:
+                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                     tf_partial_model_tensors = \
                         transpose_with_flexing_deterrence(
                             input_tensor=tf_partial_model_inputs[0],
@@ -371,7 +372,7 @@ def make_node(
         )
         tf_op_type = tf.image.crop_and_resize
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.image.crop_and_resize(
@@ -400,7 +401,7 @@ def make_node(
         )(input_tensor)
         tf_op_type = tf_resize
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     Lambda(
@@ -431,7 +432,7 @@ def make_node(
         )(input_tensor)
         tf_op_type = tf_resize
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     Lambda(
@@ -462,7 +463,7 @@ def make_node(
         )(input_tensor)
         tf_op_type = tf_resize
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     Lambda(
@@ -488,7 +489,7 @@ def make_node(
         )
         tf_op_type = tf.image.resize
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.image.resize(
@@ -500,7 +501,7 @@ def make_node(
                 ]
 
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model = tf.keras.Model(
             inputs=tf_partial_model_inputs,
             outputs=tf_partial_model_outputs,

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -81,11 +81,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -95,7 +96,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.nn.sigmoid(

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -80,11 +80,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -94,7 +95,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.sin(

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -75,22 +75,23 @@ def make_node(
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
     # Acquisition of test data for validation
-    if not isinstance(graph_node_input_1, np.ndarray) \
-        and graph_node_input_1.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-        test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-    elif isinstance(graph_node_input_1, np.ndarray):
-        test_data1: np.ndarray = graph_node_input_1
-    else:
-        test_data1 = None
-    if not isinstance(graph_node_input_2, np.ndarray) \
-        and graph_node_input_2.name in tf_layers_dict \
-        and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-        test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-    elif isinstance(graph_node_input_2, np.ndarray):
-        test_data2: np.ndarray = graph_node_input_2
-    else:
-        test_data2 = None
+    if kwargs['acc_check']:
+        if not isinstance(graph_node_input_1, np.ndarray) \
+            and graph_node_input_1.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+        elif isinstance(graph_node_input_1, np.ndarray):
+            test_data1: np.ndarray = graph_node_input_1
+        else:
+            test_data1 = None
+        if not isinstance(graph_node_input_2, np.ndarray) \
+            and graph_node_input_2.name in tf_layers_dict \
+            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
+            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
+        elif isinstance(graph_node_input_2, np.ndarray):
+            test_data2: np.ndarray = graph_node_input_2
+        else:
+            test_data2 = None
 
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
@@ -161,14 +162,15 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[
-                input_tensor_1,
-                input_tensor_2,
-            ]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[
+                    input_tensor_1,
+                    input_tensor_2,
+                ]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -179,7 +181,7 @@ def make_node(
             name=graph_node.name,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 tf.math.subtract(

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -179,11 +179,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     ### Overall model
@@ -196,7 +197,7 @@ def make_node(
             **kwargs,
         )
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model_outputs = \
             [
                 transpose_with_flexing_deterrence(

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -127,11 +127,12 @@ def make_node(
 
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
-    tf_partial_model_inputs: List[tf.keras.Input] = \
-        make_tf_partial_model_inputs(
-            input_tensors=[input_tensor]
-        )
-    tf_partial_model_outputs = None
+    if kwargs['acc_check']:
+        tf_partial_model_inputs: List[tf.keras.Input] = \
+            make_tf_partial_model_inputs(
+                input_tensors=[input_tensor]
+            )
+        tf_partial_model_outputs = None
 
     # Generation of TF OP
     # https://github.com/onnx/onnx/blob/main/docs/Changelog.md#unsqueeze-13
@@ -158,7 +159,7 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.identity(input=input_tensor)
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.identity(
@@ -172,7 +173,7 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.identity(input=input_tensor)
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.identity(
@@ -191,7 +192,7 @@ def make_node(
                 name=graph_node.name,
             )
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.expand_dims(
@@ -208,7 +209,7 @@ def make_node(
                 name=graph_node.name,
             )
         ### Partial model
-        if tf_partial_model_inputs is not None:
+        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
             tf_partial_model_outputs = \
                 [
                     tf.reshape(
@@ -218,7 +219,7 @@ def make_node(
                 ]
 
     ### Partial model
-    if tf_partial_model_inputs is not None:
+    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
         tf_partial_model = tf.keras.Model(
             inputs=tf_partial_model_inputs,
             outputs=tf_partial_model_outputs,


### PR DESCRIPTION
### 1. Content and background
1. Temporarily disabled accuracy check function added as a backend function. https://github.com/PINTO0309/onnx2tf/pull/184
    - Significantly reduced RAM consumption during model conversion
    - Significantly improved model conversion speed 
2. Backward to v1.13.1 because I noticed a bug in `sigmoid` behavior in onnxruntime v1.14.0. After updating to v1.14.0, all `sigmoid` output values are Nan.
    - https://github.com/microsoft/onnxruntime/pulls?q=sigmoid 

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Add option to disable backend inference for accuracy checks. #208](https://github.com/PINTO0309/onnx2tf/issues/208)