### PR TITLE
Expanding the types of target OPs for which NHWC information is inherited to reduce the frequency of conversion errors. Part.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.11.3
+  ghcr.io/pinto0309/onnx2tf:1.11.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.11.3'
+__version__ = '1.11.4'

--- a/onnx2tf/ops/And.py
+++ b/onnx2tf/ops/And.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Equal.py
+++ b/onnx2tf/ops/Equal.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Greater.py
+++ b/onnx2tf/ops/Greater.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/GreaterOrEqual.py
+++ b/onnx2tf/ops/GreaterOrEqual.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Less.py
+++ b/onnx2tf/ops/Less.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/LessOrEqual.py
+++ b/onnx2tf/ops/LessOrEqual.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/Or.py
+++ b/onnx2tf/ops/Or.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -60,6 +61,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Generation of TF OP


### PR DESCRIPTION
### 1. Content and background
- `And`, `Equal`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Or`
  - Expanding the types of target OPs for which NHWC information is inherited to reduce the frequency of conversion errors. Part.2

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Dimension mismatch with Netron visualization and tflite actual outputs shape #351](https://github.com/PINTO0309/onnx2tf/issues/351)