### PR TITLE
Improved error judgment regarding calibration data for INT8 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.13
+  ghcr.io/pinto0309/onnx2tf:1.7.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.13'
+__version__ = '1.7.14'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -989,6 +989,18 @@ def convert(
                 calib_data: np.ndarray = download_test_image_data()
                 data_count = calib_data.shape[0]
                 for model_input in model.inputs:
+                    if model_input.dtype != tf.float32 \
+                        or len(model_input.shape) != 4 \
+                        or model_input.shape[-1] != 3:
+                        print(
+                            f'{Color.RED}ERROR:{Color.RESET} ' +
+                            f'For models that have multiple input OPs and need to perform INT8 quantization calibration '+
+                            f'using non-image input tensors, specify the calibration data with '+
+                            f'--quant_calib_input_op_name_np_data_path. '+
+                            f'model_input[n].shape: {model_input.shape}'
+                        )
+                        sys.exit(1)
+
                     calib_data_dict[model_input.name] = \
                         [
                             tf.image.resize(

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -995,7 +995,7 @@ def convert(
                         print(
                             f'{Color.RED}ERROR:{Color.RESET} ' +
                             f'For models that have multiple input OPs and need to perform INT8 quantization calibration '+
-                            f'using non-image input tensors, specify the calibration data with '+
+                            f'using non-rgb-image input tensors, specify the calibration data with '+
                             f'--quant_calib_input_op_name_np_data_path. '+
                             f'model_input[n].shape: {model_input.shape}'
                         )


### PR DESCRIPTION
### 1. Content and background
- Improved error judgment regarding calibration data for INT8 quantization.
- Models with multiple input OPs and non-image input OPs force automatic calibration to be aborted.
- e.g. [cf_fus.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/10884363/cf_fus.onnx.zip)
  ![image](https://user-images.githubusercontent.com/33194443/222779034-78192d45-5992-4410-b2fd-a929e9aeaf02.png)
  ```python
  if model_input.dtype != tf.float32 \
      or len(model_input.shape) != 4 \
      or model_input.shape[-1] != 3:
      print(
          f'{Color.RED}ERROR:{Color.RESET} ' +
          f'For models that have multiple input OPs and need to perform INT8 quantization calibration '+
          f'using non-rgb-image input tensors, specify the calibration data with '+
          f'--quant_calib_input_op_name_np_data_path. '+
          f'model_input[n].shape: {model_input.shape}'
      )
      sys.exit(1)
  ```
### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[CenterFusion] Model Full Interger Quantize problem #222](https://github.com/PINTO0309/onnx2tf/issues/222)