### PR TITLE
Modified to continue the matching process when the product of dimensions of the output geometry does not match between ONNX and TF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.18
+  ghcr.io/pinto0309/onnx2tf:1.9.19
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.18'
+__version__ = '1.9.19'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -812,43 +812,41 @@ def convert(
         # Used to verify the output error of each OP in the TensorFlow model.
         full_ops_output_names = []
         onnx_tensor_infos_for_validation = None
-        if check_onnx_tf_outputs_elementwise_close \
-            or check_onnx_tf_outputs_elementwise_close_full:
-            for graph_node in graph.nodes:
-                full_ops_output_names_sub = []
-                for graph_node_output in graph_node.outputs:
-                    full_ops_output_names_sub.append(graph_node_output.name)
-                full_ops_output_names.extend(full_ops_output_names_sub)
-            # Models with errors during inference in onnxruntime skip dummy inference.
-            try:
-                onnx_outputs_for_validation: List[np.ndarray] = dummy_onnx_inference(
-                    onnx_graph=onnx_graph,
-                    output_names=full_ops_output_names,
-                    test_data_nhwc=test_data_nhwc,
-                    custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
-                    tf_layers_dict=tf_layers_dict,
-                )
-                """
-                onnx_tensor_infos_for_validation:
-                    {
-                        onnx_output_name: np.ndarray,
-                        onnx_output_name: np.ndarray,
-                        onnx_output_name: np.ndarray,
-                                    :
-                    }
-                """
-                onnx_tensor_infos_for_validation = {
-                    ops_output_name: onnx_output_for_validation \
-                        for ops_output_name, onnx_output_for_validation \
-                            in zip(full_ops_output_names, onnx_outputs_for_validation)
+        for graph_node in graph.nodes:
+            full_ops_output_names_sub = []
+            for graph_node_output in graph_node.outputs:
+                full_ops_output_names_sub.append(graph_node_output.name)
+            full_ops_output_names.extend(full_ops_output_names_sub)
+        # Models with errors during inference in onnxruntime skip dummy inference.
+        try:
+            onnx_outputs_for_validation: List[np.ndarray] = dummy_onnx_inference(
+                onnx_graph=onnx_graph,
+                output_names=full_ops_output_names,
+                test_data_nhwc=test_data_nhwc,
+                custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                tf_layers_dict=tf_layers_dict,
+            )
+            """
+            onnx_tensor_infos_for_validation:
+                {
+                    onnx_output_name: np.ndarray,
+                    onnx_output_name: np.ndarray,
+                    onnx_output_name: np.ndarray,
+                                :
                 }
-            except Exception as ex:
-                print(
-                    f'{Color.YELLOW}WARNING:{Color.RESET} ' +\
-                    f'The optimization process for shape estimation is skipped ' +
-                    f'because it contains OPs that cannot be inferred by the standard onnxruntime.'
-                )
-                print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
+            """
+            onnx_tensor_infos_for_validation = {
+                ops_output_name: onnx_output_for_validation \
+                    for ops_output_name, onnx_output_for_validation \
+                        in zip(full_ops_output_names, onnx_outputs_for_validation)
+            }
+        except Exception as ex:
+            print(
+                f'{Color.YELLOW}WARNING:{Color.RESET} ' +\
+                f'The optimization process for shape estimation is skipped ' +
+                f'because it contains OPs that cannot be inferred by the standard onnxruntime.'
+            )
+            print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
         additional_parameters['onnx_tensor_infos_for_validation'] = onnx_tensor_infos_for_validation
         additional_parameters['test_data_nhwc'] = test_data_nhwc
         additional_parameters['custom_input_op_name_np_data_path'] = custom_input_op_name_np_data_path

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -850,6 +850,8 @@ def convert(
                 )
                 print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
         additional_parameters['onnx_tensor_infos_for_validation'] = onnx_tensor_infos_for_validation
+        additional_parameters['test_data_nhwc'] = test_data_nhwc
+        additional_parameters['custom_input_op_name_np_data_path'] = custom_input_op_name_np_data_path
 
         # Nodes
         # https://github.com/onnx/onnx/blob/main/docs/Operators.md

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -1,3 +1,5 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
@@ -14,10 +16,14 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
     transpose_with_flexing_deterrence,
+    get_tf_model_inputs,
+    dummy_tf_inference,
+    onnx_tf_tensor_validation,
 )
 from onnx2tf.utils.enums import (
     NUMPY_DTYPES_TO_TF_DTYPES,
 )
+from typing import Any, Dict, List
 
 
 @print_node_info
@@ -72,6 +78,82 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = \
+        kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = \
+        kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = \
+        kwargs['custom_input_op_name_np_data_path']
+
+    # Get the output tensor of one previous OP of TensorFlow only once
+    tf_model_inputs = get_tf_model_inputs(
+        tf_layers_dict=tf_layers_dict,
+    )
+    val_model = None
+    if not isinstance(input_tensor_1, np.ndarray) \
+        and not isinstance(input_tensor_2, np.ndarray):
+        val_model = tf.keras.Model(
+            inputs=tf_model_inputs,
+            outputs=[
+                input_tensor_1,
+                input_tensor_2,
+            ],
+        )
+    elif not isinstance(input_tensor_1, np.ndarray) \
+        and isinstance(input_tensor_2, np.ndarray):
+        val_model = tf.keras.Model(
+            inputs=tf_model_inputs,
+            outputs=[
+                input_tensor_1
+            ],
+        )
+    elif isinstance(input_tensor_1, np.ndarray) \
+        and not isinstance(input_tensor_2, np.ndarray):
+        val_model = tf.keras.Model(
+            inputs=tf_model_inputs,
+            outputs=[
+                input_tensor_2
+            ],
+        )
+
+    else:
+        # TODO: Error
+        pass
+
+    # TF dummy inference
+    #   Get the output tensor of the previous layer of MatMul
+    #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+    #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+    tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
+        model=val_model,
+        inputs=tf_model_inputs,
+        test_data_nhwc=test_data_nhwc,
+        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+    )
+    del val_model
+
+    # Get np.ndarray for validation
+    validation_data_1 = None
+    validation_data_2 = None
+    if len(tf_pre_tensor_infos) == 2:
+        validation_data_1 = list(tf_pre_tensor_infos.values())[0]
+        validation_data_2 = list(tf_pre_tensor_infos.values())[1]
+    elif len(tf_pre_tensor_infos) == 1:
+        if not isinstance(input_tensor_1, np.ndarray):
+            validation_data_1 = list(tf_pre_tensor_infos.values())[0]
+            validation_data_2 = copy.deepcopy(input_tensor_2)
+        else:
+            validation_data_1 = copy.deepcopy(input_tensor_1)
+            validation_data_2 = list(tf_pre_tensor_infos.values())[0]
+
+    # Get ONNX inference results
+    onnx_tensor_infos = None
+    if onnx_tensor_infos_for_validation is not None:
+        onnx_tensor_infos = {
+            graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+        }
+        del onnx_tensor_infos_for_validation
+
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(
         value_before_transpose=input_tensor_1,
@@ -91,46 +173,175 @@ def make_node(
 
     # Shape Unmatch Error Mitigation Measures
     # Search for and transpose shapes that do not cause shape unmatch errors
+    min_abs_err = sys.maxsize
+    min_abs_err_perm_1: int = [idx for idx in range(len(input_tensor_1.shape))]
+    min_abs_err_perm_2: int = [idx for idx in range(len(input_tensor_2.shape))]
+
+    def define_matmul(
+        *,
+        target_input_tensor_1: Any,
+        target_perm_1: List,
+        target_input_tensor_2: Any,
+        target_perm_2: List,
+        taget_output_dtype: tf.dtypes.DType,
+        target_name: str,
+        **kwargs: Dict,
+    ):
+        return \
+            tf.matmul(
+                a=transpose_with_flexing_deterrence(
+                    input_tensor=target_input_tensor_1 \
+                        if not isinstance(target_input_tensor_1, np.ndarray) \
+                            else tf.convert_to_tensor(target_input_tensor_1),
+                    perm=target_perm_1,
+                    **kwargs,
+                ),
+                b=transpose_with_flexing_deterrence(
+                    input_tensor=target_input_tensor_2 \
+                        if not isinstance(target_input_tensor_2, np.ndarray) \
+                            else tf.convert_to_tensor(target_input_tensor_2),
+                    perm=target_perm_2,
+                    **kwargs,
+                ),
+                output_type=taget_output_dtype,
+                name=target_name,
+            )
+
     tensor_1_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_1.shape))))
     tensor_2_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_2.shape))))
     for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
         for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
             try:
