### PR TITLE
Improved `GridSample` conversion stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.10
+  ghcr.io/pinto0309/onnx2tf:1.9.11
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.10'
+__version__ = '1.9.11'


### PR DESCRIPTION
### 1. Content and background
- `GridSample`
  - Improved conversion stability.
  - When the input shape of ONNX and the input shape of TF are exactly the same, it is assumed to be the input tensor of NCHW and transposed to NHWC forcibly before processing.
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_324/rtdetr_hgnetv2_x_6x_coco_192x320.onnx

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
