### PR TITLE
Fixed lack of sanitizing of OP names when outputting INT8 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.28
+  ghcr.io/pinto0309/onnx2tf:1.7.29
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.28'
+__version__ = '1.7.29'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -508,7 +508,7 @@ def convert(
                 replacement_parameters = json.load(f)['operations']
                 for operations in replacement_parameters:
                     operations['op_name'] = operations['op_name'].replace(':','_')
-                    if output_signaturedefs:
+                    if output_signaturedefs or output_integer_quantized_tflite:
                         operations['op_name'] = re.sub('^/', 'wa/', operations['op_name'])
         except json.decoder.JSONDecodeError as ex:
             print(
@@ -737,7 +737,7 @@ def convert(
             # substitution because saved_model does not allow colons
             graph_input.name = graph_input.name.replace(':','_')
             # Substitution because saved_model does not allow leading slashes in op names
-            if output_signaturedefs:
+            if output_signaturedefs or output_integer_quantized_tflite:
                 graph_input.name = re.sub('^/', 'wa/', graph_input.name)
             op.make_node(
                 graph_input=graph_input,
@@ -763,7 +763,7 @@ def convert(
             # substitution because saved_model does not allow colons
             graph_node.name = graph_node.name.replace(':','_')
             # Substitution because saved_model does not allow leading slashes in op names
-            if output_signaturedefs:
+            if output_signaturedefs or output_integer_quantized_tflite:
                 graph_node.name = re.sub('^/', 'wa/', graph_node.name)
             op.make_node(
                 graph_node=graph_node,
@@ -783,7 +783,7 @@ def convert(
         # Bring back output names from ONNX model
         for output, name in zip(outputs, output_names):
             output.node.layer._name = name.replace(':','_')
-            if output_signaturedefs:
+            if output_signaturedefs or output_integer_quantized_tflite:
                 output.node.layer._name = re.sub('^/', '', output.node.layer._name)
 
         model = tf.keras.Model(inputs=inputs, outputs=outputs)


### PR DESCRIPTION
### 1. Content and background
- Fixed lack of sanitizing of OP names when outputting INT8 models

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
