### PR TITLE
Added automatic correction function for conversion accuracy errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.10.3
+  ghcr.io/pinto0309/onnx2tf:1.11.0
 
   or
 
@@ -795,6 +795,7 @@ usage: onnx2tf
 [-dsft]
 [-nodaftc]
 [-dsfs]
+[-dsm]
 [-nodafsc]
 [-ofgd]
 [-rari64 | -rarf32 | -rafi64 | -raff32]
@@ -1027,6 +1028,13 @@ optional arguments:
   -dsfs, --disable_suppression_flexstridedslice
     Disables FlexStridedSlice generation suppression.
 
+  -dsm, --disable_strict_mode
+    If specified, the conversion speed is greatly accelerated because the strict accuracy
+    correction process is skipped, but the frequency of transposition errors increases
+    and accuracy errors are more likely to occur. Strict mode is enabled by default.
+    As of 2023.05.07, this is a work in progress and is an experimental feature.
+    Therefore, only some OPs are converted in exact mode for accuracy correction.
+
   -nodafsc, --number_of_dimensions_after_flexstridedslice_compression
     Number of StridedSlice OP dimensions generated after avoiding FlexStridedSlice generation.
     Default: 5
@@ -1232,6 +1240,7 @@ convert(
   disable_suppression_flextranspose: Optional[bool] = False,
   number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
   disable_suppression_flexstridedslice: Optional[bool] = False,
+  disable_strict_mode: Optional[bool] = False,
   number_of_dimensions_after_flexstridedslice_compression: Optional[int] = 5,
   optimization_for_gpu_delegate: Optional[bool] = False,
   replace_argmax_to_reducemax_and_indicies_is_int64: Union[bool, NoneType] = False,
@@ -1283,7 +1292,7 @@ convert(
       Output model in TF v1 (.pb) format.
 
     output_weights: Optional[bool]
-        Output weights in hdf5 format.
+      Output weights in hdf5 format.
 
     copy_onnx_input_output_names_to_tflite: Optional[bool]
       Copy the input/output OP name of ONNX to the input/output OP name of tflite.
@@ -1404,20 +1413,20 @@ convert(
       Ignores batch_size if specified at the same time as batch_size.
 
     no_large_tensor: Optional[bool]
-        Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim.
-        See: https://github.com/daquexian/onnx-simplifier/issues/178
+      Suppresses constant bloat caused by Tile OP when optimizing models in onnxsim.
+      See: https://github.com/daquexian/onnx-simplifier/issues/178
 
     output_nms_with_dynamic_tensor: Optional[bool]
-        The number of bounding boxes in the NMS output results is
-        not fixed at the maximum number of max_output_boxes_per_class,
-        but rather at the smallest possible number of dynamic tensors.
-        If this option is disabled, NMS output is padded to the number
-        set in the max_output_boxes_per_class attribute.
-        e.g.
-        disable --output_nms_with_dynamic_tensor:
-            output_tensor_shape: [100, 7]
-        enable --output_nms_with_dynamic_tensor:
-            output_tensor_shape: [N, 7]
+      The number of bounding boxes in the NMS output results is
+      not fixed at the maximum number of max_output_boxes_per_class,
+      but rather at the smallest possible number of dynamic tensors.
+      If this option is disabled, NMS output is padded to the number
+      set in the max_output_boxes_per_class attribute.
+      e.g.
+      disable --output_nms_with_dynamic_tensor:
+          output_tensor_shape: [100, 7]
+      enable --output_nms_with_dynamic_tensor:
+          output_tensor_shape: [N, 7]
 
     keep_ncw_or_nchw_or_ncdhw_input_names: Optional[List[str]]
       Holds the NCW or NCHW or NCDHW of the input shape for the specified INPUT OP names.
@@ -1436,10 +1445,10 @@ convert(
       keep_nwc_or_nhwc_or_ndhwc_input_names=['input0','input1','input2']
 
     keep_shape_absolutely_input_names: Optional[List[str]]
-        Name of the INPUT that unconditionally maintains its shape.
-        If a nonexistent INPUT OP name is specified, it is ignored.
-        e.g.
-        keep_shape_absolutely_input_names=['input0','input1','input2']
+      Name of the INPUT that unconditionally maintains its shape.
+      If a nonexistent INPUT OP name is specified, it is ignored.
+      e.g.
+      keep_shape_absolutely_input_names=['input0','input1','input2']
 
     output_names_to_interrupt_model_conversion: Optional[List[str]]
       Output names that interrupt model conversion.
@@ -1470,15 +1479,22 @@ convert(
       Default: 6
 
     disable_suppression_flexstridedslice: Optional[bool]
-        Disables FlexStridedSlice generation suppression.
+      Disables FlexStridedSlice generation suppression.
+
+    disable_strict_mode: Optional[bool]
+      If specified, the conversion speed is greatly accelerated because the strict accuracy
+      correction process is skipped, but the frequency of transposition errors increases
+      and accuracy errors are more likely to occur. Strict mode is enabled by default.
+      As of 2023.05.07, this is a work in progress and is an experimental feature.
+      Therefore, only some OPs are converted in strict mode for accuracy correction.
 
     number_of_dimensions_after_flexstridedslice_compression: Optional[int]
-        Number of StridedSlice OP dimensions generated after avoiding FlexStridedSlice generation.
-        Default: 5
+      Number of StridedSlice OP dimensions generated after avoiding FlexStridedSlice generation.
+      Default: 5
 
     optimization_for_gpu_delegate: Optional[bool]
-        Replace operations that do not support gpu delegate with those
-        that do as much as possible.
+      Replace operations that do not support gpu delegate with those
+      that do as much as possible.
 
     replace_argmax_to_reducemax_and_indicies_is_int64: Optional[bool]
       Replace ArgMax with a ReduceMax. The returned indicies are int64.

--- a/json_samples/replace_InSPyReNet.json
+++ b/json_samples/replace_InSPyReNet.json
@@ -11,8 +11,6 @@
       "param_name": "axis",
       "values": 3
     },
-
-
     {
       "op_name": "/model/backbone/layers.3/blocks.0/Reshape",
       "param_target": "inputs",
@@ -20,30 +18,10 @@
       "pre_process_transpose_perm": [0,2,1]
     },
     {
-      "op_name": "/model/backbone/layers.3/blocks.0/Add",
-      "param_target": "outputs",
-      "param_name": "/model/backbone/layers.3/blocks.0/Add_output_0",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "/model/backbone/layers.3/blocks.0/mlp/fc2/Add",
-      "param_target": "outputs",
-      "param_name": "/model/backbone/layers.3/blocks.0/mlp/fc2/Add_output_0",
-      "post_process_transpose_perm": [0,2,1]
-    },
-
-
-    {
-      "op_name": "/model/backbone/layers.3/blocks.1/Reshape_9",
-      "param_target": "outputs",
-      "param_name": "/model/backbone/layers.3/blocks.1/Reshape_9_output_0",
-      "post_process_transpose_perm": [0,2,1]
-    },
-    {
-      "op_name": "/model/backbone/layers.3/blocks.1/mlp/fc2/Add",
-      "param_target": "outputs",
-      "param_name": "/model/backbone/layers.3/blocks.1/mlp/fc2/Add_output_0",
-      "post_process_transpose_perm": [0,2,1]
+    "op_name": "/model/backbone/layers.3/blocks.0/Add",
+    "param_target": "outputs",
+    "param_name": "/model/backbone/layers.3/blocks.0/Add_output_0",
+    "post_process_transpose_perm": [0,2,1]
     }
   ]
 }

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.10.3'
+__version__ = '1.11.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -80,6 +80,7 @@ def convert(
     enable_batchmatmul_unfold: Optional[bool] = False,
     enable_rnn_unroll: Optional[bool] = False,
     disable_suppression_flextranspose: Optional[bool] = False,
+    disable_strict_mode: Optional[bool] = False,
     number_of_dimensions_after_flextranspose_compression: Optional[int] = 6,
     disable_suppression_flexstridedslice: Optional[bool] = False,
     number_of_dimensions_after_flexstridedslice_compression: Optional[int] = 5,
@@ -293,6 +294,11 @@ def convert(
 
     disable_suppression_flextranspose: Optional[bool]
         Disables FlexTranspose generation suppression.
+
+    disable_strict_mode: Optional[bool]
+        If specified, the conversion speed is greatly accelerated because the strict accuracy\n
+        correction process is skipped, but the frequency of transposition errors increases\n
+        and accuracy errors are more likely to occur. Strict mode is enabled by default.
 
     number_of_dimensions_after_flextranspose_compression: Optional[int]
         Number of Transpose OP dimensions generated after avoiding FlexTranspose generation.\n
@@ -703,6 +709,7 @@ def convert(
         'disable_suppression_flextranspose': disable_suppression_flextranspose,
         'number_of_dimensions_after_flextranspose_compression': number_of_dimensions_after_flextranspose_compression,
         'disable_suppression_flexstridedslice': disable_suppression_flexstridedslice,
+        'disable_strict_mode': disable_strict_mode,
         'number_of_dimensions_after_flexstridedslice_compression': number_of_dimensions_after_flexstridedslice_compression,
         'optimization_for_gpu_delegate': optimization_for_gpu_delegate,
         'replace_argmax_to_reducemax_and_indicies_is_int64': replace_argmax_to_reducemax_and_indicies_is_int64,
@@ -1829,6 +1836,15 @@ def main():
             'Disables FlexStridedSlice generation suppression.'
     )
     parser.add_argument(
+        '-dsm',
+        '--disable_strict_mode',
+        action='store_true',
+        help=\
+            'If specified, the conversion speed is greatly accelerated because the strict accuracy \n' +
+            'correction process is skipped, but the frequency of transposition errors increases \n' +
+            'and accuracy errors are more likely to occur. Strict mode is enabled by default.'
+    )
+    parser.add_argument(
         '-nodafsc',
         '--number_of_dimensions_after_flexstridedslice_compression',
         type=int,
@@ -2081,6 +2097,7 @@ def main():
         enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
         enable_rnn_unroll=args.enable_rnn_unroll,
         disable_suppression_flextranspose=args.disable_suppression_flextranspose,
+        disable_strict_mode=args.disable_strict_mode,
         number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
         disable_suppression_flexstridedslice=args.disable_suppression_flexstridedslice,
         number_of_dimensions_after_flexstridedslice_compression=args.number_of_dimensions_after_flexstridedslice_compression,

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -81,6 +81,8 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Param replacement
     input_tensor_1 = replace_parameter(
         value_before_replacement=input_tensor_1,
@@ -157,16 +159,17 @@ def make_node(
         )
 
     # Correction process for accuracy errors
-    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_func=tf.math.add,
-        np_func=np.add,
-        graph_node_output_shape=graph_node_output_shape,
-        graph_node_output=graph_node_output,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    if not disable_strict_mode:
+        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_func=tf.math.add,
+            np_func=np.add,
+            graph_node_output_shape=graph_node_output_shape,
+            graph_node_output=graph_node_output,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Generation of TF OP
     # Merge two consecutive identical OPs into one

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -1,7 +1,10 @@
+import sys
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
+import collections
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -19,7 +22,12 @@ from onnx2tf.utils.common_functions import (
     shape_unmatched_special_avoidance_workaround,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
+    acquisition_of_validation_data,
+    onnx_tf_tensor_validation,
+    obtaining_an_inverted_pattern_for_brute_force_validation,
+    correction_process_for_accuracy_errors,
 )
+from typing import Any, Dict
 
 
 @print_node_info
@@ -147,6 +155,18 @@ def make_node(
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
         )
+
+    # Correction process for accuracy errors
+    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        tf_func=tf.math.add,
+        np_func=np.add,
+        graph_node_output_shape=graph_node_output_shape,
+        graph_node_output=graph_node_output,
+        tf_layers_dict=tf_layers_dict,
+        **kwargs,
+    )
 
     # Generation of TF OP
     # Merge two consecutive identical OPs into one

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -74,6 +74,8 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Param replacement
     input_tensor_1 = replace_parameter(
         value_before_replacement=input_tensor_1,
@@ -150,16 +152,17 @@ def make_node(
         )
 
     # Correction process for accuracy errors
-    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_func=tf.math.divide,
-        np_func=np.divide,
-        graph_node_output_shape=graph_node_output_shape,
-        graph_node_output=graph_node_output,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    if not disable_strict_mode:
+        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_func=tf.math.divide,
+            np_func=np.divide,
+            graph_node_output_shape=graph_node_output_shape,
+            graph_node_output=graph_node_output,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Generation of TF OP
     target_cast_dtype = [

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -19,6 +19,7 @@ from onnx2tf.utils.common_functions import (
     shape_unmatched_special_avoidance_workaround,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
+    correction_process_for_accuracy_errors,
 )
 
 
@@ -147,6 +148,18 @@ def make_node(
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
         )
+
+    # Correction process for accuracy errors
+    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        tf_func=tf.math.divide,
+        np_func=np.divide,
+        graph_node_output_shape=graph_node_output_shape,
+        graph_node_output=graph_node_output,
+        tf_layers_dict=tf_layers_dict,
+        **kwargs,
+    )
 
     # Generation of TF OP
     target_cast_dtype = [

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -77,19 +77,16 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
-    disable_strict_mode: bool = kwargs['disable_strict_mode']
-
     # Obtain ONNX inference results and
     # TensorFlow inference results up to the previous layer of TensorFlow
-    if not disable_strict_mode:
-        onnx_tensor_infos, validation_data_1, validation_data_2 = \
-            acquisition_of_validation_data(
-                input_tensor_1=input_tensor_1,
-                input_tensor_2=input_tensor_2,
-                graph_node_output=graph_node_output,
-                tf_layers_dict=tf_layers_dict,
-                **kwargs,
-            )
+    onnx_tensor_infos, validation_data_1, validation_data_2 = \
+        acquisition_of_validation_data(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            graph_node_output=graph_node_output,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(
@@ -144,119 +141,118 @@ def make_node(
                 name=target_name,
             )
 
-    if not disable_strict_mode:
-        tensor_1_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_1.shape))))
-        if len(input_tensor_1.shape) == 3:
-            tensor_1_candidate_for_transpositions = tensor_1_candidate_for_transpositions[:2]
-        tensor_2_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_2.shape))))
-        if len(input_tensor_2.shape) == 3:
-            tensor_2_candidate_for_transpositions = tensor_2_candidate_for_transpositions[:2]
+    tensor_1_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_1.shape))))
+    if len(input_tensor_1.shape) == 3:
+        tensor_1_candidate_for_transpositions = tensor_1_candidate_for_transpositions[:2]
+    tensor_2_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_2.shape))))
+    if len(input_tensor_2.shape) == 3:
+        tensor_2_candidate_for_transpositions = tensor_2_candidate_for_transpositions[:2]
 
