### PR TITLE
Major revision of `LSTM` conversion process

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.12
+  ghcr.io/pinto0309/onnx2tf:1.8.13
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.12'
+__version__ = '1.8.13'

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -723,9 +723,9 @@ def make_node(
         fR_i, fR_o, fR_f, fR_c = np.split(forward_recurrence_weight, 4, axis=0) # (1, 256, 256)
         fB_i, fB_o, fB_f, fB_c = np.split(forward_bias, 4, axis=0) # (1, 256)
 
-        forward_kernel = np.concatenate([fW_i, fW_f, fW_c, fW_o], axis=1).transpose(2, 0, 1).reshape(input_size, -1) # (512, 1024)
-        forward_recurrent_kernel = np.concatenate([fR_i, fR_f, fR_c, fR_o], axis=1).transpose(2, 0, 1).reshape(hidden_size, -1) # (256, 1024)
-        forward_bias = np.concatenate([fB_i, fB_f, fB_c, fB_o], axis=1) # (1, 1024)
+        forward_kernel = np.concatenate([fW_i, fW_f, fW_c, fW_o], axis=1).transpose(2, 0, 1).reshape(input_size, -1) # (1, 256*4, 512) -> (1, 1024, 512) -> (512, 1, 1024) -> (512, 1024)
+        forward_recurrent_kernel = np.concatenate([fR_i, fR_f, fR_c, fR_o], axis=1).transpose(2, 0, 1).reshape(hidden_size, -1) # (1, 256*4, 256) -> (256, 1, 1024) -> (256, 1024)
+        forward_bias = np.concatenate([fB_i, fB_f, fB_c, fB_o], axis=1) # (1, 256*4) -> (1, 1024)
         forward_unit_forget_bias = True
         if forward_bias.shape[-1] != hidden_size:
             forward_unit_forget_bias = False

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -47,7 +47,7 @@ class ScaledTanh(tf.keras.layers.Layer):
 
 # {'activateion_name': [tf_activation, default_alpha, default_beta]}
 ONNX_ACTIVATION_MAPPING: Dict[str, List] = {
-    "Elu": [tf.nn.elu, 1.0, None],
+    "Elu": [tf.nn.elu, 1.0, 0.0],
     "HardSigmoid": [tf.keras.backend.hard_sigmoid, 0.2, 0.5],
     "LeakyRelu": [tf.nn.leaky_relu, 0.01, 0.0],
     "Relu": [tf.nn.relu, 1.0, 0.0],

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -50,12 +50,12 @@ ONNX_ACTIVATION_MAPPING: Dict[str, List] = {
     "Elu": [tf.nn.elu, 1.0, None],
     "HardSigmoid": [tf.keras.backend.hard_sigmoid, 0.2, 0.5],
     "LeakyRelu": [tf.nn.leaky_relu, 0.01, 0.0],
-    "Relu": [tf.nn.relu, None, None],
-    "Sigmoid": [tf.sigmoid, None, None],
-    "Softsign": [tf.nn.softsign, None, None],
-    "Softplus": [tf.nn.softplus, None, None],
-    "Tanh": [tf.tanh, None, None],
-    "ThresholdedRelu": [tf.keras.layers.ThresholdedReLU, 1.0, None],
+    "Relu": [tf.nn.relu, 1.0, 0.0],
+    "Sigmoid": [tf.sigmoid, 1.0, 0.0],
+    "Softsign": [tf.nn.softsign, 1.0, 0.0],
+    "Softplus": [tf.nn.softplus, 1.0, 0.0],
+    "Tanh": [tf.tanh, 1.0, 0.0],
+    "ThresholdedRelu": [tf.keras.layers.ThresholdedReLU, 1.0, 0.0],
     "Affine": [Affine, 1.0, 0.0],
     "ScaledTanh": [ScaledTanh, 1.0, 1.0]
 }

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -99,13 +99,25 @@ def make_node(
     ]
 
     # NHWC -> HCHW
-    transposed_tensor = transpose_with_flexing_deterrence(
-            input_tensor=input_tensor,
-            perm=list(perm) if perm is not None else None,
-            output_shape=output_shape,
-            name=graph_node.name,
-            **kwargs,
-        )
+    try:
+        if graph_node.i().op != 'LSTM':
+            transposed_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
+                    perm=list(perm) if perm is not None else None,
+                    output_shape=output_shape,
+                    name=graph_node.name,
+                    **kwargs,
+                )
+        else:
+            transposed_tensor = input_tensor
+    except:
+        transposed_tensor = transpose_with_flexing_deterrence(
+                input_tensor=input_tensor,
+                perm=list(perm) if perm is not None else None,
+                output_shape=output_shape,
+                name=graph_node.name,
+                **kwargs,
+            )
     test_data = None
     if not isinstance(input_tensor, np.ndarray):
         if not isinstance(graph_node_input_1, np.ndarray) \


### PR DESCRIPTION
### 1. Content and background
- `LSTM`
  - Major revision of `LSTM` conversion process.
  - Supports arbitrary activation functions, biases and initial_state.
  - However, it does not yet take `P` into account.
  - Also, there is an error (`Unmatched`) in the inference results between ONNX and TFLite, although the cause is not entirely clear.
  - [LSTM.tanh.bidirectional_b10.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/11154879/LSTM.tanh.bidirectional_b10.onnx.zip)
  - onnx
    ![image](https://user-images.githubusercontent.com/33194443/229973614-da561247-98cf-40ad-a221-0e223d53f95c.png)
  - tflite
    ![image](https://user-images.githubusercontent.com/33194443/229973407-758066b0-9a25-4706-979e-559d7fec5b63.png)

![image](https://user-images.githubusercontent.com/33194443/229974613-d61b9b3b-f58a-4ba8-aa73-221829178a6f.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [LSTM Operation support #198](https://github.com/PINTO0309/onnx2tf/issues/198)