### PR TITLE
Change `tf.keras.layers.Dense()` to `tf.matmul()` to improve stability of RNN transforms with undefined dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.22
+  ghcr.io/pinto0309/onnx2tf:1.8.23
 
   or
 

--- a/json_samples/replace_lstm_undefined_dim.json
+++ b/json_samples/replace_lstm_undefined_dim.json
@@ -1,0 +1,26 @@
+{
+  "model": "https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_302/lstm_undefined_dim.onnx",
+  "cited": "https://github.com/musharaf-hossain-cs/ml-project-handwritten-text-recognition/tree/main/Saved%20Models",
+  "command": "onnx2tf -i lstm_undefined_dim.onnx -prf replace_lstm_undefined_dim.json",
+  "format_version": 1,
+  "operations": [
+    {
+      "op_name": "LSTM__185",
+      "param_target": "outputs",
+      "param_name": "LSTM__185:0",
+      "post_process_transpose_perm": [2,1,0,3]
+    },
+    {
+      "op_name": "LSTM__159",
+      "param_target": "outputs",
+      "param_name": "LSTM__159:0",
+      "post_process_transpose_perm": [2,1,0,3]
+    },
+    {
+      "op_name": "model/output/Tensordot",
+      "param_target": "outputs",
+      "param_name": "model/output/Tensordot:0",
+      "post_process_transpose_perm": [0,2,1]
+    }
+  ]
+}

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.22'
+__version__ = '1.8.23'

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -179,16 +179,6 @@ class CustomLSTMCell(tf.keras.layers.AbstractRNNCell):
         self.input_forget = input_forget
         self.is_bidirectional = is_bidirectional
         self.go_backwards = go_backwards
-        self.dense_i = tf.keras.layers.Dense(
-            units=4 * self.hidden_size,
-            kernel_initializer=tf.keras.initializers.constant(self.kernel),
-            use_bias=False,
-        )
-        self.dense_h = tf.keras.layers.Dense(
-            units=4 * self.hidden_size,
-            kernel_initializer=tf.keras.initializers.constant(self.recurrent_kernel),
-            use_bias=False,
-        )
 
     @property
     def state_size(self):
@@ -211,7 +201,7 @@ class CustomLSTMCell(tf.keras.layers.AbstractRNNCell):
         # TODO:
         # 1. Pが考慮されていない
         h_prev, c_prev = states
-        gates = self.dense_i(inputs) + self.dense_h(h_prev)
+        gates = tf.matmul(inputs, self.kernel) + tf.matmul(h_prev, self.recurrent_kernel)
         i, f, c_candidate, o = tf.split(gates, num_or_size_splits=4, axis=-1)
 
         offsetidx = 3 if self.is_bidirectional and self.go_backwards else 0

--- a/onnx2tf/ops/RNN.py
+++ b/onnx2tf/ops/RNN.py
@@ -170,16 +170,6 @@ class CustomRNNCell(tf.keras.layers.AbstractRNNCell):
         self.clip = clip
         self.is_bidirectional = is_bidirectional
         self.go_backwards = go_backwards
-        self.dense_i = tf.keras.layers.Dense(
-            units=1 * self.hidden_size,
-            kernel_initializer=tf.keras.initializers.constant(self.kernel),
-            use_bias=False,
-        )
-        self.dense_h = tf.keras.layers.Dense(
-            units=1 * self.hidden_size,
-            kernel_initializer=tf.keras.initializers.constant(self.recurrent_kernel),
-            use_bias=False,
-        )
 
     @property
     def state_size(self):
@@ -193,7 +183,7 @@ class CustomRNNCell(tf.keras.layers.AbstractRNNCell):
             Ht = f( Xt*(Wi^T) + Ht-1*(Ri^T) + Wbi + Rbi )
         """
         h_prev = states[0]
-        gates = self.dense_i(inputs) + self.dense_h(h_prev)
+        gates = tf.matmul(inputs, self.kernel) + tf.matmul(h_prev, self.recurrent_kernel)
         i = gates
         offsetidx = 1 if self.is_bidirectional and self.go_backwards else 0
 


### PR DESCRIPTION
### 1. Content and background
- `LSTM`, `RNN`, `GRU`
  - Change `tf.keras.layers.Dense()` to `tf.matmul()` to improve stability of RNN transforms with undefined dimensions.
  - I found that `tf.keras.layers.Dense()` cannot process correctly with an error if there are undefined dimensions.
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_302/lstm_undefined_dim.onnx
    ![image](https://user-images.githubusercontent.com/33194443/230723965-a2550922-89ae-45dd-87c0-73fdfa603ec5.png)
  - replace_lstm_undefined_dim.json
    ```json
    {
      "model": "https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_302/lstm_undefined_dim.onnx",
      "cited": "https://github.com/musharaf-hossain-cs/ml-project-handwritten-text-recognition/tree/main/Saved%20Models",
      "command": "onnx2tf -i lstm_undefined_dim.onnx -prf replace_lstm_undefined_dim.json",
      "format_version": 1,
      "operations": [
        {
          "op_name": "LSTM__185",
          "param_target": "outputs",
          "param_name": "LSTM__185:0",
          "post_process_transpose_perm": [2,1,0,3]
        },
        {
          "op_name": "LSTM__159",
          "param_target": "outputs",
          "param_name": "LSTM__159:0",
          "post_process_transpose_perm": [2,1,0,3]
        },
        {
          "op_name": "model/output/Tensordot",
          "param_target": "outputs",
          "param_name": "model/output/Tensordot:0",
          "post_process_transpose_perm": [0,2,1]
        }
      ]
    }
    ```
  - command
    ```
    onnx2tf -i lstm_undefined_dim.onnx -prf replace_lstm_undefined_dim.json -cotof
    ```
    ![image](https://user-images.githubusercontent.com/33194443/230724028-c106ea7c-4ba1-4e88-9624-eefa34214e43.png)
  - Although it is now possible to convert LSTMs of ONNX models with undefined dimensions, RNNs with undefined dimensions generate `FlexTensorListReserve` and `FlexTensorListStack`. However, this is technically unavoidable.
  - However, this event occurs only when the `direction` of RNN is `reverse` or `bidirectional`.
![image](https://user-images.githubusercontent.com/33194443/230724153-f129eb49-71d6-4e0e-9239-a696c18aa05c.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
