### PR TITLE
Fix `acquisition_of_validation_data` to skip processing if the input tensor is a `tf.Tensor` and has the attribute `numpy`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.14.6
+  ghcr.io/pinto0309/onnx2tf:1.14.7
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.14.6
+  docker.io/pinto0309/onnx2tf:1.14.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.14.6'
+__version__ = '1.14.7'

--- a/onnx2tf/ops/Inverse.py
+++ b/onnx2tf/ops/Inverse.py
@@ -98,7 +98,8 @@ def make_node(
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
         tf.linalg.inv(
-            input=input_tensor,
+            input=tf.convert_to_tensor(input_tensor) \
+                if isinstance(input_tensor, np.ndarray) else input_tensor,
             name=graph_node.name,
         )
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5369,7 +5369,9 @@ def acquisition_of_validation_data(
     )
     val_model = None
     if not isinstance(input_tensor_1, np.ndarray) \
-        and not isinstance(input_tensor_2, np.ndarray):
+        and not hasattr(input_tensor_1, 'numpy') \
+        and not isinstance(input_tensor_2, np.ndarray) \
+        and not hasattr(input_tensor_2, 'numpy'):
         val_model = tf.keras.Model(
             inputs=tf_model_inputs,
             outputs=[
@@ -5378,6 +5380,7 @@ def acquisition_of_validation_data(
             ],
         )
     elif not isinstance(input_tensor_1, np.ndarray) \
+        and not hasattr(input_tensor_1, 'numpy') \
         and isinstance(input_tensor_2, np.ndarray):
         val_model = tf.keras.Model(
             inputs=tf_model_inputs,
@@ -5386,7 +5389,8 @@ def acquisition_of_validation_data(
             ],
         )
     elif isinstance(input_tensor_1, np.ndarray) \
-        and not isinstance(input_tensor_2, np.ndarray):
+        and not isinstance(input_tensor_2, np.ndarray) \
+        and not hasattr(input_tensor_2, 'numpy'):
         val_model = tf.keras.Model(
             inputs=tf_model_inputs,
             outputs=[


### PR DESCRIPTION
### 1. Content and background
- `acquisition_of_validation_data`
  - Fix `acquisition_of_validation_data` to skip processing if the input tensor is a `tf.Tensor` and has the attribute `numpy`.
- `Inverse`
  - Fixed to convert to `tf.Tensor` when the input tensor is `np.ndarray`.
- Improved overall stability of model conversion behavior

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
