### PR TITLE
Implement workaround to avoid `ScatterND` shape mismatch errors as much as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.2
+  ghcr.io/pinto0309/onnx2tf:1.8.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.2'
+__version__ = '1.8.3'


### PR DESCRIPTION
### 1. Content and background
- `ScatterND`
  - Implement workaround to avoid `ScatterND` shape mismatch errors as much as possible
- `GatherND`
  - Streamlines the conversion process for `GatherND`s that do not contain negative numbers in the indices
- https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_269/yolox_nano_ti_lite_26p1_41p8.onnx
  ![image](https://user-images.githubusercontent.com/33194443/228419250-bc91e376-942e-4b6c-aec6-5ed25ab44e23.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[YOLOX-TI] ERROR: onnx_op_name: /head/ScatterND #269](https://github.com/PINTO0309/onnx2tf/issues/269)