### PR TITLE
Significantly reduced RAM consumption during model conversion when the `-cotof` option is not specifie

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.29
+  ghcr.io/pinto0309/onnx2tf:1.7.30
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.29'
+__version__ = '1.7.30'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -622,38 +622,40 @@ def convert(
     # Used to verify the output error of each OP in the TensorFlow model.
     full_ops_output_names = []
     onnx_tensor_infos_for_validation = None
-    for graph_node in graph.nodes:
-        full_ops_output_names_sub = []
-        for graph_node_output in graph_node.outputs:
-            full_ops_output_names_sub.append(graph_node_output.name)
-        full_ops_output_names.extend(full_ops_output_names_sub)
-    # Models with errors during inference in onnxruntime skip dummy inference.
-    try:
-        onnx_outputs_for_validation: List[np.ndarray] = dummy_onnx_inference(
-            onnx_graph=onnx_graph,
-            output_names=full_ops_output_names,
-        )
-        """
-        onnx_tensor_infos_for_validation:
-            {
-                onnx_output_name: np.ndarray,
-                onnx_output_name: np.ndarray,
-                onnx_output_name: np.ndarray,
-                            :
+    if check_onnx_tf_outputs_elementwise_close \
+        or check_onnx_tf_outputs_elementwise_close_full:
+        for graph_node in graph.nodes:
+            full_ops_output_names_sub = []
+            for graph_node_output in graph_node.outputs:
+                full_ops_output_names_sub.append(graph_node_output.name)
+            full_ops_output_names.extend(full_ops_output_names_sub)
+        # Models with errors during inference in onnxruntime skip dummy inference.
+        try:
+            onnx_outputs_for_validation: List[np.ndarray] = dummy_onnx_inference(
+                onnx_graph=onnx_graph,
+                output_names=full_ops_output_names,
+            )
+            """
+            onnx_tensor_infos_for_validation:
+                {
+                    onnx_output_name: np.ndarray,
+                    onnx_output_name: np.ndarray,
+                    onnx_output_name: np.ndarray,
+                                :
+                }
+            """
+            onnx_tensor_infos_for_validation = {
+                ops_output_name: onnx_output_for_validation \
+                    for ops_output_name, onnx_output_for_validation \
+                        in zip(full_ops_output_names, onnx_outputs_for_validation)
             }
-        """
-        onnx_tensor_infos_for_validation = {
-            ops_output_name: onnx_output_for_validation \
-                for ops_output_name, onnx_output_for_validation \
-                    in zip(full_ops_output_names, onnx_outputs_for_validation)
-        }
-    except Exception as ex:
-        print(
-            f'{Color.YELLOW}WARNING:{Color.RESET} ' +\
-            f'The optimization process for shape estimation is skipped ' +
-            f'because it contains OPs that cannot be inferred by the standard onnxruntime.'
-        )
-        print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
+        except Exception as ex:
+            print(
+                f'{Color.YELLOW}WARNING:{Color.RESET} ' +\
+                f'The optimization process for shape estimation is skipped ' +
+                f'because it contains OPs that cannot be inferred by the standard onnxruntime.'
+            )
+            print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
 
     if not non_verbose:
         print('')


### PR DESCRIPTION
### 1. Content and background
- Significantly reduced RAM consumption during model conversion when the `-cotof` option is not specifie
- https://github.com/PINTO0309/PINTO_model_zoo/tree/main/352_MAXIM

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
