### PR TITLE
Modified `Split` to take over NHWC information to improve stability of the conversion process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.9
+  ghcr.io/pinto0309/onnx2tf:1.13.10
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.9'
+__version__ = '1.13.10'

--- a/onnx2tf/ops/Split.py
+++ b/onnx2tf/ops/Split.py
@@ -91,6 +91,9 @@ def make_node(
             'optype': graph_node.op,
             'shape': shape,
             'dtype': dtype,
+            'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+                if isinstance(graph_node_input_1, gs.Variable) \
+                    and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
         }
 
     # Param replacement


### PR DESCRIPTION
### 1. Content and background
- `Split`
  - Modified `Split` to take over NHWC information to improve stability of the conversion process.
  - [crestereo_combined_iter2_240x320.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/11672229/crestereo_combined_iter2_240x320.onnx.zip)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [CREStereo conversion from onnx to tensorflow failed #380](https://github.com/PINTO0309/onnx2tf/issues/380)