-                tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                    tf.matmul(
-                        a=transpose_with_flexing_deterrence(
-                            input_tensor=input_tensor_1 \
-                                if not isinstance(input_tensor_1, np.ndarray) \
-                                    else tf.convert_to_tensor(input_tensor_1),
-                            perm=list(tensor_1_candidate_for_transposition),
-                            **kwargs,
-                        ),
-                        b=transpose_with_flexing_deterrence(
-                            input_tensor=input_tensor_2 \
-                                if not isinstance(input_tensor_2, np.ndarray) \
-                                    else tf.convert_to_tensor(input_tensor_2),
-                            perm=list(tensor_2_candidate_for_transposition),
-                            **kwargs,
-                        ),
-                        output_type=output_dtype,
-                        name=graph_node.name,
-                    )
+                # Build TF dummy model
+                input_1 = tf.keras.Input(
+                    shape=validation_data_1.shape[1:],
+                    batch_size=validation_data_1.shape[0] \
+                        if isinstance(validation_data_1.shape[0], int) else None,
+                    name='dummy_input_1',
+                    dtype=validation_data_1.dtype,
+                )
+                input_2 = tf.keras.Input(
+                    shape=validation_data_2.shape[1:],
+                    batch_size=validation_data_2.shape[0] \
+                        if isinstance(validation_data_2.shape[0], int) else None,
+                    name='dummy_input_2',
+                    dtype=validation_data_2.dtype,
+                )
+                dummy_matmul = define_matmul(
+                    target_input_tensor_1=input_1,
+                    target_perm_1=list(tensor_1_candidate_for_transposition),
+                    target_input_tensor_2=input_2,
+                    target_perm_2=list(tensor_2_candidate_for_transposition),
+                    taget_output_dtype=output_dtype,
+                    target_name=graph_node.name,
+                    **kwargs
+                )
                 # Verify that the output shape matches that of ONNX
                 # If the combination of each value of a dimension is not correct,
                 # invalidate the normal processing judgment.
                 onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in onnx_output_shape])
