### PR TITLE
Implement `P (peepholes)` processing in `LSTM`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.23
+  ghcr.io/pinto0309/onnx2tf:1.8.24
 
   or
 
@@ -1555,7 +1555,7 @@ Do not submit an issue that only contains an amount of information that cannot b
   |Loop|**Help wanted**|
   |LpNormalization|:heavy_check_mark:|
   |LRN|:heavy_check_mark:|
-  |LSTM|:white_check_mark: Unimplemented `P`.|
+  |LSTM|:heavy_check_mark:|
   |MatMul|:heavy_check_mark:|
   |MatMulInteger|:heavy_check_mark:|
   |MaxPool|:heavy_check_mark:|

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.23'
+__version__ = '1.8.24'


### PR DESCRIPTION
### 1. Content and background
- `LSTM`
  - Implement `P (peepholes)` processing in `LSTM`
      ```
      Default activations: f=Sigmoid, g=Tanh, h=Tanh

      ONNX:
          it = f( Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi )
          ft = f( Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf )
          ct = g( Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc )
    
          Ct = ft (.) Ct-1 + it (.) ct
    
          ot = f( Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo )
    
          Ht = ot (.) h( Ct )
      ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
