### PR TITLE
Improved transposition error when receiving tensors with all axes having the same numerical value as input, thus reducing accuracy degradation

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.5
+  ghcr.io/pinto0309/onnx2tf:1.13.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.5'
+__version__ = '1.13.6'


### PR DESCRIPTION
### 1. Content and background
- `Conv1D`, `Conv2D`, `Conv3D`, `DepthwiseConv2D`, `GroupConv1D`, `GroupConv2D`, `GroupConv3D`, `SeparableConv`
  - Improved transposition error when receiving tensors with all axes having the same numerical value as input, thus reducing accuracy degradation.
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_381/monodepth_op15.onnx
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/cc1c7086-150f-4896-bf53-0e03fdc405c6)
    ```
    onnx2tf -i monodepth_op15.onnx -cotof
    ```
- Before
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/aeee0f95-f5c4-44ff-ac7c-f0267be3e15b)
- After
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/5ba27c84-30a9-427d-9f8a-c52e87f10908)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Conversion issue when trying to run model with Vx delegate #381](https://github.com/PINTO0309/onnx2tf/issues/381)