### PR TITLE
Fix onnxsim calls using `--no_large_tensor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.31
+  ghcr.io/pinto0309/onnx2tf:1.7.32
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.31'
+__version__ = '1.7.32'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -530,7 +530,7 @@ def convert(
             for _ in range(3):
                 append_param = list(['--overwrite-input-shape'] + overwrite_input_shape) \
                     if overwrite_input_shape is not None else []
-                append_param = append_param + ['--no-large-tensor'] \
+                append_param = append_param + ['--no-large-tensor', '10MB'] \
                     if no_large_tensor else append_param
                 result = subprocess.check_output(
                     [


### PR DESCRIPTION
### 1. Content and background
- Fix onnxsim calls using `--no_large_tensor`
  ```
  onnxsim xxx.onnx yyy.onnx --no_large_tensor 10MB
  ```


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
