### PR TITLE
Fixed README wording for `-cind` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.10.2
+  ghcr.io/pinto0309/onnx2tf:1.10.3
 
   or
 
@@ -915,8 +915,8 @@ optional arguments:
         input2: [n,5]
             mean: [1] -> [0.3]
             std:  [1] -> [0.07]
-      -cind "input0" "../input0.npy" "[[[[0.485, 0.456, 0.406]]]]" "[[[[0.229, 0.224, 0.225]]]]"
-      -cind "input1" "./input1.npy" "[0.1, ..., 0.64]" "[0.05, ..., 0.08]"
+      -cind "input0" "../input0.npy" "[[[[0.485,0.456,0.406]]]]" "[[[[0.229,0.224,0.225]]]]"
+      -cind "input1" "./input1.npy" "[0.1,...,0.64]" "[0.05,...,0.08]"
       -cind "input2" "input2.npy" "[0.3]" "[0.07]"
 
     <Using -cotof and -oiqt at the same time>

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.10.2'
+__version__ = '1.10.3'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1646,9 +1646,9 @@ def main():
             '   input2: [n,5] \n' +
             '       mean: [1] -> [0.3] \n' +
             '       std:  [1] -> [0.07] \n' +
-            '-cind "input0" "../input0.npy" [[[[0.485, 0.456, 0.406]]]] [[[[0.229, 0.224, 0.225]]]] \n' +
-            '-cind "input1" "./input1.npy" [0.1, ..., 0.64] [0.05, ..., 0.08] \n' +
-            '-cind "input2" "input2.npy" [0.3] [0.07] \n\n' +
+            '-cind "input0" "../input0.npy" "[[[[0.485,0.456,0.406]]]]" "[[[[0.229,0.224,0.225]]]]" \n' +
+            '-cind "input1" "./input1.npy" "[0.1,...,0.64]" "[0.05,...,0.08]" \n' +
+            '-cind "input2" "input2.npy" "[0.3]" "[0.07]" \n\n' +
             '\n<Using -cotof and -oiqt at the same time> \n' +
             'To use -cotof and -oiqt simultaneously, \n' +
             'you need to enter the Input name of OP, path of data file, mean, and std all together. \n' +


### PR DESCRIPTION
### 1. Content and background
- Fixed README wording for `-cind` option.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Several problems when INT8-quantizing with calibration data #339](https://github.com/PINTO0309/onnx2tf/issues/339)