-                matmul_output_shapes = list(tf_layers_dict[graph_node_output.name]['tf_node'].shape)
+                matmul_output_shapes = list(dummy_matmul.shape)
                 matmul_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in matmul_output_shapes])
                 if onnx_output_shape_prod != matmul_output_shape_prod:
+                    del input_1
+                    del input_2
+                    del dummy_matmul
                     continue
-                break
-            except Exception as ex1:
+
+                # Perform simple accuracy verification
+                # Terminate when the error is less than 1e-3
+                if onnx_tensor_infos is not None:
+                    try:
+                        # Search for the axis with the smallest error
+                        val_model = tf.keras.Model(
+                            inputs=[
+                                input_1,
+                                input_2,
+                            ],
+                            outputs=[
+                                dummy_matmul,
+                            ],
+                        )
+
+                        # TF dummy inference
+                        tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                            model=val_model,
+                            inputs=[
+                                input_1,
+                                input_2,
+                            ],
+                            verification_datas=[
+                                validation_data_1,
+                                validation_data_2,
+                            ],
+                        )
+                        del input_1
+                        del input_2
+                        del dummy_matmul
+                        del val_model
+
+                        # Validation
+                        onnx_tf_output_pairs = {
+                            (oi[0], ti[0]): (oi[1], ti[1]) \
+                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                        }
+                        """
+                        check_results: Dict[str, List[np.ndarray, int, float|int]]
+                            {
+                                onnx_output_name: [
+                                    onnx_tensor,
+                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                    max_abs_err,
+                                ]
+                            }
+                        """
+                        check_results = onnx_tf_tensor_validation(
+                            output_pairs=onnx_tf_output_pairs,
+                            rtol=0.0,
+                            atol=0.0,
+                        )
+                        result_err = sum([val[2] for val in check_results.values()])
+                        if result_err < min_abs_err:
+                            min_abs_err = result_err
+                            min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                            min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
+                            if min_abs_err < 1e-3:
+                                break
+                    except tf.errors.InvalidArgumentError as ex1:
+                        pass
+            except Exception as ex2:
                 pass
         else:
             continue
         break
