### PR TITLE
Fixed to never update batch size unless the batch size dimension is an undefined dimension

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.16
+  ghcr.io/pinto0309/onnx2tf:1.9.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.16'
+__version__ = '1.9.17'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3504,7 +3504,8 @@ def dummy_onnx_inference(
         for idx, dim in enumerate(input_size):
             if idx == 0 and input_sizes[0][0] is not None \
                 and not isinstance(input_sizes[0][0], str) \
-                and len(input_sizes[0]) == len(input_size):
+                and len(input_sizes[0]) == len(input_size) \
+                and dim is None or isinstance(dim, str):
                 # Batch size assignment for input OPs
                 new_input_size.append(input_sizes[0][0])
             elif dim is None or isinstance(dim, str):
@@ -3581,7 +3582,8 @@ def dummy_tf_inference(
         new_input_size = []
         for idx, dim in enumerate(input_size):
             if idx == 0 and input_sizes[0][0] is not None \
-                and len(input_sizes[0]) == len(input_size):
+                and len(input_sizes[0]) == len(input_size) \
+                and dim is None:
                 # Batch size assignment for input OPs
                 new_input_size.append(input_sizes[0][0])
             elif dim is None:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3505,7 +3505,7 @@ def dummy_onnx_inference(
             if idx == 0 and input_sizes[0][0] is not None \
                 and not isinstance(input_sizes[0][0], str) \
                 and len(input_sizes[0]) == len(input_size) \
-                and dim is None or isinstance(dim, str):
+                and (dim is None or isinstance(dim, str)):
                 # Batch size assignment for input OPs
                 new_input_size.append(input_sizes[0][0])
             elif dim is None or isinstance(dim, str):


### PR DESCRIPTION
### 1. Content and background
- `common_functions`
  - Fixed to never update batch size unless the batch size dimension is an undefined dimension

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[DN-DAB-DETR] The output of ONNX's Mul OP is different from the TFLite's output. #327](https://github.com/PINTO0309/onnx2tf/issues/327)