### PR TITLE
1.Added RNN `unroll` speedup option, 2.Implement processing of the `clip` and `input_forget` parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1541,7 +1541,7 @@ Do not submit an issue that only contains an amount of information that cannot b
   |Loop|**Help wanted**|
   |LpNormalization|:heavy_check_mark:|
   |LRN|:heavy_check_mark:|
-  |LSTM|:white_check_mark: Unimplemented `input_forget` and `P`.|
+  |LSTM|:white_check_mark: Unimplemented `P`.|
   |MatMul|:heavy_check_mark:|
   |MatMulInteger|:heavy_check_mark:|
   |MaxPool|:heavy_check_mark:|

--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ usage: onnx2tf
 [-onimc OUTPUT_NAMES [OUTPUT_NAMES ...]]
 [-dgc]
 [-ebu]
+[-eru]
 [-dsft]
 [-nodaftc]
 [-dsfs]
@@ -717,6 +718,12 @@ optional arguments:
 
   -ebu, --enable_batchmatmul_unfold
     BatchMatMul is separated batch by batch to generate a primitive MatMul.
+
+  -eru, --enable_rnn_unroll
+    Instead of increasing inference speed by expanding all symbolic loops of
+    the RNN (LSTM, GRU, RNN), RAM consumption will increase because all tensors
+    are expanded and embedded in the model.
+    https://keras.io/api/layers/recurrent_layers/
 
   -dsft, --disable_suppression_flextranspose
     Disables FlexTranspose generation suppression.
