### PR TITLE
Significantly improved processing of `GridSample`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.5
+  ghcr.io/pinto0309/onnx2tf:1.8.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.5'
+__version__ = '1.8.6'

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -87,15 +87,6 @@ def make_node(
     mode = graph_node.attrs.get('mode', 'bilinear')
     padding_mode = graph_node.attrs.get('padding_mode', 'zeros')
 
-    if not align_corners:
-        print(
-            f'{Color.RED}ERROR:{Color.RESET} '+
-            f'The current implementation of GridSample supports only align_corners=1. '+
-            f'Pull requests are welcome. \n'+
-            f'align_corners: 0'
-        )
-        sys.exit(1)
-
     ENABLE_MODES = ['bilinear']
     if mode not in ENABLE_MODES:
         print(
@@ -124,209 +115,326 @@ def make_node(
     grid
         [N, grid_H, grid_W, 2]
     """
-    Nt, H, W, C = image.shape
-    grid_H = grid.shape[1]
-    grid_W = grid.shape[2]
-    xgrid, ygrid = tf.split(
-        value=grid,
-        num_or_size_splits=2,
-        axis=-1,
-    )
-    mask = tf.cast(
-        (xgrid >= 0) & (ygrid >= 0) & (xgrid < W - 1) & (ygrid < H - 1),
-        dtype=tf.float32,
-    )
-    x0 = tf.math.floor(xgrid)
-    x1 = x0 + 1
-    y0 = tf.math.floor(ygrid)
-    y1 = y0 + 1
+    split11, split12 = tf.split(grid, num_or_size_splits=2, axis=3) # x, y
 
-    wa = transpose_with_flexing_deterrence(
-        input_tensor=(x1 - xgrid) * (y1 - ygrid),
-        perm=[3, 0, 1, 2],
-        **kwargs,
-    )
-    wb = transpose_with_flexing_deterrence(
-        input_tensor=(x1 - xgrid) * (ygrid - y0),
-        perm=[3, 0, 1, 2],
-        **kwargs,
-    )
-    wc = transpose_with_flexing_deterrence(
-        input_tensor=(xgrid - x0) * (y1 - ygrid),
-        perm=[3, 0, 1, 2],
-        **kwargs,
-    )
-    wd = transpose_with_flexing_deterrence(
-        input_tensor=(xgrid - x0) * (ygrid - y0),
-        perm=[3, 0, 1, 2],
-        **kwargs,
-    )
+    if align_corners:
+        add1 = tf.math.add(split11, tf.convert_to_tensor(1.0)) # Add_output_0
+        div1 = tf.math.divide(add1, tf.convert_to_tensor(2.0)) # Div_output_0
+        mul1 = tf.math.multiply(div1, tf.convert_to_tensor(image.shape[2]-1, dtype=tf.float32)) # Mul_output_0
+    else:
+        add1 = tf.math.add(split11, tf.convert_to_tensor(1.0)) # Add_output_0
+        mul00 = tf.math.multiply(add1, tf.convert_to_tensor(image.shape[2], dtype=tf.float32)) # Mul_output_0
+        sub1 = tf.math.subtract(mul00, tf.convert_to_tensor(1, dtype=tf.float32)) # Sub_output_0
+        mul1 = tf.math.multiply(sub1, tf.convert_to_tensor(0.5, dtype=tf.float32)) # Div_output_0
+    reshape1 = tf.reshape(mul1, [tf.shape(mul1)[0], tf.reduce_prod(tf.shape(mul1)[1:])]) # Reshape_output_0
 
-    x0 = tf.cast(
-        tf.reshape(
-            tensor=(x0 * mask),
-            shape=[Nt, grid_H, grid_W],
-        ),
-        dtype=tf.int64,
-    )
-    y0 = tf.cast(
-        tf.reshape(
-            tensor=(y0 * mask),
-            shape=[Nt, grid_H, grid_W]
-        ),
-        dtype=tf.int64,
-    )
-    x1 = tf.cast(
-        tf.reshape(
-            tensor=(x1 * mask),
-            shape=[Nt, grid_H, grid_W]
-        ),
-        dtype=tf.int64,
-    )
-    y1 = tf.cast(
-        tf.reshape(
-            tensor=(y1 * mask),
-            shape=[Nt, grid_H, grid_W]
-        ),
-        dtype=tf.int64,
-    )
+    if align_corners:
+        add2 = tf.math.add(split12, tf.convert_to_tensor(1.0)) # Add_1_output_0
+        div2 = tf.math.divide(add2, tf.convert_to_tensor(2.0)) # Div_1_output_0
+        mul2 = tf.math.multiply(div2, tf.convert_to_tensor(image.shape[1]-1, dtype=tf.float32)) # Mul_1_output_0
+    else:
+        add2 = tf.math.add(split12, tf.convert_to_tensor(1.0)) # Add_output_0
+        mul01 = tf.math.multiply(add2, tf.convert_to_tensor(image.shape[1], dtype=tf.float32)) # Mul_output_0
+        sub2 = tf.math.subtract(mul01, tf.convert_to_tensor(1, dtype=tf.float32)) # Sub_output_0
+        mul2 = tf.math.multiply(sub2, tf.convert_to_tensor(0.5, dtype=tf.float32)) # Div_output_0
+    reshape2 = tf.reshape(mul2, [tf.shape(mul2)[0], tf.reduce_prod(tf.shape(mul2)[1:])]) # Reshape_1_output_0
 
-    ind = np.arange(Nt)
-    ind = tf.reshape(tensor=ind, shape=[Nt, 1])
-    ind = tf.tile(input=ind, multiples=[1, grid_H])
-    ind = tf.reshape(tensor=ind, shape=[Nt, grid_H, 1])
-    ind = tf.tile(input=ind, multiples=[1, 1, grid_W])
-    ind = tf.cast(ind, dtype=tf.int64)
+    floor1 = tf.math.floor(reshape1) # Floor_output_0
+    sub11 = tf.math.subtract(reshape1, floor1) # Sub_3_output_0
+    add12 = tf.math.add(floor1, tf.convert_to_tensor(1, dtype=tf.float32)) # Add_2_output_0
+    sub12 = tf.math.subtract(add12, reshape1) # Sub_output_0
 
-    ### common
-    temp_image = tf.reshape(
-        tensor=image,
-        shape=[-1, image.shape[-1]],
-    )
-    temp_ind = ind * H * W
-    ### wa
-    temp_y0 = y0 * W
-    temp_x0 = x0
-    temp_x0y0ind = temp_x0 + temp_y0 + temp_ind
-    temp_gather_wa = tf.gather(
-        params=temp_image,
-        indices=temp_x0y0ind,
-    )
-    temp_reshape1_wa = tf.reshape(
-        tensor=temp_gather_wa,
-        shape=[-1, temp_gather_wa.shape[3]],
-    )
-    temp_traspose_wa = transpose_with_flexing_deterrence(
-        input_tensor=temp_reshape1_wa,
-        perm=[1,0],
-        **kwargs,
-    )
-    temp_reshape2_wa = tf.reshape(
-        tensor=temp_traspose_wa,
-        shape=[
-            temp_gather_wa.shape[3],
-            temp_gather_wa.shape[0],
-            temp_gather_wa.shape[1],
-            temp_gather_wa.shape[2],
-        ],
-    )
-    temp_wa = temp_reshape2_wa * wa
-    ### wb
-    temp_y1 = y1 * W
-    temp_x0 = x0
-    temp_ind_y1x0 = temp_x0 + temp_y1 + temp_ind
-    temp_gather_wb = tf.gather(
-        params=temp_image,
-        indices=temp_ind_y1x0,
-    )
-    temp_reshape1_wb = tf.reshape(
-        tensor=temp_gather_wb,
-        shape=[-1, temp_gather_wb.shape[3]],
-    )
-    temp_traspose_wb = transpose_with_flexing_deterrence(
-        input_tensor=temp_reshape1_wb,
-        perm=[1,0],
-        **kwargs,
-    )
-    temp_reshape2_wb = tf.reshape(
-        tensor=temp_traspose_wb,
-        shape=[
-            temp_gather_wb.shape[3],
-            temp_gather_wb.shape[0],
-            temp_gather_wb.shape[1],
-            temp_gather_wb.shape[2],
-        ],
-    )
-    temp_wb = temp_reshape2_wb * wb
-    ### wc
-    temp_y0 = y0 * W
-    temp_x1 = x1
-    temp_ind_y0x1 = temp_x1 + temp_y0 + temp_ind
-    temp_gather_wc = tf.gather(
-        params=temp_image,
-        indices=temp_ind_y0x1,
-    )
-    temp_reshape1_wc = tf.reshape(
-        tensor=temp_gather_wc,
-        shape=[-1, temp_gather_wc.shape[3]],
-    )
-    temp_traspose_wc = transpose_with_flexing_deterrence(
-        input_tensor=temp_reshape1_wc,
-        perm=[1,0],
-        **kwargs,
-    )
-    temp_reshape2_wc = tf.reshape(
-        tensor=temp_traspose_wc,
-        shape=[
-            temp_gather_wc.shape[3],
-            temp_gather_wc.shape[0],
-            temp_gather_wc.shape[1],
-            temp_gather_wc.shape[2],
-        ],
-    )
-    temp_wc = temp_reshape2_wc * wc
-    ### wd
-    temp_y1 = y1 * W
-    temp_x1 = x1
-    temp_ind_y1x1 = temp_x1 + temp_y1 + temp_ind
-    temp_gather_wd = tf.gather(
-        params=temp_image,
-        indices=temp_ind_y1x1,
-    )
-    temp_reshape1_wd = tf.reshape(
-        tensor=temp_gather_wd,
-        shape=[-1, temp_gather_wd.shape[3]],
-    )
-    temp_traspose_wd = transpose_with_flexing_deterrence(
-        input_tensor=temp_reshape1_wd,
-        perm=[1,0],
-        **kwargs,
-    )
-    temp_reshape2_wd = tf.reshape(
-        tensor=temp_traspose_wd,
-        shape=[
-            temp_gather_wd.shape[3],
-            temp_gather_wd.shape[0],
-            temp_gather_wd.shape[1],
-            temp_gather_wd.shape[2],
-        ],
-    )
-    temp_wd = temp_reshape2_wd * wd
-    ### wa + wb + wc + wd
-    output_tensor = temp_wa + temp_wb + temp_wc + temp_wd
+    floor2 = tf.math.floor(reshape2) # Floor_1_output_0
+    sub21 = tf.math.subtract(reshape2, floor2) # Sub_2_output_0
+    add22 = tf.math.add(floor2, tf.convert_to_tensor(1, dtype=tf.float32)) # Add_3_output_0
+    sub22 = tf.math.subtract(add22, reshape2) # Sub_1_output_0
 
-    output_tensor = transpose_with_flexing_deterrence(
-        input_tensor=output_tensor,
-        perm=[1,2,3,0],
-        **kwargs,
-    )
-    mask = tf.tile(
-        input=mask,
-        multiples=[1,1,1,C],
-    )
 
-    tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        output_tensor = output_tensor * mask
+    # Sub_output_0 Sub_1_output_0 -> Mul_2_output_0
+    mul11 = tf.math.multiply(sub12, sub22) # Mul_2_output_0
+    unsqueeze11 = tf.expand_dims(mul11, axis=1) # Unsqueeze_output_0 @@@
+
+    # Sub_output_0 Sub_2_output_0 -> Mul_3_output_0
+    mul12 = tf.math.multiply(sub12, sub21) # Mul_3_output_0
+    unsqueeze12 = tf.expand_dims(mul12, axis=1) # Unsqueeze_1_output_0 @@@
+
+    # Sub_3_output_0 Sub_2_output_0 -> Mul_5_output_0
+    mul21 = tf.math.multiply(sub11, sub21) # Mul_5_output_0
+    unsqueeze21 = tf.expand_dims(mul21, axis=1) # Unsqueeze_3_output_0 @@@
+
+    # Sub_3_output_0 Sub_1_output_0 -> Mul_4_output_0
+    mul22 = tf.math.multiply(sub11, sub22) # Mul_4_output_0
+    unsqueeze22 = tf.expand_dims(mul22, axis=1) # Unsqueeze_2_output_0 @@@
+
+
+    # Add_2_output_0 Constant_1_output_0 -> Add_4_output_0
+    add31 = tf.math.add(add12, tf.convert_to_tensor(1, dtype=tf.float32)) # Add_4_output_0
+    # Add_4_output_0 -> Cast_2_output_0
+    cast31 = tf.cast(add31, dtype=tf.int64) # Cast_2_output_0
+    # Cast_2_output_0 Constant_26_output_0 -> Less_1_output_0
+    less31 = tf.less(cast31, tf.convert_to_tensor(0, dtype=tf.int64)) # Less_1_output_0
+    # Less_1_output_0 Constant_26_output_0 Cast_2_output_0 -> Where_2_output_0
+    where311 = \
+        tf.where(
+            condition=less31,
+            x=tf.convert_to_tensor(0, dtype=tf.int64),
+            y=cast31,
+        )
+    # Where_2_output_0 Constant_27_output_0 -> Greater_1_output_0
+    greter31 = tf.greater(where311, tf.convert_to_tensor(image.shape[2]+1, dtype=tf.int64)) # Greater_1_output_0
+    # Greater_1_output_0 Constant_27_output_0 Where_2_output_0 -> Where_3_output_0 @@@
+    where312 = \
+        tf.where(
+            condition=greter31,
+            x=tf.convert_to_tensor(image.shape[2]+1, dtype=tf.int64),
+            y=where311,
+        )
+
+
+    # Add_2_output_0 -> Cast_1_output_0
+    cast32 = tf.cast(add12, dtype=tf.int64) # Cast_1_output_0
+    # Cast_1_output_0 Constant_26_output_0 -> Less_output_0
+    less32 = tf.less(cast32, tf.convert_to_tensor(0, dtype=tf.int64)) # Less_output_0
+    # Less_output_0 Constant_26_output_0 Cast_1_output_0 -> Where_output_0
+    where321 = \
+        tf.where(
+            condition=less32,
+            x=tf.convert_to_tensor(0, dtype=tf.int64),
+            y=cast32,
+        )
+    # Where_output_0 Constant_27_output_0 -> Greater_output_0
+    greter32 = tf.greater(where321, tf.convert_to_tensor(image.shape[2]+1, dtype=tf.int64)) # Greater_output_0
+    # Greater_output_0 Constant_27_output_0 Where_output_0 -> Where_1_output_0 @@@
+    where322 = \
+        tf.where(
+            condition=greter32,
+            x=tf.convert_to_tensor(image.shape[2]+1, dtype=tf.int64),
+            y=where321,
+        )
+
+
+    # Add_3_output_0 Constant_1_output_0 -> Add_5_output_0
+    add33 = tf.math.add(add22, tf.convert_to_tensor(1, dtype=tf.float32)) # Add_5_output_0
+    # Add_5_output_0 -> Cast_4_output_0
+    cast33 = tf.cast(add33, dtype=tf.int64) # Cast_4_output_0
+    # Cast_4_output_0 Constant_26_output_0 -> Less_3_output_0
+    less33 = tf.less(cast33, tf.convert_to_tensor(0, dtype=tf.int64)) # Less_3_output_0
+    # Less_3_output_0 Constant_26_output_0 Cast_4_output_0 -> Where_6_output_0
+    where331 = \
+        tf.where(
+            condition=less33,
+            x=tf.convert_to_tensor(0, dtype=tf.int64),
+            y=cast33,
+        )
+    # Where_6_output_0 Constant_32_output_0 -> Greater_3_output_0
+    greter33 = tf.greater(where331, tf.convert_to_tensor(image.shape[1]+1, dtype=tf.int64)) # Greater_3_output_0
+    # Greater_3_output_0 Constant_32_output_0 Where_6_output_0 -> Where_7_output_0
+    where332 = \
+        tf.where(
+            condition=greter33,
+            x=tf.convert_to_tensor(image.shape[1]+1, dtype=tf.int64),
+            y=where331,
+        )
+    # Where_7_output_0 Constant_37_output_0 -> Mul_8_output_0
+    mul33 = tf.math.multiply(where332, tf.convert_to_tensor(image.shape[2]+2, dtype=tf.int64)) # Mul_8_output_0 @@@
+
+
+    # Add_3_output_0 -> Cast_3_output_0
+    cast34 = tf.cast(add22, dtype=tf.int64) # Cast_3_output_0
+    # Cast_3_output_0 Constant_26_output_0 -> Less_2_output_0
+    less34 = tf.less(cast34, tf.convert_to_tensor(0, dtype=tf.int64)) # Less_2_output_0
+    # Less_2_output_0 Constant_26_output_0 Cast_3_output_0 -> Where_4_output_0
+    where341 = \
+        tf.where(
+            condition=less34,
+            x=tf.convert_to_tensor(0, dtype=tf.int64),
+            y=cast34,
+        )
+    # Where_4_output_0 Constant_32_output_0 -> Greater_2_output_0
+    greter34 = tf.greater(where341, tf.convert_to_tensor(image.shape[1]+1, dtype=tf.int64)) # Greater_2_output_0
+    # Greater_2_output_0 Constant_32_output_0 Where_4_output_0 -> Where_5_output_0
+    where342 = \
+        tf.where(
+            condition=greter34,
+            x=tf.convert_to_tensor(image.shape[1]+1, dtype=tf.int64),
+            y=where341,
+        )
+    # Where_5_output_0 Constant_37_output_0 -> Mul_6_output_0
+    mul34 = tf.math.multiply(where342, tf.convert_to_tensor(image.shape[2]+2, dtype=tf.int64)) # Mul_6_output_0 @@@
+
+
+    # Where_3_output_0 Mul_6_output_0 -> Add_8_output_0
+    add41 = tf.math.add(where312, mul34) # Add_8_output_0
+    # Add_8_output_0 Constant_11_output_0 -> Unsqueeze_6_output_0
+    unsqueeze41 = tf.expand_dims(add41, axis=1) # Unsqueeze_6_output_0
+    # Unsqueeze_6_output_0 Where_8_output_0 -> Expand_2_output_0
+    expand41_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
+    expand41 = tf.math.multiply(unsqueeze41, expand41_ones) # Expand_2_output_0 @@@
+
+    # Where_1_output_0 Mul_6_output_0 -> Add_6_output_0
+    add42 = tf.math.add(where322, mul34) # Add_6_output_0
+    # Add_6_output_0 Constant_11_output_0 -> Unsqueeze_4_output_0
+    unsqueeze42 = tf.expand_dims(add42, axis=1) # Unsqueeze_4_output_0
+    # Unsqueeze_4_output_0 Where_8_output_0 -> Expand_output_0
+    expand42_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
+    expand42 = tf.math.multiply(unsqueeze42, expand42_ones) # Expand_output_0 @@@
+
+    # Where_3_output_0 Mul_8_output_0 -> Add_9_output_0
+    add43 = tf.math.add(where312, mul33) # Add_9_output_0
+    # Add_9_output_0 Constant_11_output_0 -> Unsqueeze_7_output_0
+    unsqueeze43 = tf.expand_dims(add43, axis=1) # Unsqueeze_7_output_0
+    # Unsqueeze_7_output_0 Where_8_output_0 -> Expand_3_output_0
+    expand43_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
+    expand43 = tf.math.multiply(unsqueeze43, expand43_ones) # Expand_3_output_0 @@@
+
+    # Where_1_output_0 Mul_8_output_0 -> Add_7_output_0
+    add44 = tf.math.add(where322, mul33) # Add_7_output_0
+    # Add_7_output_0 Constant_11_output_0 -> Unsqueeze_5_output_0
+    unsqueeze44 = tf.expand_dims(add44, axis=1) # Unsqueeze_5_output_0
+    # Unsqueeze_5_output_0 Where_8_output_0 -> Expand_1_output_0
+    expand44_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
+    expand44 = tf.math.multiply(unsqueeze44, expand44_ones) # Expand_1_output_0 @@@
+
+
+    ################################################## image
+    image_padded = tf.pad(image, paddings=[[0,0],[1,1],[1,1],[0,0]]) # Pad_output_0
+    # Pad_output_0 Constant_36_output_0 -> Reshape_4_output_0
+    image_reshape = tf.reshape(image_padded, shape=[image_padded.shape[0]] + [np.prod(image_padded.shape[1:3])] + [image_padded.shape[3]])
+    image_reshape_transpose = tf.transpose(image_reshape, perm=[0,2,1])
+
+
+    # Reshape_4_output_0 Expand_3_output_0 -> GatherElements_3_output_0
+    axis_perm1 = tf.tensor_scatter_nd_update(
+        tf.range(tf.rank(image_reshape_transpose)),
+        tf.constant([[0], [2]]),
+        tf.constant([2, 0])
+    )
+    data_swaped1 = tf.transpose(image_reshape_transpose, perm=axis_perm1)
+    index_swaped1 = tf.transpose(expand43, perm=axis_perm1)
+    idx_tensors_per_axis1 = [
+        tf.range(tf.shape(index_swaped1, index_swaped1.dtype)[i]) \
+            for i in range(index_swaped1.shape.rank)
+    ]
+    idx_tensors_per_axis1 = tf.meshgrid(
+        *idx_tensors_per_axis1,
+        indexing='ij',
+    )
+    idx_tensors_per_axis1[0] = index_swaped1
+    dim_expanded_idx_tensors_per_axis1 = [
+        tf.expand_dims(idx_tensor, axis=-1)
+        for idx_tensor in idx_tensors_per_axis1
+    ]
+    index_expanded1 = tf.concat(dim_expanded_idx_tensors_per_axis1, axis=-1)
+    gathernd1 = tf.gather_nd(data_swaped1, index_expanded1)
+    gatherelements1 = tf.transpose(gathernd1, perm=[2,1,0]) # GatherElements_3_output_0
+
+
+    # Reshape_4_output_0 Expand_2_output_0 -> GatherElements_2_output_0
+    axis_perm2 = tf.tensor_scatter_nd_update(
+        tf.range(tf.rank(image_reshape_transpose)),
+        tf.constant([[0], [2]]),
+        tf.constant([2, 0])
+    )
+    data_swaped2 = tf.transpose(image_reshape_transpose, perm=axis_perm2)
+    index_swaped2 = tf.transpose(expand41, perm=axis_perm2)
+    idx_tensors_per_axis2 = [
+        tf.range(tf.shape(index_swaped2, index_swaped2.dtype)[i]) \
+            for i in range(index_swaped2.shape.rank)
+    ]
+    idx_tensors_per_axis2 = tf.meshgrid(
+        *idx_tensors_per_axis2,
+        indexing='ij',
+    )
+    idx_tensors_per_axis2[0] = index_swaped2
+    dim_expanded_idx_tensors_per_axis2 = [
+        tf.expand_dims(idx_tensor, axis=-1)
+        for idx_tensor in idx_tensors_per_axis2
+    ]
+    index_expanded2 = tf.concat(dim_expanded_idx_tensors_per_axis2, axis=-1)
+    gathernd2 = tf.gather_nd(data_swaped2, index_expanded2)
+    gatherelements2 = tf.transpose(gathernd2, perm=[2,1,0]) # GatherElements_2_output_0
+
+
+    # Reshape_4_output_0 Expand_1_output_0 -> GatherElements_1_output_0
+    axis_perm3 = tf.tensor_scatter_nd_update(
+        tf.range(tf.rank(image_reshape_transpose)),
+        tf.constant([[0], [2]]),
+        tf.constant([2, 0])
+    )
+    data_swaped3 = tf.transpose(image_reshape_transpose, perm=axis_perm3)
+    index_swaped3 = tf.transpose(expand44, perm=axis_perm3)
+    idx_tensors_per_axis3 = [
+        tf.range(tf.shape(index_swaped3, index_swaped3.dtype)[i]) \
+            for i in range(index_swaped3.shape.rank)
+    ]
+    idx_tensors_per_axis3 = tf.meshgrid(
+        *idx_tensors_per_axis3,
+        indexing='ij',
+    )
+    idx_tensors_per_axis3[0] = index_swaped3
+    dim_expanded_idx_tensors_per_axis3 = [
+        tf.expand_dims(idx_tensor, axis=-1)
+        for idx_tensor in idx_tensors_per_axis3
+    ]
+    index_expanded3 = tf.concat(dim_expanded_idx_tensors_per_axis3, axis=-1)
+    gathernd3 = tf.gather_nd(data_swaped3, index_expanded3)
+    gatherelements3 = tf.transpose(gathernd3, perm=[2,1,0]) # GatherElements_1_output_0
+
+
+    # Reshape_4_output_0 Expand_output_0 -> GatherElements_output_0
+    axis_perm4 = tf.tensor_scatter_nd_update(
+        tf.range(tf.rank(image_reshape_transpose)),
+        tf.constant([[0], [2]]),
+        tf.constant([2, 0])
+    )
+    data_swaped4 = tf.transpose(image_reshape_transpose, perm=axis_perm4)
+    index_swaped4 = tf.transpose(expand42, perm=axis_perm4)
+    idx_tensors_per_axis4 = [
+        tf.range(tf.shape(index_swaped4, index_swaped4.dtype)[i]) \
+            for i in range(index_swaped4.shape.rank)
+    ]
+    idx_tensors_per_axis4 = tf.meshgrid(
+        *idx_tensors_per_axis4,
+        indexing='ij',
+    )
+    idx_tensors_per_axis4[0] = index_swaped4
+    dim_expanded_idx_tensors_per_axis4 = [
+        tf.expand_dims(idx_tensor, axis=-1)
+        for idx_tensor in idx_tensors_per_axis4
+    ]
+    index_expanded4 = tf.concat(dim_expanded_idx_tensors_per_axis4, axis=-1)
+    gathernd4 = tf.gather_nd(data_swaped4, index_expanded4)
+    gatherelements4 = tf.transpose(gathernd4, perm=[2,1,0]) # GatherElements_output_0
+
+
+    # GatherElements_3_output_0 Unsqueeze_3_output_0 -> Mul_15_output_0
+    mul51 = tf.math.multiply(gatherelements1, unsqueeze21)
+    # GatherElements_2_output_0 Unsqueeze_2_output_0 -> Mul_14_output_0
+    mul52 = tf.math.multiply(gatherelements2, unsqueeze22)
+    # GatherElements_1_output_0 Unsqueeze_1_output_0 -> Mul_13_output_0
+    mul53 = tf.math.multiply(gatherelements3, unsqueeze12)
+    # GatherElements_output_0 Unsqueeze_output_0 -> Mul_12_output_0
+    mul54 = tf.math.multiply(gatherelements4, unsqueeze11)
+
+
+    # Mul_12_output_0 Mul_13_output_0 -> Add_10_output_0
+    add61 = tf.math.add(mul54, mul53)
+    # Add_10_output_0 Mul_14_output_0 -> Add_11_output_0
+    add62 = tf.math.add(add61, mul52)
+    # Add_11_output_0 Mul_15_output_0 -> Add_12_output_0
+    add63 = tf.math.add(add62, mul51)
+
+    # Add_12_output_0 Constant_55_output_0 -> output_tensor
+    output_shape = [
+        image.shape[0],
+        image.shape[3],
+        grid.shape[1],
+        grid.shape[2],
+    ]
+    final_reshape = tf.reshape(add63, shape=output_shape)
+    output = tf.transpose(final_reshape, perm=[0,2,3,1])
+
+    tf_layers_dict[graph_node_output.name]['tf_node'] = output
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- `GridSample`
  - Significantly improved processing of `GridSample`
  - Support for `align_corners == True` and `align_corners == False`

    ![image](https://user-images.githubusercontent.com/33194443/229153645-24298311-8a91-4332-b9b9-1f57a14e7407.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[IGEV] AvgPool aborts under kernel_shape = [1, 2], strides = [1,2], input = [3840,1,1,80] conditions. #267](https://github.com/PINTO0309/onnx2tf/issues/267)
- [[GridSample] GridSample operation gives different outputs between onnx and tflite models #274](https://github.com/PINTO0309/onnx2tf/issues/274)
- [[Deformable DETR] RuntimeError: tensorflow/lite/kernels/gather.cc:132 indices_has_only_positive_elements was not true.gather index out of boundsNode number 5885 (GATHER) failed to invoke. #275](https://github.com/PINTO0309/onnx2tf/issues/275)