### PR TITLE
Improve conversion stability of `explicit_broadcast`

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.7
+  ghcr.io/pinto0309/onnx2tf:1.13.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.7'
+__version__ = '1.13.8'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -897,6 +897,7 @@ def explicit_broadcast(
         const_or_var_2.shape (ONNX const pettern): [3,128]
         new_const_or_var_2.shape (ONNX): [1,3,128] -> [1,128,3]
     """
+    tmp_graph_node_input_shape2 = list(const_or_var_2.shape)
     for _ in range(len(const_or_var_1.shape) - len(const_or_var_2.shape)):
         if isinstance(const_or_var_2, np.ndarray):
             const_or_var_2 = const_or_var_2[np.newaxis, ...]
@@ -911,7 +912,9 @@ def explicit_broadcast(
                 input=const_or_var_2,
                 axis=0,
             )
-        graph_node_input_shape2 = [1] + graph_node_input_shape2
+        tmp_graph_node_input_shape2 = [1] + tmp_graph_node_input_shape2
+    if len(tmp_graph_node_input_shape2) == len(const_or_var_1.shape):
+        graph_node_input_shape2 = tmp_graph_node_input_shape2
 
     # Swap operands to apply transpose to correct target if needed
     # second operand is always target of transpose


### PR DESCRIPTION
### 1. Content and background
- `common_functions`
  - Improve conversion stability of `explicit_broadcast`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
