### PR TITLE
Fix version to 0.4.17 because there appears to be a bug inherent in onnxsim==0.4.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 
 RUN pip install pip -U \
     && pip install -U onnx \
-    && pip install -U onnxsim \
+    && pip install -U onnxsim==0.4.17 \
     && python3 -m pip install -U onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com \
     && pip install -U onnx2tf \
     && pip install -U onnx2tf \

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 ## Environment
 - onnx
 - onnxruntime
-- onnx-simplifier
+- onnx-simplifier==0.4.17 See: https://github.com/PINTO0309/onnx2tf/issues/312
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
 - tensorflow==2.12.0
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.3
+  ghcr.io/pinto0309/onnx2tf:1.9.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.3'
+__version__ = '1.9.4'


### PR DESCRIPTION
### 1. Content and background
- `onnxsim`
  - Fix version to `0.4.17` because there appears to be a bug inherent in `onnxsim==0.4.19`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[InSPyReNet] Swin Transformer Support question #312](https://github.com/PINTO0309/onnx2tf/issues/312)