### PR TITLE
Added batch size adjustment process for dummy inference when test data is specified with the `-cind` option. Also, added processing to suppress warning messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.10.1
+  ghcr.io/pinto0309/onnx2tf:1.10.2
 
   or
 
@@ -565,9 +565,16 @@ print(f'loaded_data.shape: {loaded_data.shape}') # [10,112,200,3]
 -cind INPUT_NAME NUMPY_FILE_PATH MEAN STD
 int8_calib_datas = (loaded_data - MEAN) / STD # -1.0 - 1.0
 
-e.g.
--cind pc_dep 'data/calibdata.npy' [[[[0.485, 0.456, 0.406]]]] [[[[0.229, 0.224, 0.225]]]]
--cind feat 'data/calibdata2.npy' [[[[0.123, ..., 0.321]]]] [[[[0.112, ..., 0.451]]]]
+e.g. How to specify calibration data in CLI or Script respectively.
+1. CLI
+  -cind "pc_dep" "data/calibdata.npy" [[[[0.485, 0.456, 0.406]]]] [[[[0.229, 0.224, 0.225]]]]
+  -cind "feat" "data/calibdata2.npy" [[[[0.123, ..., 0.321]]]] [[[[0.112, ..., 0.451]]]]
+
+2. Script
+  custom_input_op_name_np_data_path=[
+      ["pc_dep", "data/calibdata.npy", [[[[0.485, 0.456, 0.406]]]], [[[[0.229, 0.224, 0.225]]]]],
+      ["feat", "data/calibdata2.npy", [[[[0.123, ..., 0.321]]]], [[[[0.112, ..., 0.451]]]],
+  ]
 """
 ```
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.10.1'
+__version__ = '1.10.2'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -160,9 +160,9 @@ def convert(
         The type of the input OP must be Float32.\n
         Data for calibration must be pre-normalized to a range of 0 to 1.\n
         [\n
-            [{input_op_name: str} {numpy_file_path: str} {mean: np.ndarray} {std: np.ndarray}],\n
-            [{input_op_name: str} {numpy_file_path: str} {mean: np.ndarray} {std: np.ndarray}],\n
-            [{input_op_name: str} {numpy_file_path: str} {mean: np.ndarray} {std: np.ndarray}],\n
+            [{input_op_name: str}, {numpy_file_path: str}, {mean: np.ndarray}, {std: np.ndarray}],\n
+            [{input_op_name: str}, {numpy_file_path: str}, {mean: np.ndarray}, {std: np.ndarray}],\n
+            [{input_op_name: str}, {numpy_file_path: str}, {mean: np.ndarray}, {std: np.ndarray}],\n
             :\n
         ]\n
         Numpy file paths must be specified the same number of times as the number of input OPs.\n
@@ -200,7 +200,7 @@ def convert(
             input2: [n,5]\n
                 mean: [1] -> [0.3]\n
                 std:  [1] -> [0.07]\n
-        cind=[
+        custom_input_op_name_np_data_path=[
             ["input0","../input0.npy",[[[[0.485, 0.456, 0.406]]]],[[[[0.229, 0.224, 0.225]]]]],\n
             ["input1","./input1.npy",[0.1, ..., 0.64],[0.05, ..., 0.08]],\n
             ["input2","input2.npy",[0.3],[0.07]],\n
@@ -1062,13 +1062,13 @@ def convert(
         STD = np.asarray([[[[0.229, 0.224, 0.225]]]], dtype=np.float32)
         if output_integer_quantized_tflite:
             # Get signatures/input keys
+            loaded_saved_model = tf.saved_model.load(
+                output_folder_path
+            ).signatures[SIGNATURE_KEY]
+            input_keys = list(loaded_saved_model.structured_input_signature[1].keys())
+            input_shapes = [v.shape for v in loaded_saved_model.structured_input_signature[1].values()]
+            input_dtypes = [v.dtype for v in loaded_saved_model.structured_input_signature[1].values()]
             if not non_verbose:
-                loaded_saved_model = tf.saved_model.load(
-                    output_folder_path
-                ).signatures[SIGNATURE_KEY]
-                input_keys = list(loaded_saved_model.structured_input_signature[1].keys())
-                input_shapes = [v.shape for v in loaded_saved_model.structured_input_signature[1].values()]
-                input_dtypes = [v.dtype for v in loaded_saved_model.structured_input_signature[1].values()]
                 print(f'{Color.BLUE}Input signature information for quantization{Color.RESET}')
                 print(f'{Color.BLUE}signature_name{Color.RESET}: {SIGNATURE_KEY}')
                 for idx, (input_key, input_shape, input_dtype) in enumerate(zip(input_keys, input_shapes, input_dtypes)):
@@ -1170,8 +1170,7 @@ def convert(
                     input_op_name = str(param[0])
                     numpy_file_path = str(param[1])
                     calib_data = np.load(numpy_file_path)
-                    if data_count == 0:
-                        data_count = calib_data.shape[0]
+                    data_count = calib_data.shape[0]
                     mean = param[2]
                     std = param[3]
 

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -92,6 +92,8 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
     input_tensor_shape = input_tensor.shape
 
+    non_verbose = bool(kwargs['non_verbose'])
+
     # Pre-process transpose
     input_tensor = pre_process_transpose(
         value_before_transpose=input_tensor,
@@ -246,11 +248,12 @@ def make_node(
     # 2. when extra padding layer is not added and count_include_pad is True
     # 3. when last stride has extra padding due to ceil_mode and count_include_pad is True
     if is_explicit_padding and tf_pads != [0] * spatial_size * 2:
-        warning_msg = \
-            f'{Color.YELLOW}WARNING:{Color.RESET} ' \
-            f'Tensorflow incompatible padding detected. ' \
-            f'Extra pad layer is inserted automatically. '
-        print(warning_msg)
+        if not non_verbose:
+            warning_msg = \
+                f'{Color.YELLOW}WARNING:{Color.RESET} ' \
+                f'Tensorflow incompatible padding detected. ' \
+                f'Extra pad layer is inserted automatically. '
+            print(warning_msg)
 
         if auto_pad == 'SAME_LOWER':
             # switch the order of pads
@@ -340,13 +343,14 @@ def make_node(
     # tensorflow average pooling needs extra process to get same output with onnx
     # https://github.com/PINTO0309/onnx2tf/issues/124
     if average_multiplier is not None:
-        warning_msg = \
-            f'{Color.YELLOW}WARNING:{Color.RESET} ' \
-            f'Tensorflow incompatible action detected. ' \
-            f'Some additional layers are inserted to reproduce same output. ' \
-            f'Please refer to the following link for more information: ' \
-            f'https://github.com/PINTO0309/onnx2tf/issues/124'
-        print(warning_msg)
+        if not non_verbose:
+            warning_msg = \
+                f'{Color.YELLOW}WARNING:{Color.RESET} ' \
+                f'Tensorflow incompatible action detected. ' \
+                f'Some additional layers are inserted to reproduce same output. ' \
+                f'Please refer to the following link for more information: ' \
+                f'https://github.com/PINTO0309/onnx2tf/issues/124'
+            print(warning_msg)
 
         average_multiplier = summarize_multiplier(average_multiplier)
 

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -60,6 +60,8 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
     input_tensor_shape = input_tensor.shape
 
+    non_verbose = bool(kwargs['non_verbose'])
+
     # Pre-process transpose
     input_tensor = pre_process_transpose(
         value_before_transpose=input_tensor,
@@ -199,11 +201,12 @@ def make_node(
 
     # add extra pad layer if needed
     if is_explicit_padding and tf_pads != [0] * spatial_size * 2:
-        warning_msg = \
-            f'{Color.YELLOW}WARNING:{Color.RESET} ' \
-            f'Tensorflow incompatible padding detected. ' \
-            f'Extra pad layer is inserted automatically. '
-        print(warning_msg)
+        if not non_verbose:
+            warning_msg = \
+                f'{Color.YELLOW}WARNING:{Color.RESET} ' \
+                f'Tensorflow incompatible padding detected. ' \
+                f'Extra pad layer is inserted automatically. '
+            print(warning_msg)
 
         if auto_pad == 'SAME_LOWER':
             # switch the order of pads

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3540,6 +3540,13 @@ def dummy_onnx_inference(
                 ncw_nchw_ncdhw_perm: List = input_op_info.get('ncw_nchw_ncdhw_perm', None)
                 if ncw_nchw_ncdhw_perm is not None:
                     custom_input_data = custom_input_data.transpose(ncw_nchw_ncdhw_perm)
+                onnx_batch_size = input_op_info['shape'][0]
+                cdata_batch_size = custom_input_data.shape[0]
+                if isinstance(onnx_batch_size, int) and onnx_batch_size != cdata_batch_size and cdata_batch_size > 1:
+                    custom_input_data = custom_input_data[0:onnx_batch_size, ...]
+                elif isinstance(onnx_batch_size, str) and cdata_batch_size > 1:
+                    custom_input_data = custom_input_data[0:1, ...]
+
             input_datas[input_op_name] = custom_input_data
 
     else:
@@ -3623,6 +3630,13 @@ def dummy_tf_inference(
             numpy_file_path = str(param[1])
             custom_input_data = np.load(numpy_file_path)
             input_size = input_sizes[idx]
+
+            tf_batch_size = input_size[0]
+            cdata_batch_size = custom_input_data.shape[0]
+            if isinstance(tf_batch_size, int) and tf_batch_size != cdata_batch_size and cdata_batch_size > 1:
+                custom_input_data = custom_input_data[0:tf_batch_size, ...]
+            elif tf_batch_size is None and cdata_batch_size > 1:
+                custom_input_data = custom_input_data[0:1, ...]
 
             if list(custom_input_data.shape) != input_size:
                 error_msg = f'' + \


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf`, `common_functions`
  - Added batch size adjustment process for dummy inference when test data is specified with the `-cind` option.
- `AveragePool`, `MaxPool`
  - Added processing to suppress warning messages.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Several problems when INT8-quantizing with calibration data #339](https://github.com/PINTO0309/onnx2tf/issues/339)