### PR TITLE
Improved stability of slice size determination (Keras Tensor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.14
+  ghcr.io/pinto0309/onnx2tf:1.8.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.14'
+__version__ = '1.8.15'

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -390,6 +390,8 @@ def make_node(
             onnx_slice_dims_count = len(starts.numpy())
         elif isinstance(starts, int):
             onnx_slice_dims_count = 1
+        elif tf.keras.backend.is_keras_tensor(starts):
+            onnx_slice_dims_count = len(starts.shape)
         else:
             onnx_slice_dims_count = len(starts)
 


### PR DESCRIPTION
### 1. Content and background
- `Slice`
  - Improved stability of slice size determination (Keras Tensor)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Deformable DETR] TFLite output is differed from the ONNX output #282](https://github.com/PINTO0309/onnx2tf/issues/282)