-        for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
-            for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
-                try:
-                    # Build TF dummy model
-                    input_1 = tf.keras.Input(
-                        shape=validation_data_1.shape[1:],
-                        batch_size=validation_data_1.shape[0] \
-                            if isinstance(validation_data_1.shape[0], int) else None,
-                        name='dummy_input_1',
-                        dtype=validation_data_1.dtype,
-                    )
-                    input_2 = tf.keras.Input(
-                        shape=validation_data_2.shape[1:],
-                        batch_size=validation_data_2.shape[0] \
-                            if isinstance(validation_data_2.shape[0], int) else None,
-                        name='dummy_input_2',
-                        dtype=validation_data_2.dtype,
-                    )
-                    dummy_matmul = define_matmul(
-                        target_input_tensor_1=input_1,
-                        target_perm_1=list(tensor_1_candidate_for_transposition),
-                        target_input_tensor_2=input_2,
-                        target_perm_2=list(tensor_2_candidate_for_transposition),
-                        taget_output_dtype=output_dtype,
-                        target_name=graph_node.name,
-                        **kwargs
-                    )
-                    # Verify that the output shape matches that of ONNX
-                    # If the combination of each value of a dimension is not correct,
-                    # invalidate the normal processing judgment.
-                    onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in onnx_output_shape])
-                    matmul_output_shapes = list(dummy_matmul.shape)
-                    matmul_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in matmul_output_shapes])
-                    if onnx_output_shape_prod != matmul_output_shape_prod:
+    for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
+        for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
+            try:
+                # Build TF dummy model
+                input_1 = tf.keras.Input(
+                    shape=validation_data_1.shape[1:],
+                    batch_size=validation_data_1.shape[0] \
+                        if isinstance(validation_data_1.shape[0], int) else None,
+                    name='dummy_input_1',
+                    dtype=validation_data_1.dtype,
+                )
+                input_2 = tf.keras.Input(
+                    shape=validation_data_2.shape[1:],
+                    batch_size=validation_data_2.shape[0] \
+                        if isinstance(validation_data_2.shape[0], int) else None,
+                    name='dummy_input_2',
+                    dtype=validation_data_2.dtype,
+                )
+                dummy_matmul = define_matmul(
+                    target_input_tensor_1=input_1,
+                    target_perm_1=list(tensor_1_candidate_for_transposition),
+                    target_input_tensor_2=input_2,
+                    target_perm_2=list(tensor_2_candidate_for_transposition),
+                    taget_output_dtype=output_dtype,
+                    target_name=graph_node.name,
+                    **kwargs
+                )
+                # Verify that the output shape matches that of ONNX
+                # If the combination of each value of a dimension is not correct,
+                # invalidate the normal processing judgment.
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in onnx_output_shape])
+                matmul_output_shapes = list(dummy_matmul.shape)
+                matmul_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in matmul_output_shapes])
+                if onnx_output_shape_prod != matmul_output_shape_prod:
+                    del input_1
+                    del input_2
+                    del dummy_matmul
+                    continue
+
+                # Perform simple accuracy verification
+                # Terminate when the error is less than 1e-3
+                if onnx_tensor_infos:
+                    try:
+                        # Search for the axis with the smallest error
+                        val_model = tf.keras.Model(
+                            inputs=[
+                                input_1,
+                                input_2,
+                            ],
+                            outputs=[
+                                dummy_matmul,
+                            ],
+                        )
+
+                        # TF dummy inference
+                        tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                            model=val_model,
+                            inputs=[
+                                input_1,
+                                input_2,
+                            ],
+                            verification_datas=[
+                                validation_data_1,
+                                validation_data_2,
+                            ],
+                        )
                         del input_1
                         del input_2
                         del dummy_matmul
