### PR TITLE
LpNormalization.py bugfix - parameters

### DIFF
--- a/onnx2tf/ops/LpNormalization.py
+++ b/onnx2tf/ops/LpNormalization.py
@@ -61,13 +61,13 @@ def make_node(
     shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    axis = bool(graph_node.attrs.get('axis', -1))
+    axis = graph_node.attrs.get('axis', -1)
     axis = convert_axis(
         axis=axis,
         tensor_rank=input_tensor_rank,
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
-    p = bool(graph_node.attrs.get('p', 2))
+    p = graph_node.attrs.get('p', 2)
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {


### PR DESCRIPTION
Parameters were not converted to tf.norm, instead of parameter value, 1 was set because of bool->int conversion.

### 1. Content and background
LpNormalization conversion does not set parameters axis and p properly.

### 2. Summary of corrections
removed bool conversion

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
