### PR TITLE
Improvements to reduce processing time for CI

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   conversion-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check space before cleanup
       run: df -h

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.1
+  ghcr.io/pinto0309/onnx2tf:1.13.2
 
   or
 
@@ -844,6 +844,7 @@ usage: onnx2tf
 [-coton]
 [-cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL]
 [-cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL]
+[-dms]
 [-n]
 
 optional arguments:
@@ -1235,6 +1236,9 @@ optional arguments:
     The absolute tolerance parameter.
     Default: 1e-4
 
+  -dms, --disable_model_save
+    Does not save the converted model. For CIs RAM savings.
+
   -n, --non_verbose
     Do not show all information logs. Only error logs are displayed.
 ```
@@ -1293,6 +1297,7 @@ convert(
   check_onnx_tf_outputs_sample_data_normalization: Optional[str] = 'norm',
   check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
   check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
+  disable_model_save: Union[bool, NoneType] = False,
   non_verbose: Union[bool, NoneType] = False
 ) -> keras.engine.training.Model
 
@@ -1651,44 +1656,48 @@ convert(
       """
 
     check_onnx_tf_outputs_elementwise_close: Optional[bool]
-        Returns "Matches" if the output of onnx and the output of TF are
-        within acceptable proximity element by element.
-        Returns "Unmatched" if the output of onnx and the output of TF are
-        not within acceptable proximity element by element.
-        If the output of onnx is 1D, it returns "Skipped" and skips the comparison
-        between the output of onnx and that of TF. This is because when undefined
-        dimensions are present, a situation often arises where very large index
-        values are compared, causing OutOfMemory.
-        Only the output content of the models final output OP is checked.
+      Returns "Matches" if the output of onnx and the output of TF are
+      within acceptable proximity element by element.
+      Returns "Unmatched" if the output of onnx and the output of TF are
+      not within acceptable proximity element by element.
+      If the output of onnx is 1D, it returns "Skipped" and skips the comparison
+      between the output of onnx and that of TF. This is because when undefined
+      dimensions are present, a situation often arises where very large index
+      values are compared, causing OutOfMemory.
+      Only the output content of the models final output OP is checked.
 
     check_onnx_tf_outputs_elementwise_close_full: Optional[bool]
-        Returns "Matches" if the output of onnx and the output of TF are
-        within acceptable proximity element by element.
-        Check the output of all OPs in sequence from the beginning,
-        including all but the final output OP of the model.
-        Returns "Unmatched" if the output of onnx and the output of TF are
-        not within acceptable proximity element by element.
-        If the output of onnx is 1D, it returns "Skipped" and skips the comparison
-        between the output of onnx and that of TF. This is because when undefined
-        dimensions are present, a situation often arises where very large index
-        values are compared, causing OutOfMemory.
-        It is very time consuming because it performs as many inferences as
-        there are operations.
+      Returns "Matches" if the output of onnx and the output of TF are
+      within acceptable proximity element by element.
+      Check the output of all OPs in sequence from the beginning,
+      including all but the final output OP of the model.
+      Returns "Unmatched" if the output of onnx and the output of TF are
+      not within acceptable proximity element by element.
+      If the output of onnx is 1D, it returns "Skipped" and skips the comparison
+      between the output of onnx and that of TF. This is because when undefined
+      dimensions are present, a situation often arises where very large index
+      values are compared, causing OutOfMemory.
+      It is very time consuming because it performs as many inferences as
+      there are operations.
 
     check_onnx_tf_outputs_sample_data_normalization: Optional[str]
-        norm: Validate using random data normalized to the range 0.0 to 1.0
-        denorm: Validate using random data in the range 0.0 to 255.0
-        If there is a normalization layer at the models entry point, or
-        if the model was trained on denormalized data, "denorm" must be specified.
-        Default: "norm"
+      norm: Validate using random data normalized to the range 0.0 to 1.0
+      denorm: Validate using random data in the range 0.0 to 255.0
+      If there is a normalization layer at the models entry point, or
+      if the model was trained on denormalized data, "denorm" must be specified.
+      Default: "norm"
 
     check_onnx_tf_outputs_elementwise_close_rtol: Optional[float]
-        The relative tolerance parameter.
-        Default: 0.0
+      The relative tolerance parameter.
+      Default: 0.0
 
     check_onnx_tf_outputs_elementwise_close_atol: Optional[float]
-        The absolute tolerance parameter.
-        Default: 1e-4
+      The absolute tolerance parameter.
+      Default: 1e-4
+
+    disable_model_save: Optional[bool]
+      Does not save the converted model. For CIs RAM savings.
+      Default: False
 
     non_verbose: Optional[bool]
       Do not show all information logs. Only error logs are displayed.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.1'
+__version__ = '1.13.2'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -830,37 +830,36 @@ def convert(
                 full_ops_output_names_sub.append(graph_node_output.name)
             full_ops_output_names.extend(full_ops_output_names_sub)
         # Models with errors during inference in onnxruntime skip dummy inference.
-        if not disable_strict_mode:
-            try:
-                onnx_outputs_for_validation: List[np.ndarray] = dummy_onnx_inference(
-                    onnx_graph=onnx_graph,
-                    output_names=full_ops_output_names,
-                    test_data_nhwc=test_data_nhwc,
-                    custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
-                    tf_layers_dict=tf_layers_dict,
-                )
-                """
-                onnx_tensor_infos_for_validation:
-                    {
-                        onnx_output_name: np.ndarray,
-                        onnx_output_name: np.ndarray,
-                        onnx_output_name: np.ndarray,
-                                    :
-                    }
-                """
-                onnx_tensor_infos_for_validation = {
-                    ops_output_name: onnx_output_for_validation \
-                        for ops_output_name, onnx_output_for_validation \
-                            in zip(full_ops_output_names, onnx_outputs_for_validation)
+        try:
+            onnx_outputs_for_validation: List[np.ndarray] = dummy_onnx_inference(
+                onnx_graph=onnx_graph,
+                output_names=full_ops_output_names,
+                test_data_nhwc=test_data_nhwc,
+                custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                tf_layers_dict=tf_layers_dict,
+            )
+            """
+            onnx_tensor_infos_for_validation:
+                {
+                    onnx_output_name: np.ndarray,
+                    onnx_output_name: np.ndarray,
+                    onnx_output_name: np.ndarray,
+                                :
                 }
-                del onnx_outputs_for_validation
-            except Exception as ex:
-                print(
-                    f'{Color.YELLOW}WARNING:{Color.RESET} ' +\
-                    f'The optimization process for shape estimation is skipped ' +
-                    f'because it contains OPs that cannot be inferred by the standard onnxruntime.'
-                )
-                print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
+            """
+            onnx_tensor_infos_for_validation = {
+                ops_output_name: onnx_output_for_validation \
+                    for ops_output_name, onnx_output_for_validation \
+                        in zip(full_ops_output_names, onnx_outputs_for_validation)
+            }
+            del onnx_outputs_for_validation
+        except Exception as ex:
+            print(
+                f'{Color.YELLOW}WARNING:{Color.RESET} ' +\
+                f'The optimization process for shape estimation is skipped ' +
+                f'because it contains OPs that cannot be inferred by the standard onnxruntime.'
+            )
+            print(f'{Color.YELLOW}WARNING:{Color.RESET} {ex}')
         additional_parameters['onnx_tensor_infos_for_validation'] = onnx_tensor_infos_for_validation
         additional_parameters['test_data_nhwc'] = test_data_nhwc
         additional_parameters['custom_input_op_name_np_data_path'] = custom_input_op_name_np_data_path

--- a/tests/test_model_convert.py
+++ b/tests/test_model_convert.py
@@ -114,6 +114,7 @@ def _report_convert_model(file_path):
             output_folder_path=_CFG['output_directory'],
             output_nms_with_dynamic_tensor=True,
             disable_strict_mode=True,
+            disable_model_save=True,
             non_verbose=True,
         )
         os.remove(file_path)


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf`
  - Improvements to reduce processing time for CI
  - Added option to disable model saving process after conversion.
    ```
    -dms, --disable_model_save
      Does not save the converted model. For CIs RAM savings.
    ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