-                        continue
+                        del val_model
 
-                    # Perform simple accuracy verification
-                    # Terminate when the error is less than 1e-3
-                    if onnx_tensor_infos:
-                        try:
-                            # Search for the axis with the smallest error
-                            val_model = tf.keras.Model(
-                                inputs=[
-                                    input_1,
-                                    input_2,
-                                ],
-                                outputs=[
-                                    dummy_matmul,
-                                ],
-                            )
-
-                            # TF dummy inference
-                            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                                model=val_model,
-                                inputs=[
-                                    input_1,
-                                    input_2,
-                                ],
-                                verification_datas=[
-                                    validation_data_1,
-                                    validation_data_2,
-                                ],
-                            )
-                            del input_1
-                            del input_2
-                            del dummy_matmul
-                            del val_model
-
-                            # Validation
-                            onnx_tf_output_pairs = {
-                                (oi[0], ti[0]): (oi[1], ti[1]) \
-                                    for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                        # Validation
+                        onnx_tf_output_pairs = {
+                            (oi[0], ti[0]): (oi[1], ti[1]) \
+                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                        }
+                        """
+                        check_results: Dict[str, List[np.ndarray, int, float|int]]
+                            {
+                                onnx_output_name: [
+                                    onnx_tensor,
+                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                    max_abs_err,
+                                ]
                             }
-                            """
-                            check_results: Dict[str, List[np.ndarray, int, float|int]]
-                                {
-                                    onnx_output_name: [
-                                        onnx_tensor,
-                                        matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
-                                        max_abs_err,
-                                    ]
-                                }
-                            """
-                            check_results = onnx_tf_tensor_validation(
-                                output_pairs=onnx_tf_output_pairs,
-                                rtol=0.0,
-                                atol=0.0,
-                            )
-                            result_err = sum([val[2] for val in check_results.values()])
-                            if result_err < min_abs_err:
-                                min_abs_err = result_err
-                                min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
-                                min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
-                                if min_abs_err < 1e-3:
-                                    break
-                        except Exception as ex1:
-                            pass
-                except Exception as ex2:
-                    pass
-            else:
-                continue
-            break
+                        """
+                        check_results = onnx_tf_tensor_validation(
+                            output_pairs=onnx_tf_output_pairs,
+                            rtol=0.0,
+                            atol=0.0,
+                        )
+                        result_err = sum([val[2] for val in check_results.values()])
+                        if result_err < min_abs_err:
+                            min_abs_err = result_err
+                            min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                            min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
+                            if min_abs_err < 1e-3:
+                                break
+                    except Exception as ex1:
+                        pass
+            except Exception as ex2:
+                pass
+        else:
+            continue
+        break
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         define_matmul(

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -77,16 +77,19 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Obtain ONNX inference results and
     # TensorFlow inference results up to the previous layer of TensorFlow
-    onnx_tensor_infos, validation_data_1, validation_data_2 = \
-        acquisition_of_validation_data(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-            graph_node_output=graph_node_output,
-            tf_layers_dict=tf_layers_dict,
-            **kwargs,
-        )
+    if not disable_strict_mode:
+        onnx_tensor_infos, validation_data_1, validation_data_2 = \
+            acquisition_of_validation_data(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+                graph_node_output=graph_node_output,
+                tf_layers_dict=tf_layers_dict,
+                **kwargs,
+            )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(
@@ -141,118 +144,119 @@ def make_node(
                 name=target_name,
             )
 
-    tensor_1_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_1.shape))))
-    if len(input_tensor_1.shape) == 3:
-        tensor_1_candidate_for_transpositions = tensor_1_candidate_for_transpositions[:2]
-    tensor_2_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_2.shape))))
-    if len(input_tensor_2.shape) == 3:
-        tensor_2_candidate_for_transpositions = tensor_2_candidate_for_transpositions[:2]
+    if not disable_strict_mode:
+        tensor_1_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_1.shape))))
+        if len(input_tensor_1.shape) == 3:
+            tensor_1_candidate_for_transpositions = tensor_1_candidate_for_transpositions[:2]
+        tensor_2_candidate_for_transpositions = list(itertools.permutations(range(len(input_tensor_2.shape))))
+        if len(input_tensor_2.shape) == 3:
+            tensor_2_candidate_for_transpositions = tensor_2_candidate_for_transpositions[:2]
 
