### PR TITLE
Improved stability of transformations when `axes` is None and slices are for multiple axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   Username (xxxx): {Enter}
   Password: {Personal Access Token}
   Login Succeeded
-  
+
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.3
+  ghcr.io/pinto0309/onnx2tf:1.13.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.3'
+__version__ = '1.13.4'

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -400,21 +400,25 @@ def make_node(
             else:
                 onnx_slice_dims_count = len(starts)
 
-            tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                stridedslice_with_flexing_deterrence(
-                    input_tensor=input_tensor,
-                    begin=begin_,
-                    end=end_,
-                    strides=strides_,
-                    begin_mask=begin_mask_,
-                    end_mask=end_mask_,
-                    ignore_axes=axes,
-                    compression_defult_value=COMPRESSION_DEFAULT_VALUE,
-                    onnx_slice_dims_count=onnx_slice_dims_count,
-                    output_shape=tf_layers_dict[graph_node_output.name]['tf_node'].shape,
-                    name=graph_node.name,
-                    **kwargs,
-                )
+            if onnx_slice_dims_count > COMPRESSION_DEFAULT_VALUE:
+                ignore_axes = axes
+                if axes is None:
+                    ignore_axes = [idx for idx in range(input_tensor_rank)]
+                tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                    stridedslice_with_flexing_deterrence(
+                        input_tensor=input_tensor,
+                        begin=begin_,
+                        end=end_,
+                        strides=strides_,
+                        begin_mask=begin_mask_,
+                        end_mask=end_mask_,
+                        ignore_axes=ignore_axes,
+                        compression_defult_value=COMPRESSION_DEFAULT_VALUE,
+                        onnx_slice_dims_count=onnx_slice_dims_count,
+                        output_shape=tf_layers_dict[graph_node_output.name]['tf_node'].shape,
+                        name=graph_node.name,
+                        **kwargs,
+                    )
     else:
         # OP replacement
         tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `Slice`
  - Improved stability of transformations when `axes` is None and slices are for multiple axes
  - [lite-model_rosetta_float16_1_part.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/11614800/lite-model_rosetta_float16_1_part.onnx.zip)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/86884f9a-1e8c-499b-9deb-4d95a7cd4ed8)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
