### PR TITLE
Improved INT8 quantization to be performed based on `saved_model` signature information

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.26
+  ghcr.io/pinto0309/onnx2tf:1.7.27
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.26'
+__version__ = '1.7.27'


### PR DESCRIPTION
### 1. Content and background
- Improved INT8 quantization to be performed based on `saved_model` signature information
- Ref: https://www.tensorflow.org/lite/performance/post_training_quantization#full_integer_quantization
  - Improved matching of the input OP name specified in the dataset for calibration with the input OP name in the signature to prevent input order discrepancies.
  - When quantizing INT8 for models with multiple inputs, you no longer need to be aware of the order in which the calibration data sets are specified.
  - Only when performing INT8 quantization, the `saved_model` signature information of the converted model is displayed in the log as reference information, as shown in the figure below.
    ![image](https://user-images.githubusercontent.com/33194443/225372379-6bc5194d-4170-469a-a697-96b28b32bd25.png)
  - The input OP name in ONNX and the input OP name after conversion to `saved_model` may mismatch. This is due to automatic sanitization of strings that cannot be used in the input OP name of `saved_model`. e.g. `:`, `/`
  - [[BERT-Squad] INT8 quantization: The input data type must be Float32. #248](https://github.com/PINTO0309/onnx2tf/issues/248)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
