### PR TITLE
`-coion / --copy_onnx_input_output_names_to_tflite` output tflite with options so that the signature is embedded in the tflite by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,18 +177,9 @@ print("[ONNX] Model Predictions:", onnx_output)
 onnx2tf.convert(
     input_onnx_file_path="model.onnx",
     output_folder_path="model.tf",
-    output_signaturedefs=True,
     copy_onnx_input_output_names_to_tflite=True,
     non_verbose=True,
 )
-
-# Let's check TensorFlow model
-tf_model = tf.saved_model.load("model.tf")
-tf_output = tf_model.signatures["serving_default"](
-    x=tf.constant((10,), dtype=tf.int64),
-    y=tf.constant((2,), dtype=tf.int64),
-)
-print("[TF] Model Predictions:", tf_output)
 
 # Now, test the newer TFLite model
 interpreter = tf.lite.Interpreter(model_path="model.tf/model_float32.tflite")
@@ -215,11 +206,6 @@ print("[TFLite] Model Predictions:", tt_lite_output)
     array(12, dtype=int64),
     array(8, dtype=int64)
   ]
-[TF] Model Predictions:
-  {
-    'add': <tf.Tensor: shape=(1,), dtype=int64, numpy=array([12])>,
-    'sub': <tf.Tensor: shape=(1,), dtype=int64, numpy=array([8])>
-  }
 [TFLite] Model Predictions:
   {
     'add': array([12]),

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ print("[ONNX] Model Predictions:", onnx_output)
 onnx2tf.convert(
     input_onnx_file_path="model.onnx",
     output_folder_path="model.tf",
+    output_signaturedefs=True,
     copy_onnx_input_output_names_to_tflite=True,
     non_verbose=True,
 )

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.17
+  ghcr.io/pinto0309/onnx2tf:1.7.18
 
   or
 
@@ -136,7 +136,7 @@ $ onnx2tf -i mobilenetv2-12.onnx -ois input:1,3,224,224 -cotof -cotoa 1e-1
 ![image](https://user-images.githubusercontent.com/33194443/216901668-5fdb1e38-8670-46a4-b4b9-8a774fa7545e.png)
 ![Kazam_screencast_00108_](https://user-images.githubusercontent.com/33194443/212460284-f3480105-4d94-4519-94dc-320d641f5647.gif)
 
-If you want to match tflite's input/output OP names and the order of input/output OPs with ONNX, you can use the `interpreter.get_signature_runner()` to infer this after using the `-osd` / `--output_signaturedefs` option to output `saved_model`. This workaround has already been available since a much earlier version of onnx2tf. Ref: https://github.com/PINTO0309/onnx2tf/pull/185
+If you want to match tflite's input/output OP names and the order of input/output OPs with ONNX, you can use the `interpreter.get_signature_runner()` to infer this after using the `-coion` / `--copy_onnx_input_output_names_to_tflite` option to output tflite file. See: https://github.com/PINTO0309/onnx2tf/issues/228
 ```python
 import torch
 import onnxruntime
@@ -177,7 +177,7 @@ print("[ONNX] Model Predictions:", onnx_output)
 onnx2tf.convert(
     input_onnx_file_path="model.onnx",
     output_folder_path="model.tf",
-    output_signaturedefs=True,
+    copy_onnx_input_output_names_to_tflite=True,
     non_verbose=True,
 )
 
@@ -188,16 +188,6 @@ tf_output = tf_model.signatures["serving_default"](
     y=tf.constant((2,), dtype=tf.int64),
 )
 print("[TF] Model Predictions:", tf_output)
-
-# Rerun TFLite conversion but from saved model
-converter = tf.lite.TFLiteConverter.from_saved_model("model.tf")
-converter.target_spec.supported_ops = [
-    tf.lite.OpsSet.TFLITE_BUILTINS,
-    tf.lite.OpsSet.SELECT_TF_OPS,
-]
-tf_lite_model = converter.convert()
-with open("model.tf/model_float32.tflite", "wb") as f:
-    f.write(tf_lite_model)
 
 # Now, test the newer TFLite model
 interpreter = tf.lite.Interpreter(model_path="model.tf/model_float32.tflite")

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.17'
+__version__ = '1.7.18'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3538,6 +3538,59 @@ def rewrite_tflite_inout_opname(
             for idx, flat_output_info in enumerate(flat_output_infos):
                 flat_output_info['name'] = onnx_output_names[idx]
 
+            # make signature_defs
+            """
+            "signature_defs": [
+                {
+                    "inputs": [
+                        {
+                            "name": "input",
+                            "tensor_index": 0
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "boxes",
+                            "tensor_index": 208
+                        },
+                        {
+                            "name": "scores",
+                            "tensor_index": 190
+                        }
+                    ],
+                    "signature_key": "serving_default",
+                    "subgraph_index": 0
+                }
+            ]
+            """
+            signature_defs = {}
+            # signature_defs_inputs
+            signature_defs_inputs = []
+            for idx, flat_input_info in enumerate(flat_input_infos):
+                signature_defs_inputs.append(
+                    {
+                        'name': onnx_input_names[idx],
+                        'tensor_index': flat_input_info['buffer'] - 1,
+                    }
+                )
+            signature_defs['inputs'] = signature_defs_inputs
+            # signature_defs_outputs
+            signature_defs_outputs = []
+            for idx, flat_output_info in enumerate(flat_output_infos):
+                signature_defs_outputs.append(
+                    {
+                        'name': onnx_output_names[idx],
+                        'tensor_index': flat_output_info['buffer'] - 1,
+                    }
+                )
+            signature_defs['outputs'] = signature_defs_outputs
+            # signature_defs_inputs
+            signature_defs['signature_key'] = 'serving_default'
+            # subgraph_index
+            signature_defs['subgraph_index'] = 0
+            # update json
+            flat_json['signature_defs'] = [signature_defs]
+
         if flat_json is not None:
             with open(json_file_path, 'w') as f:
                 json.dump(flat_json, f)


### PR DESCRIPTION
### 1. Content and background
- Improvement of tflite's I/O OP name rewriting process and I/O order control process
    - Writing input/output information to tflite as `signature_defs`.
    - Rewrite binaries so that input/output names match ONNX using `concrete_function`.
    - `-coion / --copy_onnx_input_output_names_to_tflite` output tflite with options so that the signature is embedded in the tflite by default.
        ![image](https://user-images.githubusercontent.com/33194443/222949934-05067344-e8a6-40d5-94a1-e7bd96e83e87.png)
        - onnx
          ![image](https://user-images.githubusercontent.com/33194443/222954383-46631e2b-11bf-4e17-95f4-322f8859a342.png)
        - tflite
          ![image](https://user-images.githubusercontent.com/33194443/222955387-bd996fff-ca24-4530-9213-35fdbe674800.png)

        https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/version-RFB-640.onnx
        ```bash
        onnx2tf -i version-RFB-640.onnx -coion
        ```
        ```python
        import numpy as np
        import tensorflow as tf
        
        interpreter = tf.lite.Interpreter(
            model_path="saved_model/version-RFB-640_float32.tflite"
        )
        tf_lite_model = interpreter.get_signature_runner()
        test_data = tf.convert_to_tensor(
            value=np.ones(
                shape=[1,480,640,3],
                dtype=np.float32
            )
        )
        tt_lite_output = tf_lite_model(
            input=test_data,
        )
        print("[TFLite] Model Predictions:", tt_lite_output)
        ```
        ```
        [TFLite] Model Predictions:
        {'boxes': array([[[ 1.3372814e-04,  8.5677393e-04,  1.3687836e-02,  2.6055152e-02],
                [-2.9060002e-03, -1.7406903e-03,  1.7976686e-02,  4.0702272e-02],
                [-5.9925802e-03, -8.2277283e-03,  2.4591457e-02,  5.8303714e-02],
                ...,
                [ 8.6583459e-01,  8.3152449e-01,  1.0436372e+00,  1.0488608e+00],
                [ 8.2547259e-01,  7.7981573e-01,  1.0946229e+00,  1.1140716e+00],
                [ 7.7743149e-01,  7.2188163e-01,  1.1553301e+00,  1.1767489e+00]]],
              dtype=float32),
         'scores': array([[[0.9121739 , 0.08782604],
                [0.9121672 , 0.0878328 ],
                [0.9121579 , 0.08784208],
                ...,
                [0.9487316 , 0.05126836],
                [0.96191823, 0.03808172],
                [0.96088   , 0.03912005]]], dtype=float32)}
        ```
    - Ref: https://www.tensorflow.org/lite/guide/signatures
### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Improvement of tflite's I/O OP name rewriting process and I/O order control process #228](https://github.com/PINTO0309/onnx2tf/issues/228)
- [ONNX model input & output names are not preserved in TensorFlow & TensorFlow Lite models #178](https://github.com/PINTO0309/onnx2tf/issues/178)