### PR TITLE
Remove duplicated pip install onnx2tf in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@ RUN pip install pip -U \
     && pip install nvidia-pyindex \
     && pip install onnx_graphsurgeon \
     && pip install onnx2tf \
-    && pip install onnx2tf \
     && pip install simple_onnx_processing_tools \
     && pip install tensorflow==2.13.0rc0 \
     && pip install protobuf==3.20.3 \


### PR DESCRIPTION
### 1. Content and background
`pip install onnx2tf` is duplicated in current dockerfile

### 2. Summary of corrections
Remove one of `pip install onnx2tf`
### 3. Before/After (If there is an operating log that can be used as a reference)
None
### 4. Issue number (only if there is a related issue)
None