### PR TITLE
Support for `MaxPoolWithArgmax`

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.13.11
+  ghcr.io/pinto0309/onnx2tf:1.13.12
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.13.11'
+__version__ = '1.13.12'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -894,6 +894,14 @@ def convert(
             tf_layers_dict=tf_layers_dict,
             output_names=output_names,
         )
+        if not outputs:
+            output_names = [output_name.replace(':','_') for output_name in output_names]
+            if output_signaturedefs or output_integer_quantized_tflite:
+                output_names = [re.sub('^/', '', output_name) for output_name in output_names]
+            outputs = get_tf_model_outputs(
+                tf_layers_dict=tf_layers_dict,
+                output_names=output_names,
+            )
 
         # Bring back output names from ONNX model
         for output, name in zip(outputs, output_names):


### PR DESCRIPTION
### 1. Content and background
- `MaxPool`
  - `MaxPoolWithArgmax` support.
  - `MaxPoolWithArgmax` with `dilations` is not yet implemented.
  - Since TFLite runtime does not support `MaxPoolWithArgmax`, the OP in the .tflite file is `FlexMaxPoolWithArgmax`.
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/e6718ba4-f06a-4691-b44a-a9bf05c30781)
  - Also, the replacement of `MaxPoolWithArgmax` with the standard OP was not performed because the computational complexity of ArgMax would be unrealistically large.
  - Partial support.
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_397/hair_segmenter.onnx
- `onnx2tf.py`
  - Fixed a problem where models were not generated correctly if the model output name contained `:`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] [hair_segmenter] Implementation of MaxPoolWithArgmax #397](https://github.com/PINTO0309/onnx2tf/issues/397)