-    for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
-        for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
-            try:
-                # Build TF dummy model
-                input_1 = tf.keras.Input(
-                    shape=validation_data_1.shape[1:],
-                    batch_size=validation_data_1.shape[0] \
-                        if isinstance(validation_data_1.shape[0], int) else None,
-                    name='dummy_input_1',
-                    dtype=validation_data_1.dtype,
-                )
-                input_2 = tf.keras.Input(
-                    shape=validation_data_2.shape[1:],
-                    batch_size=validation_data_2.shape[0] \
-                        if isinstance(validation_data_2.shape[0], int) else None,
-                    name='dummy_input_2',
-                    dtype=validation_data_2.dtype,
-                )
-                dummy_matmul = define_matmul(
-                    target_input_tensor_1=input_1,
-                    target_perm_1=list(tensor_1_candidate_for_transposition),
-                    target_input_tensor_2=input_2,
-                    target_perm_2=list(tensor_2_candidate_for_transposition),
-                    taget_output_dtype=output_dtype,
-                    target_name=graph_node.name,
-                    **kwargs
-                )
-                # Verify that the output shape matches that of ONNX
-                # If the combination of each value of a dimension is not correct,
-                # invalidate the normal processing judgment.
-                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in onnx_output_shape])
-                matmul_output_shapes = list(dummy_matmul.shape)
-                matmul_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in matmul_output_shapes])
-                if onnx_output_shape_prod != matmul_output_shape_prod:
-                    del input_1
-                    del input_2
-                    del dummy_matmul
-                    continue
-
-                # Perform simple accuracy verification
-                # Terminate when the error is less than 1e-3
-                if onnx_tensor_infos:
-                    try:
-                        # Search for the axis with the smallest error
-                        val_model = tf.keras.Model(
-                            inputs=[
-                                input_1,
-                                input_2,
-                            ],
-                            outputs=[
-                                dummy_matmul,
-                            ],
-                        )
-
-                        # TF dummy inference
-                        tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                            model=val_model,
-                            inputs=[
-                                input_1,
-                                input_2,
-                            ],
-                            verification_datas=[
-                                validation_data_1,
-                                validation_data_2,
-                            ],
-                        )
+        for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
+            for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
+                try:
+                    # Build TF dummy model
+                    input_1 = tf.keras.Input(
+                        shape=validation_data_1.shape[1:],
+                        batch_size=validation_data_1.shape[0] \
+                            if isinstance(validation_data_1.shape[0], int) else None,
+                        name='dummy_input_1',
+                        dtype=validation_data_1.dtype,
+                    )
+                    input_2 = tf.keras.Input(
+                        shape=validation_data_2.shape[1:],
+                        batch_size=validation_data_2.shape[0] \
+                            if isinstance(validation_data_2.shape[0], int) else None,
+                        name='dummy_input_2',
+                        dtype=validation_data_2.dtype,
+                    )
+                    dummy_matmul = define_matmul(
+                        target_input_tensor_1=input_1,
+                        target_perm_1=list(tensor_1_candidate_for_transposition),
+                        target_input_tensor_2=input_2,
+                        target_perm_2=list(tensor_2_candidate_for_transposition),
+                        taget_output_dtype=output_dtype,
+                        target_name=graph_node.name,
+                        **kwargs
+                    )
+                    # Verify that the output shape matches that of ONNX
+                    # If the combination of each value of a dimension is not correct,
+                    # invalidate the normal processing judgment.
+                    onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in onnx_output_shape])
+                    matmul_output_shapes = list(dummy_matmul.shape)
+                    matmul_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in matmul_output_shapes])
+                    if onnx_output_shape_prod != matmul_output_shape_prod:
                         del input_1
                         del input_2
                         del dummy_matmul
