### PR TITLE
Added `Strict Mode` disable option to `MatMul` to reduce processing time for regression test CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.5
+  ghcr.io/pinto0309/onnx2tf:1.13.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.5'
+__version__ = '1.13.6'


### PR DESCRIPTION
### 1. Content and background
- `MatMul`
  - Added `Strict Mode` disable option to `MatMul` to reduce processing time for regression test CI.
  - Since this correction affects only CI, there is no change in normal conversion behavior.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
