### PR TITLE
Corrected an error in the `axis` specification for `ReduceMean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.2
+  ghcr.io/pinto0309/onnx2tf:1.9.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.2'
+__version__ = '1.9.3'

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -132,7 +132,7 @@ def make_node(
     # Generation of TF OP
     reduce_meaned_1 = tf.reduce_mean(
         input_tensor=input_tensor,
-        axis=[i for i in range(1, axis+1)],
+        axis=[axis],
         keepdims=True,
     )
     subed = tf.math.subtract(
@@ -146,7 +146,7 @@ def make_node(
     )
     reduce_meaned_2 = tf.reduce_mean(
         input_tensor=squared,
-        axis=[i for i in range(1, axis+1)],
+        axis=[axis],
         keepdims=True,
     )
     added = tf.math.add(


### PR DESCRIPTION
### 1. Content and background
- `LayerNormalization`
  - Corrected an error in the `axis` specification for `ReduceMean`
- Before
  ![image](https://user-images.githubusercontent.com/33194443/232227620-1d7ea746-36c1-4bc4-b578-413db4bc5789.png)
- After
  ![image](https://user-images.githubusercontent.com/33194443/232227635-98bccc76-013c-41a9-b5d7-e9a1b0cad9d5.png)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[InSPyReNet] Swin Transformer Support question #312](https://github.com/PINTO0309/onnx2tf/issues/312)