-                        del val_model
+                        continue
 
-                        # Validation
-                        onnx_tf_output_pairs = {
-                            (oi[0], ti[0]): (oi[1], ti[1]) \
-                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
-                        }
-                        """
-                        check_results: Dict[str, List[np.ndarray, int, float|int]]
-                            {
-                                onnx_output_name: [
-                                    onnx_tensor,
-                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
-                                    max_abs_err,
-                                ]
+                    # Perform simple accuracy verification
+                    # Terminate when the error is less than 1e-3
+                    if onnx_tensor_infos:
+                        try:
+                            # Search for the axis with the smallest error
+                            val_model = tf.keras.Model(
+                                inputs=[
+                                    input_1,
+                                    input_2,
+                                ],
+                                outputs=[
+                                    dummy_matmul,
+                                ],
+                            )
+
+                            # TF dummy inference
+                            tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                                model=val_model,
+                                inputs=[
+                                    input_1,
+                                    input_2,
+                                ],
+                                verification_datas=[
+                                    validation_data_1,
+                                    validation_data_2,
+                                ],
+                            )
+                            del input_1
+                            del input_2
+                            del dummy_matmul
+                            del val_model
+
+                            # Validation
+                            onnx_tf_output_pairs = {
+                                (oi[0], ti[0]): (oi[1], ti[1]) \
+                                    for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
                             }
-                        """
-                        check_results = onnx_tf_tensor_validation(
-                            output_pairs=onnx_tf_output_pairs,
-                            rtol=0.0,
-                            atol=0.0,
-                        )
-                        result_err = sum([val[2] for val in check_results.values()])
-                        if result_err < min_abs_err:
-                            min_abs_err = result_err
-                            min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
-                            min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
-                            if min_abs_err < 1e-3:
-                                break
-                    except Exception as ex1:
-                        pass
-            except Exception as ex2:
-                pass
-        else:
-            continue
-        break
+                            """
+                            check_results: Dict[str, List[np.ndarray, int, float|int]]
+                                {
+                                    onnx_output_name: [
+                                        onnx_tensor,
+                                        matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                        max_abs_err,
+                                    ]
+                                }
+                            """
+                            check_results = onnx_tf_tensor_validation(
+                                output_pairs=onnx_tf_output_pairs,
+                                rtol=0.0,
+                                atol=0.0,
+                            )
+                            result_err = sum([val[2] for val in check_results.values()])
+                            if result_err < min_abs_err:
+                                min_abs_err = result_err
+                                min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                                min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
+                                if min_abs_err < 1e-3:
+                                    break
+                        except Exception as ex1:
+                            pass
+                except Exception as ex2:
+                    pass
+            else:
+                continue
+            break
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         define_matmul(

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -18,6 +18,7 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
     deterring_shape_corruption_due_to_broadcast,
+    correction_process_for_accuracy_errors,
 )
 
 
