### PR TITLE
Expanding the types of target OPs for which NHWC information is inherited to reduce the frequency of conversion errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.11.2
+  ghcr.io/pinto0309/onnx2tf:1.11.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.11.2'
+__version__ = '1.11.3'

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -26,6 +26,7 @@ from onnx2tf.utils.common_functions import (
     onnx_tf_tensor_validation,
     obtaining_an_inverted_pattern_for_brute_force_validation,
     correction_process_for_accuracy_errors,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 from typing import Any, Dict
 
@@ -74,6 +75,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': graph_node_output_shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \

--- a/onnx2tf/ops/BatchNormalization.py
+++ b/onnx2tf/ops/BatchNormalization.py
@@ -86,6 +86,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[X.name]['nhwc'] \
+            if isinstance(X, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[X.name].keys() else False
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -20,6 +20,7 @@ from onnx2tf.utils.common_functions import (
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
     correction_process_for_accuracy_errors,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -67,6 +68,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': graph_node_output_shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -139,6 +139,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -19,6 +19,7 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     deterring_shape_corruption_due_to_broadcast,
     correction_process_for_accuracy_errors,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -66,6 +67,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': graph_node_output_shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -21,6 +21,7 @@ from onnx2tf.utils.common_functions import (
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
     correction_process_for_accuracy_errors,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -68,6 +69,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': graph_node_output_shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -20,6 +20,7 @@ from onnx2tf.utils.common_functions import (
     merge_two_consecutive_identical_ops_into_one,
     deterring_shape_corruption_due_to_broadcast,
     correction_process_for_accuracy_errors,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -67,6 +68,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': graph_node_output_shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5499,3 +5499,41 @@ def correction_process_for_accuracy_errors(
                         del validation_data_1
                         del validation_data_2
     return input_tensor_1, input_tensor_2
+
+
+def nhwc_determination_of_output_value_of_binary_input_op(
+    *,
+    graph_node_input_1: Any,
+    graph_node_input_2: Any,
+    tf_layers_dict: Dict,
+):
+    """NHWC determination of output value of binary input OP.
+
+    Parameters
+    ----------
+    graph_node_input_1: Any
+        Input variable to be verified
+
+    graph_node_input_2: Any
+        Input variable to be verified
+
+    tf_layers_dict: Dict
+        TensorFlow Model Structure Dictionary
+
+    Returns
+    -------
+    NHWC or not NHWC: bool
+        True: "NHWC"
+        False: not "NHWC"
+    """
+    is_output_nhwc_1 = \
+        tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
+
+    is_output_nhwc_2 = \
+        tf_layers_dict[graph_node_input_2.name]['nhwc'] \
+            if isinstance(graph_node_input_2, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_2.name].keys() else False
+
+    return is_output_nhwc_1 or is_output_nhwc_2


### PR DESCRIPTION
### 1. Content and background
- `Add`, `Div`, `Mul`, `Mod`, `Sub`, `BatchNormalization`, `LayerNormalization`
  - Expanding the types of target OPs for which NHWC information is inherited to reduce the frequency of conversion errors.
- Reduce the frequency of JSON descriptions for injection.
- However, if the model contains undefined dimensions, it will not be highly effective.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Dimension mismatch with Netron visualization and tflite actual outputs shape #351](https://github.com/PINTO0309/onnx2tf/issues/351)