### PR TITLE
Prevent saved_model (.pb) bloat

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.16
+  ghcr.io/pinto0309/onnx2tf:1.7.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.16'
+__version__ = '1.7.17'

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -161,8 +161,12 @@ def make_node(
     ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.add(
-            x=input_tensor_1,
-            y=input_tensor_2,
+            x=input_tensor_1 \
+                if not isinstance(input_tensor_1, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_1),
+            y=input_tensor_2 \
+                if not isinstance(input_tensor_2, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_2),
             name=graph_node.name,
         )
     ### Partial model
@@ -170,8 +174,12 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.add(
-                    x=tf_partial_model_inputs[0],
-                    y=tf_partial_model_inputs[1],
+                    x=tf_partial_model_inputs[0] \
+                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
+                    y=tf_partial_model_inputs[1] \
+                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -150,7 +150,11 @@ def make_node(
             param_name=graph_node_input.name,
             **kwargs,
         )
-        new_values.append(value)
+        new_values.append(
+            value \
+                if not isinstance(value, np.ndarray) \
+                    else tf.convert_to_tensor(value)
+        )
     values = new_values
 
     # TensorFlow does not support Concat for scalar values, so convert to tensor

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -215,6 +215,13 @@ def make_node(
         depthwise_filter_shape = list(input_weights_shape[0:2]) + [-1, input_weights_shape[3] // group]
         input_weights = tf.reshape(input_weights, depthwise_filter_shape)
 
+    input_weights = input_weights \
+        if not isinstance(input_weights, np.ndarray) \
+            else tf.convert_to_tensor(input_weights)
+    input_bias = input_bias \
+        if not isinstance(input_bias, np.ndarray) \
+            else tf.convert_to_tensor(input_bias)
+
     # Generate input OPs for TensorFlow subgraphs
     # For inference testing on OP stand-alone
     if kwargs['acc_check']:

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -230,7 +230,9 @@ def make_node(
             try:
                 conv_rs = conv_func(
                     input=input_tensor_split,
-                    filters=weight_split,
+                    filters=weight_split \
+                        if not isinstance(weight_split, np.ndarray) \
+                            else tf.convert_to_tensor(weight_split),
                     output_shape=split_conv_output_shape,
                     strides=strides,
                     padding=pad_mode,
@@ -251,7 +253,9 @@ def make_node(
                                     **kwargs,
                                 ),
                                 filters=transpose_with_flexing_deterrence(
-                                    input_tensor=weight_split,
+                                    input_tensor=weight_split \
+                                        if not isinstance(weight_split, np.ndarray) \
+                                            else tf.convert_to_tensor(weight_split),
                                     perm=tensor_2_candidate_for_transposition,
                                     **kwargs,
                                 ),
@@ -273,7 +277,9 @@ def make_node(
             # OP replacement
             conv_rs = conv_func(
                 input=input_tensor_splits,
-                filters=weight_splits,
+                filters=weight_splits \
+                    if not isinstance(weight_splits, np.ndarray) \
+                        else tf.convert_to_tensor(weight_splits),
                 output_shape=output_shape_,
                 strides=strides_,
                 padding=padding_,

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -193,8 +193,12 @@ def make_node(
     # Generation of TF OP
     ### Overall model
     divided_tensor = tf.math.divide(
-        x=input_tensor_1,
-        y=input_tensor_2,
+        x=input_tensor_1 \
+            if not isinstance(input_tensor_1, np.ndarray) \
+                else tf.convert_to_tensor(input_tensor_1),
+        y=input_tensor_2 \
+            if not isinstance(input_tensor_2, np.ndarray) \
+                else tf.convert_to_tensor(input_tensor_2),
         name=graph_node.name,
     )
     ### Partial model
@@ -202,8 +206,12 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.divide(
-                    x=tf_partial_model_inputs[0],
-                    y=tf_partial_model_inputs[1],
+                    x=tf_partial_model_inputs[0] \
+                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
+                    y=tf_partial_model_inputs[1] \
+                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -200,7 +200,9 @@ def make_node(
         end_mask_ = begin_mask_
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.strided_slice(
-                input_=input_tensor,
+                input_=input_tensor \
+                    if not isinstance(input_tensor, np.ndarray) \
+                        else tf.convert_to_tensor(input_tensor),
                 begin=begin_,
                 end=end_,
                 begin_mask=begin_mask_,
@@ -209,12 +211,15 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['unnecessary_gather'] = True
     else:
         # No-replace
+        indices_values = indices._inferred_value \
+            if hasattr(indices, "_inferred_value") \
+                and indices._inferred_value is not None else indices
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.gather(
                 params=input_tensor,
-                indices=indices._inferred_value \
-                    if hasattr(indices, "_inferred_value") \
-                        and indices._inferred_value is not None else indices,
+                indices=indices_values \
+                    if not isinstance(indices_values, np.ndarray) \
+                        else tf.convert_to_tensor(indices_values),
                 axis=axis,
                 name=graph_node.name,
             )

--- a/onnx2tf/ops/GatherElements.py
+++ b/onnx2tf/ops/GatherElements.py
@@ -93,6 +93,12 @@ def make_node(
     }
 
     # Generation of TF OP
+    input_tensor = input_tensor \
+        if not isinstance(input_tensor, np.ndarray) \
+            else tf.convert_to_tensor(input_tensor)
+    indices_tensor = indices_tensor \
+        if not isinstance(indices_tensor, np.ndarray) \
+            else tf.convert_to_tensor(indices_tensor)
     indices_tensor = process_neg_idx_along_axis(
         data=input_tensor,
         axis=axis,

--- a/onnx2tf/ops/GatherND.py
+++ b/onnx2tf/ops/GatherND.py
@@ -97,6 +97,12 @@ def make_node(
     }
 
     # Generation of TF OP
+    input_tensor = input_tensor \
+        if not isinstance(input_tensor, np.ndarray) \
+            else tf.convert_to_tensor(input_tensor)
+    indices_tensor = indices_tensor \
+        if not isinstance(indices_tensor, np.ndarray) \
+            else tf.convert_to_tensor(indices_tensor)
     indices_tensor = process_neg_idx(
         data=input_tensor,
         indices=indices_tensor,

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -206,6 +206,16 @@ def make_node(
     )
 
     # Generation of TF OP
+    x = x \
+        if not isinstance(x, np.ndarray) \
+            else tf.convert_to_tensor(x)
+    y = y \
+        if not isinstance(y, np.ndarray) \
+            else tf.convert_to_tensor(y)
+    if z is not None:
+        z = z \
+            if not isinstance(z, np.ndarray) \
+                else tf.convert_to_tensor(z)
     if transA == True:
         x = tf.transpose(x)
         if kwargs['acc_check'] and test_data1 is not None:

--- a/onnx2tf/ops/Max.py
+++ b/onnx2tf/ops/Max.py
@@ -50,7 +50,11 @@ def make_node(
         if isinstance(const_or_var, gs.Variable):
             values.append(tf_layers_dict[const_or_var.name]['tf_node'])
         else:
-            values.append(const_or_var)
+            values.append(
+                const_or_var \
+                    if not isinstance(const_or_var, np.ndarray) \
+                        else tf.convert_to_tensor(const_or_var)
+            )
 
     graph_node_output: gs.Variable = graph_node.outputs[0]
 

--- a/onnx2tf/ops/Min.py
+++ b/onnx2tf/ops/Min.py
@@ -77,9 +77,16 @@ def make_node(
     values = new_values
 
     # Generation of TF OP
-    minimumed_tesnor = values[0]
+    minimumed_tesnor = values[0] \
+        if not isinstance(values[0], np.ndarray) \
+            else tf.convert_to_tensor(values[0])
     for i in range(1, len(values)):
-        minimumed_tesnor = tf.minimum(minimumed_tesnor, values[i])
+        minimumed_tesnor = tf.minimum(
+            minimumed_tesnor,
+            values[i] \
+                if not isinstance(values[i], np.ndarray) \
+                    else tf.convert_to_tensor(values[i])
+        )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = minimumed_tesnor
 

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -162,8 +162,12 @@ def make_node(
     ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.mod(
-            x=input_tensor_1,
-            y=input_tensor_2,
+            x=input_tensor_1 \
+                if not isinstance(input_tensor_1, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_1),
+            y=input_tensor_2 \
+                if not isinstance(input_tensor_2, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_2),
             name=graph_node.name,
         )
     ### Partial model
@@ -171,8 +175,12 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.mod(
-                    x=tf_partial_model_inputs[0],
-                    y=tf_partial_model_inputs[1],
+                    x=tf_partial_model_inputs[0] \
+                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
+                    y=tf_partial_model_inputs[1] \
+                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -184,8 +184,12 @@ def make_node(
     ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.multiply(
-            x=input_tensor_1,
-            y=input_tensor_2,
+            x=input_tensor_1 \
+                if not isinstance(input_tensor_1, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_1),
+            y=input_tensor_2 \
+                if not isinstance(input_tensor_2, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_2),
             name=graph_node.name,
         )
     ### Partial model
@@ -193,8 +197,12 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.multiply(
-                    x=tf_partial_model_inputs[0],
-                    y=tf_partial_model_inputs[1],
+                    x=tf_partial_model_inputs[0] \
+                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
+                    y=tf_partial_model_inputs[1] \
+                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -185,12 +185,16 @@ def make_node(
         has_none_outputshape = None in output_shape
         has_str_outputshape = True in [True for dim in output_shape if isinstance(dim, str)]
         has_undefined_outputshape = has_none_outputshape or has_str_outputshape
+    final_shape = transposed_reshape_shape \
+        if (has_undefined_outputshape or shape_replaced_flg) else output_shape
+    final_shape = final_shape \
+        if not isinstance(final_shape, np.ndarray) \
+            else tf.convert_to_tensor(final_shape)
     ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.reshape(
             tensor=transposed_tensor,
-            shape=transposed_reshape_shape \
-                if (has_undefined_outputshape or shape_replaced_flg) else output_shape,
+            shape=final_shape,
             name=graph_node.name,
         )
     ### Partial model
@@ -199,8 +203,7 @@ def make_node(
             [
                 tf.reshape(
                     tensor=tf_partial_model_inputs[0],
-                    shape=transposed_reshape_shape \
-                        if has_undefined_outputshape else output_shape,
+                    shape=final_shape,
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -176,8 +176,12 @@ def make_node(
     ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.subtract(
-            x=input_tensor_1,
-            y=input_tensor_2,
+            x=input_tensor_1 \
+                if not isinstance(input_tensor_1, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_1),
+            y=input_tensor_2 \
+                if not isinstance(input_tensor_2, np.ndarray) \
+                    else tf.convert_to_tensor(input_tensor_2),
             name=graph_node.name,
         )
     ### Partial model
@@ -185,8 +189,12 @@ def make_node(
         tf_partial_model_outputs = \
             [
                 tf.math.subtract(
-                    x=tf_partial_model_inputs[0],
-                    y=tf_partial_model_inputs[1],
+                    x=tf_partial_model_inputs[0] \
+                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
+                    y=tf_partial_model_inputs[1] \
+                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
+                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
                 )
             ]
         tf_partial_model = tf.keras.Model(

--- a/onnx2tf/ops/Sum.py
+++ b/onnx2tf/ops/Sum.py
@@ -57,7 +57,11 @@ def make_node(
         if isinstance(const_or_var, gs.Variable):
             values.append(tf_layers_dict[const_or_var.name]['tf_node'])
         else:
-            values.append(const_or_var)
+            values.append(
+                const_or_var \
+                    if not isinstance(const_or_var, np.ndarray) \
+                        else tf.convert_to_tensor(const_or_var)
+            )
 
     graph_node_output: gs.Variable = graph_node.outputs[0]
 

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -191,7 +191,9 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         transpose_with_flexing_deterrence(
             input_tensor=input_tensor,
-            perm=perm,
+            perm=perm \
+                if not isinstance(perm, np.ndarray) \
+                    else tf.convert_to_tensor(perm),
             output_shape=output_shape,
             name=graph_node.name,
             **kwargs,
@@ -202,7 +204,9 @@ def make_node(
             [
                 transpose_with_flexing_deterrence(
                     input_tensor=tf_partial_model_inputs[0],
-                    perm=perm,
+                    perm=perm \
+                        if not isinstance(perm, np.ndarray) \
+                            else tf.convert_to_tensor(perm),
                     output_shape=output_shape,
                     **kwargs,
                 )


### PR DESCRIPTION
### 1. Content and background
- Prevent `saved_model` (.pb) bloat
  - Before
      ![20230304205404](https://user-images.githubusercontent.com/33194443/222903514-407ae1b0-92bb-4fc6-aa54-d02e8bec112d.png)
  - After
      ![20230304220423](https://user-images.githubusercontent.com/33194443/222903517-49c0b791-d095-40a1-8e55-ed1b40a26caf.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