@@ -147,6 +148,18 @@ def make_node(
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
         )
+
+    # Correction process for accuracy errors
+    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        tf_func=tf.math.mod,
+        np_func=np.mod,
+        graph_node_output_shape=graph_node_output_shape,
+        graph_node_output=graph_node_output,
+        tf_layers_dict=tf_layers_dict,
+        **kwargs,
+    )
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -74,6 +74,8 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Param replacement
     input_tensor_1 = replace_parameter(
         value_before_replacement=input_tensor_1,
@@ -150,16 +152,17 @@ def make_node(
         )
 
     # Correction process for accuracy errors
-    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_func=tf.math.mod,
-        np_func=np.mod,
-        graph_node_output_shape=graph_node_output_shape,
-        graph_node_output=graph_node_output,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    if not disable_strict_mode:
+        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_func=tf.math.mod,
+            np_func=np.mod,
+            graph_node_output_shape=graph_node_output_shape,
+            graph_node_output=graph_node_output,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -75,6 +75,8 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Param replacement
     input_tensor_1 = replace_parameter(
         value_before_replacement=input_tensor_1,
@@ -158,16 +160,17 @@ def make_node(
         )
 
     # Correction process for accuracy errors
-    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_func=tf.math.multiply,
-        np_func=np.multiply,
-        graph_node_output_shape=graph_node_output_shape,
-        graph_node_output=graph_node_output,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    if not disable_strict_mode:
+        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_func=tf.math.multiply,
+            np_func=np.multiply,
+            graph_node_output_shape=graph_node_output_shape,
+            graph_node_output=graph_node_output,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Generation of TF OP
     # TODO: Temporarily Revert due to missing decision conditions

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -20,6 +20,7 @@ from onnx2tf.utils.common_functions import (
     broadcast_for_gpu_delegate,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
+    correction_process_for_accuracy_errors,
 )
 
 
@@ -155,6 +156,18 @@ def make_node(
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
         )
+
+    # Correction process for accuracy errors
+    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        tf_func=tf.math.multiply,
+        np_func=np.multiply,
+        graph_node_output_shape=graph_node_output_shape,
+        graph_node_output=graph_node_output,
+        tf_layers_dict=tf_layers_dict,
+        **kwargs,
+    )
 
     # Generation of TF OP
     # TODO: Temporarily Revert due to missing decision conditions

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -90,59 +90,60 @@ def make_node(
                 and 'nwc_nhwc_ndhwc_keep' in tf_layers_dict[graph_node_input.name].keys() else False,
     }
 
-    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = \
-        kwargs['onnx_tensor_infos_for_validation']
-    test_data_nhwc: np.ndarray = \
-        kwargs['test_data_nhwc']
-    custom_input_op_name_np_data_path: str = \
-        kwargs['custom_input_op_name_np_data_path']
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
 
     # Get the output tensor of one previous OP of TensorFlow only once
-    tf_model_inputs = get_tf_model_inputs(
-        tf_layers_dict=tf_layers_dict,
-    )
-    val_model = None
-    if not isinstance(input_tensor, np.ndarray):
-        val_model = tf.keras.Model(
-            inputs=tf_model_inputs,
-            outputs=[
-                input_tensor,
-            ],
+    if not disable_strict_mode:
+        tf_model_inputs = get_tf_model_inputs(
+            tf_layers_dict=tf_layers_dict,
         )
-    else:
-        pass
+        val_model = None
+        if not isinstance(input_tensor, np.ndarray):
+            val_model = tf.keras.Model(
+                inputs=tf_model_inputs,
+                outputs=[
+                    input_tensor,
+                ],
+            )
+        else:
+            pass
 
     # TF dummy inference
     #   Get the output tensor of the previous layer of MatMul
     #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
     #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
     tf_pre_tensor_infos = {}
-    try:
-        tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
-            model=val_model,
-            inputs=tf_model_inputs,
-            test_data_nhwc=test_data_nhwc,
-            custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
-        )
-    except Exception as ex:
-        pass
-    del val_model
+    if not disable_strict_mode:
+        try:
+            tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
+                model=val_model,
+                inputs=tf_model_inputs,
+                test_data_nhwc=test_data_nhwc,
+                custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+            )
+        except Exception as ex:
+            pass
+        del val_model
 
     # Get np.ndarray for validation
     validation_data = None
