### PR TITLE
added to read from local test image data file if available in current working dir instead of getting from remote

### DIFF
--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -4003,8 +4003,14 @@ def download_test_image_data() -> np.ndarray:
     """
     DATA_COUNT = 20
     FILE_NAME = f'calibration_image_sample_data_{DATA_COUNT}x128x128x3_float32.npy'
-    URL = f'https://s3.us-central-1.wasabisys.com/onnx2tf-en/datas/{FILE_NAME}'
-    test_sample_images_npy = requests.get(URL).content
+    LOCAL_FILE_PATH = os.path.join(os.getcwd(), FILE_NAME)
+
+    if not os.path.isfile(LOCAL_FILE_PATH):
+        URL = f'https://s3.us-central-1.wasabisys.com/onnx2tf-en/datas/{FILE_NAME}'
+        test_sample_images_npy = requests.get(URL).content
+    else:
+        with open(LOCAL_FILE_PATH, 'rb') as test_sample_images_npy_file:
+            test_sample_images_npy = test_sample_images_npy_file.read()
     test_image_data = None
     with io.BytesIO(test_sample_images_npy) as f:
         test_image_data: np.ndarray = np.load(f)


### PR DESCRIPTION
I was using https://github.com/ultralytics/ultralytics to export a model from .pt to tfjs and ran into a problem where on an offline environment it would not work as it will try to fetch a file from the web.
I had to make this work on an offline machine with no access to the internet, so I updated the source where it tries to fetch the test file to check if that file exists at the current working directory and try to read it from there and else to try to fetch it.