### PR TITLE
Eliminate all redundant partial graph accuracy check processes that have no prospect of being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.13
+  ghcr.io/pinto0309/onnx2tf:1.9.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.13'
+__version__ = '1.9.14'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -753,7 +753,6 @@ def convert(
         'output_signaturedefs': output_signaturedefs,
         'onnx_tensor_infos_for_validation': onnx_tensor_infos_for_validation,
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
-        'acc_check': False,
     }
 
     tf_layers_dict = {}

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -17,12 +17,9 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -104,25 +101,6 @@ def make_node(
         **kwargs,
     )
 
-    # Acquisition of test data for validation
-    if kwargs['acc_check']:
-        if not isinstance(graph_node_input_1, np.ndarray) \
-            and graph_node_input_1.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-        elif isinstance(graph_node_input_1, np.ndarray):
-            test_data1: np.ndarray = graph_node_input_1
-        else:
-            test_data1 = None
-        if not isinstance(graph_node_input_2, np.ndarray) \
-            and graph_node_input_2.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-        elif isinstance(graph_node_input_2, np.ndarray):
-            test_data2: np.ndarray = graph_node_input_2
-        else:
-            test_data2 = None
-
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
     #   2. If only one of the two is the output of Transpose
@@ -170,20 +148,7 @@ def make_node(
             input_tensor_2=input_tensor_2,
         )
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[
-                    input_tensor_1,
-                    input_tensor_2,
-                ]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     # Merge two consecutive identical OPs into one
     # https://github.com/PINTO0309/onnx2tf/issues/230
     #   A constant is calculated in advance only
@@ -211,45 +176,6 @@ def make_node(
         tf_layers_dict=tf_layers_dict,
         tf_func='Add'
     )
