### PR TITLE
Implemented a workaround for a problem where the TFLite runtime produces heavily corrupted output when it receives INT64 `paddings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.11.6
+  ghcr.io/pinto0309/onnx2tf:1.11.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.11.6'
+__version__ = '1.11.7'

--- a/onnx2tf/ops/Pad.py
+++ b/onnx2tf/ops/Pad.py
@@ -195,6 +195,13 @@ def make_node(
     }
 
     # Generation of TF OP
+    # Workaround for problem with TFLite runtime outputting anomalous values with INT64 padding specification
+    # https://github.com/PINTO0309/onnx2tf/issues/351
+    if isinstance(paddings, np.ndarray):
+        paddings = tf.cast(tf.convert_to_tensor(paddings), dtype=tf.int32)
+    else:
+        paddings = tf.cast(paddings, dtype=tf.int32)
+
     if mode != 'edge':
         # mode != 'edge'
         tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `Pad`
  - Implemented a workaround for a problem where the TFLite runtime produces heavily corrupted output when it receives INT64 `paddings`.
  - This is a fix for a rather critical bug.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Dimension mismatch with Netron visualization and tflite actual outputs shape #351](https://github.com/PINTO0309/onnx2tf/issues/351)