### PR TITLE
Optimize model structure when `indices` in `ScatterND` do not contain negative numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.1
+  ghcr.io/pinto0309/onnx2tf:1.8.2
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.1'
+__version__ = '1.8.2'

--- a/onnx2tf/ops/ScatterND.py
+++ b/onnx2tf/ops/ScatterND.py
@@ -96,11 +96,26 @@ def make_node(
         **kwargs,
     )
 
+    # Complex ScatterND -> Simple ScatterND
+    simple_scatternd = False
+    # Verify if negative numbers need to be converted to positive numbers
+    if isinstance(indices_tensor, np.ndarray) and None not in indices_tensor:
+        flatten_indices_tensor = indices_tensor.flatten()
+        if np.sum(np.where(flatten_indices_tensor < 0, 1, 0)) > 0:
+            simple_scatternd = False
+        else:
+            simple_scatternd = True
+    elif isinstance(indices_tensor, int):
+        simple_scatternd = True
+    else:
+        simple_scatternd = False
+
     # Generation of TF OP
-    indices_tensor = process_neg_idx(
-        data=input_tensor,
-        indices=indices_tensor,
-    )
+    if not simple_scatternd:
+        indices_tensor = process_neg_idx(
+            data=input_tensor,
+            indices=indices_tensor,
+        )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.tensor_scatter_nd_update(

--- a/onnx2tf/ops/ScatterND.py
+++ b/onnx2tf/ops/ScatterND.py
@@ -105,7 +105,7 @@ def make_node(
             simple_scatternd = False
         else:
             simple_scatternd = True
-    elif isinstance(indices_tensor, int):
+    elif isinstance(indices_tensor, int) and indices_tensor >= 0:
         simple_scatternd = True
     else:
         simple_scatternd = False


### PR DESCRIPTION
### 1. Content and background
- `ScatterND`
  - Optimize model structure when `indices` in `ScatterND` do not contain negative numbers
    ![image](https://user-images.githubusercontent.com/33194443/228395299-9e44eb96-dd5b-451f-b41b-f352dfbb1cc2.png)
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.1.28/htnet_1x17x2_without_norm.onnx

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)