-    if len(tf_pre_tensor_infos) == 1:
-        if not isinstance(input_tensor, np.ndarray):
-            validation_data = list(tf_pre_tensor_infos.values())[0]
-        else:
-            validation_data = copy.deepcopy(input_tensor)
+    if not disable_strict_mode:
+        if len(tf_pre_tensor_infos) == 1:
+            if not isinstance(input_tensor, np.ndarray):
+                validation_data = list(tf_pre_tensor_infos.values())[0]
+            else:
+                validation_data = copy.deepcopy(input_tensor)
 
-    # Get ONNX inference results
-    onnx_tensor_infos = None
-    if onnx_tensor_infos_for_validation is not None:
-        onnx_tensor_infos = {
-            graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
-        }
-        del onnx_tensor_infos_for_validation
+        # Get ONNX inference results
+        onnx_tensor_infos = None
+        if onnx_tensor_infos_for_validation is not None:
+            onnx_tensor_infos = {
+                graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+            }
+            del onnx_tensor_infos_for_validation
 
     # Param replacement
     input_tensor = replace_parameter(
@@ -197,77 +198,78 @@ def make_node(
     min_abs_err = sys.maxsize
     min_abs_err_axis: int = axis
 
-    if onnx_tensor_infos is not None:
-        check_axes = None
-        if not error_check_unnecessary_flag:
-            check_axes = reversed([idx for idx in range(tensor_rank)])
-        else:
-            check_axes = [axis]
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None:
+            check_axes = None
+            if not error_check_unnecessary_flag:
+                check_axes = reversed([idx for idx in range(tensor_rank)])
+            else:
+                check_axes = [axis]
 
-        # Search for the axis with the smallest error
-        for check_axis in check_axes:
-            try:
-                # Build TF dummy model
-                input = tf.keras.Input(
-                    shape=validation_data.shape[1:],
-                    batch_size=validation_data.shape[0] \
-                        if isinstance(validation_data.shape[0], int) else None,
-                    name='dummy_input',
-                    dtype=validation_data.dtype,
-                )
-                val_model = tf.keras.Model(
-                    inputs=[
-                        input,
-                    ],
-                    outputs=[
-                        tf.nn.softmax(
-                            logits=input,
-                            axis=check_axis,
-                            name=graph_node.name,
-                        )
-                    ],
-                )
-                # TF dummy inference
-                tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                    model=val_model,
-                    inputs=[
-                        input,
-                    ],
-                    verification_datas=[
-                        validation_data,
-                    ],
-                )
-                del input
-                del val_model
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                try:
+                    # Build TF dummy model
+                    input = tf.keras.Input(
+                        shape=validation_data.shape[1:],
+                        batch_size=validation_data.shape[0] \
+                            if isinstance(validation_data.shape[0], int) else None,
+                        name='dummy_input',
+                        dtype=validation_data.dtype,
+                    )
+                    val_model = tf.keras.Model(
+                        inputs=[
+                            input,
+                        ],
+                        outputs=[
+                            tf.nn.softmax(
+                                logits=input,
+                                axis=check_axis,
+                                name=graph_node.name,
+                            )
+                        ],
+                    )
+                    # TF dummy inference
+                    tf_tensor_infos: Dict[Any] = dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                    del input
+                    del val_model
 
-                # Validation
-                onnx_tf_output_pairs = {
-                    (oi[0], ti[0]): (oi[1], ti[1]) \
-                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
-                }
-                """
-                check_results: Dict[str, List[np.ndarray, int, float|int]]
-                    {
-                        onnx_output_name: [
-                            onnx_tensor,
-                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
-                            max_abs_err,
-                        ]
+                    # Validation
+                    onnx_tf_output_pairs = {
+                        (oi[0], ti[0]): (oi[1], ti[1]) \
+                            for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
                     }
-                """
-                check_results = onnx_tf_tensor_validation(
-                    output_pairs=onnx_tf_output_pairs,
-                    rtol=0.0,
-                    atol=0.0,
-                )
-                result_err = sum([val[2] for val in check_results.values()])
-                if result_err < min_abs_err:
-                    min_abs_err = result_err
-                    min_abs_err_axis = check_axis
-                    if min_abs_err < 1e-3:
-                        break
-            except Exception as ex:
-                pass
+                    """
+                    check_results: Dict[str, List[np.ndarray, int, float|int]]
+                        {
+                            onnx_output_name: [
+                                onnx_tensor,
+                                matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                max_abs_err,
+                            ]
+                        }
+                    """
+                    check_results = onnx_tf_tensor_validation(
+                        output_pairs=onnx_tf_output_pairs,
+                        rtol=0.0,
+                        atol=0.0,
+                    )
+                    result_err = sum([val[2] for val in check_results.values()])
+                    if result_err < min_abs_err:
+                        min_abs_err = result_err
+                        min_abs_err_axis = check_axis
+                        if min_abs_err < 1e-3:
+                            break
+                except Exception as ex:
+                    pass
 
     # Suppress automatic Traspose extrapolation behavior by Softmax in TensorFlow
     flex_deterrent_perm_rev = []

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -19,6 +19,7 @@ from onnx2tf.utils.common_functions import (
     shape_unmatched_special_avoidance_workaround,
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
+    correction_process_for_accuracy_errors,
 )
 
 
@@ -147,6 +148,18 @@ def make_node(
             input_tensor_1=input_tensor_1,
             input_tensor_2=input_tensor_2,
         )
+
+    # Correction process for accuracy errors
+    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+        input_tensor_1=input_tensor_1,
+        input_tensor_2=input_tensor_2,
+        tf_func=tf.math.subtract,
+        np_func=np.subtract,
+        graph_node_output_shape=graph_node_output_shape,
+        graph_node_output=graph_node_output,
+        tf_layers_dict=tf_layers_dict,
+        **kwargs,
+    )
 
     # Generation of TF OP
     # Merge two consecutive identical OPs into one

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -74,6 +74,8 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Param replacement
     input_tensor_1 = replace_parameter(
         value_before_replacement=input_tensor_1,
@@ -150,16 +152,17 @@ def make_node(
         )
 
     # Correction process for accuracy errors
-    input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_func=tf.math.subtract,
-        np_func=np.subtract,
-        graph_node_output_shape=graph_node_output_shape,
-        graph_node_output=graph_node_output,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    if not disable_strict_mode:
+        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_func=tf.math.subtract,
+            np_func=np.subtract,
+            graph_node_output_shape=graph_node_output_shape,
+            graph_node_output=graph_node_output,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Generation of TF OP
     # Merge two consecutive identical OPs into one

--- a/tests/test_model_convert.py
+++ b/tests/test_model_convert.py
@@ -113,6 +113,7 @@ def _report_convert_model(file_path):
             input_onnx_file_path=file_path,
             output_folder_path=_CFG['output_directory'],
             output_nms_with_dynamic_tensor=True,
+            disable_strict_mode=True,
             non_verbose=True,
         )
         os.remove(file_path)


### PR DESCRIPTION
### 1. Content and background
- `Add`, `Sub`, `Mul`, `Div`, `Mod`
  - Added automatic correction function for conversion accuracy errors
  - Conversion speed is reduced instead of compensating for accuracy errors
- `Add`, `Sub`, `Mul`, `Div`, `Mod`, `MatMul`, `Softmax`
  - Strict conversion mode implemented
  - As of 2023.05.07, this is a work in progress and is an experimental feature.
- Added option to disable strict conversion mode
  - `-dsm`, `--disable_strict_mode`
    ```
    -dsm, --disable_strict_mode
      If specified, the conversion speed is greatly accelerated because the strict accuracy
      correction process is skipped, but the frequency of transposition errors increases
      and accuracy errors are more likely to occur. Strict mode is enabled by default.
      As of 2023.05.07, this is a work in progress and is an experimental feature.
      Therefore, only some OPs are converted in exact mode for accuracy correction.
    ```
- Enable `-dsm` to greatly reduce the time to complete testing, as CI testing only checks the conversion structure.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[InSPyReNet] Swin Transformer Support question #312](https://github.com/PINTO0309/onnx2tf/issues/312)