### PR TITLE
Fixed a type conversion bug in the OP optimization process for `Div` -> `Mul` and `Mul` -> `Div` and `Div` -> `Div`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.7.33
+  ghcr.io/pinto0309/onnx2tf:1.7.34
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.7.33'
+__version__ = '1.7.34'

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -281,7 +281,7 @@ def make_node(
         del test_data2
 
     # Post-process transpose
-    tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
+    divided_tensor = post_process_transpose(
         value_before_transpose=divided_tensor,
         param_target='outputs',
         param_name=graph_node.outputs[0].name,

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -202,33 +202,40 @@ def make_node(
 
     # Generation of TF OP
     ### Overall model
-    # Merge two consecutive identical OPs into one
-    # https://github.com/PINTO0309/onnx2tf/issues/230
-    #   A constant is calculated in advance only
-    #   when one of the operations of the current OP
-    #   is a constant and one of the operations of
-    #   the next OP is also a constant.
-    # By merging two OPs into one, an accuracy error always occurs
-    # in the merged OP during the accuracy check.
-    # 1. `Mul` -> `Mul` to `Single-Mul` : `10 * 5 * 8 -> 10 * 40`
-    # 2. `Mul` -> `Div` to `Single-Mul` : `10 * 5 / 8 -> 10 * 0.625`
-    # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
-    # 4. `Div` -> `Div` to `Single-Mul` : `10 / 5 / 8 -> 10 * 0.025`
-    # 5. `Sub` -> `Sub` to `Single-Sub` : `10 - 5 - 8 -> 10 - 13`
-    # 6. `Sub` -> `Add` to `Single-Sub` : `10 - 5 + 8 -> 10 + 3`
-    # 7. `Add` -> `Add` to `Single-Add`  : `10 + 5 + 8 -> 10 + 13`
-    # 8. `Add` -> `Sub` to `Single-Add`  : `10 + 5 - 8 -> 10 - 3`
-    divided_tensor, tf_type = merge_two_consecutive_identical_ops_into_one(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        graph_node_output=graph_node_output,
-        before_op_output_shape_trans=before_op_output_shape_trans,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        graph_node=graph_node,
-        tf_layers_dict=tf_layers_dict,
-        tf_func='Div'
+    # TODO: Temporarily Revert due to missing decision conditions
+    # # Merge two consecutive identical OPs into one
+    # # https://github.com/PINTO0309/onnx2tf/issues/230
+    # #   A constant is calculated in advance only
+    # #   when one of the operations of the current OP
+    # #   is a constant and one of the operations of
+    # #   the next OP is also a constant.
+    # # By merging two OPs into one, an accuracy error always occurs
+    # # in the merged OP during the accuracy check.
+    # # 1. `Mul` -> `Mul` to `Single-Mul` : `10 * 5 * 8 -> 10 * 40`
+    # # 2. `Mul` -> `Div` to `Single-Mul` : `10 * 5 / 8 -> 10 * 0.625`
+    # # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
+    # # 4. `Div` -> `Div` to `Single-Mul` : `10 / 5 / 8 -> 10 * 0.025`
+    # # 5. `Sub` -> `Sub` to `Single-Sub` : `10 - 5 - 8 -> 10 - 13`
+    # # 6. `Sub` -> `Add` to `Single-Sub` : `10 - 5 + 8 -> 10 + 3`
+    # # 7. `Add` -> `Add` to `Single-Add`  : `10 + 5 + 8 -> 10 + 13`
+    # # 8. `Add` -> `Sub` to `Single-Add`  : `10 + 5 - 8 -> 10 - 3`
+    # divided_tensor, tf_type = merge_two_consecutive_identical_ops_into_one(
+    #     graph_node_input_1=graph_node_input_1,
+    #     graph_node_input_2=graph_node_input_2,
+    #     graph_node_output=graph_node_output,
+    #     before_op_output_shape_trans=before_op_output_shape_trans,
+    #     input_tensor_1=input_tensor_1,
+    #     input_tensor_2=input_tensor_2,
+    #     graph_node=graph_node,
+    #     tf_layers_dict=tf_layers_dict,
+    #     tf_func='Div'
+    # )
+    divided_tensor = tf.math.divide(
+        x=input_tensor_1,
+        y=input_tensor_2,
+        name=graph_node.name,
     )
+    tf_type = tf.math.divide
 
     ### Partial model
     if kwargs['acc_check'] and tf_partial_model_inputs is not None:

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -192,33 +192,41 @@ def make_node(
 
     # Generation of TF OP
     ### Overall model
-    # Merge two consecutive identical OPs into one
-    # https://github.com/PINTO0309/onnx2tf/issues/230
-    #   A constant is calculated in advance only
-    #   when one of the operations of the current OP
-    #   is a constant and one of the operations of
-    #   the next OP is also a constant.
-    # By merging two OPs into one, an accuracy error always occurs
-    # in the merged OP during the accuracy check.
-    # 1. `Mul` -> `Mul` to `Single-Mul` : `10 * 5 * 8 -> 10 * 40`
-    # 2. `Mul` -> `Div` to `Single-Mul` : `10 * 5 / 8 -> 10 * 0.625`
-    # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
-    # 4. `Div` -> `Div` to `Single-Mul` : `10 / 5 / 8 -> 10 * 0.025`
-    # 5. `Sub` -> `Sub` to `Single-Sub` : `10 - 5 - 8 -> 10 - 13`
-    # 6. `Sub` -> `Add` to `Single-Sub` : `10 - 5 + 8 -> 10 + 3`
-    # 7. `Add` -> `Add` to `Single-Add`  : `10 + 5 + 8 -> 10 + 13`
-    # 8. `Add` -> `Sub` to `Single-Add`  : `10 + 5 - 8 -> 10 - 3`
-    _, tf_type = merge_two_consecutive_identical_ops_into_one(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        graph_node_output=graph_node_output,
-        before_op_output_shape_trans=before_op_output_shape_trans,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        graph_node=graph_node,
-        tf_layers_dict=tf_layers_dict,
-        tf_func='Mul'
-    )
+    # TODO: Temporarily Revert due to missing decision conditions
+    # # Merge two consecutive identical OPs into one
+    # # https://github.com/PINTO0309/onnx2tf/issues/230
+    # #   A constant is calculated in advance only
+    # #   when one of the operations of the current OP
+    # #   is a constant and one of the operations of
+    # #   the next OP is also a constant.
+    # # By merging two OPs into one, an accuracy error always occurs
+    # # in the merged OP during the accuracy check.
+    # # 1. `Mul` -> `Mul` to `Single-Mul` : `10 * 5 * 8 -> 10 * 40`
+    # # 2. `Mul` -> `Div` to `Single-Mul` : `10 * 5 / 8 -> 10 * 0.625`
+    # # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
+    # # 4. `Div` -> `Div` to `Single-Mul` : `10 / 5 / 8 -> 10 * 0.025`
+    # # 5. `Sub` -> `Sub` to `Single-Sub` : `10 - 5 - 8 -> 10 - 13`
+    # # 6. `Sub` -> `Add` to `Single-Sub` : `10 - 5 + 8 -> 10 + 3`
+    # # 7. `Add` -> `Add` to `Single-Add`  : `10 + 5 + 8 -> 10 + 13`
+    # # 8. `Add` -> `Sub` to `Single-Add`  : `10 + 5 - 8 -> 10 - 3`
+    # _, tf_type = merge_two_consecutive_identical_ops_into_one(
+    #     graph_node_input_1=graph_node_input_1,
+    #     graph_node_input_2=graph_node_input_2,
+    #     graph_node_output=graph_node_output,
+    #     before_op_output_shape_trans=before_op_output_shape_trans,
+    #     input_tensor_1=input_tensor_1,
+    #     input_tensor_2=input_tensor_2,
+    #     graph_node=graph_node,
+    #     tf_layers_dict=tf_layers_dict,
+    #     tf_func='Mul'
+    # )
+    tf_layers_dict[graph_node_output.name]['tf_node'] = \
+        tf.math.multiply(
+            x=input_tensor_1,
+            y=input_tensor_2,
+            name=graph_node.name,
+        )
+    tf_type = tf.math.multiply
 
     ### Partial model
     if kwargs['acc_check'] and tf_partial_model_inputs is not None:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -4016,9 +4016,11 @@ def merge_two_consecutive_identical_ops_into_one(
                             # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
                             if isinstance(next_graph_node_input_1, np.ndarray) or hasattr(next_graph_node_input_1, 'numpy'):
                                 if isinstance(input_tensor_1, np.ndarray) or hasattr(input_tensor_1, 'numpy'):
-                                    input_tensor_1 = 1 / (input_tensor_1 / next_graph_node_input_1)
+                                    input_tensor_1 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_1.dtype) / (input_tensor_1 / next_graph_node_input_1)
                                 elif isinstance(input_tensor_2, np.ndarray) or hasattr(input_tensor_2, 'numpy'):
-                                    input_tensor_2 = 1 / (input_tensor_2 / next_graph_node_input_1)
+                                    input_tensor_2 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_1.dtype) / (input_tensor_2 / next_graph_node_input_1)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
                                 ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -4034,9 +4036,11 @@ def merge_two_consecutive_identical_ops_into_one(
                                 tf_type = tf.identity
                             elif isinstance(next_graph_node_input_2, np.ndarray) or hasattr(next_graph_node_input_2, 'numpy'):
                                 if isinstance(input_tensor_1, np.ndarray) or hasattr(input_tensor_1, 'numpy'):
-                                    input_tensor_1 = 1 / (input_tensor_1 / next_graph_node_input_2)
+                                    input_tensor_1 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_2.dtype) / (input_tensor_1 / next_graph_node_input_2)
                                 elif isinstance(input_tensor_2, np.ndarray) or hasattr(input_tensor_2, 'numpy'):
-                                    input_tensor_2 = 1 / (input_tensor_2 / next_graph_node_input_2)
+                                    input_tensor_2 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_2.dtype) / (input_tensor_2 / next_graph_node_input_2)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
                                 ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -4068,9 +4072,11 @@ def merge_two_consecutive_identical_ops_into_one(
                             # 4. `Div` -> `Div` to `Single-Nul` : `10 / 5 / 8 -> 10 * 0.025`
                             if isinstance(next_graph_node_input_1, np.ndarray) or hasattr(next_graph_node_input_1, 'numpy'):
                                 if isinstance(input_tensor_1, np.ndarray) or hasattr(input_tensor_1, 'numpy'):
-                                    input_tensor_1 = 1 / (input_tensor_1 * next_graph_node_input_1)
+                                    input_tensor_1 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_1.dtype) / (input_tensor_1 * next_graph_node_input_1)
                                 elif isinstance(input_tensor_2, np.ndarray) or hasattr(input_tensor_2, 'numpy'):
-                                    input_tensor_2 = 1 / (input_tensor_2 * next_graph_node_input_1)
+                                    input_tensor_2 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_1.dtype) / (input_tensor_2 * next_graph_node_input_1)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
                                 ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -4086,9 +4092,11 @@ def merge_two_consecutive_identical_ops_into_one(
                                 tf_type = tf.identity
                             elif isinstance(next_graph_node_input_2, np.ndarray) or hasattr(next_graph_node_input_2, 'numpy'):
                                 if isinstance(input_tensor_1, np.ndarray) or hasattr(input_tensor_1, 'numpy'):
-                                    input_tensor_1 = 1 / (input_tensor_1 * next_graph_node_input_2)
+                                    input_tensor_1 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_2.dtype) / (input_tensor_1 * next_graph_node_input_2)
                                 elif isinstance(input_tensor_2, np.ndarray) or hasattr(input_tensor_2, 'numpy'):
-                                    input_tensor_2 = 1 / (input_tensor_2 * next_graph_node_input_2)
+                                    input_tensor_2 = \
+                                        np.asarray(1.0, dtype=next_graph_node_input_2.dtype) / (input_tensor_2 * next_graph_node_input_2)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
                                 ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `Div`
  - Fixed a type conversion bug in the OP optimization process for
    1. `Div` -> `Mul`
    2. `Mul` -> `Div`
    3. `Div` -> `Div`
- CenterFusion
  -  [cf_fus.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/11037276/cf_fus.onnx.zip)

      ![image](https://user-images.githubusercontent.com/33194443/226826802-6aee692b-e801-4798-9157-70291f416ca2.png)

```
TypeError: Exception encountered when calling layer "tf.math.divide" (type TFOpLambda).

`x` and `y` must have the same dtype, got tf.float64 != tf.float32.

Call arguments received by layer "tf.math.divide" (type TFOpLambda):
  • x=tf.Tensor(shape=(), dtype=float64)
  • y=tf.Tensor(shape=(1, 112, 200, 1), dtype=float32)
  • name='Div_33'
```

- Revert: [Merge two consecutive identical OPs into one #231](https://github.com/PINTO0309/onnx2tf/pull/231)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
