### PR TITLE
Revert TF v2.13.0-rc0 -> TF v2.12.0

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -37,7 +37,7 @@ jobs:
         pip install pip -U
         pip install cmake==3.22.5
         pip install onnx==1.13.1
-        pip install tensorflow==2.13.0rc0
+        pip install tensorflow==2.12.0
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon
         pip install protobuf==3.20.3


### PR DESCRIPTION
### 1. Content and background
- `CI`
  - Revert TF v2.13.0-rc0 -> TF v2.12.0
  - The processing performance of TensorFlow v2.13.0-rc0 appears to have deteriorated considerably, so we reverted back to v2.12.0.
  - Originally the whole regression test took 40 minutes, but as soon as I changed to v2.13.0-rc0 it took 2 hours and 30 minutes.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
