### PR TITLE
Fix to onnx==1.13.1 because onnxruntime does not support IR9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install pip -U \
-    && pip install -U onnx \
+    && pip install -U onnx==1.13.1 \
     && pip install -U onnxsim==0.4.17 \
     && python3 -m pip install -U onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com \
     && pip install -U onnx2tf \

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.11.1
+  ghcr.io/pinto0309/onnx2tf:1.11.2
 
   or
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ or
   !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
   !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 2
   !python3.9 -m pip install tensorflow==2.12.0 \
-    && python3.9 -m pip install -U onnx \
+    && python3.9 -m pip install -U onnx==1.13.1 \
     && python3.9 -m pip install -U nvidia-pyindex \
     && python3.9 -m pip install -U onnx-graphsurgeon \
     && python3.9 -m pip install -U onnxruntime==1.13.1 \

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 
   or
 
-  $ pip install -U onnx \
+  $ pip install -U onnx==1.13.1 \
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
   && pip install -U onnxruntime==1.13.1 \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.11.1'
+__version__ = '1.11.2'


### PR DESCRIPTION
### 1. Content and background
- Fix to onnx==1.13.1 because onnxruntime does not support IR9
  ```
  ONNX and TF output value validation started =========================================
  INFO: validation_conditions: np.allclose(onnx_outputs, tf_outputs, rtol=0.0, atol=0.0001, equal_nan=True)
  WARNING: The accuracy error measurement process was skipped because
  the standard onnxruntime contains OPs that cannot be inferred.
  WARNING: [ONNXRuntimeError] : 2 : INVALID_ARGUMENT : Failed to load model with error: 
  /home/user/workdir/onnxruntime/onnxruntime/core/graph/model.cc:146 
  onnxruntime::Model::Model(onnx::ModelProto&&, const PathString&,
  const IOnnxRuntimeOpSchemaRegistryList*, const onnxruntime::logging::Logger&,
  const onnxruntime::ModelOptions&) Unsupported model IR version: 9, max supported IR version: 8
  ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
