### PR TITLE
Set `NHWC` flag to `True` if all input tensors are determined by `NHWC`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.7
+  ghcr.io/pinto0309/onnx2tf:1.15.8
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.7
+  docker.io/pinto0309/onnx2tf:1.15.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.7'
+__version__ = '1.15.8'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -130,11 +130,29 @@ def make_node(
     )
 
     # Preserving Graph Structure (Dict)
-    tf_layers_dict[graph_node_output.name] = {
-        'optype': graph_node.op,
-        'shape': shape,
-        'dtype': dtype,
-    }
+    nhwc_judge = True
+    for graph_node_input in graph_node.inputs:
+        if isinstance(graph_node_input, gs.Variable) \
+            and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() \
+            and tf_layers_dict[graph_node_input.name]['nhwc'] == True:
+                nhwc_judge = nhwc_judge and True
+        else:
+            nhwc_judge = nhwc_judge and False
+
+    # Set NHWC flag to True if all input tensors are determined by NHWC
+    if nhwc_judge:
+        tf_layers_dict[graph_node_output.name] = {
+            'optype': graph_node.op,
+            'shape': shape,
+            'dtype': dtype,
+            'nhwc': True,
+        }
+    else:
+        tf_layers_dict[graph_node_output.name] = {
+            'optype': graph_node.op,
+            'shape': shape,
+            'dtype': dtype,
+        }
 
     # Generation of TF OP
 


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Set `NHWC` flag to `True` if all input tensors are determined by `NHWC`
  - Significantly reduces the frequency of conversion errors in the overall model.
  - https://github.com/PINTO0309/PINTO_model_zoo/tree/main/303_FAN
  - Before
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/c22633b2-ad88-468e-b60d-7a6d1145ffa1)
  - After
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/39a583dc-7eb3-4bbf-828f-a133ce350e5e)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
