### PR TITLE
Fixed an out-of-range reference error when `Flatten`'s `axis` is the maximum of the tensor's rank

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.0
+  ghcr.io/pinto0309/onnx2tf:1.8.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -57,7 +57,8 @@ def make_node(
     dtype = graph_node_output.dtype
 
     axis = graph_node.attrs.get("axis", 0)
-    if graph_node_input.shape is not None:
+    if graph_node_input.shape is not None \
+        and axis < input_tensor_rank:
         axis = convert_axis(
             axis=axis,
             tensor_rank=len(graph_node_input.shape),
@@ -83,6 +84,8 @@ def make_node(
     cal_shape = None
     if axis == 0:
         cal_shape = (1, -1)
+    elif axis >= input_tensor_rank:
+        cal_shape = (-1, 1)
     elif graph_node_output.shape is not None and len(graph_node_output.shape) == 2 and axis == input_tensor_rank - 1:
         cal_shape = (1, -1)
     elif input_tensor_rank >= 2 \


### PR DESCRIPTION
### 1. Content and background
- `Flatten`
  - Fixed an out-of-range reference error when `Flatten`'s `axis` is the maximum of the tensor's rank

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- ["IndexError: list index out of range" occurs after flattening #265](https://github.com/PINTO0309/onnx2tf/issues/265)