### PR TITLE
Improved `Gather` to disable negative indexes as much as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.6
+  ghcr.io/pinto0309/onnx2tf:1.8.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.6'
+__version__ = '1.8.7'

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -248,6 +248,19 @@ def make_node(
         indices_values = indices._inferred_value \
             if hasattr(indices, "_inferred_value") \
                 and indices._inferred_value is not None else simple_indices
+
+        # Disable negative indexes
+        if isinstance(indices_values, np.ndarray) and input_tensor.shape[axis] is not None:
+            maximum_number_of_elements = input_tensor.shape[axis]
+            indices_values = np.where(
+                condition=indices_values < 0,
+                x=indices_values+maximum_number_of_elements,
+                y=indices_values
+            )
+        elif isinstance(indices_values, int) and input_tensor.shape[axis] is not None:
+            maximum_number_of_elements = input_tensor.shape[axis]
+            indices_values = indices_values + maximum_number_of_elements
+
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.gather(
                 params=input_tensor,
@@ -262,6 +275,19 @@ def make_node(
         indices_values = indices._inferred_value \
             if hasattr(indices, "_inferred_value") \
                 and indices._inferred_value is not None else indices
+
+        # Disable negative indexes
+        if isinstance(indices_values, np.ndarray) and input_tensor.shape[axis] is not None:
+            maximum_number_of_elements = input_tensor.shape[axis]
+            indices_values = np.where(
+                condition=indices_values < 0,
+                x=indices_values+maximum_number_of_elements,
+                y=indices_values
+            )
+        elif isinstance(indices_values, int) and input_tensor.shape[axis] is not None:
+            maximum_number_of_elements = input_tensor.shape[axis]
+            indices_values = indices_values + maximum_number_of_elements
+
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.gather(
                 params=input_tensor,

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -257,7 +257,7 @@ def make_node(
                 x=indices_values+maximum_number_of_elements,
                 y=indices_values
             )
-        elif isinstance(indices_values, int) and input_tensor.shape[axis] is not None:
+        elif isinstance(indices_values, int) and indices_values < 0 and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = indices_values + maximum_number_of_elements
 
@@ -284,7 +284,7 @@ def make_node(
                 x=indices_values+maximum_number_of_elements,
                 y=indices_values
             )
-        elif isinstance(indices_values, int) and input_tensor.shape[axis] is not None:
+        elif isinstance(indices_values, int) and indices_values < 0 and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = indices_values + maximum_number_of_elements
 

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -250,14 +250,18 @@ def make_node(
                 and indices._inferred_value is not None else simple_indices
 
         # Disable negative indexes
-        if isinstance(indices_values, np.ndarray) and input_tensor.shape[axis] is not None:
+        if isinstance(indices_values, np.ndarray) \
+            and None not in indices_values \
+            and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = np.where(
-                condition=indices_values < 0,
-                x=indices_values+maximum_number_of_elements,
-                y=indices_values
+                indices_values < 0,
+                indices_values+maximum_number_of_elements,
+                indices_values
             )
-        elif isinstance(indices_values, int) and indices_values < 0 and input_tensor.shape[axis] is not None:
+        elif isinstance(indices_values, int) \
+            and indices_values < 0 \
+            and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = indices_values + maximum_number_of_elements
 
@@ -277,14 +281,18 @@ def make_node(
                 and indices._inferred_value is not None else indices
 
         # Disable negative indexes
-        if isinstance(indices_values, np.ndarray) and input_tensor.shape[axis] is not None:
+        if isinstance(indices_values, np.ndarray) \
+            and None not in indices_values \
+            and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = np.where(
-                condition=indices_values < 0,
-                x=indices_values+maximum_number_of_elements,
-                y=indices_values
+                indices_values < 0,
+                indices_values+maximum_number_of_elements,
+                indices_values
             )
-        elif isinstance(indices_values, int) and indices_values < 0 and input_tensor.shape[axis] is not None:
+        elif isinstance(indices_values, int) \
+            and indices_values < 0 \
+            and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = indices_values + maximum_number_of_elements
 


### PR DESCRIPTION
### 1. Content and background
- `Gather`
  - Improved `Gather` to disable negative indexes as much as possible
  - Before
    ![image](https://user-images.githubusercontent.com/33194443/229164526-0b473ee9-d873-407e-8f3a-4959bc262e21.png)
  - After
    ![image](https://user-images.githubusercontent.com/33194443/229164673-dbf646e7-a062-40ae-8c06-72bc24e2fbc3.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Deformable DETR] RuntimeError: tensorflow/lite/kernels/gather.cc:132 indices_has_only_positive_elements was not true.gather index out of boundsNode number 5885 (GATHER) failed to invoke. #275](https://github.com/PINTO0309/onnx2tf/issues/275)