### PR TITLE
Improved stability when `slope` is less than the number of axes in the input tensor and `slope` is `np.ndarray` and the input tensor is fixed in NHWC

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.14.4
+  ghcr.io/pinto0309/onnx2tf:1.14.5
 
   or
 
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.14.4
+  docker.io/pinto0309/onnx2tf:1.14.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.14.4'
+__version__ = '1.14.5'

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -96,6 +96,7 @@ def make_node(
     if tf_layers_dict[graph_node_output.name]['nhwc'] == True \
         and input_tensor_shape is not None \
         and input_tensor_rank >= 3 \
+        and sum([1 if isinstance(s, int) and s == input_tensor_shape[1] else 0 for s in input_tensor_shape]) == input_tensor_rank - 1 \
         and slope.shape is not None \
         and len(slope.shape) >= 3 \
         and input_tensor_rank == len(slope.shape) \

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -51,9 +51,13 @@ def make_node(
     )
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    input_tensor_shape = input_tensor.shape
+    input_tensor_rank = len(input_tensor_shape)
     graph_node_input_2 = get_constant_or_variable(
         graph_node.inputs[1],
-        before_op_output_shape_trans,
+        before_op_output_shape_trans \
+            if graph_node.inputs[1].shape is not None \
+                and input_tensor_rank == len(graph_node.inputs[1].shape) else False,
     )
     slope = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
@@ -86,8 +90,21 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
+    # input_tensor: [1, 4, 4, 4]
+    # slope: [4, 1, 1] -> [1, 4, 1, 1]
+    # https://github.com/PINTO0309/onnx2tf/issues/418
+    if tf_layers_dict[graph_node_output.name]['nhwc'] == True \
+        and input_tensor_shape is not None \
+        and input_tensor_rank >= 3 \
+        and slope.shape is not None \
+        and len(slope.shape) >= 3 \
+        and input_tensor_rank == len(slope.shape) \
+        and isinstance(slope, np.ndarray):
+        convertion_table = [0] + [i for i in range(2, input_tensor_rank)] + [1]
+        slope = slope.transpose(convertion_table)
+
     # Pre-process transpose
-    before_trans_shape = input_tensor.shape
+    before_trans_shape = input_tensor_shape
     input_tensor = pre_process_transpose(
         value_before_transpose=input_tensor,
         param_target='inputs',


### PR DESCRIPTION
### 1. Content and background
- Improved stability when `slope` is less than the number of axes in the input tensor and `slope` is `np.ndarray` and the input tensor is fixed in NHWC.
- [example.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12067229/example.onnx.zip)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/800afa7e-ec19-4983-bc10-379ee64ccef0)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [PRelu "not compatible with provided weight shape" conversion problem #418](https://github.com/PINTO0309/onnx2tf/issues/418)