### PR TITLE
Improvement to set NHWC finalized status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.7
+  ghcr.io/pinto0309/onnx2tf:1.8.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.7'
+__version__ = '1.8.8'

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -62,6 +62,7 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': True,
     }
 
     image = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -432,6 +433,7 @@ def make_node(
         grid.shape[2],
     ]
     final_reshape = tf.reshape(add63, shape=output_shape)
+    # NCHW -> NHWC
     output = tf.transpose(final_reshape, perm=[0,2,3,1])
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = output

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -153,19 +153,19 @@ def make_node(
 
     # Sub_output_0 Sub_1_output_0 -> Mul_2_output_0
     mul11 = tf.math.multiply(sub12, sub22) # Mul_2_output_0
-    unsqueeze11 = tf.expand_dims(mul11, axis=1) # Unsqueeze_output_0 @@@
+    unsqueeze11 = tf.expand_dims(mul11, axis=1) # Unsqueeze_output_0
 
     # Sub_output_0 Sub_2_output_0 -> Mul_3_output_0
     mul12 = tf.math.multiply(sub12, sub21) # Mul_3_output_0
-    unsqueeze12 = tf.expand_dims(mul12, axis=1) # Unsqueeze_1_output_0 @@@
+    unsqueeze12 = tf.expand_dims(mul12, axis=1) # Unsqueeze_1_output_0
 
     # Sub_3_output_0 Sub_2_output_0 -> Mul_5_output_0
     mul21 = tf.math.multiply(sub11, sub21) # Mul_5_output_0
-    unsqueeze21 = tf.expand_dims(mul21, axis=1) # Unsqueeze_3_output_0 @@@
+    unsqueeze21 = tf.expand_dims(mul21, axis=1) # Unsqueeze_3_output_0
 
     # Sub_3_output_0 Sub_1_output_0 -> Mul_4_output_0
     mul22 = tf.math.multiply(sub11, sub22) # Mul_4_output_0
-    unsqueeze22 = tf.expand_dims(mul22, axis=1) # Unsqueeze_2_output_0 @@@
+    unsqueeze22 = tf.expand_dims(mul22, axis=1) # Unsqueeze_2_output_0
 
 
     # Add_2_output_0 Constant_1_output_0 -> Add_4_output_0
@@ -183,7 +183,7 @@ def make_node(
         )
     # Where_2_output_0 Constant_27_output_0 -> Greater_1_output_0
     greter31 = tf.greater(where311, tf.convert_to_tensor(image.shape[2]+1, dtype=tf.int64)) # Greater_1_output_0
-    # Greater_1_output_0 Constant_27_output_0 Where_2_output_0 -> Where_3_output_0 @@@
+    # Greater_1_output_0 Constant_27_output_0 Where_2_output_0 -> Where_3_output_0
     where312 = \
         tf.where(
             condition=greter31,
@@ -205,7 +205,7 @@ def make_node(
         )
     # Where_output_0 Constant_27_output_0 -> Greater_output_0
     greter32 = tf.greater(where321, tf.convert_to_tensor(image.shape[2]+1, dtype=tf.int64)) # Greater_output_0
-    # Greater_output_0 Constant_27_output_0 Where_output_0 -> Where_1_output_0 @@@
+    # Greater_output_0 Constant_27_output_0 Where_output_0 -> Where_1_output_0
     where322 = \
         tf.where(
             condition=greter32,
@@ -237,7 +237,7 @@ def make_node(
             y=where331,
         )
     # Where_7_output_0 Constant_37_output_0 -> Mul_8_output_0
-    mul33 = tf.math.multiply(where332, tf.convert_to_tensor(image.shape[2]+2, dtype=tf.int64)) # Mul_8_output_0 @@@
+    mul33 = tf.math.multiply(where332, tf.convert_to_tensor(image.shape[2]+2, dtype=tf.int64)) # Mul_8_output_0
 
 
     # Add_3_output_0 -> Cast_3_output_0
@@ -261,7 +261,7 @@ def make_node(
             y=where341,
         )
     # Where_5_output_0 Constant_37_output_0 -> Mul_6_output_0
-    mul34 = tf.math.multiply(where342, tf.convert_to_tensor(image.shape[2]+2, dtype=tf.int64)) # Mul_6_output_0 @@@
+    mul34 = tf.math.multiply(where342, tf.convert_to_tensor(image.shape[2]+2, dtype=tf.int64)) # Mul_6_output_0
 
 
     # Where_3_output_0 Mul_6_output_0 -> Add_8_output_0
@@ -270,7 +270,7 @@ def make_node(
     unsqueeze41 = tf.expand_dims(add41, axis=1) # Unsqueeze_6_output_0
     # Unsqueeze_6_output_0 Where_8_output_0 -> Expand_2_output_0
     expand41_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
-    expand41 = tf.math.multiply(unsqueeze41, expand41_ones) # Expand_2_output_0 @@@
+    expand41 = tf.math.multiply(unsqueeze41, expand41_ones) # Expand_2_output_0
 
     # Where_1_output_0 Mul_6_output_0 -> Add_6_output_0
     add42 = tf.math.add(where322, mul34) # Add_6_output_0
@@ -278,7 +278,7 @@ def make_node(
     unsqueeze42 = tf.expand_dims(add42, axis=1) # Unsqueeze_4_output_0
     # Unsqueeze_4_output_0 Where_8_output_0 -> Expand_output_0
     expand42_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
-    expand42 = tf.math.multiply(unsqueeze42, expand42_ones) # Expand_output_0 @@@
+    expand42 = tf.math.multiply(unsqueeze42, expand42_ones) # Expand_output_0
 
     # Where_3_output_0 Mul_8_output_0 -> Add_9_output_0
     add43 = tf.math.add(where312, mul33) # Add_9_output_0
@@ -286,7 +286,7 @@ def make_node(
     unsqueeze43 = tf.expand_dims(add43, axis=1) # Unsqueeze_7_output_0
     # Unsqueeze_7_output_0 Where_8_output_0 -> Expand_3_output_0
     expand43_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
-    expand43 = tf.math.multiply(unsqueeze43, expand43_ones) # Expand_3_output_0 @@@
+    expand43 = tf.math.multiply(unsqueeze43, expand43_ones) # Expand_3_output_0
 
     # Where_1_output_0 Mul_8_output_0 -> Add_7_output_0
     add44 = tf.math.add(where322, mul33) # Add_7_output_0
@@ -294,7 +294,7 @@ def make_node(
     unsqueeze44 = tf.expand_dims(add44, axis=1) # Unsqueeze_5_output_0
     # Unsqueeze_5_output_0 Where_8_output_0 -> Expand_1_output_0
     expand44_ones = tf.ones([1] + [image.shape[3]] + [1], dtype=tf.int64)
-    expand44 = tf.math.multiply(unsqueeze44, expand44_ones) # Expand_1_output_0 @@@
+    expand44 = tf.math.multiply(unsqueeze44, expand44_ones) # Expand_1_output_0
 
 
     ################################################## image


### PR DESCRIPTION
### 1. Content and background
- `GridSample`
  - Improvement to set NHWC finalized status

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[IGEV] AvgPool aborts under kernel_shape = [1, 2], strides = [1,2], input = [3840,1,1,80] conditions. #267](https://github.com/PINTO0309/onnx2tf/issues/267)