### PR TITLE
Improved stability of `MatMul`, `explicit_broadcast`, and `InstanceNormalization` transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.8
+  ghcr.io/pinto0309/onnx2tf:1.13.9
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.8'
+__version__ = '1.13.9'

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -246,7 +246,7 @@ def make_node(
                     if result_err < min_abs_err:
                         min_abs_err = result_err
                         min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
-                        if min_abs_err < 1e-3:
+                        if min_abs_err < 1e-2:
                             break
                 except Exception as ex:
                     pass

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -814,6 +814,10 @@ def explicit_broadcast(
     if graph_node_input_shape1 == [] or graph_node_input_shape2 == []:
         return const_or_var_1, const_or_var_2
 
+    # If const_or_var_1 and const_or_var_2 of TF have exactly the same shape, skip processing
+    if list(const_or_var_1.shape) == list(const_or_var_2.shape):
+        return const_or_var_1, const_or_var_2
+
     # If all dimensions are undefined dimensions, return without doing anything
     if graph_node_input_shape1 is not None \
         and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_shape1]) == len(graph_node_input_shape1):


### PR DESCRIPTION
### 1. Content and background
- `MatMul`
  - Improved stability of transformations when `MatMul` input tensor contains undefined dimensions in cases where onnxsim (shape_inference) fails.
- `InstanceNormalization`
  - Since the error between ONNX and TF in `InstanceNormalization` was originally large, the criteria for accuracy check was relaxed.
- `common_functions (explicit_broadcast)`
  - Fixed `explicit_broadcast` to skip subsequent processing if `input_1` and `input_2` have exactly the same shape from the beginning.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [CREStereo conversion from onnx to tensorflow failed #380](https://github.com/PINTO0309/onnx2tf/issues/380)