### PR TITLE
Correction of 3D Resize shape acquisition process

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.12.0
+  ghcr.io/pinto0309/onnx2tf:1.12.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.12.0'
+__version__ = '1.12.1'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1068,9 +1068,9 @@ def upsampling3d_bicubic(
     half_pixel_centers,
     name,
 ):
-    d = new_size.shape[0]
-    h = new_size.shape[1]
-    w = new_size.shape[2]
+    d = new_size[0]
+    h = new_size[1]
+    w = new_size[2]
     # Dpeth (height x width)
     resized_list = []
     unstack_img_list = tf.unstack(input_tensor, axis=1)
@@ -1108,9 +1108,9 @@ def upsampling3d_nearest(
     half_pixel_centers,
     name,
 ):
-    d = new_size.shape[0]
-    h = new_size.shape[1]
-    w = new_size.shape[2]
+    d = new_size[0]
+    h = new_size[1]
+    w = new_size[2]
     # Dpeth (height x width)
     resized_list = []
     unstack_img_list = tf.unstack(input_tensor, axis=1)


### PR DESCRIPTION
### 1. Content and background
- `common_functions`
  - Correction of 3D Resize shape acquisition process
  - `upsampling3d_bicubic`, `upsampling3d_nearest`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Support 5D input for operator Resize #362](https://github.com/PINTO0309/onnx2tf/issues/362)