-    if 'tf_node' not in tf_layers_dict[graph_node_output.name]:
-        raise ex1
+
+    tf_layers_dict[graph_node_output.name]['tf_node'] = \
+        define_matmul(
+            target_input_tensor_1=input_tensor_1,
+            target_perm_1=min_abs_err_perm_1,
+            target_input_tensor_2=input_tensor_2,
+            target_perm_2=min_abs_err_perm_2,
+            taget_output_dtype=output_dtype,
+            target_name=graph_node.name,
+            **kwargs
+        )
+
+    # Transpose to match ONNX output shape
+    post_matmul_shape = list(tf_layers_dict[graph_node_output.name]['tf_node'].shape)
+    if sum([1 if dim is None else 0 for dim in post_matmul_shape]) <= 1 \
+        and post_matmul_shape != list(onnx_output_shape):
+
+        post_transpose_perm = []
+        for dim in onnx_output_shape:
+            idx = post_matmul_shape.index(dim)
+            post_transpose_perm.append(idx)
+            post_matmul_shape[idx] = -999
+
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.transpose(
+                a=tf_layers_dict[graph_node_output.name]['tf_node'],
+                perm=post_transpose_perm,
+            )
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -331,6 +331,9 @@ def make_node(
     if sum([1 if dim is None else 0 for dim in post_matmul_shape]) <= 1 \
         and post_matmul_shape != list(onnx_output_shape):
 
+        onnx_output_shape = [
+            dim if not isinstance(dim, str) else None for dim in onnx_output_shape
+        ]
         post_transpose_perm = []
         for dim in onnx_output_shape:
             idx = post_matmul_shape.index(dim)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3583,6 +3583,12 @@ def dummy_tf_inference(
     test_data_nhwc: Optional[np.ndarray]
         Test Image Data
 
+    verification_datas: Optional[List[np.ndarray]]
+        Test Data
+
+    custom_input_op_name_np_data_path
+        Path to Numpy file for custom data used for dummy inference
+
     Returns
     ----------
     outputs: Dict[np.ndarray]


### PR DESCRIPTION
### 1. Content and background
- `MatMul`
  - Modified to continue the matching process when the product of dimensions of the output geometry does not match between ONNX and TF.
  - Significant updates to `MatMul` consistency auto-adjustment.
  - I have changed the `MatMul` consistency checks to be much stricter, so the transformation speed of Transformer models with large amounts of `MatMul` is significantly slower.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[InSPyReNet] Swin Transformer Support question #312](https://github.com/PINTO0309/onnx2tf/issues/312)
- [[DN-DAB-DETR] The output of ONNX's Mul OP is different from the TFLite's output. #327](https://github.com/PINTO0309/onnx2tf/issues/327)
- [[TODO] Implement a process to reduce accuracy degradation due to transposition errors in the Transformer's MatMul input values. #317](https://github.com/PINTO0309/onnx2tf/issues/317)