### PR TITLE
Improved the situation where `FlexMul` is generated when the input tensor of `Expand` is `bool`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.4
+  ghcr.io/pinto0309/onnx2tf:1.15.5
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.4
+  docker.io/pinto0309/onnx2tf:1.15.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.4'
+__version__ = '1.15.5'

--- a/onnx2tf/ops/Expand.py
+++ b/onnx2tf/ops/Expand.py
@@ -107,11 +107,11 @@ def make_node(
             tf.identity(input=input_tensor)
         tf_type = tf.identity
     else:
-        # tf.math.multiply does not support bool therefore use int8
+        # tf.math.multiply does not support bool therefore use int32
         expanded_tensor = None
         if input_tensor.dtype is tf.bool:
-            ones = tf.ones(input_tensor_shape, dtype=tf.int8)
-            r = tf.cast(input_tensor, tf.int8) * ones
+            ones = tf.ones(input_tensor_shape, dtype=tf.int32)
+            r = tf.cast(input_tensor, tf.int32) * ones
             expanded_tensor = tf.cast(r, tf.bool)
         else:
             ones = tf.ones(input_tensor_shape, dtype=input_tensor.dtype)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -263,7 +263,7 @@ def print_node_info(func):
                 debug('')
                 debug(
                     Color.GREEN(f'INFO:') + ' ' + Color.MAGENTA(f'onnx_op_type') + ': '+
-                    f'{graph_node.op}' + Color.MAGENTA('onnx_op_name') + f': {graph_node.name}')
+                    f'{graph_node.op}' + Color.MAGENTA(' onnx_op_name') + f': {graph_node.name}')
                 for idx, graph_node_input in enumerate(graph_node.inputs):
                     debug(
                         Color.GREEN(f'INFO:') + ' '+


### PR DESCRIPTION
### 1. Content and background
- `Expand`
  - Improved the situation where `FlexMul` is generated when the input tensor of `Expand` is `bool`.
  - Stop using INT8 and use INT32 instead.
- Before
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/02f146cc-b2f8-4646-bd31-9b1e22ac16ef)
- After
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/89a39615-6374-4d82-89a4-940738270a7c)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[ParSeq] [Error] convert error mismatch after saved_model output complete #436](https://github.com/PINTO0309/onnx2tf/issues/436)