### PR TITLE
TF v2.12.0 -> TF v2.13.0-rc0

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -12,6 +12,17 @@ jobs:
   conversion-test:
     runs-on: ubuntu-20.04
     steps:
+    - name: Check space before cleanup
+      run: df -h
+    - name: Clean space as per https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -q --filter "reference=node*")
+        docker rmi $(docker image ls -q --filter "reference=buildpack*")
+        docker rmi $(docker image ls -q --filter "reference=debian*")
+        docker rmi $(docker image ls -q --filter "reference=alpine*")
+        df -h
     - name: Set Swap Space
       uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
       with:

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -26,7 +26,7 @@ jobs:
         pip install pip -U
         pip install cmake==3.22.5
         pip install onnx==1.13.1
-        pip install tensorflow==2.12.0
+        pip install tensorflow==2.13.0rc0
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon
         pip install protobuf==3.20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN pip install pip -U \
     && pip install -U onnx2tf \
     && pip install -U onnx2tf \
     && pip install -U simple_onnx_processing_tools \
-    && pip install tensorflow==2.12.0 \
+    && pip install tensorflow==2.13.0rc0 \
     && pip install protobuf==3.20.3 \
     && pip install h5py==3.7.0 \
     && pip install -U onnxruntime==1.13.1 \

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - onnx-simplifier==0.4.17 See: https://github.com/PINTO0309/onnx2tf/issues/312
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
-- tensorflow==2.12.0
+- tensorflow==2.13.0rc0
 - flatbuffers-compiler (Optional, Only when using the `-coion` option. Executable file named `flatc`.)
   ```bash
   # Custom flatc binary for Ubuntu 20.04+
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.11.11
+  ghcr.io/pinto0309/onnx2tf:1.12.0
 
   or
 
@@ -279,7 +279,7 @@ or
     && python3.9 -m pip install -U distlib
   !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 1
   !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 2
-  !python3.9 -m pip install tensorflow==2.12.0 \
+  !python3.9 -m pip install tensorflow==2.13.0rc0 \
     && python3.9 -m pip install -U onnx==1.13.1 \
     && python3.9 -m pip install -U nvidia-pyindex \
     && python3.9 -m pip install -U onnx-graphsurgeon \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.11.11'
+__version__ = '1.12.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -906,7 +906,7 @@ def convert(
             try:
                 if not non_verbose:
                     print(f'{Color.REVERCE}h5 output started{Color.RESET}', '=' * 67)
-                model.save(f'{output_folder_path}/{output_file_name}_float32.h5')
+                model.save(f'{output_folder_path}/{output_file_name}_float32.h5', save_format='h5')
                 if not non_verbose:
                     print(f'{Color.GREEN}h5 output complete!{Color.RESET}')
             except ValueError as e:


### PR DESCRIPTION
### 1. Content and background
- TF v2.12.0 -> TF v2.13.0-rc0
- https://github.com/tensorflow/tensorflow/releases/tag/v2.13.0-rc0

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Verification of operation when upgrading to TensorFlow v1.13.0 #348](https://github.com/PINTO0309/onnx2tf/issues/348)