@@ -930,6 +937,7 @@ convert(
   output_names_to_interrupt_model_conversion: Union[List[str], NoneType] = None,
   disable_group_convolution: Union[bool, NoneType] = False,
   enable_batchmatmul_unfold: Optional[bool] = False,
+  enable_rnn_unroll: Optional[bool] = False,
   disable_suppression_flextranspose: Optional[bool] = False,
   number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
   disable_suppression_flexstridedslice: Optional[bool] = False,
@@ -1136,6 +1144,12 @@ convert(
 
     enable_batchmatmul_unfold: Optional[bool]
       BatchMatMul is separated batch by batch to generate a primitive MatMul.
+
+    enable_rnn_unroll: Optional[bool]
+      Instead of increasing inference speed by expanding all symbolic loops of
+      the RNN (LSTM, GRU, RNN), RAM consumption will increase because all tensors
+      are expanded and embedded in the model.
+      https://keras.io/api/layers/recurrent_layers/
 
     disable_suppression_flextranspose: Optional[bool]
       Disables FlexTranspose generation suppression.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.18
+  ghcr.io/pinto0309/onnx2tf:1.8.19
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.18'
+__version__ = '1.8.19'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -79,6 +79,7 @@ def convert(
     output_names_to_interrupt_model_conversion: Optional[List[str]] = None,
     disable_group_convolution: Optional[bool] = False,
     enable_batchmatmul_unfold: Optional[bool] = False,
+    enable_rnn_unroll: Optional[bool] = False,
     disable_suppression_flextranspose: Optional[bool] = False,
     number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
     disable_suppression_flexstridedslice: Optional[bool] = False,
@@ -285,6 +286,11 @@ def convert(
 
     enable_batchmatmul_unfold: Optional[bool]
         BatchMatMul is separated batch by batch to generate a primitive MatMul.
+
+    enable_rnn_unroll: Optional[bool]
+        Instead of increasing inference speed by expanding all symbolic loops of the RNN (LSTM, GRU, RNN),\n
+        RAM consumption will increase because all tensors are expanded and embedded in the model.\n
+        https://keras.io/api/layers/recurrent_layers/
 
     disable_suppression_flextranspose: Optional[bool]
         Disables FlexTranspose generation suppression.
@@ -705,6 +711,7 @@ def convert(
         'batch_size': batch_size,
         'non_verbose': non_verbose,
         'disable_group_convolution': disable_group_convolution,
+        'enable_rnn_unroll': enable_rnn_unroll,
         'disable_suppression_flextranspose': disable_suppression_flextranspose,
         'number_of_dimensions_after_flextranspose_compression': number_of_dimensions_after_flextranspose_compression,
         'disable_suppression_flexstridedslice': disable_suppression_flexstridedslice,
@@ -1724,6 +1731,15 @@ def main():
             'BatchMatMul is separated batch by batch to generate a primitive MatMul.'
     )
     parser.add_argument(
+        '-eru',
+        '--enable_rnn_unroll',
+        action='store_true',
+        help=\
+            'Instead of increasing inference speed by expanding all symbolic loops of the RNN (LSTM, GRU, RNN), \n' +
+            'RAM consumption will increase because all tensors are expanded and embedded in the model. \n' +
+            'https://keras.io/api/layers/recurrent_layers/'
+    )
+    parser.add_argument(
         '-dsft',
         '--disable_suppression_flextranspose',
         action='store_true',
@@ -1990,6 +2006,7 @@ def main():
         output_names_to_interrupt_model_conversion=args.output_names_to_interrupt_model_conversion,
         disable_group_convolution=args.disable_group_convolution,
         enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
+        enable_rnn_unroll=args.enable_rnn_unroll,
         disable_suppression_flextranspose=args.disable_suppression_flextranspose,
         number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
         disable_suppression_flexstridedslice=args.disable_suppression_flexstridedslice,

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -152,6 +152,7 @@ class CustomLSTM(Layer):
         bias_o,
         is_bidirectional,
         go_backwards,
+        enable_rnn_unroll,
         return_sequences=True,
         **kwargs
     ):
@@ -165,6 +166,7 @@ class CustomLSTM(Layer):
         self.return_sequences = return_sequences
         self.is_bidirectional = is_bidirectional
         self.go_backwards = go_backwards
+        self.enable_rnn_unroll = enable_rnn_unroll
         self.bias_i = bias_i
         self.bias_f = bias_f
         self.bias_c = bias_c
@@ -189,6 +191,7 @@ class CustomLSTM(Layer):
             return_sequences=self.return_sequences,
             go_backwards=self.go_backwards,
             return_state=True,
+            unroll=self.enable_rnn_unroll,
         )
 
     def call(self, inputs, initial_state=None):
@@ -502,6 +505,7 @@ def make_node(
         shape3 = graph_node_output3.shape
         dtype3 = graph_node_output3.dtype
 
+    enable_rnn_unroll: bool = kwargs['enable_rnn_unroll']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output1.name] = {
@@ -692,6 +696,7 @@ def make_node(
             bias_o=fB_o, # (1, 256)
             is_bidirectional=False,
             go_backwards=False,
+            enable_rnn_unroll=enable_rnn_unroll,
         )
         output, hidden_state, cell_state = forward_lstm(X, initial_state=forward_initial_state)
         output = tf.expand_dims(output, axis=1)
@@ -723,6 +728,7 @@ def make_node(
             bias_o=rB_o, # (1, 256)
             is_bidirectional=False,
             go_backwards=True,
+            enable_rnn_unroll=enable_rnn_unroll,
         )
         output, hidden_state, cell_state = reverse_lstm(X, initial_state=backward_initial_state)
         output = tf.reverse(output, axis=[1])
@@ -767,6 +773,7 @@ def make_node(
             bias_o=fB_o, # (1, 256)
             is_bidirectional=True,
             go_backwards=False,
+            enable_rnn_unroll=enable_rnn_unroll,
         )
 
         # backward
@@ -783,6 +790,7 @@ def make_node(
             bias_o=rB_o, # (1, 256)
             is_bidirectional=True,
             go_backwards=True,
+            enable_rnn_unroll=enable_rnn_unroll,
         )
         forward_output, forward_h, forward_c = \
             forward_lstm(X, initial_state=forward_initial_state) # [1, 24, 512], [[1, 256], [1, 256]] -> [1, 24, 256], [1, 256], [1, 256]

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -72,6 +72,7 @@ class CustomLSTMCell(tf.keras.layers.AbstractRNNCell):
         bias_f,
         bias_c,
         bias_o,
+        clip,
         is_bidirectional,
         go_backwards,
         **kwargs
@@ -87,6 +88,7 @@ class CustomLSTMCell(tf.keras.layers.AbstractRNNCell):
         self.bf = bias_f
         self.bc = bias_c
         self.bo = bias_o
+        self.clip = clip
         self.is_bidirectional = is_bidirectional
         self.go_backwards = go_backwards
         self.dense_i = tf.keras.layers.Dense(
@@ -126,10 +128,48 @@ class CustomLSTMCell(tf.keras.layers.AbstractRNNCell):
 
         offsetidx = 3 if self.is_bidirectional and self.go_backwards else 0
 
-        i = self.activations[0 + offsetidx](i * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bi)
-        f = self.activations[0 + offsetidx](f * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bf)
-        c_candidate = self.activations[1 + offsetidx](c_candidate * self.activation_alphas[1 + offsetidx] + self.activation_betas[1 + offsetidx] + self.bc)
-        o = self.activations[0 + offsetidx](o * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bo)
+        if not self.clip:
+            i = self.activations[0 + offsetidx](
+                i * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bi
+            )
+            f = self.activations[0 + offsetidx](
+                f * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bf
+            )
+            c_candidate = self.activations[1 + offsetidx](
+                c_candidate * self.activation_alphas[1 + offsetidx] + self.activation_betas[1 + offsetidx] + self.bc
+            )
+            o = self.activations[0 + offsetidx](
+                o * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bo
+            )
+        else:
+            i = self.activations[0 + offsetidx](
+                tf.clip_by_value(
+                    i * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bi,
+                    clip_value_min=-self.clip,
+                    clip_value_max=self.clip,
+                )
+            )
+            f = self.activations[0 + offsetidx](
+                tf.clip_by_value(
+                    f * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bf,
+                    clip_value_min=-self.clip,
+                    clip_value_max=self.clip,
+                )
+            )
+            c_candidate = self.activations[1 + offsetidx](
+                tf.clip_by_value(
+                    c_candidate * self.activation_alphas[1 + offsetidx] + self.activation_betas[1 + offsetidx] + self.bc,
+                    clip_value_min=-self.clip,
+                    clip_value_max=self.clip,
+                )
+            )
+            o = self.activations[0 + offsetidx](
+                tf.clip_by_value(
+                    o * self.activation_alphas[0 + offsetidx] + self.activation_betas[0 + offsetidx] + self.bo,
+                    clip_value_min=-self.clip,
+                    clip_value_max=self.clip,
+                )
+            )
 
         c = f * c_prev + i * c_candidate
         h = o * self.activations[2 + offsetidx](c * self.activation_alphas[2 + offsetidx] + self.activation_betas[2 + offsetidx])
@@ -150,6 +190,7 @@ class CustomLSTM(Layer):
         bias_f,
         bias_c,
         bias_o,
+        clip,
         is_bidirectional,
         go_backwards,
         enable_rnn_unroll,
@@ -171,6 +212,7 @@ class CustomLSTM(Layer):
         self.bias_f = bias_f
         self.bias_c = bias_c
         self.bias_o = bias_o
+        self.clip = clip
 
         self.cell = CustomLSTMCell(
             self.hidden_size,
@@ -183,6 +225,7 @@ class CustomLSTM(Layer):
             self.bias_f,
             self.bias_c,
             self.bias_o,
+            self.clip,
             self.is_bidirectional,
             self.go_backwards,
         )
@@ -389,14 +432,6 @@ def make_node(
     tf_activation_betas: List = None
 
     clip: float =  graph_node.attrs.get('clip', None)
-    if clip is not None:
-        print(
-            f'{Color.RED}ERROR:{Color.RESET} ' +
-            f'clip is currently not implemented. ' +
-            f'clip: {clip}'
-        )
-        sys.exit(1)
-
     direction: str =  graph_node.attrs.get('direction', 'forward')
     if len(activations) == 0:
         # https://github.com/onnx/onnx/blob/main/docs/Changelog.md#LSTM-14
@@ -694,6 +729,7 @@ def make_node(
             bias_f=fB_f, # (1, 256)
             bias_c=fB_c, # (1, 256)
             bias_o=fB_o, # (1, 256)
+            clip=clip,
             is_bidirectional=False,
             go_backwards=False,
             enable_rnn_unroll=enable_rnn_unroll,
@@ -726,6 +762,7 @@ def make_node(
             bias_f=rB_f, # (1, 256)
             bias_c=rB_c, # (1, 256)
             bias_o=rB_o, # (1, 256)
+            clip=clip,
             is_bidirectional=False,
             go_backwards=True,
             enable_rnn_unroll=enable_rnn_unroll,
@@ -771,6 +808,7 @@ def make_node(
             bias_f=fB_f, # (1, 256)
             bias_c=fB_c, # (1, 256)
             bias_o=fB_o, # (1, 256)
+            clip=clip,
             is_bidirectional=True,
             go_backwards=False,
             enable_rnn_unroll=enable_rnn_unroll,
@@ -788,6 +826,7 @@ def make_node(
             bias_f=rB_f, # (1, 256)
             bias_c=rB_c, # (1, 256)
             bias_o=rB_o, # (1, 256)
+            clip=clip,
             is_bidirectional=True,
             go_backwards=True,
             enable_rnn_unroll=enable_rnn_unroll,


### PR DESCRIPTION
### 1. Content and background
- `LSTM`
  1.  Added RNN `unroll` speedup option
      ```
      -eru, --enable_rnn_unroll
        Instead of increasing inference speed by expanding all symbolic loops of
        the RNN (LSTM, GRU, RNN), RAM consumption will increase because all tensors
        are expanded and embedded in the model.
        https://keras.io/api/layers/recurrent_layers/
      ```
  2. Implement processing of the `clip` and `input_forget` parameter.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Improve the ability to specify the unroll option for hardware acceleration to speed up LSTM processing. #292](https://github.com/PINTO0309/onnx2tf/issues/292)