### PR TITLE
Fixed `LSTM` final output to be inverted on the axis of the sequence when `direction == "reverse"`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.13
+  ghcr.io/pinto0309/onnx2tf:1.8.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.13'
+__version__ = '1.8.14'

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -797,6 +797,7 @@ def make_node(
             node_info={
                 'tf_op_type': tf.keras.layers.LSTM,
                 'tf_inputs': {
+                    'direction': direction,
                     'X': X,
                     'W': W,
                     'R': R,

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -680,6 +680,7 @@ def make_node(
             go_backwards=True,
         )
         output, hidden_state, cell_state = reverse_lstm(X, initial_state=backward_initial_state)
+        output = tf.reverse(output, axis=[1])
         output = tf.expand_dims(output, axis=1)
         hidden_state = tf.expand_dims(hidden_state, axis=0)
         cell_state = tf.expand_dims(cell_state, axis=0)
@@ -739,7 +740,7 @@ def make_node(
         output = tf.concat(
             values=[
                 tf.expand_dims(forward_output, axis=1),
-                tf.expand_dims(reverse_output, axis=1),
+                tf.expand_dims(tf.reverse(reverse_output, axis=[1]), axis=1),
             ],
             axis=1,
         )


### PR DESCRIPTION
### 1. Content and background
- `LSTM`
  - Fixed `LSTM` final output to be inverted on the axis of the sequence when `direction == "reverse"`.
  - For `LSTM` that is not `direction == "bidirectional"`, the converted output now matches ONNX exactly.
  - https://github.com/PINTO0309/onnx2tf/files/11154879/LSTM.tanh.bidirectional_b10.onnx.zip
  - Ref: https://github.com/tensorflow/tensorflow/issues/40345
  - command
    ```
    onnx2tf -i LSTM.tanh.bidirectional_b10.onnx -kat Input3
    ```
  - onnx (forward + reverse)
    ![image](https://user-images.githubusercontent.com/33194443/229992326-4d994b0c-131f-4bea-bcc0-8783e9f1c9a4.png)
  - tflite
    ![image](https://user-images.githubusercontent.com/33194443/229991459-3315222d-f05b-4f10-819c-fecb5a8748d8.png)
  - result
    ![image](https://user-images.githubusercontent.com/33194443/229991528-19a26bc2-ca37-4637-be98-306902c4d02d.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [LSTM Operation support #198](https://github.com/PINTO0309/onnx2tf/issues/198)