### PR TITLE
Improved conversion stability for special 3D `BatchNormalization`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.24
+  ghcr.io/pinto0309/onnx2tf:1.8.25
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.24'
+__version__ = '1.8.25'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -833,6 +833,7 @@ def explicit_broadcast(
         and sum([0 if isinstance(dim, str) else 1 for dim in const_or_var_1.shape]) == len(const_or_var_1.shape) \
         and None not in const_or_var_2.shape \
         and sum([0 if isinstance(dim, str) else 1 for dim in const_or_var_2.shape]) == len(const_or_var_2.shape) \
+        and len(const_or_var_2.shape) == 1 \
         and np.prod(shape_for_judging_skip_processing_1) == np.prod(shape_for_judging_skip_processing_2):
 
         var2_rehsape_possible = False


### PR DESCRIPTION
### 1. Content and background
- `BatchNormalization`
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_304/mnist.onnx
  - [How do you convert a .onnx to tflite?](https://stackoverflow.com/questions/53182177/how-do-you-convert-a-onnx-to-tflite)
    - https://stackoverflow.com/questions/53182177/how-do-you-convert-a-onnx-to-tflite
  - Improved conversion stability for special 3D `BatchNormalization`
    ```
    X:     [1,1024,1]

    scale: [1024]
    B:     [1024]
    mean:  [1024]
    var:   [1024]
        ↓
    scale: [1,1024,1]
    B:     [1,1024,1]
    mean:  [1,1024,1]
    var:   [1,1024,1]
    ```
    ![image](https://user-images.githubusercontent.com/33194443/230761996-3e2244e4-f3a4-4b5e-82db-d1c6e6211aff.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
