### PR TITLE
Rewriting of tflite input/output OP names and `signature_defs`

### DIFF
--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.6'
+__version__ = '1.13.7'


### PR DESCRIPTION
### 1. Content and background
- Rewriting of tflite input/output OP names and `signature_defs`
  If you do not like tflite input/output names such as `serving_default_*:0` or `StatefulPartitionedCall:0`, you can rewrite them using the following tools and procedures. It can be rewritten from any name to any name, so it does not have to be `serving_default_*:0` or `StatefulPartitionedCall:0`.
  
  https://github.com/PINTO0309/tflite-input-output-rewriter
  
  ```bash
  # Install custom flatc
  $ wget https://github.com/PINTO0309/onnx2tf/releases/download/1.7.3/flatc.tar.gz \
      && tar -zxvf flatc.tar.gz \
      && sudo chmod +x flatc \
      && sudo mv flatc /usr/bin/ \
      && rm flatc.tar.gz
  
  # Path check
  $ which flatc
  /usr/bin/flatc
  
  # Install tfliteiorewriter
  $ pip install -U tfliteiorewriter
  ```
  - Before
  
    ![01](https://github.com/PINTO0309/onnx2tf/assets/33194443/967ea56f-f771-4ccd-bdad-e4db41710396)
  
    ```bash
    $ tfliteiorewriter \
    -i xxxx.tflite \
    -r serving_default_input_1:0 aaa \
    -r StatefulPartitionedCall:0 bbb
    ```
    ![02](https://github.com/PINTO0309/onnx2tf/assets/33194443/841ce41e-dd3e-4156-883d-888d89e507c3)
  
  - After
  
    ![03](https://github.com/PINTO0309/onnx2tf/assets/33194443/f7b7be16-c69c-4593-b8b5-e1cc23e61be9)
  