-
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.math.add(
-                    x=tf_partial_model_inputs[0] \
-                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
-                    y=tf_partial_model_inputs[1] \
-                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data1 = None
-        if isinstance(input_tensor_1, np.ndarray):
-            test_data1 = input_tensor_1
-        test_data2 = None
-        if isinstance(input_tensor_2, np.ndarray):
-            test_data2 = input_tensor_2
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data1,
-                test_data2,
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data1
-        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -121,21 +121,21 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
-                # 1D - Overall model
+                # 1D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 4:
-                # 2D - Overall model
+                # 2D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 5:
-                # 3D - Overall model
+                # 3D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -14,11 +14,8 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     transpose_with_flexing_deterrence,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -162,79 +159,13 @@ def make_node(
         value if len(value.shape) > 0 else tf.reshape(value, [1]) for value in values
     ]
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=values
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.concat(
             values=values,
             axis=axis,
             name=graph_node.name,
         )
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        test_datas = []
-        for graph_node_input, value in zip(graph_node.inputs, values):
-            test_data = None
-            if not isinstance(value, np.ndarray):
-                if not isinstance(graph_node_input, np.ndarray) \
-                    and graph_node_input.name in tf_layers_dict \
-                    and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                    test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-                elif isinstance(graph_node_input, np.ndarray):
-                    test_data: np.ndarray = graph_node_input
-                else:
-                    test_data = None
-            else:
-                test_data = value
-            test_datas.append(test_data)
-        new_test_datas = []
-        is_expanded = False
-        for tf_partial_model_input, test_data in zip(tf_partial_model_inputs, test_datas):
-            if isinstance(test_data, np.ndarray) \
-                and len(test_data.shape) == 1 \
-                and len(tf_partial_model_input.shape) == 2:
-                test_data = np.expand_dims(test_data, 0)
-                is_expanded = True
-            new_test_datas.append(test_data)
-        test_datas = new_test_datas
-        tf_partial_model_outputs = \
-            [
-                tf.concat(
-                    values=tf_partial_model_inputs,
-                    axis=axis,
-                ) if not is_expanded else \
-                tf.squeeze(
-                    input=tf.concat(
-                        values=tf_partial_model_inputs,
-                        axis=axis if not is_expanded else axis+1,
-                    ),
-                    axis=0,
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=test_datas
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Cos.py
+++ b/onnx2tf/ops/Cos.py
@@ -12,10 +12,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -78,59 +75,12 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[input_tensor]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.cos(
             x=input_tensor,
             name=graph_node.name,
         )
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.math.cos(
-                    x=tf_partial_model_inputs[0],
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data = None
-        if not isinstance(input_tensor, np.ndarray):
-            if not isinstance(graph_node_input, np.ndarray) \
-                and graph_node_input.name in tf_layers_dict \
-                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-            elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = graph_node_input
-            else:
-                test_data = None
-        else:
-            test_data = input_tensor
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -17,13 +17,9 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
 )
-from typing import Any, Dict, List
-from onnx2tf.utils.enums import TF_DTYPES_TO_NUMPY_DTYPES
 
 
 @print_node_info
@@ -105,25 +101,6 @@ def make_node(
         **kwargs,
     )
 
-    # Acquisition of test data for validation
-    if kwargs['acc_check']:
-        if not isinstance(graph_node_input_1, np.ndarray) \
-            and graph_node_input_1.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-        elif isinstance(graph_node_input_1, np.ndarray):
-            test_data1: np.ndarray = graph_node_input_1
-        else:
-            test_data1 = None
-        if not isinstance(graph_node_input_2, np.ndarray) \
-            and graph_node_input_2.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-        elif isinstance(graph_node_input_2, np.ndarray):
-            test_data2: np.ndarray = graph_node_input_2
-        else:
-            test_data2 = None
-
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
     #   2. If only one of the two is the output of Transpose
@@ -188,20 +165,7 @@ def make_node(
     input_tensor_2 = input_tensor_2 \
         if not xy_is_integer else tf.cast(input_tensor_2, dtype=tf.float32)
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[
-                    input_tensor_1,
-                    input_tensor_2,
-                ]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     # TODO: Temporarily Revert due to missing decision conditions
     # # Merge two consecutive identical OPs into one
     # # https://github.com/PINTO0309/onnx2tf/issues/230
@@ -236,49 +200,6 @@ def make_node(
         name=graph_node.name,
     )
     tf_type = tf.math.divide
-
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.math.divide(
-                    x=tf_partial_model_inputs[0] \
-                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
-                    y=tf_partial_model_inputs[1] \
-                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data1 = None
-        if isinstance(input_tensor_1, np.ndarray):
-            test_data1 = input_tensor_1
-        test_data2 = None
-        if isinstance(input_tensor_2, np.ndarray):
-            test_data2 = input_tensor_2
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data1,
-                test_data2,
-            ]
-        )
-        tf_partial_model_result: np.ndarray = list(tf_partial_model_result_infos.values())[0]
-        if xy_is_integer and dtype in target_cast_dtype:
-            cast_dtype = TF_DTYPES_TO_NUMPY_DTYPES[dtype] \
-                if isinstance(dtype, tf.dtypes.DType) else dtype
-            tf_partial_model_result = tf_partial_model_result.astype(cast_dtype)
-        tf_layers_dict[graph_node_output.name]['verification_data'] = tf_partial_model_result
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data1
-        del test_data2
 
     # Post-process transpose
     divided_tensor = post_process_transpose(

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -13,12 +13,8 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
 )
-from typing import Any, Dict, List
 from onnx2tf.utils.enums import (
-    TF_DTYPES_TO_NUMPY_DTYPES,
     NUMPY_DTYPES_TO_TF_DTYPES,
 )
 
@@ -74,35 +70,6 @@ def make_node(
     z = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
         if isinstance(graph_node_input_3, gs.Variable) else graph_node_input_3
 
-    # Acquisition of test data for validation
-    if kwargs['acc_check']:
-        if not isinstance(graph_node_input_1, np.ndarray) \
-            and graph_node_input_1.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-        elif isinstance(graph_node_input_1, np.ndarray):
-            test_data1: np.ndarray = graph_node_input_1
-        else:
-            test_data1 = None
-        if not isinstance(graph_node_input_2, np.ndarray) \
-            and not (isinstance(graph_node_input_2, int) and graph_node_input_2 == 0) \
-            and graph_node_input_2.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-        elif isinstance(graph_node_input_2, np.ndarray):
-            test_data2: np.ndarray = graph_node_input_2
-        else:
-            test_data2 = None
-        if not isinstance(graph_node_input_3, np.ndarray) \
-            and not (isinstance(graph_node_input_3, int) and graph_node_input_3 == 0) \
-            and graph_node_input_3.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_3.name].keys():
-            test_data3: np.ndarray = tf_layers_dict[graph_node_input_3.name]['verification_data']
-        elif isinstance(graph_node_input_3, np.ndarray):
-            test_data3: np.ndarray = graph_node_input_3
-        else:
-            test_data3 = None
-
     # Pre-process transpose
     x = pre_process_transpose(
         value_before_transpose=x,
@@ -128,19 +95,10 @@ def make_node(
         if isinstance(x.dtype, np.dtype) else x.dtype
     x = tf.keras.layers.Flatten()(x)
 
-    if kwargs['acc_check']:
-        if test_data1 is not None and isinstance(test_data1, np.ndarray):
-            test_data1 = tf.keras.layers.Flatten()(test_data1).numpy()
-
     # The Flatten API changes data type from tf.float64 to tf.float32
     # so we need the following line to get the original type back
     x = tf.cast(x, input_tensor_x_dtype) \
         if input_tensor_x_dtype is tf.float64 else x
-
-    if kwargs['acc_check']:
-        if test_data1 is not None and isinstance(test_data1, np.ndarray):
-            test_data1 = test_data1.astype(TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_x_dtype]) \
-                if input_tensor_x_dtype is tf.float64 else test_data1
 
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
@@ -218,162 +176,33 @@ def make_node(
                 else tf.convert_to_tensor(z)
     if transA == True:
         x = tf.transpose(x)
-        if kwargs['acc_check'] and test_data1 is not None:
-            test_data1 = tf.transpose(test_data1)
     if transB == True:
         y = tf.transpose(y)
-        if kwargs['acc_check'] and test_data2 is not None:
-            test_data2 = tf.transpose(test_data2)
-
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[
-                    x,
-                    y,
-                ] + ([z] if len(graph_node.inputs) > 2 else [])
-            )
-        tf_partial_x = tf_partial_model_inputs[0] \
-            if tf_partial_model_inputs is not None else None
-        tf_partial_y = tf_partial_model_inputs[1] \
-            if tf_partial_model_inputs is not None else None
-        tf_partial_z = tf_partial_model_inputs[2] \
-            if tf_partial_model_inputs is not None \
-                and len(tf_partial_model_inputs) > 2 else None
-        if tf_partial_model_inputs is not None:
-            if isinstance(test_data3, np.ndarray) \
-                and len(test_data3.shape) == 1 \
-                and tf_partial_z is not None \
-                and len(tf_partial_z.shape) == 2:
-                test_data3 = np.expand_dims(test_data3, 0)
-        tf_partial_model_outputs = None
 
     # We cast to either input or attribute data type to preserve precision
     if input_tensor_x_dtype in [tf.float64]:
         # cast to input data type
         alpha = tf.cast(alpha, input_tensor_x_dtype)
         beta = tf.cast(beta, input_tensor_x_dtype)
-        ### Overall model
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             alpha * tf.matmul(x, y) + beta * z
-        ### Partial model
-        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-            tf_partial_model_outputs = \
-                [
-                    alpha * tf.matmul(tf_partial_x, tf_partial_y) + beta * tf_partial_z
-                ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data1,
-                    test_data2,
-                ] + ([test_data3] if len(graph_node.inputs) > 2 else [])
-            )
-            tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                list(tf_partial_model_result_infos.values())[0]
-            del tf_partial_model
-            del tf_partial_model_inputs
-            del tf_partial_model_outputs
-            del test_data1
-            del test_data2
-            del test_data3
 
     else:
         # cast to attribute data type
         x = tf.cast(x, tf.float32)
-        if kwargs['acc_check'] and test_data1 is not None:
-            test_data1 = tf.cast(test_data1, tf.float32)
         y = tf.cast(y, tf.float32)
-        if kwargs['acc_check'] and test_data2 is not None:
-            test_data2 = tf.cast(test_data2, tf.float32)
         z = tf.cast(z, tf.float32)
-        if kwargs['acc_check'] and test_data3 is not None:
-            test_data3 = tf.cast(test_data3, tf.float32)
         if not optimization_for_gpu_delegate:
-            ### Overall model
             if z is not None:
                 result = alpha * tf.matmul(x, y) + beta * z
             else:
                 result = alpha * tf.matmul(x, y) + beta
-            ### Partial model
-            if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-                if tf_partial_z is not None:
-                    tf_partial_model_outputs = \
-                        [
-                            alpha * tf.matmul(tf_partial_x, tf_partial_y) + beta * tf_partial_z
-                        ]
-                else:
-                    tf_partial_model_outputs = \
-                        [
-                            alpha * tf.matmul(tf_partial_x, tf_partial_y) + beta
-                        ]
-                tf_partial_model = tf.keras.Model(
-                    inputs=tf_partial_model_inputs,
-                    outputs=tf_partial_model_outputs,
-                )
-                tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-                    model=tf_partial_model,
-                    inputs=tf_partial_model_inputs,
-                    verification_datas=[
-                        test_data1,
-                        test_data2,
-                    ] + ([test_data3] if len(graph_node.inputs) > 2 else [])
-                )
-                tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                    list(tf_partial_model_result_infos.values())[0]
-                del tf_partial_model
-                del tf_partial_model_inputs
-                del tf_partial_model_outputs
-                del test_data1
-                del test_data2
-                del test_data3
 
         else:
-            ### Overall model
             result = alpha * tf.matmul(x, y) - (beta * z) * -1
-            ### Partial model
-            if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-                tf_partial_model_outputs = \
-                    [
-                        alpha * tf.matmul(tf_partial_x, tf_partial_y) - (beta * tf_partial_z) * -1
-                    ]
-                tf_partial_model = tf.keras.Model(
-                    inputs=tf_partial_model_inputs,
-                    outputs=tf_partial_model_outputs,
-                )
-                tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-                    model=tf_partial_model,
-                    inputs=tf_partial_model_inputs,
-                    verification_datas=[
-                        test_data1,
-                        test_data2,
-                        test_data3,
-                    ]
-                )
-                tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                    list(tf_partial_model_result_infos.values())[0]
-                del tf_partial_model
-                del tf_partial_model_inputs
-                del tf_partial_model_outputs
-                del test_data1
-                del test_data2
-                del test_data3
 
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.cast(result, input_tensor_x_dtype)
-        if kwargs['acc_check']:
-            if 'verification_data' in tf_layers_dict[graph_node_output.name].keys():
-                tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                    tf_layers_dict[graph_node_output.name]['verification_data'].astype(
-                        TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_x_dtype]
-                    )
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/GlobalAveragePool.py
+++ b/onnx2tf/ops/GlobalAveragePool.py
@@ -98,21 +98,21 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
-                # 1D - Overall model
+                # 1D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 4:
-                # 2D - Overall model
+                # 2D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 5:
-                # 3D - Overall model
+                # 3D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],

