### PR TITLE
Upgrade to onnxruntime 1.15.0 and increase inference speed with onnxruntime

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         pip install pip -U
         pip install cmake==3.22.5
+        pip install psutil==5.9.5
         pip install onnx==1.13.1
         pip install tensorflow==2.13.0rc0
         pip install nvidia-pyindex
@@ -43,7 +44,7 @@ jobs:
         pip install protobuf==3.20.3
         pip install onnxsim==0.4.17
         pip install sng4onnx
-        pip install onnxruntime==1.13.1
+        pip install onnxruntime==1.15.0
         pip install -e .
     - name: Download models
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,18 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install pip -U \
-    && pip install -U onnx==1.13.1 \
-    && pip install -U onnxsim==0.4.17 \
-    && python3 -m pip install -U onnx_graphsurgeon --index-url https://pypi.ngc.nvidia.com \
-    && pip install -U onnx2tf \
-    && pip install -U onnx2tf \
-    && pip install -U simple_onnx_processing_tools \
+    && pip install onnx==1.13.1 \
+    && pip install onnxsim==0.4.17 \
+    && pip install nvidia-pyindex \
+    && pip install onnx_graphsurgeon \
+    && pip install onnx2tf \
+    && pip install onnx2tf \
+    && pip install simple_onnx_processing_tools \
     && pip install tensorflow==2.13.0rc0 \
     && pip install protobuf==3.20.3 \
     && pip install h5py==3.7.0 \
-    && pip install -U onnxruntime==1.13.1 \
+    && pip install psutil==5.9.5 \
+    && pip install onnxruntime==1.15.0 \
     && python -m pip cache purge
 
 # Re-release flatc with some customizations of our own to address

--- a/README.md
+++ b/README.md
@@ -217,11 +217,12 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 
 ## Environment
 - onnx==1.13.1
-- onnxruntime==1.13.1 See: [When using onnxruntime v1.14.1, all output values of Sigmoid are Nan. #14885](https://github.com/microsoft/onnxruntime/issues/14885)
+- onnxruntime==1.15.0
 - onnx-simplifier==0.4.17 See: https://github.com/PINTO0309/onnx2tf/issues/312
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
 - tensorflow==2.13.0rc0
+- psutil==5.9.5
 - flatbuffers-compiler (Optional, Only when using the `-coion` option. Executable file named `flatc`.)
   ```bash
   # Custom flatc binary for Ubuntu 20.04+
@@ -244,18 +245,19 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.12.7
+  ghcr.io/pinto0309/onnx2tf:1.13.0
 
   or
 
   $ pip install -U onnx==1.13.1 \
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
-  && pip install -U onnxruntime==1.13.1 \
+  && pip install -U onnxruntime==1.15.0 \
   && pip install -U onnxsim==0.4.17 \
   && pip install -U simple_onnx_processing_tools \
   && pip install -U onnx2tf \
-  && pip install -U h5py==3.7.0
+  && pip install -U h5py==3.7.0 \
+  && pip install -U psutil==5.9.5
 
   or
 
@@ -286,12 +288,13 @@ or
     && python3.9 -m pip install -U onnx==1.13.1 \
     && python3.9 -m pip install -U nvidia-pyindex \
     && python3.9 -m pip install -U onnx-graphsurgeon \
-    && python3.9 -m pip install -U onnxruntime==1.13.1 \
+    && python3.9 -m pip install -U onnxruntime==1.15.0 \
     && python3.9 -m pip install -U onnxsim==0.4.17 \
     && python3.9 -m pip install -U simple_onnx_processing_tools \
     && python3.9 -m pip install -U onnx2tf \
     && python3.9 -m pip install -U protobuf==3.20.3 \
-    && python3.9 -m pip install -U h5py==3.7.0
+    && python3.9 -m pip install -U h5py==3.7.0 \
+    && python3.9 -m pip install -U psutil==5.9.5
   ```
 
 ### 2. Run test

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.12.7'
+__version__ = '1.13.0'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -4,6 +4,7 @@ import io
 import sys
 import copy
 import json
+import psutil
 import random
 import requests
 random.seed(0)
@@ -3517,8 +3518,11 @@ def dummy_onnx_inference(
 
     new_onnx_graph = gs.export_onnx(gs_graph)
     serialized_graph = onnx._serialize(new_onnx_graph)
+    sess_options = ort.SessionOptions()
+    sess_options.intra_op_num_threads = psutil.cpu_count(logical=True) - 1
     onnx_session = ort.InferenceSession(
         path_or_bytes=serialized_graph,
+        sess_options=sess_options,
         providers=['CPUExecutionProvider'],
     )
     onnx_inputs = gs_graph.inputs


### PR DESCRIPTION
### 1. Content and background
- `onnxruntime`
  - Upgrade to onnxruntime 1.15.0
  - Increase inference speed with onnxruntime
    - `(upper limit of the number of logical cores in the CPU - 1)` threads are launched for parallel inference, improving the speed of dummy inference.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
