### PR TITLE
Fix Abort problem with Inverse transformations when the input tensor is np.ndarray

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.14.5
+  ghcr.io/pinto0309/onnx2tf:1.14.6
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.14.5
+  docker.io/pinto0309/onnx2tf:1.14.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.14.5'
+__version__ = '1.14.6'

--- a/onnx2tf/ops/Inverse.py
+++ b/onnx2tf/ops/Inverse.py
@@ -74,7 +74,8 @@ def make_node(
     # The input is a tensor of shape [..., M, M] whose inner-most 2 dimensions form square matrices.
     # The output is a tensor of the same shape as the input containing the inverse for all input submatrices [..., :, :].
     nhwc_flag = tf_layers_dict[graph_node_input.name]['nhwc'] \
-        if 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
+        if not isinstance(graph_node_input, np.ndarray) \
+            and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     input_tensor_shape = input_tensor.shape
     input_tensor_rank = len(input_tensor_shape)
     inv_transpose = \


### PR DESCRIPTION
### 1. Content and background
- `Inverse`
  - Fix Abort problem with Inverse transformations when the input tensor is `np.ndarray`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Fix Abort problem with Inverse transformations when the input tensor is np.ndarray. #421](https://github.com/PINTO0309/onnx2tf/issues/421)