--- a/onnx2tf/ops/GlobalLpPool.py
+++ b/onnx2tf/ops/GlobalLpPool.py
@@ -96,21 +96,21 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
-                # 1D - Overall model
+                # 1D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 4:
-                # 2D - Overall model
+                # 2D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 5:
-                # 3D - Overall model
+                # 3D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],

--- a/onnx2tf/ops/GlobalMaxPool.py
+++ b/onnx2tf/ops/GlobalMaxPool.py
@@ -93,21 +93,21 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
-                # 1D - Overall model
+                # 1D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 4:
-                # 2D - Overall model
+                # 2D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 5:
-                # 3D - Overall model
+                # 3D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -133,21 +133,21 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
-                # 1D - Overall model
+                # 1D
                 image = transpose_with_flexing_deterrence(
                     input_tensor=image,
                     perm=[0,2,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 4:
-                # 2D - Overall model
+                # 2D
                 image = transpose_with_flexing_deterrence(
                     input_tensor=image,
                     perm=[0,2,3,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 5:
-                # 3D - Overall model
+                # 3D
                 image = transpose_with_flexing_deterrence(
                     input_tensor=image,
                     perm=[0,2,3,4,1],

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -12,11 +12,8 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     transpose_with_flexing_deterrence,
 )
-from typing import Any, Dict, List
 from onnx2tf.utils.enums import NUMPY_DTYPES_TO_TF_DTYPES
 
 INF_INDEX_VALUE: int = 4294967296
@@ -107,8 +104,6 @@ def make_node(
     }
 
     # transpose
-    tf_transposed_perm = None
-    test_data_transposed_perm = None
     try:
         if graph_node.i().op == 'Reshape':
             onnx_input_shape = [
@@ -131,7 +126,6 @@ def make_node(
                             perm=[0,2,1],
                             **kwargs,
                         )
-                        tf_transposed_perm = [0,2,1]
                     elif len(onnx_input_shape) == 4:
                         # 2D
                         input_tensor = transpose_with_flexing_deterrence(
@@ -139,28 +133,11 @@ def make_node(
                             perm=[0,2,3,1],
                             **kwargs,
                         )
-                        tf_transposed_perm = [0,2,3,1]
-                else:
-                    if len(onnx_input_shape) == 3:
-                        test_data_transposed_perm = [0,2,1]
-                    elif len(onnx_input_shape) == 4:
-                        test_data_transposed_perm = [0,2,3,1]
     except:
         pass
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[input_tensor]
-            )
-        tf_partial_model_outputs = None
-
-
     # Generation of TF OP
     axes = [idx for idx in range(1, input_tensor_rank - 1)]
-    ### Overall model
     mean = tf.reduce_mean(
         input_tensor=input_tensor,
         axis=axes,
@@ -173,59 +150,6 @@ def make_node(
     )
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         (input_tensor - mean) / tf.math.sqrt(variance + epsilon) * scale + B
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        mean = tf.reduce_mean(
-            input_tensor=tf_partial_model_inputs[0],
-            axis=axes,
-            keepdims=True,
-        )
-        variance = tf.math.reduce_variance(
-            input_tensor=tf_partial_model_inputs[0],
-            axis=axes,
-            keepdims=True,
-        )
-        pre_instance_norm = (tf_partial_model_inputs[0] - mean) / tf.math.sqrt(variance + epsilon)
-        tf_partial_model_outputs = \
-            [
-                pre_instance_norm * scale + B
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data = None
-        if not isinstance(input_tensor, np.ndarray):
-            if not isinstance(graph_node_input, np.ndarray) \
-                and graph_node_input.name in tf_layers_dict \
-                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-            elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = graph_node_input
-            else:
-                test_data = None
-        else:
-            test_data = input_tensor
-        if tf_transposed_perm is not None \
-            and isinstance(test_data, np.ndarray):
-            test_data = test_data.transpose(tf_transposed_perm)
-        elif test_data_transposed_perm is not None \
-            and isinstance(test_data, np.ndarray) \
-            and tf_input_shape != list(test_data.shape):
-            test_data = test_data.transpose(test_data_transposed_perm)
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -13,14 +13,10 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     transpose_with_flexing_deterrence,
 )
-from typing import Any, Dict, List
 from onnx2tf.utils.enums import (
     NUMPY_DTYPES_TO_TF_DTYPES,
-    TF_DTYPES_TO_NUMPY_DTYPES,
 )
 
 
@@ -94,18 +90,6 @@ def make_node(
         if isinstance(dtype, np.dtype) else dtype
 
     try:
-        # Generate input OPs for TensorFlow subgraphs
-        # For inference testing on OP stand-alone
-        if kwargs['acc_check']:
-            tf_partial_model_inputs: List[tf.keras.Input] = \
-                make_tf_partial_model_inputs(
-                    input_tensors=[
-                        input_tensor_1,
-                        input_tensor_2,
-                    ]
-                )
-            tf_partial_model_outputs = None
-        ### Overall model
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.matmul(
                 a=input_tensor_1 \
@@ -117,60 +101,6 @@ def make_node(
                 output_type=output_dtype,
                 name=graph_node.name,
             )
-        ### Partial model
-        if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-            tf_partial_model_outputs = \
-                [
-                    tf.matmul(
-                        a=tf_partial_model_inputs[0],
-                        b=tf_partial_model_inputs[1],
-                        output_type=output_dtype,
-                    )
-                ]
-            tf_partial_model = tf.keras.Model(
-                inputs=tf_partial_model_inputs,
-                outputs=tf_partial_model_outputs,
-            )
-            test_data1 = None
-            if not isinstance(input_tensor_1, np.ndarray):
-                if not isinstance(graph_node_input_1, np.ndarray) \
-                    and graph_node_input_1.name in tf_layers_dict \
-                    and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                    test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-                elif isinstance(graph_node_input_1, np.ndarray):
-                    test_data1: np.ndarray = graph_node_input_1
-                else:
-                    test_data1 = None
-            else:
-                test_data1 = input_tensor_1
-            test_data2 = None
-            if not isinstance(input_tensor_2, np.ndarray):
-                if not isinstance(graph_node_input_2, np.ndarray) \
-                    and graph_node_input_2.name in tf_layers_dict \
-                    and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-                    test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-                elif isinstance(graph_node_input_2, np.ndarray):
-                    test_data2: np.ndarray = graph_node_input_2
-                else:
-                    test_data2 = None
-            else:
-                test_data2 = input_tensor_2
-
-            tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-                model=tf_partial_model,
-                inputs=tf_partial_model_inputs,
-                verification_datas=[
-                    test_data1,
-                    test_data2,
-                ]
-            )
-            tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                list(tf_partial_model_result_infos.values())[0]
-            del tf_partial_model
-            del tf_partial_model_inputs
-            del tf_partial_model_outputs
-            del test_data1
-            del test_data2
 
     except Exception as ex1:
         # Shape Unmatch Error Mitigation Measures
@@ -180,28 +110,6 @@ def make_node(
         for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
             for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
                 try:
-                    # Generate input OPs for TensorFlow subgraphs
-                    # For inference testing on OP stand-alone
-                    if kwargs['acc_check']:
-                        tf_partial_model_inputs: List[tf.keras.Input] = \
-                                make_tf_partial_model_inputs(
-                                    input_tensors=[
-                                        np.zeros(
-                                            list(input_tensor_1.shape),
-                                            dtype=input_tensor_1.dtype \
-                                                if isinstance(input_tensor_1, np.ndarray) \
-                                                    else TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_1.dtype],
-                                        ).transpose(tensor_1_candidate_for_transposition),
-                                        np.zeros(
-                                            list(input_tensor_2.shape),
-                                            dtype=input_tensor_2.dtype \
-                                                if isinstance(input_tensor_2, np.ndarray) \
-                                                    else TF_DTYPES_TO_NUMPY_DTYPES[input_tensor_2.dtype],
-                                        ).transpose(tensor_2_candidate_for_transposition),
-                                    ]
-                                )
-                        tf_partial_model_outputs = None
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.matmul(
                             a=transpose_with_flexing_deterrence(
@@ -221,87 +129,6 @@ def make_node(
                             output_type=output_dtype,
                             name=graph_node.name,
                         )
-                    ### Partial model
-                    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-                        tf_partial_model_outputs = \
-                            [
-                                tf.matmul(
-                                    a=tf_partial_model_inputs[0] \
-                                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
-                                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
-                                    b=tf_partial_model_inputs[1] \
-                                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
-                                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
-                                    output_type=output_dtype,
-                                )
-                            ]
-                        tf_partial_model = tf.keras.Model(
-                            inputs=tf_partial_model_inputs,
-                            outputs=tf_partial_model_outputs,
-                        )
-                        test_data1 = None
-                        if not isinstance(input_tensor_1, np.ndarray):
-                            if not isinstance(graph_node_input_1, np.ndarray) \
-                                and graph_node_input_1.name in tf_layers_dict \
-                                and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-                                test_data1: np.ndarray = transpose_with_flexing_deterrence(
-                                    input_tensor=tf_layers_dict[graph_node_input_1.name]['verification_data'],
-                                    perm=list(tensor_1_candidate_for_transposition),
-                                    **kwargs,
-                                )
-                            elif isinstance(graph_node_input_1, np.ndarray):
-                                test_data1: np.ndarray = transpose_with_flexing_deterrence(
-                                    input_tensor=graph_node_input_1,
-                                    perm=list(tensor_1_candidate_for_transposition),
-                                    **kwargs,
-                                )
-                            else:
-                                test_data1 = None
-                        else:
-                            test_data1 = transpose_with_flexing_deterrence(
-                                input_tensor=input_tensor_1,
-                                perm=list(tensor_1_candidate_for_transposition),
-                                **kwargs,
-                            )
-                        test_data2 = None
-                        if not isinstance(input_tensor_2, np.ndarray):
-                            if not isinstance(graph_node_input_2, np.ndarray) \
-                                and graph_node_input_2.name in tf_layers_dict \
-                                and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-                                test_data2: np.ndarray = transpose_with_flexing_deterrence(
-                                    input_tensor=tf_layers_dict[graph_node_input_2.name]['verification_data'],
-                                    perm=list(tensor_2_candidate_for_transposition),
-                                    **kwargs,
-                                )
-                            elif isinstance(graph_node_input_2, np.ndarray):
-                                test_data2: np.ndarray = transpose_with_flexing_deterrence(
-                                    input_tensor=graph_node_input_2,
-                                    perm=list(tensor_2_candidate_for_transposition),
-                                    **kwargs,
-                                )
-                            else:
-                                test_data2 = None
-                        else:
-                            test_data2 = transpose_with_flexing_deterrence(
-                                input_tensor=input_tensor_2,
-                                perm=list(tensor_2_candidate_for_transposition),
-                                **kwargs,
-                            )
-                        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-                            model=tf_partial_model,
-                            inputs=tf_partial_model_inputs,
-                            verification_datas=[
-                                test_data1,
-                                test_data2,
-                            ]
-                        )
-                        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                            list(tf_partial_model_result_infos.values())[0]
-                        del tf_partial_model
-                        del tf_partial_model_inputs
-                        del tf_partial_model_outputs
-                        del test_data1
-                        del test_data2
                     break
                 except Exception as ex2:
                     pass

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -89,21 +89,21 @@ def make_node(
         ]
         if shape_for_judging_skip.count(shape_for_judging_skip[0]) != len(shape_for_judging_skip):
             if len(onnx_input_shape) == 3:
-                # 1D - Overall model
+                # 1D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 4:
-                # 2D - Overall model
+                # 2D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,1],
                     **kwargs,
                 )
             elif len(onnx_input_shape) == 5:
-                # 3D - Overall model
+                # 3D
                 input_tensor = transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
                     perm=[0,2,3,4,1],

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -17,11 +17,8 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     deterring_shape_corruption_due_to_broadcast,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -104,25 +101,6 @@ def make_node(
         **kwargs,
     )
 
-    # Acquisition of test data for validation
-    if kwargs['acc_check']:
-        if not isinstance(graph_node_input_1, np.ndarray) \
-            and graph_node_input_1.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-        elif isinstance(graph_node_input_1, np.ndarray):
-            test_data1: np.ndarray = graph_node_input_1
-        else:
-            test_data1 = None
-        if not isinstance(graph_node_input_2, np.ndarray) \
-            and graph_node_input_2.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-        elif isinstance(graph_node_input_2, np.ndarray):
-            test_data2: np.ndarray = graph_node_input_2
-        else:
-            test_data2 = None
-
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
     #   2. If only one of the two is the output of Transpose
@@ -170,20 +148,7 @@ def make_node(
             input_tensor_2=input_tensor_2,
         )
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[
-                    input_tensor_1,
-                    input_tensor_2,
-                ]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.mod(
             x=input_tensor_1 \
@@ -194,44 +159,6 @@ def make_node(
                     else tf.convert_to_tensor(input_tensor_2),
             name=graph_node.name,
         )
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.math.mod(
-                    x=tf_partial_model_inputs[0] \
-                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
-                    y=tf_partial_model_inputs[1] \
-                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data1 = None
-        if isinstance(input_tensor_1, np.ndarray):
-            test_data1 = input_tensor_1
-        test_data2 = None
-        if isinstance(input_tensor_2, np.ndarray):
-            test_data2 = input_tensor_2
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data1,
-                test_data2,
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data1
-        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -14,11 +14,9 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     transpose_with_flexing_deterrence,
 )
-from typing import Any, Dict, List
+from typing import List
 
 
 @print_node_info
@@ -182,15 +180,6 @@ def make_node(
         **kwargs,
     )
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[transposed_tensor]
-            )
-        tf_partial_model_outputs = None
-
     # Reshape
     has_undefined_outputshape = output_shape is None
     if not has_undefined_outputshape:
@@ -245,39 +234,12 @@ def make_node(
         # No-replace
         pass
 
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.reshape(
             tensor=transposed_tensor,
             shape=final_shape,
             name=graph_node.name,
         )
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.reshape(
-                    tensor=tf_partial_model_inputs[0],
-                    shape=final_shape,
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Special support for ShuffleNet patterns
     # 5D Reshape -> 5D Transpose -> 4D Reshape
@@ -302,17 +264,12 @@ def make_node(
                 and two_previous_op_output_shape[2] == one_previous_op_output_shape[1] \
                 and current_op_output_shape[1] == (one_previous_op_output_shape[1] * one_previous_op_output_shape[2]):
                 # ShuffleNet patterns - 4D only
-                ### Overall model
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     transpose_with_flexing_deterrence(
                         input_tensor=tf_layers_dict[graph_node_output.name]['tf_node'],
                         perm=[0,2,3,1],
                         **kwargs,
                     )
-                ### Partial model
-                if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-                    tf_layers_dict[graph_node_output.name]['verification_data'] = \
-                        tf_layers_dict[graph_node_output.name]['verification_data'].transpose([0,2,3,1])
             else:
                 pass
     except:

--- a/onnx2tf/ops/Sigmoid.py
+++ b/onnx2tf/ops/Sigmoid.py
@@ -12,10 +12,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -79,59 +76,12 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[input_tensor]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.nn.sigmoid(
             x=input_tensor,
             name=graph_node.name,
         )
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.nn.sigmoid(
-                    x=tf_partial_model_inputs[0],
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data = None
-        if not isinstance(input_tensor, np.ndarray):
-            if not isinstance(graph_node_input, np.ndarray) \
-                and graph_node_input.name in tf_layers_dict \
-                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-            elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = graph_node_input
-            else:
-                test_data = None
-        else:
-            test_data = input_tensor
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Sin.py
+++ b/onnx2tf/ops/Sin.py
@@ -12,10 +12,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -78,59 +75,12 @@ def make_node(
         and before_trans_shape != after_trans_shape:
         tf_layers_dict[graph_node_output.name].pop('nhwc')
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[input_tensor]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.math.sin(
             x=input_tensor,
             name=graph_node.name,
         )
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.math.sin(
-                    x=tf_partial_model_inputs[0],
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data = None
-        if not isinstance(input_tensor, np.ndarray):
-            if not isinstance(graph_node_input, np.ndarray) \
-                and graph_node_input.name in tf_layers_dict \
-                and 'verification_data' in tf_layers_dict[graph_node_input.name].keys():
-                test_data: np.ndarray = tf_layers_dict[graph_node_input.name]['verification_data']
-            elif isinstance(graph_node_input, np.ndarray):
-                test_data: np.ndarray = graph_node_input
-            else:
-                test_data = None
-        else:
-            test_data = input_tensor
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -17,12 +17,9 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     disable_unnecessary_transpose,
     shape_unmatched_special_avoidance_workaround,
-    make_tf_partial_model_inputs,
-    dummy_tf_inference,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
 )
-from typing import Any, Dict, List
 
 
 @print_node_info
@@ -104,25 +101,6 @@ def make_node(
         **kwargs,
     )
 
-    # Acquisition of test data for validation
-    if kwargs['acc_check']:
-        if not isinstance(graph_node_input_1, np.ndarray) \
-            and graph_node_input_1.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data1: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-        elif isinstance(graph_node_input_1, np.ndarray):
-            test_data1: np.ndarray = graph_node_input_1
-        else:
-            test_data1 = None
-        if not isinstance(graph_node_input_2, np.ndarray) \
-            and graph_node_input_2.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_2.name].keys():
-            test_data2: np.ndarray = tf_layers_dict[graph_node_input_2.name]['verification_data']
-        elif isinstance(graph_node_input_2, np.ndarray):
-            test_data2: np.ndarray = graph_node_input_2
-        else:
-            test_data2 = None
-
     # Disable unnecessary Transpose
     #   1. If both x and y are gs.Variable
     #   2. If only one of the two is the output of Transpose
@@ -170,20 +148,7 @@ def make_node(
             input_tensor_2=input_tensor_2,
         )
 
-    # Generate input OPs for TensorFlow subgraphs
-    # For inference testing on OP stand-alone
-    if kwargs['acc_check']:
-        tf_partial_model_inputs: List[tf.keras.Input] = \
-            make_tf_partial_model_inputs(
-                input_tensors=[
-                    input_tensor_1,
-                    input_tensor_2,
-                ]
-            )
-        tf_partial_model_outputs = None
-
     # Generation of TF OP
-    ### Overall model
     # Merge two consecutive identical OPs into one
     # https://github.com/PINTO0309/onnx2tf/issues/230
     #   A constant is calculated in advance only
@@ -211,45 +176,6 @@ def make_node(
         tf_layers_dict=tf_layers_dict,
         tf_func='Sub'
     )
-
-    ### Partial model
-    if kwargs['acc_check'] and tf_partial_model_inputs is not None:
-        tf_partial_model_outputs = \
-            [
-                tf.math.subtract(
-                    x=tf_partial_model_inputs[0] \
-                        if not isinstance(tf_partial_model_inputs[0], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[0]),
-                    y=tf_partial_model_inputs[1] \
-                        if not isinstance(tf_partial_model_inputs[1], np.ndarray) \
-                            else tf.convert_to_tensor(tf_partial_model_inputs[1]),
-                )
-            ]
-        tf_partial_model = tf.keras.Model(
-            inputs=tf_partial_model_inputs,
-            outputs=tf_partial_model_outputs,
-        )
-        test_data1 = None
-        if isinstance(input_tensor_1, np.ndarray):
-            test_data1 = input_tensor_1
-        test_data2 = None
-        if isinstance(input_tensor_2, np.ndarray):
-            test_data2 = input_tensor_2
-        tf_partial_model_result_infos: Dict[Any] = dummy_tf_inference(
-            model=tf_partial_model,
-            inputs=tf_partial_model_inputs,
-            verification_datas=[
-                test_data1,
-                test_data2,
-            ]
-        )
-        tf_layers_dict[graph_node_output.name]['verification_data'] = \
-            list(tf_partial_model_result_infos.values())[0]
-        del tf_partial_model
-        del tf_partial_model_inputs
-        del tf_partial_model_outputs
-        del test_data1
-        del test_data2
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -4549,7 +4549,6 @@ def merge_two_consecutive_identical_ops_into_one(
                     else:
                         tf_type = tf.math.multiply
 
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.multiply(
                             x=input_tensor_1 \
@@ -4562,7 +4561,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
 
                 except Exception as ex:
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.multiply(
                             x=input_tensor_1 \
@@ -4575,7 +4573,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
                     tf_type = tf.math.multiply
             else:
-                ### Overall model
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     tf.math.multiply(
                         x=input_tensor_1 \
@@ -4653,7 +4650,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     input_tensor_2 = \
                                         np.asarray(1.0, dtype=next_graph_node_input_1.dtype) / (input_tensor_2 / next_graph_node_input_1)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
-                                ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                     tf.math.multiply(
                                         x=input_tensor_1 \
@@ -4673,7 +4669,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     input_tensor_2 = \
                                         np.asarray(1.0, dtype=next_graph_node_input_2.dtype) / (input_tensor_2 / next_graph_node_input_2)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
-                                ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                     tf.math.multiply(
                                         x=input_tensor_1 \
@@ -4686,7 +4681,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     )
                                 tf_type = tf.identity
                             else:
-                                ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                     tf.math.multiply(
                                         x=input_tensor_1 \
@@ -4709,7 +4703,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     input_tensor_2 = \
                                         np.asarray(1.0, dtype=next_graph_node_input_1.dtype) / (input_tensor_2 * next_graph_node_input_1)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
-                                ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                     tf.math.multiply(
                                         x=input_tensor_1 \
@@ -4729,7 +4722,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     input_tensor_2 = \
                                         np.asarray(1.0, dtype=next_graph_node_input_2.dtype) / (input_tensor_2 * next_graph_node_input_2)
                                 tf_layers_dict[graph_node_output.name]['merge_div'] = True
-                                ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                     tf.math.multiply(
                                         x=input_tensor_1 \
@@ -4742,7 +4734,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     )
                                 tf_type = tf.identity
                             else:
-                                ### Overall model
                                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                     tf.math.divide(
                                         x=input_tensor_1 \
@@ -4755,7 +4746,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                     )
                                 tf_type = tf.math.divide
                         else:
-                            ### Overall model
                             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                                 tf.math.divide(
                                     x=input_tensor_1 \
@@ -4768,7 +4758,6 @@ def merge_two_consecutive_identical_ops_into_one(
                                 )
                             tf_type = tf.math.divide
                     else:
-                        ### Overall model
                         tf_layers_dict[graph_node_output.name]['tf_node'] = \
                             tf.math.divide(
                                 x=input_tensor_1 \
@@ -4782,7 +4771,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         tf_type = tf.math.divide
 
                 except Exception as ex:
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.divide(
                             x=input_tensor_1 \
@@ -4795,7 +4783,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
                     tf_type = tf.math.divide
             else:
-                ### Overall model
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     tf.math.divide(
                         x=input_tensor_1 \
@@ -4905,7 +4892,6 @@ def merge_two_consecutive_identical_ops_into_one(
                     else:
                         tf_type = tf.math.subtract
 
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.subtract(
                             x=input_tensor_1 \
@@ -4918,7 +4904,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
 
                 except Exception as ex:
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.subtract(
                             x=input_tensor_1 \
@@ -4931,7 +4916,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
                     tf_type = tf.math.subtract
             else:
-                ### Overall model
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     tf.math.subtract(
                         x=input_tensor_1 \
@@ -5041,7 +5025,6 @@ def merge_two_consecutive_identical_ops_into_one(
                     else:
                         tf_type = tf.math.add
 
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.add(
                             x=input_tensor_1 \
@@ -5054,7 +5037,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
 
                 except Exception as ex:
-                    ### Overall model
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
                         tf.math.add(
                             x=input_tensor_1 \
@@ -5067,7 +5049,6 @@ def merge_two_consecutive_identical_ops_into_one(
                         )
                     tf_type = tf.math.add
             else:
-                ### Overall model
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \
                     tf.math.add(
                         x=input_tensor_1 \


### PR DESCRIPTION
### 1. Content and background
- Eliminate all redundant partial graph accuracy check processes that have no prospect of being used

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
https://github.com/PINTO0309/onnx2tf/issues/145
