### PR TITLE
Fixed `Softmax` accuracy check bug and reduced `Pow` calculation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.14
+  ghcr.io/pinto0309/onnx2tf:1.7.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.14'
+__version__ = '1.7.15'

--- a/onnx2tf/ops/Pow.py
+++ b/onnx2tf/ops/Pow.py
@@ -120,11 +120,14 @@ def make_node(
                 y=input_tensor_2,
                 name=graph_node.name,
             )
-    powed_tensor = tf.cast(
-        powed_tensor,
-        dtype=NUMPY_DTYPES_TO_TF_DTYPES[output_dtype] \
-            if isinstance(output_dtype, np.dtype) else output_dtype
-    )
+    to_dtype = NUMPY_DTYPES_TO_TF_DTYPES[output_dtype] \
+        if isinstance(output_dtype, np.dtype) else output_dtype
+    if powed_tensor.dtype != to_dtype:
+        powed_tensor = tf.cast(
+            powed_tensor,
+            dtype=NUMPY_DTYPES_TO_TF_DTYPES[output_dtype] \
+                if isinstance(output_dtype, np.dtype) else output_dtype
+        )
     tf_layers_dict[graph_node_output.name]['tf_node'] = powed_tensor
 
     # Post-process transpose

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -180,7 +180,7 @@ def make_node(
         # Search for the axis with the smallest error
         for check_axis in check_axes:
             try:
-                if tf_partial_model_inputs is not None:
+                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
                     ### Partial model check
                     tf_partial_model_outputs = \
                         [


### PR DESCRIPTION
### 1. Content and background
- `Softmax`
  - Fixed `Softmax` accuracy check bug
- `Pow`
  - Reduced `Pow` calculation error

![image](https://user-images.githubusercontent.com/33194443/222872869-d7d17090-3f59-481d-9b49-f99f71ff2509.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] [unimatch] Creation of JSON for unimatch accuracy error resolution #203](https://github.com/PINTO0309/onnx2tf/issues/203)