### PR TITLE
Support for `Float32` inverse conversion of `Float16` models

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.14.7
+  ghcr.io/pinto0309/onnx2tf:1.15.0
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.14.7
+  docker.io/pinto0309/onnx2tf:1.15.0
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.14.7'
+__version__ = '1.15.0'

--- a/onnx2tf/ops/Input.py
+++ b/onnx2tf/ops/Input.py
@@ -60,7 +60,7 @@ def make_node(
     graph_input_name = kwargs.get('subgraph_input_name', graph_input.name)
 
     shape = graph_input.shape
-    dtype = graph_input.dtype
+    dtype = graph_input.dtype if graph_input.dtype != np.float16 else np.float32
 
     # Overwrite batch or shapes
     if batch_size is not None \


### PR DESCRIPTION
### 1. Content and background
- Support for `Float32` inverse conversion of `Float16` models.
- [text_recognition_CRNN_EN_2023feb_fp16.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12178287/text_recognition_CRNN_EN_2023feb_fp16.onnx.zip)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/7c80a7f0-f5a8-44cb-9e15-438748110c87)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
