### PR TITLE
Speeds up `Softmax` tensor correction process

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.9.19
+  ghcr.io/pinto0309/onnx2tf:1.10.0
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.9.19'
+__version__ = '1.10.0'

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -124,12 +124,16 @@ def make_node(
     #   Get the output tensor of the previous layer of MatMul
     #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
     #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
-    tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
-        model=val_model,
-        inputs=tf_model_inputs,
-        test_data_nhwc=test_data_nhwc,
-        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
-    )
+    tf_pre_tensor_infos = {}
+    try:
+        tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
+            model=val_model,
+            inputs=tf_model_inputs,
+            test_data_nhwc=test_data_nhwc,
+            custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+        )
+    except Exception as ex:
+        pass
     del val_model
 
     # Get np.ndarray for validation
@@ -307,7 +311,7 @@ def make_node(
                             min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
                             if min_abs_err < 1e-3:
                                 break
-                    except tf.errors.InvalidArgumentError as ex1:
+                    except Exception as ex1:
                         pass
             except Exception as ex2:
                 pass

--- a/onnx2tf/ops/Pow.py
+++ b/onnx2tf/ops/Pow.py
@@ -97,12 +97,30 @@ def make_node(
                                     or "pow" in kwargs['replace_to_pseudo_operators']
 
     if not replace_power_to_pseudo_power:
-        powed_tensor = \
-            tf.math.pow(
-                x=input_tensor_1,
-                y=input_tensor_2,
-                name=graph_node.name,
-            )
+        if input_tensor_2 == 2:
+            powed_tensor = \
+                tf.math.multiply(
+                    x=input_tensor_1,
+                    y=input_tensor_1,
+                    name=graph_node.name,
+                )
+        elif input_tensor_2 == 3:
+            powed_tensor = \
+                tf.math.multiply(
+                    x=tf.math.multiply(
+                        x=input_tensor_1,
+                        y=input_tensor_1,
+                    ),
+                    y=input_tensor_1,
+                    name=graph_node.name,
+                )
+        else:
+            powed_tensor = \
+                tf.math.pow(
+                    x=input_tensor_1,
+                    y=input_tensor_2,
+                    name=graph_node.name,
+                )
     else:
         if is_integer_num(x=input_tensor_2):
             if isinstance(input_tensor_2, np.ndarray):

--- a/onnx2tf/ops/Pow.py
+++ b/onnx2tf/ops/Pow.py
@@ -97,14 +97,20 @@ def make_node(
                                     or "pow" in kwargs['replace_to_pseudo_operators']
 
     if not replace_power_to_pseudo_power:
-        if input_tensor_2 == 2:
+        if isinstance(input_tensor_2, np.ndarray) and input_tensor_2.ndim == 0 and input_tensor_2 == 2 \
+            or isinstance(input_tensor_2, np.ndarray) and input_tensor_2.ndim == 1 and np.squeeze(input_tensor_2) == 2 \
+            or isinstance(input_tensor_2, float) and input_tensor_2 == 2 \
+            or isinstance(input_tensor_2, int) and input_tensor_2 == 2:
             powed_tensor = \
                 tf.math.multiply(
                     x=input_tensor_1,
                     y=input_tensor_1,
                     name=graph_node.name,
                 )
-        elif input_tensor_2 == 3:
+        elif isinstance(input_tensor_2, np.ndarray) and input_tensor_2.ndim == 0 and input_tensor_2 == 3 \
+            or isinstance(input_tensor_2, np.ndarray) and input_tensor_2.ndim == 1 and np.squeeze(input_tensor_2) == 3 \
+            or isinstance(input_tensor_2, float) and input_tensor_2 == 3 \
+            or isinstance(input_tensor_2, int) and input_tensor_2 == 3:
             powed_tensor = \
                 tf.math.multiply(
                     x=tf.math.multiply(

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -116,12 +116,16 @@ def make_node(
     #   Get the output tensor of the previous layer of MatMul
     #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
     #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
-    tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
-        model=val_model,
-        inputs=tf_model_inputs,
-        test_data_nhwc=test_data_nhwc,
-        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
-    )
+    tf_pre_tensor_infos = {}
+    try:
+        tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
+            model=val_model,
+            inputs=tf_model_inputs,
+            test_data_nhwc=test_data_nhwc,
+            custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+        )
+    except Exception as ex:
+        pass
     del val_model
 
     # Get np.ndarray for validation
@@ -262,7 +266,7 @@ def make_node(
                     min_abs_err_axis = check_axis
                     if min_abs_err < 1e-3:
                         break
-            except tf.errors.InvalidArgumentError as ex:
+            except Exception as ex:
                 pass
 
     # Suppress automatic Traspose extrapolation behavior by Softmax in TensorFlow

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -1,4 +1,5 @@
 import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
@@ -89,6 +90,56 @@ def make_node(
                 and 'nwc_nhwc_ndhwc_keep' in tf_layers_dict[graph_node_input.name].keys() else False,
     }
 
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = \
+        kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = \
+        kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = \
+        kwargs['custom_input_op_name_np_data_path']
+
+    # Get the output tensor of one previous OP of TensorFlow only once
+    tf_model_inputs = get_tf_model_inputs(
+        tf_layers_dict=tf_layers_dict,
+    )
+    val_model = None
+    if not isinstance(input_tensor, np.ndarray):
+        val_model = tf.keras.Model(
+            inputs=tf_model_inputs,
+            outputs=[
+                input_tensor,
+            ],
+        )
+    else:
+        pass
+
+    # TF dummy inference
+    #   Get the output tensor of the previous layer of MatMul
+    #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+    #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+    tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
+        model=val_model,
+        inputs=tf_model_inputs,
+        test_data_nhwc=test_data_nhwc,
+        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+    )
+    del val_model
+
+    # Get np.ndarray for validation
+    validation_data = None
+    if len(tf_pre_tensor_infos) == 1:
+        if not isinstance(input_tensor, np.ndarray):
+            validation_data = list(tf_pre_tensor_infos.values())[0]
+        else:
+            validation_data = copy.deepcopy(input_tensor)
+
+    # Get ONNX inference results
+    onnx_tensor_infos = None
+    if onnx_tensor_infos_for_validation is not None:
+        onnx_tensor_infos = {
+            graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+        }
+        del onnx_tensor_infos_for_validation
+
     # Param replacement
     input_tensor = replace_parameter(
         value_before_replacement=input_tensor,
@@ -141,30 +192,32 @@ def make_node(
     # with the smallest possible error and replace it.
     min_abs_err = sys.maxsize
     min_abs_err_axis: int = axis
-    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = \
-        kwargs['onnx_tensor_infos_for_validation']
-    if onnx_tensor_infos_for_validation is not None:
-        onnx_tensor_infos = {
-            graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
-        }
-        del onnx_tensor_infos_for_validation
+
+    if onnx_tensor_infos is not None:
         check_axes = None
         if not error_check_unnecessary_flag:
             check_axes = reversed([idx for idx in range(tensor_rank)])
         else:
             check_axes = [axis]
-        tf_model_inputs = get_tf_model_inputs(
-            tf_layers_dict=tf_layers_dict,
-        )
+
         # Search for the axis with the smallest error
         for check_axis in check_axes:
             try:
-                ### model check
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
                 val_model = tf.keras.Model(
-                    inputs=tf_model_inputs,
+                    inputs=[
+                        input,
+                    ],
                     outputs=[
                         tf.nn.softmax(
-                            logits=input_tensor,
+                            logits=input,
                             axis=check_axis,
                             name=graph_node.name,
                         )
@@ -173,8 +226,14 @@ def make_node(
                 # TF dummy inference
                 tf_tensor_infos: Dict[Any] = dummy_tf_inference(
                     model=val_model,
-                    inputs=tf_model_inputs,
+                    inputs=[
+                        input,
+                    ],
+                    verification_datas=[
+                        validation_data,
+                    ],
                 )
+                del input
                 del val_model
 
                 # Validation


### PR DESCRIPTION
### 1. Content and background
- `Softmax`
  - Speeds up `Softmax` tensor correction process.
  - Eliminates test data mix-ups for accuracy checks.
  - Improvement of R-CNN transformation stability.
- `MatMul`
  - Improvement of R-CNN transformation stability.
- `Pow`
  - Match `Pow` behavior to onnxruntime implementation.
- mod_dn_dab_detr.onnx
  ```
  onnx2tf -i mod_dn_dab_detr.onnx -cotof
  ```
  ![image](https://user-images.githubusercontent.com/33194443/236079054-e43cc81e-bfca-419b-9910-a82ef9fdbea5.png)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[InSPyReNet] Swin Transformer Support question #312](https://github.com/PINTO0309/onnx2tf/issues/312)
- [[DN-DAB-DETR] The output of ONNX's Mul OP is different from the TFLite's output. #327](https://github.com/PINTO0309/onnx2tf/issues/327)
- [[TODO] Implement a process to reduce accuracy degradation due to transposition errors in the Transformer's MatMul input values. #317](https://github.com/PINTO0309/onnx2tf/issues/317)