### PR TITLE
Enhancements to prevent `Slice` with more than 6 dimensions from being converted to `FlexStridedSlice`. Step.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.9
+  ghcr.io/pinto0309/onnx2tf:1.8.10
 
   or
 
@@ -719,10 +719,17 @@ optional arguments:
   -dsft, --disable_suppression_flextranspose
     Disables FlexTranspose generation suppression.
 
-  -nodafc, --number_of_dimensions_after_flextranspose_compression
+  -nodaftc, --number_of_dimensions_after_flextranspose_compression
     Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
     Also suppress the creation of the Transpose itself by specifying 2.
     Default: 6
+
+  -dsfs, --disable_suppression_flexstridedslice
+    Disables FlexStridedSlice generation suppression.
+
+  -nodafsc, --number_of_dimensions_after_flexstridedslice_compression
+    Number of StridedSlice OP dimensions generated after avoiding FlexStridedSlice generation.
+    Default: 5
 
   -ofgd, --optimization_for_gpu_delegate
     Replace operations that do not support gpu delegate with those
@@ -922,7 +929,9 @@ convert(
   disable_group_convolution: Union[bool, NoneType] = False,
   enable_batchmatmul_unfold: Optional[bool] = False,
   disable_suppression_flextranspose: Optional[bool] = False,
-  number_of_dimensions_after_flextranspose_compression: Optional[int] = 5,
+  number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
+  disable_suppression_flexstridedslice: Optional[bool] = False,
+  number_of_dimensions_after_flexstridedslice_compression: Optional[int] = 5,
   optimization_for_gpu_delegate: Optional[bool] = False,
   replace_argmax_to_reducemax_and_indicies_is_int64: Union[bool, NoneType] = False,
   replace_argmax_to_reducemax_and_indicies_is_float32: Union[bool, NoneType] = False,
@@ -1133,6 +1142,13 @@ convert(
       Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.
       Also suppress the creation of the Transpose itself by specifying 2.
       Default: 6
+
+    disable_suppression_flexstridedslice: Optional[bool]
+        Disables FlexStridedSlice generation suppression.
+
+    number_of_dimensions_after_flexstridedslice_compression: Optional[int]
+        Number of StridedSlice OP dimensions generated after avoiding FlexStridedSlice generation.
+        Default: 5
 
     optimization_for_gpu_delegate: Optional[bool]
         Replace operations that do not support gpu delegate with those

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.9'
+__version__ = '1.8.10'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -81,6 +81,8 @@ def convert(
     enable_batchmatmul_unfold: Optional[bool] = False,
     disable_suppression_flextranspose: Optional[bool] = False,
     number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
+    disable_suppression_flexstridedslice: Optional[bool] = False,
+    number_of_dimensions_after_flexstridedslice_compression: Optional[int] = 5,
     optimization_for_gpu_delegate: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool] = False,
     replace_argmax_to_reducemax_and_indicies_is_float32: Optional[bool] = False,
@@ -292,6 +294,13 @@ def convert(
         Also suppress the creation of the Transpose itself by specifying 2.\n
         Default: 6
 
+    disable_suppression_flexstridedslice: Optional[bool]
+        Disables FlexStridedSlice generation suppression.
+
+    number_of_dimensions_after_flexstridedslice_compression: Optional[int]
+        Number of StridedSlice OP dimensions generated after avoiding FlexStridedSlice generation.\n
+        Default: 5
+
     optimization_for_gpu_delegate: Optional[bool]
         Replace operations that do not support gpu delegate with those\n
         that do as much as possible.
@@ -500,6 +509,16 @@ def convert(
         )
         sys.exit(1)
 
+    # number_of_dimensions_after_flexstridedslice_compression
+    if number_of_dimensions_after_flexstridedslice_compression < 1:
+        print(
+            f'{Color.RED}ERROR:{Color.RESET} ' +
+            f'number_of_dimensions_after_flexstridedslice_compression must be at least 1. '+
+            f'number_of_dimensions_after_flexstridedslice_compression: ' +
+            f'{number_of_dimensions_after_flexstridedslice_compression}'
+        )
+        sys.exit(1)
+
     replacement_parameters = None
     if param_replacement_file:
         if not os.path.isfile(param_replacement_file):
@@ -688,6 +707,8 @@ def convert(
         'disable_group_convolution': disable_group_convolution,
         'disable_suppression_flextranspose': disable_suppression_flextranspose,
         'number_of_dimensions_after_flextranspose_compression': number_of_dimensions_after_flextranspose_compression,
+        'disable_suppression_flexstridedslice': disable_suppression_flexstridedslice,
+        'number_of_dimensions_after_flexstridedslice_compression': number_of_dimensions_after_flexstridedslice_compression,
         'optimization_for_gpu_delegate': optimization_for_gpu_delegate,
         'replace_argmax_to_reducemax_and_indicies_is_int64': replace_argmax_to_reducemax_and_indicies_is_int64,
         'replace_argmax_to_reducemax_and_indicies_is_float32': replace_argmax_to_reducemax_and_indicies_is_float32,
@@ -1710,7 +1731,7 @@ def main():
             'Disables FlexTranspose generation suppression.'
     )
     parser.add_argument(
-        '-nodafc',
+        '-nodaftc',
         '--number_of_dimensions_after_flextranspose_compression',
         type=int,
         default=6,
@@ -1718,6 +1739,22 @@ def main():
             'Number of Transpose OP dimensions generated after avoiding FlexTranspose generation. \n' +
             'Also suppress the creation of the Transpose itself by specifying 2. \n' +
             'Default: 6'
+    )
+    parser.add_argument(
+        '-dsfs',
+        '--disable_suppression_flexstridedslice',
+        action='store_true',
+        help=\
+            'Disables FlexStridedSlice generation suppression.'
+    )
+    parser.add_argument(
+        '-nodafsc',
+        '--number_of_dimensions_after_flexstridedslice_compression',
+        type=int,
+        default=5,
+        help=\
+            'Number of StricedSlice OP dimensions generated after avoiding FlexStridedSlice generation. \n' +
+            'Default: 5'
     )
     parser.add_argument(
         '-ofgd',
@@ -1955,6 +1992,8 @@ def main():
         enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
         disable_suppression_flextranspose=args.disable_suppression_flextranspose,
         number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
+        disable_suppression_flexstridedslice=args.disable_suppression_flexstridedslice,
+        number_of_dimensions_after_flexstridedslice_compression=args.number_of_dimensions_after_flexstridedslice_compression,
         optimization_for_gpu_delegate=args.optimization_for_gpu_delegate,
         replace_argmax_to_reducemax_and_indicies_is_int64=args.replace_argmax_to_reducemax_and_indicies_is_int64,
         replace_argmax_to_reducemax_and_indicies_is_float32=args.replace_argmax_to_reducemax_and_indicies_is_float32,

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -15,6 +15,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    stridedslice_with_flexing_deterrence,
 )
 from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 from onnx2tf.utils.colors import Color
@@ -379,6 +380,22 @@ def make_node(
                 begin_mask=begin_mask_,
                 end_mask=end_mask_,
                 name=graph_node.name,
+            )
+        # FlexStridedSlice generation suppression process
+        COMPRESSION_DEFAULT_VALUE = 5
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            stridedslice_with_flexing_deterrence(
+                input_tensor=input_tensor,
+                begin=begin_,
+                end=end_,
+                strides=strides_,
+                begin_mask=begin_mask_,
+                end_mask=end_mask_,
+                ignore_axes=axes,
+                compression_defult_value=COMPRESSION_DEFAULT_VALUE,
+                output_shape=tf_layers_dict[graph_node_output.name]['tf_node'].shape,
+                name=graph_node.name,
+                **kwargs,
             )
     else:
         # OP replacement


### PR DESCRIPTION
### 1. Content and background
- `Slice`
  - Enhancements to prevent `Slice` with more than 6 dimensions from being converted to `FlexStridedSlice`.
  - Implement only the simplest Flex avoidance workaround.
  - Compress only dimensions of size 1 before `Slice`.
- Before
  ![image](https://user-images.githubusercontent.com/33194443/229400968-69cde16c-c28f-4b50-bd75-d096539fe43d.png)
- After
  ![image](https://user-images.githubusercontent.com/33194443/229400588-cbdf3b03-614f-4538-a841-6bd47a29fea9.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Deformable DETR] RuntimeError: tensorflow/lite/kernels/gather.cc:132 indices_has_only_positive_elements was not true.gather index out of boundsNode number 5885 (GATHER) failed to invoke. #275](https://github.com/PINTO0309/onnx2tf/issues/275)
- [[Deformable DETR] Enhancements to prevent Slice with more than 6 dimensions from being converted to FlexStridedSlice #280](https://github.com/PINTO0309/onnx2tf/issues/280)