### PR TITLE
Improved stability when models exceeding the ProtocolBuffers size limit of 2 GB are targeted for conversion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.0
+  ghcr.io/pinto0309/onnx2tf:1.15.1
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.0
+  docker.io/pinto0309/onnx2tf:1.15.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.0'
+__version__ = '1.15.1'

--- a/onnx2tf/ops/ConstantOfShape.py
+++ b/onnx2tf/ops/ConstantOfShape.py
@@ -48,6 +48,9 @@ def make_node(
         before_op_output_shape_trans=False,
         is_bias=True,
     )
+    if isinstance(shape, gs.Variable) \
+        and graph_node.inputs[0].name in tf_layers_dict:
+        shape = tf_layers_dict[graph_node.inputs[0].name]['tf_node']
 
     # make sure the shape dtype is either int32 or int64
     if shape.dtype not in [tf.int64, tf.int32]:
@@ -60,7 +63,7 @@ def make_node(
         value = attr_value.values
         constant_tensor = value[0]
     else:
-        constant_tensor = 0.
+        constant_tensor = 0.0
 
     cons = tf.fill(
         dims=shape,

--- a/onnx2tf/ops/ConstantOfShape.py
+++ b/onnx2tf/ops/ConstantOfShape.py
@@ -8,6 +8,7 @@ import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     print_node_info,
     make_tf_node_info,
+    get_constant_or_variable,
 )
 
 
@@ -28,7 +29,6 @@ def make_node(
     tf_layers_dict: dict
         optype, shape, dtype, tensorflow graph
     """
-    graph_node_input: gs.Variable = graph_node.inputs[0]
     graph_node_output: gs.Variable = graph_node.outputs[0]
 
     shape = graph_node_output.shape
@@ -43,7 +43,11 @@ def make_node(
 
     # Generation of TF OP
     # https://github.com/onnx/onnx-tensorflow/blob/main/onnx_tf/handlers/backend/constant_of_shape.py
-    shape = tf_layers_dict[graph_node_input.name]['tf_node']
+    shape = get_constant_or_variable(
+        graph_node.inputs[0],
+        before_op_output_shape_trans=False,
+        is_bias=True,
+    )
 
     # make sure the shape dtype is either int32 or int64
     if shape.dtype not in [tf.int64, tf.int32]:


### PR DESCRIPTION
### 1. Content and background
- Improved stability when models exceeding the ProtocolBuffers size limit of 2 GB are targeted for conversion.
  - However, if the model size is about 4 GB, as in StableDiffusion, the conversion target is expected to require resources of about 128 GB RAM + 1 TB SWAP.
  - Since it is not possible to prepare such a huge resource in the development environment, it is not possible to confirm that the conversion completes successfully.
  - TensorFlow's `saved_model` format uses the same file format as ONNX ([Protocol Buffers](https://protobuf.dev/)), so it cannot generate models with file sizes larger than 2 GB.
- `ConstantOfShape`
  - Improved stability of `ConstantOfShape` conversions
### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Conversion error with stable diffusion model. #424](https://github.com/PINTO0309/onnx2tf/issues/424)