### PR TITLE
Improved stability of constant transformations when `paddings` is `Numpy.ndarray`

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -42,7 +42,7 @@ jobs:
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon
         pip install protobuf==3.20.3
-        pip install onnxsim==0.4.17
+        pip install onnxsim==0.4.33
         pip install sng4onnx
         pip install onnxruntime==1.15.0
         pip install -e .

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 
 RUN pip install pip -U \
     && pip install onnx==1.13.1 \
-    && pip install onnxsim==0.4.17 \
+    && pip install onnxsim==0.4.33 \
     && pip install nvidia-pyindex \
     && pip install onnx_graphsurgeon \
     && pip install onnx2tf \

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - Linux / Windows
 - onnx==1.13.1
 - onnxruntime==1.15.0
-- onnx-simplifier==0.4.17 See: https://github.com/PINTO0309/onnx2tf/issues/312
+- onnx-simplifier==0.4.33
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
 - tensorflow==2.13.0
@@ -254,14 +254,14 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.14.3
+  ghcr.io/pinto0309/onnx2tf:1.14.4
 
   or
 
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.14.3
+  docker.io/pinto0309/onnx2tf:1.14.4
 
   or
 
@@ -269,7 +269,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
   && pip install -U onnxruntime==1.15.0 \
-  && pip install -U onnxsim==0.4.17 \
+  && pip install -U onnxsim==0.4.33 \
   && pip install -U simple_onnx_processing_tools \
   && pip install -U onnx2tf \
   && pip install -U h5py==3.7.0 \
@@ -305,7 +305,7 @@ or
     && python3.9 -m pip install -U nvidia-pyindex \
     && python3.9 -m pip install -U onnx-graphsurgeon \
     && python3.9 -m pip install -U onnxruntime==1.15.0 \
-    && python3.9 -m pip install -U onnxsim==0.4.17 \
+    && python3.9 -m pip install -U onnxsim==0.4.33 \
     && python3.9 -m pip install -U simple_onnx_processing_tools \
     && python3.9 -m pip install -U onnx2tf \
     && python3.9 -m pip install -U protobuf==3.20.3 \
@@ -898,6 +898,7 @@ usage: onnx2tf
 [-cotor CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_RTOL]
 [-cotoa CHECK_ONNX_TF_OUTPUTS_ELEMENTWISE_CLOSE_ATOL]
 [-dms]
+[-uc]
 [-n]
 
 optional arguments:
@@ -1292,6 +1293,11 @@ optional arguments:
   -dms, --disable_model_save
     Does not save the converted model. For CIs RAM savings.
 
+  -uc, --use_cuda
+    CUDA is used for dummy inference during accuracy checks, but accuracy is degraded.
+    Note that if you need to convert extended OPs such as com.microsoft.xxx,
+    you must enable this flag.
+
   -n, --non_verbose
     Do not show all information logs. Only error logs are displayed.
 ```
@@ -1351,6 +1357,7 @@ convert(
   check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
   check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
   disable_model_save: Union[bool, NoneType] = False,
+  use_cuda: Union[bool, NoneType] = False,
   non_verbose: Union[bool, NoneType] = False
 ) -> keras.engine.training.Model
 
@@ -1750,6 +1757,13 @@ convert(
 
     disable_model_save: Optional[bool]
       Does not save the converted model. For CIs RAM savings.
+      Default: False
+
+    use_cuda: Optional[bool]
+      CUDA is used for dummy inference during accuracy checks,
+      but accuracy is degraded.
+      Note that if you need to convert extended OPs such as com.microsoft.xxx,
+      you must enable this flag.
       Default: False
 
     non_verbose: Optional[bool]

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.14.3'
+__version__ = '1.14.4'

--- a/onnx2tf/ops/ConvTranspose.py
+++ b/onnx2tf/ops/ConvTranspose.py
@@ -175,10 +175,13 @@ def make_node(
                 )
                 sys.exit(1)
             onnx_graph = kwargs['onnx_graph']
-            convtranspose_output = dummy_onnx_inference(
-                onnx_graph=onnx_graph,
-                output_names=[graph_node_output.name],
-            )[0]
+            use_cuda = bool(kwargs['use_cuda'])
+            convtranspose_output = \
+                dummy_onnx_inference(
+                    onnx_graph=onnx_graph,
+                    output_names=[graph_node_output.name],
+                    use_cuda=use_cuda,
+                )[0]
             onnx_output_shape = list(convtranspose_output.shape)
             tf_output_shape = []
             for idx in range(input_tensor_rank):

--- a/tests/test_model_convert.py
+++ b/tests/test_model_convert.py
@@ -115,6 +115,7 @@ def _report_convert_model(file_path):
             output_nms_with_dynamic_tensor=True,
             disable_strict_mode=True,
             disable_model_save=True,
+            use_cuda=False,
             non_verbose=True,
         )
         os.remove(file_path)


### PR DESCRIPTION
### 1. Content and background
- `Pad`
  - Improved stability of constant transformations when `paddings` is `Numpy.ndarray`
- Dummy inference with `CUDAExcecutionProvider` causes large errors in inference results, so fixed to infer using CUDA only when `--use_cuda` is explicitly specified.
- Upgrade `onnxsim` to 0.4.33

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Add option to disable CUDAExecutionProvider during inference #412](https://github.com/PINTO0309/onnx2tf/issues/412)
- [Error in tf.pad operation #413](https://github.com/PINTO0309/onnx2tf/issues/413)