### PR TITLE
Implement `Resize` workaround for 1D (3D) tensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.11
+  ghcr.io/pinto0309/onnx2tf:1.8.12
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.11'
+__version__ = '1.8.12'


### PR DESCRIPTION
### 1. Content and background
- `Resize`
  - Implement `Resize` workaround for 1D tensors
  - https://github.com/PINTO0309/onnx2tf/files/11137146/make_sin_d.zip
  - onnx
    ![image](https://user-images.githubusercontent.com/33194443/229763988-eb4d47d6-a2fa-4fd5-8be9-73fec748ad63.png)
  - tflite
    ![image](https://user-images.githubusercontent.com/33194443/229764321-43a3e527-c2e7-42c3-b07b-3f96a45eea78.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[MMVC]Error occurs stating 'Resize operations other than 4D and 5D are not supported' for a 3D operation #283](https://github.com/PINTO0309/onnx2tf/issues/283)