### PR TITLE
Fixed out-of-range reference errors for begin and end when executing `Slice` for padding removal after `ConvTranspose` generatio

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.23
+  ghcr.io/pinto0309/onnx2tf:1.7.24
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.23'
+__version__ = '1.7.24'


### PR DESCRIPTION
### 1. Content and background
- `ConvTranspose`
  - Fixed out-of-range reference errors for begin and end when executing `Slice` for padding removal after `ConvTranspose` generation.
  - If `begin` or `end` is an irregular padding size, focusing only on `begin` and the maximum size of the tensor will break the tensor.
  - Modified to remove padding from only before the tensor, only after the tensor, or both before and after, depending on the padding size of `begin` and `end`.
    ```
    error: 'tf.Slice' op requires 0 <= begin[i] <= begin[i] + size[i] <= Di
    ```
    ```
    loc(fused["Slice:", callsite("model/tf.slice/Slice"("/usr/local/lib/python3.8/dist-packages/keras/engine/training.py":558:0) at callsite("/usr/local/lib/python3.8/dist-packages/keras/utils/traceback_utils.py":65:0 at callsite("/home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py":812:0 at callsite("/usr/local/lib/python3.8/dist-packages/tensorflow/python/autograph/core/function_wrappers.py":113:0 at callsite("/home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py":812:0 at callsite("/usr/local/lib/python3.8/dist-packages/tensorflow/python/framework/func_graph.py":1189:0 at callsite("/usr/local/lib/python3.8/dist-packages/tensorflow/python/eager/polymorphic_function/polymorphic_function.py":667:0 at callsite("/usr/local/lib/python3.8/dist-packages/tensorflow/python/framework/func_graph.py":1214:0 at callsite("/usr/local/lib/python3.8/dist-packages/tensorflow/python/eager/polymorphic_function/tracing_compiler.py":300:0 at "/usr/local/lib/python3.8/dist-packages/tensorflow/python/eager/polymorphic_function/tracing_compiler.py":396:0)))))))))]): error: 'tf.Slice' op requires 0 <= begin[i] <= begin[i] + size[i] <= Di
    [E] No function: __iter__ registered for opset: 13
    Traceback (most recent call last):
      File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/home/xxxx/.vscode/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
        cli.main()
      File "/home/xxxx/.vscode/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
        run()
      File "/home/xxxx/.vscode/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
        runpy.run_path(target, run_name="__main__")
      File "/home/xxxx/.vscode/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
        return _run_module_code(code, init_globals, run_name,
      File "/home/xxxx/.vscode/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/home/xxxx/.vscode/extensions/ms-python.python-2023.4.1/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
        exec(code, run_globals)
      File "/home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 1913, in <module>
        main()
      File "/home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 1867, in main
        model = convert(
      File "/home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py", line 875, in convert
        tflite_model = converter.convert()
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/lite.py", line 1897, in convert
        return super(TFLiteConverterV2, self).convert()
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/lite.py", line 962, in wrapper
        return self._convert_and_export_metrics(convert_func, *args, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/lite.py", line 940, in _convert_and_export_metrics
        result = convert_func(self, *args, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/lite.py", line 1546, in convert
        return super(TFLiteFrozenGraphConverterV2,
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/lite.py", line 1166, in convert
        result = _convert_graphdef(
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/convert_phase.py", line 212, in wrapper
        raise converter_error from None  # Re-throws the exception.
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/convert_phase.py", line 205, in wrapper
        return func(*args, **kwargs)
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/convert.py", line 817, in convert_graphdef
        data = convert(
      File "/usr/local/lib/python3.8/dist-packages/tensorflow/lite/python/convert.py", line 322, in convert
        raise converter_error
    tensorflow.lite.python.convert_phase.ConverterError: /usr/local/lib/python3.8/dist-packages/keras/engine/training.py:558:0: error: 'tf.Slice' op requires 0 <= begin[i] <= begin[i] + size[i] <= Di
    /usr/local/lib/python3.8/dist-packages/keras/utils/traceback_utils.py:65:0: note: called from
    /home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py:812:0: note: called from
    /usr/local/lib/python3.8/dist-packages/tensorflow/python/autograph/core/function_wrappers.py:113:0: note: called from
    /home/xxxx/git/onnx2tf/onnx2tf/onnx2tf.py:812:0: note: called from
    /usr/local/lib/python3.8/dist-packages/tensorflow/python/framework/func_graph.py:1189:0: note: called from
    /usr/local/lib/python3.8/dist-packages/tensorflow/python/eager/polymorphic_function/polymorphic_function.py:667:0: note: called from
    /usr/local/lib/python3.8/dist-packages/tensorflow/python/framework/func_graph.py:1214:0: note: called from
    /usr/local/lib/python3.8/dist-packages/tensorflow/python/eager/polymorphic_function/tracing_compiler.py:300:0: note: called from
    /usr/local/lib/python3.8/dist-packages/tensorflow/python/eager/polymorphic_function/tracing_compiler.py:396:0: note: called from
    ```
- [MSPFN](https://github.com/kuijiang94/MSPFN)
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_243/mspfn_320x480.onnx

```
ssc4onnx -if mspfn_320x480.onnx

┏━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
┃ OP Type                ┃ OPs        ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
│ Add                    │ 438        │
│ Concat                 │ 59         │
│ Conv                   │ 260        │
│ ConvTranspose          │ 121        │
│ GlobalAveragePool      │ 51         │
│ Min                    │ 273        │
│ Mul                    │ 333        │
│ Relu                   │ 273        │
│ Sigmoid                │ 60         │
│ Split                  │ 3          │
│ Sub                    │ 1          │
│ Tanh                   │ 6          │
│ Transpose              │ 7          │
│ ---------------------- │ ---------- │
│ Total number of OPs    │ 1885       │
│ ====================== │ ========== │
│ Model Size             │ 403.2MiB   │
└────────────────────────┴────────────┘
INFO: file: mspfn_320x480.onnx
INFO: producer: tf2onnx 1.13.0 2c1db5
INFO: opset: 13
INFO: input_name.1: input shape: [1, 3, 320, 480] dtype: float32
INFO: output_name.1: sub shape: [1, 320, 480, 3] dtype: float32
```
![image](https://user-images.githubusercontent.com/33194443/224526412-7c8ea707-b30a-4bfb-83cd-d2e777dd097c.png)

![image](https://user-images.githubusercontent.com/33194443/224526343-608dbfa5-04e2-4ea4-a3ae-983003565da5.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
