### PR TITLE
README Adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.8.25
+  ghcr.io/pinto0309/onnx2tf:1.9.0
 
   or
 
@@ -434,13 +434,13 @@ print("[TFLite] Model Predictions:", tt_lite_output)
 ```
 [PyTorch] Model Predictions:
   {
-    'add': 12,
-    'sub': 8
+    add': 12,
+    sub': 8
   }
 [ONNX] Model Outputs:
   [
-    'add',
-    'sub'
+    add',
+    sub'
   ]
 [ONNX] Model Predictions:
   [
@@ -449,8 +449,8 @@ print("[TFLite] Model Predictions:", tt_lite_output)
   ]
 [TFLite] Model Predictions:
   {
-    'add': array([12]),
-    'sub': array([8])
+    add': array([12]),
+    sub': array([8])
   }
 ```
 ![image](https://user-images.githubusercontent.com/33194443/223318437-b89e56c1-4376-4e91-8c0c-08d29a604637.png)
@@ -701,7 +701,7 @@ usage: onnx2tf
 [-coion]
 [-oiqt]
 [-qt {per-channel,per-tensor}]
-[-qcind INPUT_NAME NUMPY_FILE_PATH MEAN STD]
+[-cind INPUT_NAME NUMPY_FILE_PATH MEAN STD]
 [-ioqd {int8,uint8}]
 [-nuo]
 [-nuonag]
@@ -781,56 +781,74 @@ optional arguments:
     Selects whether "per-channel" or "per-tensor" quantization is used.
     Default: "per-channel"
 
-  -qcind INPUT_NAME NUMPY_FILE_PATH MEAN STD, \
-    --quant_calib_input_op_name_np_data_path INPUT_NAME NUMPY_FILE_PATH MEAN STD
-    INPUT Name of OP and path of calibration data file (Numpy) for quantization and mean and std.
-    The specification can be omitted only when the input OP is a single 4D tensor image data.
-    If omitted, it is automatically calibrated using 20 normalized MS-COCO images.
-    The type of the input OP must be Float32.
-    Data for calibration must be pre-normalized to a range of 0 to 1.
-    -qcind {input_op_name} {numpy_file_path} {mean} {std}
-    Numpy file paths must be specified the same number of times as the number of input OPs.
-    Normalize the value of the input OP based on the tensor specified in mean and std.
-    (input_value - mean) / std
-    Tensors in Numpy file format must be in dimension order after conversion to TF.
-    Note that this is intended for deployment on low-resource devices,
-    so the batch size is limited to 1 only.
+  -cind INPUT_NAME NUMPY_FILE_PATH MEAN STD, \
+    --custom_input_op_name_np_data_path INPUT_NAME NUMPY_FILE_PATH MEAN STD
+    Input name of OP and path of data file (Numpy) for custom input for -cotof or -oiqt,
+    and mean (optional) and std (optional).
 
-    e.g.
-    The example below shows a case where there are three input OPs.
-    Assume input0 is 128x128 RGB image data.
-    In addition, input0 should be a value that has been divided by 255
-    in the preprocessing and normalized to a range between 0 and 1.
-    input1 and input2 assume the input of something that is not an image.
-    Because input1 and input2 assume something that is not an image,
-    the divisor is not 255 when normalizing from 0 to 1.
-    "n" is the number of calibration data.
+    <Usage in -cotof>
+      When using -cotof, custom input defined by the user, instead of dummy data, is used.
+      In this case, mean and std are omitted from the input.
+      -cind {input_op_name} {numpy_file_path}
+      e.g. -cind onnx::Equal_0 test_cind/x_1.npy -cind onnx::Add_1 test_cind/x_2.npy -cotof
+      The input_op_name must be the same as in ONNX,
+      and it may not work if the input format is different between ONNX and TF.
 
-    ONNX INPUT shapes:
-      input0: [n,3,128,128]
-        mean: [1,3,1,1] -> [[[[0.485]],[[0.456]],[[0.406]]]]
-        std : [1,3,1,1] -> [[[[0.229]],[[0.224]],[[0.225]]]]
-      input1: [n,64,64]
-        mean: [1,64] -> [[0.1, ..., 0.64]]
-        std : [1,64] -> [[0.05, ..., 0.08]]
-      input2: [n,5]
-        mean: [1] -> [0.3]
-        std : [1] -> [0.07]
+    <Usage in -oiqt>
+      INPUT Name of OP and path of calibration data file (Numpy) for quantization
+      and mean and std.
+      The specification can be omitted only when the input OP is a single 4D tensor image data.
+      If omitted, it is automatically calibrated using 20 normalized MS-COCO images.
+      The type of the input OP must be Float32.
+      Data for calibration must be pre-normalized to a range of 0 to 1.
+      -cind {input_op_name} {numpy_file_path} {mean} {std}
+      Numpy file paths must be specified the same number of times as the number of input OPs.
+      Normalize the value of the input OP based on the tensor specified in mean and std.
+      (input_value - mean) / std
+      Tensors in Numpy file format must be in dimension order after conversion to TF.
+      Note that this is intended for deployment on low-resource devices,
+      so the batch size is limited to 1 only.
 
-    TensorFlow INPUT shapes (Numpy file ndarray shapes):
-      input0: [n,128,128,3]
-        mean: [1,1,1,3] -> [[[[0.485, 0.456, 0.406]]]]
-        std : [1,1,1,3] -> [[[[0.229, 0.224, 0.225]]]]
-      input1: [n,64,64]
-        mean: [1,64] -> [[0.1, ..., 0.64]]
-        std : [1,64] -> [[0.05, ..., 0.08]]
-      input2: [n,5]
-        mean: [1] -> [0.3]
-        std : [1] -> [0.07]
+      e.g.
+      The example below shows a case where there are three input OPs.
+      Assume input0 is 128x128 RGB image data.
+      In addition, input0 should be a value that has been divided by 255
+      in the preprocessing and normalized to a range between 0 and 1.
+      input1 and input2 assume the input of something that is not an image.
+      Because input1 and input2 assume something that is not an image,
+      the divisor is not 255 when normalizing from 0 to 1.
+      "n" is the number of calibration data.
 
-    -qcind "input0" "../input0.npy" [[[[0.485, 0.456, 0.406]]]] [[[[0.229, 0.224, 0.225]]]]
-    -qcind "input1" "./input1.npy" [[0.1, ..., 0.64]] [[0.05, ..., 0.08]]
-    -qcind "input2" "input2.npy" [0.3] [0.07]
+      ONNX INPUT shapes:
+        input0: [n,3,128,128]
+            mean: [1,3,1,1] -> [[[[0.485]],[[0.456]],[[0.406]]]]
+            std:  [1,3,1,1] -> [[[[0.229]],[[0.224]],[[0.225]]]]
+        input1: [n,64,64]
+            mean: [1,64] -> [0.1, ..., 0.64]
+            std:  [1,64] -> [0.05, ..., 0.08]
+        input2: [n,5]
+            mean: [1] -> [0.3]
+            std:  [1] -> [0.07]
+      TensorFlow INPUT shapes (Numpy file ndarray shapes):
+        input0: [n,128,128,3]
+            mean: [1,1,1,3] -> [[[[0.485, 0.456, 0.406]]]]
+            std:  [1,1,1,3] -> [[[[0.229, 0.224, 0.225]]]]
+        input1: [n,64,64]
+            mean: [1,64] -> [0.1, ..., 0.64]
+            std:  [1,64] -> [0.05, ..., 0.08]
+        input2: [n,5]
+            mean: [1] -> [0.3]
+            std:  [1] -> [0.07]
+      -cind "input0" "../input0.npy" [[[[0.485, 0.456, 0.406]]]] [[[[0.229, 0.224, 0.225]]]]
+      -cind "input1" "./input1.npy" [0.1, ..., 0.64] [0.05, ..., 0.08]
+      -cind "input2" "input2.npy" [0.3] [0.07]
+
+    <Using -cotof and -oiqt at the same time>
+      To use -cotof and -oiqt simultaneously,
+      you need to enter the Input name of OP, path of data file, mean, and std all together.
+      And the data file must be in Float32 format,
+      and {input_op_name}, {numpy_file_path}, {mean}, and {std} must all be entered.
+      Otherwise, an error will occur during the -oiqt stage.
 
   -ioqd {int8,uint8}, --input_output_quant_dtype {int8,uint8}
     Input and Output dtypes when doing Full INT8 Quantization.
@@ -1120,7 +1138,7 @@ convert(
   copy_onnx_input_output_names_to_tflite: Optional[bool] = False,
   output_integer_quantized_tflite: Optional[bool] = False,
   quant_type: Optional[str] = 'per-channel',
-  quant_calib_input_op_name_np_data_path: Optional[List] = None,
+  custom_input_op_name_np_data_path: Optional[List] = None,
   input_output_quant_dtype: Optional[str] = 'int8',
   not_use_onnxsim: Optional[bool] = False,
   not_use_opname_auto_generate: Optional[bool] = False,
@@ -1209,58 +1227,77 @@ convert(
       Selects whether "per-channel" or "per-tensor" quantization is used.
       Default: "per-channel"
 
-    quant_calib_input_op_name_np_data_path: Optional[List]
-      --quant_calib_input_op_name_np_data_path INPUT_NAME NUMPY_FILE_PATH MEAN STD
-      INPUT Name of OP and path of calibration data file (Numpy) for quantization and mean and std.
-      The specification can be omitted only when the input OP is a single 4D tensor image data.
-      If omitted, it is automatically calibrated using 20 normalized MS-COCO images.
-      The type of the input OP must be Float32.
-      Data for calibration must be pre-normalized to a range of 0 to 1.
-      -qcind {input_op_name} {numpy_file_path} {mean} {std}
-      Numpy file paths must be specified the same number of times as the number of input OPs.
-      Normalize the value of the input OP based on the tensor specified in mean and std.
-      (input_value - mean) / std
-      Tensors in Numpy file format must be in dimension order after conversion to TF.
-      Note that this is intended for deployment on low-resource devices,
-      so the batch size is limited to 1 only.
+    custom_input_op_name_np_data_path: Optional[List]
+      --custom_input_op_name_np_data_path INPUT_NAME NUMPY_FILE_PATH MEAN STD
+      Input name of OP and path of data file (Numpy) for custom input for -cotof or -oiqt,
+      and mean (optional) and std (optional).
 
-      e.g.
-      The example below shows a case where there are three input OPs.
-      Assume input0 is 128x128 RGB image data.
-      In addition, input0 should be a value that has been divided by 255
-      in the preprocessing and normalized to a range between 0 and 1.
-      input1 and input2 assume the input of something that is not an image.
-      Because input1 and input2 assume something that is not an image,
-      the divisor is not 255 when normalizing from 0 to 1.
-      "n" is the number of calibration data.
+      <Usage in -cotof>
+        When using -cotof, custom input defined by the user, instead of dummy data, is used.
+        In this case, mean and std are omitted from the input.
+        -cind {input_op_name} {numpy_file_path}
+        e.g. -cind onnx::Equal_0 test_cind/x_1.npy -cind onnx::Add_1 test_cind/x_2.npy -cotof
+        The input_op_name must be the same as in ONNX,
+        and it may not work if the input format is different between ONNX and TF.
 
-      ONNX INPUT shapes:
-        input0: [n,3,128,128]
-          mean: [1,3,1,1] -> [[[[0.485]],[[0.456]],[[0.406]]]]
-          std : [1,3,1,1] -> [[[[0.229]],[[0.224]],[[0.225]]]]
-        input1: [n,64,64]
-          mean: [1,64] -> [[0.1, ..., 0.64]]
-          std : [1,64] -> [[0.05, ..., 0.08]]
-        input2: [n,5]
-          mean: [1] -> [0.3]
-          std : [1] -> [0.07]
+      <Usage in -oiqt>
+        INPUT Name of OP and path of calibration data file (Numpy) for quantization
+        and mean and std.
+        The specification can be omitted only when the input OP is a single 4D tensor image data.
+        If omitted, it is automatically calibrated using 20 normalized MS-COCO images.
+        The type of the input OP must be Float32.
+        Data for calibration must be pre-normalized to a range of 0 to 1.
+        -cind {input_op_name} {numpy_file_path} {mean} {std}
+        Numpy file paths must be specified the same number of times as the number of input OPs.
+        Normalize the value of the input OP based on the tensor specified in mean and std.
+        (input_value - mean) / std
+        Tensors in Numpy file format must be in dimension order after conversion to TF.
+        Note that this is intended for deployment on low-resource devices,
+        so the batch size is limited to 1 only.
+        e.g.
+        The example below shows a case where there are three input OPs.
+        Assume input0 is 128x128 RGB image data.
+        In addition, input0 should be a value that has been divided by 255
+        in the preprocessing and normalized to a range between 0 and 1.
+        input1 and input2 assume the input of something that is not an image.
+        Because input1 and input2 assume something that is not an image,
+        the divisor is not 255 when normalizing from 0 to 1.
+        "n" is the number of calibration data.
 
-      TensorFlow INPUT shapes (Numpy file ndarray shapes):
-        input0: [n,128,128,3]
-          mean: [1,1,1,3] -> [[[[0.485, 0.456, 0.406]]]]
-          std : [1,1,1,3] -> [[[[0.229, 0.224, 0.225]]]]
-        input1: [n,64,64]
-          mean: [1,64] -> [[0.1, ..., 0.64]]
-          std : [1,64] -> [[0.05, ..., 0.08]]
-        input2: [n,5]
-          mean: [1] -> [0.3]
-          std : [1] -> [0.07]
+        ONNX INPUT shapes:
+          input0: [n,3,128,128]
+            mean: [1,3,1,1] -> [[[[0.485]],[[0.456]],[[0.406]]]]
+            std : [1,3,1,1] -> [[[[0.229]],[[0.224]],[[0.225]]]]
+          input1: [n,64,64]
+            mean: [1,64] -> [[0.1, ..., 0.64]]
+            std : [1,64] -> [[0.05, ..., 0.08]]
+          input2: [n,5]
+            mean: [1] -> [0.3]
+            std : [1] -> [0.07]
 
-        qcind=[
-            ["input0","../input0.npy",[[[[0.485, 0.456, 0.406]]]],[[[[0.229, 0.224, 0.225]]]]],
-            ["input1","./input1.npy",[0.1, ..., 0.64],[0.05, ..., 0.08]],
-            ["input2","input2.npy",[0.3],[0.07]],
-        ]
+        TensorFlow INPUT shapes (Numpy file ndarray shapes):
+          input0: [n,128,128,3]
+            mean: [1,1,1,3] -> [[[[0.485, 0.456, 0.406]]]]
+            std : [1,1,1,3] -> [[[[0.229, 0.224, 0.225]]]]
+          input1: [n,64,64]
+            mean: [1,64] -> [[0.1, ..., 0.64]]
+            std : [1,64] -> [[0.05, ..., 0.08]]
+          input2: [n,5]
+            mean: [1] -> [0.3]
+            std : [1] -> [0.07]
+
+          cind=[
+              ["input0","../input0.npy",[[[[0.485, 0.456, 0.406]]]],[[[[0.229, 0.224, 0.225]]]]],
+              ["input1","./input1.npy",[0.1, ..., 0.64],[0.05, ..., 0.08]],
+              ["input2","input2.npy",[0.3],[0.07]],
+          ]
+
+      <Using -cotof and -oiqt at the same time>
+        To use -cotof and -oiqt simultaneously,
+        you need to enter the Input name of OP, path of data file, mean, and std all together.
+        And the data file must be in Float32 format,
+        and {input_op_name}, {numpy_file_path}, {mean}, and {std} must all be entered.
+        Otherwise, an error will occur during the -oiqt stage.
 
     input_output_quant_dtype: Optional[str]
       Input and Output dtypes when doing Full INT8 Quantization.

--- a/README.md
+++ b/README.md
@@ -434,13 +434,13 @@ print("[TFLite] Model Predictions:", tt_lite_output)
 ```
 [PyTorch] Model Predictions:
   {
-    add': 12,
-    sub': 8
+    'add': 12,
+    'sub': 8
   }
 [ONNX] Model Outputs:
   [
-    add',
-    sub'
+    'add',
+    'sub'
   ]
 [ONNX] Model Predictions:
   [
@@ -449,8 +449,8 @@ print("[TFLite] Model Predictions:", tt_lite_output)
   ]
 [TFLite] Model Predictions:
   {
-    add': array([12]),
-    sub': array([8])
+    'add': array([12]),
+    'sub': array([8])
   }
 ```
 ![image](https://user-images.githubusercontent.com/33194443/223318437-b89e56c1-4376-4e91-8c0c-08d29a604637.png)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.8.25'
+__version__ = '1.9.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -422,16 +422,6 @@ def convert(
     model: tf.keras.Model
         Model
     """
-    # determination of errors in custom input
-    if custom_input_op_name_np_data_path is not None:
-        for param in custom_input_op_name_np_data_path:
-            if len(param) not in [2, 4]:
-                error_msg = f'' + \
-                            f'{Color.RED}ERROR:{Color.RESET} ' + \
-                            f"'-cind' option must have INPUT_NAME, NUMPY_FILE_PATH, MEAN(optional), STD(optional)"
-                print(error_msg)
-                raise ValueError(error_msg)
-    
     # Either designation required
     if not input_onnx_file_path and not onnx_graph:
         print(
@@ -482,6 +472,16 @@ def convert(
             f'overwrite_input_shape must be specified by list.'
         )
         sys.exit(1)
+
+    # determination of errors in custom input
+    if custom_input_op_name_np_data_path is not None:
+        for param in custom_input_op_name_np_data_path:
+            if len(param) not in [2, 4]:
+                print(
+                    f'{Color.RED}ERROR:{Color.RESET} ' +
+                    f"'-cind' option must have INPUT_NAME, NUMPY_FILE_PATH, MEAN(optional), STD(optional)"
+                )
+                sys.exit(1)
 
     # replace_argmax_to_reducemax_and_indicies_is_int64
     # replace_argmax_to_reducemax_and_indicies_is_float32
@@ -746,8 +746,8 @@ def convert(
         print('')
         print(f'{Color.REVERCE}Model convertion started{Color.RESET}', '=' * 60)
 
-    with graph.node_ids():     
-        
+    with graph.node_ids():
+
         onnx_graph_input_names: List[str] = [
             inputop.name for inputop in graph.inputs
         ]
@@ -1114,8 +1114,8 @@ def convert(
                             "{input_op_name}, {numpy_file_path}, {mean}, and {std} must all be entered. " +
                             f"However, you have only entered {len(param)} options. "
                         )
-                        sys.exit(1)                    
-                    
+                        sys.exit(1)
+
                     input_op_name = str(param[0])
                     numpy_file_path = str(param[1])
                     calib_data = np.load(numpy_file_path)
@@ -1123,7 +1123,7 @@ def convert(
                         data_count = calib_data.shape[0]
                     mean = param[2]
                     std = param[3]
-                    
+
                     calib_data_dict[input_op_name] = \
                         [
                             calib_data.copy(),
@@ -1567,7 +1567,7 @@ def main():
         action='append',
         nargs='+',
         help=\
-            'Input name of OP and path of data file (Numpy) for custom input for -cotof or -oiqt, \n' + 
+            'Input name of OP and path of data file (Numpy) for custom input for -cotof or -oiqt, \n' +
             'and mean (optional) and std (optional). \n' +
 
             '\n<Usage in -cotof> \n' +
@@ -1575,8 +1575,8 @@ def main():
             'In this case, mean and std are omitted from the input. \n' +
             '-cind {input_op_name} {numpy_file_path} \n' +
             'ex) -cind onnx::Equal_0 test_cind/x_1.npy -cind onnx::Add_1 test_cind/x_2.npy -cotof \n' +
-            'The input_op_name must be the same as in ONNX, \n'
-            'and it may not work if the input format is different between ONNX and TF. \n'
+            'The input_op_name must be the same as in ONNX, \n' +
+            'and it may not work if the input format is different between ONNX and TF. \n' +
 
             '\n<Usage in -oiqt> \n' +
             'INPUT Name of OP and path of calibration data file (Numpy) for quantization \n' +
@@ -1623,8 +1623,7 @@ def main():
             '       std:  [1] -> [0.07] \n' +
             '-cind "input0" "../input0.npy" [[[[0.485, 0.456, 0.406]]]] [[[[0.229, 0.224, 0.225]]]] \n' +
             '-cind "input1" "./input1.npy" [0.1, ..., 0.64] [0.05, ..., 0.08] \n' +
-            '-cind "input2" "input2.npy" [0.3] [0.07]' +
-
+            '-cind "input2" "input2.npy" [0.3] [0.07] \n\n' +
             '\n<Using -cotof and -oiqt at the same time> \n' +
             'To use -cotof and -oiqt simultaneously, \n' +
             'you need to enter the Input name of OP, path of data file, mean, and std all together. \n' +
@@ -2011,11 +2010,11 @@ def main():
             if len(param) == 2:
                 tmp.append(str(param[0])) # input_op_name
                 tmp.append(str(param[1])) # numpy_file_path
-                
+
                 if len(param) == 4:
                     tmp.append(np.asarray(ast.literal_eval(param[2]), dtype=np.float32)) # mean
                     tmp.append(np.asarray(ast.literal_eval(param[3]), dtype=np.float32)) # std
-                    
+
                 custom_params.append(
                     tmp
                 )

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3505,7 +3505,7 @@ def dummy_onnx_inference(
     input_sizes = new_input_sizes
     input_dtypes: List[Any] = [inp.dtype for inp in onnx_inputs]
     input_datas = {}
-    
+
     # -cid
     if custom_input_op_name_np_data_path:
         for param in custom_input_op_name_np_data_path:
@@ -3514,7 +3514,7 @@ def dummy_onnx_inference(
             custom_input_data = np.load(numpy_file_path)
 
             input_datas[input_op_name] = custom_input_data
-        
+
     else:
         for input_name, input_size, input_dtype in zip(input_names, input_sizes, input_dtypes):
             if test_data_nhwc is None:
@@ -3581,27 +3581,27 @@ def dummy_tf_inference(
     input_sizes = new_input_sizes
     input_dtypes: List[Any] = [inp.dtype for inp in inputs]
     input_datas = {}
-    
+
     # -cid
     if custom_input_op_name_np_data_path:
         for idx, param in enumerate(custom_input_op_name_np_data_path):
             numpy_file_path = str(param[1])
             custom_input_data = np.load(numpy_file_path)
             input_size = input_sizes[idx]
-            
+
             if list(custom_input_data.shape) != input_size:
                 error_msg = f'' + \
                     f'{Color.RED}ERROR:{Color.RESET} ' + \
                     f"The format of custom input data is different from Tensorflow's format. " + \
                     f"Therefore, you cannot use custom input. "
-                
+
                 raise ValueError(error_msg)
 
-            input_datas[input_names[idx]] = custom_input_data    
-             
+            input_datas[input_names[idx]] = custom_input_data
+
     else:
         if verification_datas is None:
-            for input_name, input_size, input_dtype in zip(input_names, input_sizes, input_dtypes):            
+            for input_name, input_size, input_dtype in zip(input_names, input_sizes, input_dtypes):
                 if test_data_nhwc is None:
                     input_datas[input_name] = np.ones(
                         input_size,


### PR DESCRIPTION
### 1. Content and background

- **Improvement without backward compatibility**
  - [new parameter -cind, —custom_input_op_name_np_data_path #296](https://github.com/PINTO0309/onnx2tf/pull/296)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
