### PR TITLE
Fixed a transposition error when the input tensor of `grid` in `GridSample` is a constant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.14.1
+  ghcr.io/pinto0309/onnx2tf:1.14.2
 
   or
 
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.14.1
+  docker.io/pinto0309/onnx2tf:1.14.2
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.14.1'
+__version__ = '1.14.2'

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -54,7 +54,10 @@ def make_node(
     )
     graph_node_input_2 = get_constant_or_variable(
         graph_node.inputs[1],
-        before_op_output_shape_trans,
+        False \
+            if hasattr(graph_node.inputs[1], 'values') \
+                and isinstance(graph_node.inputs[1].values, np.ndarray) \
+                    else before_op_output_shape_trans,
     )
     graph_node_output: gs.Variable = graph_node.outputs[0]
     shape = graph_node_output.shape

--- a/onnx2tf/ops/Tile.py
+++ b/onnx2tf/ops/Tile.py
@@ -65,6 +65,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     input_tensor_1 = tf_layers_dict[graph_node_input_1.name]['tf_node'] \


### PR DESCRIPTION
### 1. Content and background
- Fixed a transposition error when the input tensor of `grid` in `GridSample` is a constant.
- Added NHWC information propagation process to `Tile`.
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/74abfca2-c137-487c-8884-921d1e99c778)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/eb7b794e-63bc-4a7e-9b5a-9116b5cfd3a1)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Fail to understand the GridSample error message #402](https://github.com/PINTO0309/onnx2tf/issues/402)