### PR TITLE
Eliminated the `use_cuda` option and modified it so that CUDA is automatically used when an OP that requires CUDA is present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.3
+  ghcr.io/pinto0309/onnx2tf:1.15.4
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.3
+  docker.io/pinto0309/onnx2tf:1.15.4
 
   or
 
@@ -1298,11 +1298,6 @@ optional arguments:
   -dms, --disable_model_save
     Does not save the converted model. For CIs RAM savings.
 
-  -uc, --use_cuda
-    CUDA is used for dummy inference during accuracy checks, but accuracy is degraded.
-    Note that if you need to convert extended OPs such as com.microsoft.xxx,
-    you must enable this flag.
-
   -n, --non_verbose
     Shorthand to specify a verbosity of "error".
 
@@ -1367,7 +1362,6 @@ convert(
   check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
   check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
   disable_model_save: Union[bool, NoneType] = False,
-  use_cuda: Union[bool, NoneType] = False,
   non_verbose: Union[bool, NoneType] = False,
   verbosity: Optional[str] = 'debug'
 ) -> keras.engine.training.Model
@@ -1768,13 +1762,6 @@ convert(
 
     disable_model_save: Optional[bool]
       Does not save the converted model. For CIs RAM savings.
-      Default: False
-
-    use_cuda: Optional[bool]
-      CUDA is used for dummy inference during accuracy checks,
-      but accuracy is degraded.
-      Note that if you need to convert extended OPs such as com.microsoft.xxx,
-      you must enable this flag.
       Default: False
 
     non_verbose: Optional[bool]

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.3'
+__version__ = '1.15.4'

--- a/onnx2tf/utils/enums.py
+++ b/onnx2tf/utils/enums.py
@@ -69,3 +69,7 @@ TF_DTYPES_TO_NUMPY_DTYPES = {
 
     tf.bool: np.dtype('bool_'),
 }
+
+CUDA_ONLY_OPS = [
+    'GroupNorm',
+]

--- a/tests/test_model_convert.py
+++ b/tests/test_model_convert.py
@@ -115,7 +115,6 @@ def _report_convert_model(file_path):
             output_nms_with_dynamic_tensor=True,
             disable_strict_mode=True,
             disable_model_save=True,
-            use_cuda=False,
             verbosity="error",
         )
         os.remove(file_path)


### PR DESCRIPTION
### 1. Content and background
- Eliminated the `use_cuda` option and modified it so that CUDA is automatically used when an OP that requires CUDA is present.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Add option to disable CUDAExecutionProvider during inference #412](https://github.com/PINTO0309/onnx2tf/issues/412)