### PR TITLE
Fixed to sanitize all error messages to be more understandable to avoid confusion caused by error messages related to TensorFlow bug that does not allow `GroupConvolution` to be output to saved_model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.11.10
+  ghcr.io/pinto0309/onnx2tf:1.11.11
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.11.10'
+__version__ = '1.11.11'


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf`
  - Fixed to sanitize all error messages to be more understandable to avoid confusion caused by error messages related to TensorFlow bug that does not allow `GroupConvolution` to be output to saved_model.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[PaddleOCR] Unable to convert paddleOCR model to tensorflow/keras only tflite #360](https://github.com/PINTO0309/onnx2tf/issues/360)