### PR TITLE
Suppress automatic `FlexTraspose` extrapolation behavior by `Softmax` in TensorFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.15
+  ghcr.io/pinto0309/onnx2tf:1.7.16
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.15'
+__version__ = '1.7.16'

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -300,6 +300,7 @@ def make_node(
             transpose_with_flexing_deterrence(
                 input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
                 perm=flex_deterrent_perm_rev,
+                output_shape=after_trans_shape,
                 **kwargs,
             )
 

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -20,6 +20,7 @@ from onnx2tf.utils.common_functions import (
     get_tf_model_inputs,
     onnx_tf_tensor_validation,
     make_tf_partial_model_inputs,
+    transpose_with_flexing_deterrence,
 )
 from typing import Any, Dict, List
 
@@ -266,13 +267,41 @@ def make_node(
             except tf.errors.InvalidArgumentError as ex:
                 pass
 
+    # Suppress automatic Traspose extrapolation behavior by Softmax in TensorFlow
+    flex_deterrent_perm_rev = []
+    if min_abs_err_axis != tensor_rank - 1:
+        # 0,1,3,4,5,6,2
+        flex_deterrent_perm = [
+            idx for idx in range(tensor_rank) if idx != min_abs_err_axis
+        ] + [min_abs_err_axis]
+        # 0,1,3,4,5,6,2 -> 0,1,6,2,3,4,5
+        flex_deterrent_perm_rev = [
+            idx if idx != min_abs_err_axis else tensor_rank - 1 for idx in range(min_abs_err_axis + 1)
+        ] + [
+            idx for idx in range(min_abs_err_axis, tensor_rank - 1)
+        ]
+        input_tensor = transpose_with_flexing_deterrence(
+            input_tensor=input_tensor,
+            perm=flex_deterrent_perm,
+            **kwargs,
+        )
+
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.nn.softmax(
             logits=input_tensor,
-            axis=min_abs_err_axis,
+            axis=min_abs_err_axis if not flex_deterrent_perm_rev else tensor_rank - 1,
             name=graph_node.name,
         )
+
+    # Inversion of suppression of automatic Traspose extrapolation behavior by Softmax in TensorFlow
+    if flex_deterrent_perm_rev:
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            transpose_with_flexing_deterrence(
+                input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
+                perm=flex_deterrent_perm_rev,
+                **kwargs,
+            )
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -280,9 +280,12 @@ def make_node(
         ] + [
             idx for idx in range(min_abs_err_axis, tensor_rank - 1)
         ]
+        transpose_output_shape = np.asarray(input_tensor.shape)[flex_deterrent_perm]
         input_tensor = transpose_with_flexing_deterrence(
             input_tensor=input_tensor,
             perm=flex_deterrent_perm,
+            output_shape=transpose_output_shape \
+                if None not in transpose_output_shape else None,
             **kwargs,
         )
 
@@ -300,7 +303,8 @@ def make_node(
             transpose_with_flexing_deterrence(
                 input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
                 perm=flex_deterrent_perm_rev,
-                output_shape=after_trans_shape,
+                output_shape=after_trans_shape \
+                    if None not in after_trans_shape else None,
                 **kwargs,
             )
 


### PR DESCRIPTION
### 1. Content and background
- `Softmax`
  - Suppress automatic `FlexTraspose` extrapolation behavior by `Softmax` in TensorFlow
  - Automatic extrapolation of `FlexTranspose` by `Softmax` occurs when the rank of the input tensor to `Softmax` is 7 or more dimensions and the `axis` is not the last dimension.
  - Before
    ![20230304162845](https://user-images.githubusercontent.com/33194443/222882402-038b04e7-9c08-4c5e-b764-f8ba690c41db.png)
  - After
    ![image](https://user-images.githubusercontent.com/33194443/222884060-35f875ba-3fad-4121-acfa-d39387348d5a.png)
    ![image](https://user-images.githubusercontent.com/33194443/222883790-59552c7d-13e3-4241-b976-2ba4da03f55a.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
