### PR TITLE
Fixed a lack of processing of OP name sanitizing when the `-onimc` and `-osd` or `-oiqt` options are specified in combination.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.8
+  ghcr.io/pinto0309/onnx2tf:1.15.9
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.8
+  docker.io/pinto0309/onnx2tf:1.15.9
 
   or
 

--- a/json_samples/replace_mobilenetmss.json
+++ b/json_samples/replace_mobilenetmss.json
@@ -1,0 +1,17 @@
+{
+  "format_version": 1,
+  "operations": [
+    {
+      "op_name": "/Transpose_1",
+      "param_target": "attributes",
+      "param_name": "perm",
+      "values": [0,1,2,3]
+    },
+    {
+      "op_name": "/Transpose_2",
+      "param_target": "attributes",
+      "param_name": "perm",
+      "values": [0,2,3,1]
+    }
+  ]
+}

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.8'
+__version__ = '1.15.9'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -667,13 +667,13 @@ def convert(
 
     def sanitizing(node):
         if hasattr(node, 'name'):
-            node.name = node.name.replace(':','_')
+            node.name = node.name.replace(':','__')
             if hasattr(node, 'outputs'):
                 for o in node.outputs:
                     if hasattr(o, 'name'):
-                        o.name = o.name.replace(':','_')
+                        o.name = o.name.replace(':','__')
                     elif hasattr(o, '_name'):
-                        o._name = o._name.replace(':','_')
+                        o._name = o._name.replace(':','__')
             if output_signaturedefs or output_integer_quantized_tflite:
                 node.name = re.sub('^/', 'wa/', node.name)
                 if hasattr(node, 'outputs'):
@@ -683,13 +683,13 @@ def convert(
                         elif hasattr(o, '_name'):
                             o._name = re.sub('^/', 'wa/', o._name)
         elif hasattr(node, '_name'):
-            node._name = node._name.replace(':','_')
+            node._name = node._name.replace(':','__')
             if hasattr(node, 'outputs'):
                 for o in node.outputs:
                     if hasattr(o, 'name'):
-                        o.name = o.name.replace(':','_')
+                        o.name = o.name.replace(':','__')
                     elif hasattr(o, '_name'):
-                        o._name = o._name.replace(':','_')
+                        o._name = o._name.replace(':','__')
             if output_signaturedefs or output_integer_quantized_tflite:
                 node._name = re.sub('^/', 'wa/', node._name)
                 if hasattr(node, 'outputs'):
@@ -706,7 +706,7 @@ def convert(
     if output_signaturedefs or output_integer_quantized_tflite:
         new_output_names = []
         for output_name in output_names:
-            output_name = output_name.replace(':','_')
+            output_name = output_name.replace(':','__')
             output_name = re.sub('^/', 'wa/', output_name)
             new_output_names.append(output_name)
         output_names = new_output_names
@@ -934,7 +934,7 @@ def convert(
             output_names=output_names,
         )
         if not outputs:
-            output_names = [output_name.replace(':','_') for output_name in output_names]
+            output_names = [output_name.replace(':','__') for output_name in output_names]
             if output_signaturedefs or output_integer_quantized_tflite:
                 output_names = [re.sub('^/', '', output_name) for output_name in output_names]
             outputs = get_tf_model_outputs(
@@ -945,7 +945,7 @@ def convert(
         # Bring back output names from ONNX model
         for output, name in zip(outputs, output_names):
             if hasattr(output, 'node'):
-                output.node.layer._name = name.replace(':','_')
+                output.node.layer._name = name.replace(':','__')
                 if output_signaturedefs or output_integer_quantized_tflite:
                     output.node.layer._name = re.sub('^/', '', output.node.layer._name)
 

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -668,17 +668,48 @@ def convert(
     def sanitizing(node):
         if hasattr(node, 'name'):
             node.name = node.name.replace(':','_')
+            if hasattr(node, 'outputs'):
+                for o in node.outputs:
+                    if hasattr(o, 'name'):
+                        o.name = o.name.replace(':','_')
+                    elif hasattr(o, '_name'):
+                        o._name = o._name.replace(':','_')
             if output_signaturedefs or output_integer_quantized_tflite:
                 node.name = re.sub('^/', 'wa/', node.name)
+                if hasattr(node, 'outputs'):
+                    for o in node.outputs:
+                        if hasattr(o, 'name'):
+                            o.name = re.sub('^/', 'wa/', o.name)
+                        elif hasattr(o, '_name'):
+                            o._name = re.sub('^/', 'wa/', o._name)
         elif hasattr(node, '_name'):
             node._name = node._name.replace(':','_')
+            if hasattr(node, 'outputs'):
+                for o in node.outputs:
+                    if hasattr(o, 'name'):
+                        o.name = o.name.replace(':','_')
+                    elif hasattr(o, '_name'):
+                        o._name = o._name.replace(':','_')
             if output_signaturedefs or output_integer_quantized_tflite:
                 node._name = re.sub('^/', 'wa/', node._name)
+                if hasattr(node, 'outputs'):
+                    for o in node.outputs:
+                        if hasattr(o, 'name'):
+                            o.name = re.sub('^/', 'wa/', o.name)
+                        elif hasattr(o, '_name'):
+                            o._name = re.sub('^/', 'wa/', o._name)
 
     # sanitizing ':', '/'
     _ = [sanitizing(graph_input) for graph_input in graph.inputs]
     _ = [sanitizing(graph_node) for graph_node in graph.nodes]
     _ = [sanitizing(graph_output) for graph_output in graph.outputs]
+    if output_signaturedefs or output_integer_quantized_tflite:
+        new_output_names = []
+        for output_name in output_names:
+            output_name = output_name.replace(':','_')
+            output_name = re.sub('^/', 'wa/', output_name)
+            new_output_names.append(output_name)
+        output_names = new_output_names
     try:
         onnx_graph = gs.export_onnx(graph)
     except Exception as ex:

--- a/onnx2tf/ops/If.py
+++ b/onnx2tf/ops/If.py
@@ -66,7 +66,7 @@ def make_node(
             )
             sys.exit(1)
         # substitution because saved_model does not allow colons
-        then_branch_graph_node.name = then_branch_graph_node.name.replace(':','_')
+        then_branch_graph_node.name = then_branch_graph_node.name.replace(':','__')
         # Substitution because saved_model does not allow leading slashes in op names
         if kwargs['output_signaturedefs']:
             then_branch_graph_node.name = re.sub('^/', 'wa/', then_branch_graph_node.name)
@@ -108,7 +108,7 @@ def make_node(
             )
             sys.exit(1)
         # substitution because saved_model does not allow colons
-        else_branch_graph_node.name = else_branch_graph_node.name.replace(':','_')
+        else_branch_graph_node.name = else_branch_graph_node.name.replace(':','__')
         # Substitution because saved_model does not allow leading slashes in op names
         if kwargs['output_signaturedefs']:
             else_branch_graph_node.name = re.sub('^/', 'wa/', else_branch_graph_node.name)

--- a/onnx2tf/ops/_Loop.py
+++ b/onnx2tf/ops/_Loop.py
@@ -130,7 +130,7 @@ def make_node(
                 )
                 sys.exit(1)
             # substitution because saved_model does not allow colons
-            body_input.name = body_input.name.replace(':','_')
+            body_input.name = body_input.name.replace(':','__')
             # Substitution because saved_model does not allow leading slashes in op names
             if kwargs['output_signaturedefs']:
                 body_input.name = re.sub('^/', 'wa/', body_input.name)
@@ -152,7 +152,7 @@ def make_node(
                 )
                 sys.exit(1)
             # substitution because saved_model does not allow colons
-            body_node.name = body_node.name.replace(':','_')
+            body_node.name = body_node.name.replace(':','__')
             # Substitution because saved_model does not allow leading slashes in op names
             if kwargs['output_signaturedefs']:
                 body_node.name = re.sub('^/', 'wa/', body_node.name)

--- a/onnx2tf/ops/__Loop.py
+++ b/onnx2tf/ops/__Loop.py
@@ -89,10 +89,10 @@ def make_node(
     ) if M is not None else tf.constant(tf.int32.max, tf.int32)
     M_name = None
     if not isinstance(graph_node_input_1, np.ndarray):
-        graph_node_input_1.name = graph_node_input_1.name.replace(':','_')
+        graph_node_input_1.name = graph_node_input_1.name.replace(':','__')
         M_name = graph_node_input_1.name
     else:
-        M_name = graph_node.inputs[0].name.replace(':','_')
+        M_name = graph_node.inputs[0].name.replace(':','__')
     M_name = f'{M_name}_M'
     if kwargs['output_signaturedefs']:
         M_name = re.sub('^/', 'wa/', M_name)
@@ -113,10 +113,10 @@ def make_node(
 
     cond_init_name = None
     if not isinstance(graph_node_input_2, np.ndarray):
-        graph_node_input_2.name = graph_node_input_2.name.replace(':','_')
+        graph_node_input_2.name = graph_node_input_2.name.replace(':','__')
         cond_init_name = graph_node_input_2.name
     else:
-        cond_init_name = graph_node.inputs[0].name.replace(':','_')
+        cond_init_name = graph_node.inputs[0].name.replace(':','__')
     cond_init_name = f'{cond_init_name}_cond_init'
     if kwargs['output_signaturedefs']:
         cond_init_name = re.sub('^/', 'wa/', cond_init_name)
@@ -182,7 +182,7 @@ def make_node(
     #             )
     #             sys.exit(1)
     #         # substitution because saved_model does not allow colons
-    #         body_input.name = body_input.name.replace(':','_')
+    #         body_input.name = body_input.name.replace(':','__')
     #         # Substitution because saved_model does not allow leading slashes in op names
     #         if kwargs['output_signaturedefs']:
     #             body_input.name = re.sub('^/', 'wa/', body_input.name)
@@ -204,7 +204,7 @@ def make_node(
     #             )
     #             sys.exit(1)
     #         # substitution because saved_model does not allow colons
-    #         body_node.name = body_node.name.replace(':','_')
+    #         body_node.name = body_node.name.replace(':','__')
     #         # Substitution because saved_model does not allow leading slashes in op names
     #         if kwargs['output_signaturedefs']:
     #             body_node.name = re.sub('^/', 'wa/', body_node.name)
@@ -243,7 +243,7 @@ def make_node(
                 )
                 sys.exit(1)
             # substitution because saved_model does not allow colons
-            body_input.name = body_input.name.replace(':','_')
+            body_input.name = body_input.name.replace(':','__')
             # Substitution because saved_model does not allow leading slashes in op names
             if kwargs['output_signaturedefs']:
                 body_input.name = re.sub('^/', 'wa/', body_input.name)
@@ -265,7 +265,7 @@ def make_node(
                 )
                 sys.exit(1)
             # substitution because saved_model does not allow colons
-            body_node.name = body_node.name.replace(':','_')
+            body_node.name = body_node.name.replace(':','__')
             # Substitution because saved_model does not allow leading slashes in op names
             if kwargs['output_signaturedefs']:
                 body_node.name = re.sub('^/', 'wa/', body_node.name)
@@ -309,7 +309,7 @@ def make_node(
             )
             sys.exit(1)
         # substitution because saved_model does not allow colons
-        body_input.name = body_input.name.replace(':','_')
+        body_input.name = body_input.name.replace(':','__')
         # Substitution because saved_model does not allow leading slashes in op names
         if kwargs['output_signaturedefs']:
             body_input.name = re.sub('^/', 'wa/', body_input.name)
@@ -332,7 +332,7 @@ def make_node(
             )
             sys.exit(1)
         # substitution because saved_model does not allow colons
-        body_node.name = body_node.name.replace(':','_')
+        body_node.name = body_node.name.replace(':','__')
         # Substitution because saved_model does not allow leading slashes in op names
         if kwargs['output_signaturedefs']:
             body_node.name = re.sub('^/', 'wa/', body_node.name)


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf.py`
  - Fixed a lack of processing of OP name sanitizing when the `-onimc` and `-osd` or `-oiqt` options are specified in combination.
  - [osnet_x1_0_fp_32_bs_1.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12291783/osnet_x1_0_fp_32_bs_1.onnx.zip)
    ```bash
    onnx2tf \
    -i osnet_x1_0_fp_32_bs_1.onnx \
    -onimc /conv2/conv2.0/Relu_output_0 \
    -oiqt \
    -qt per-tensor
    ```
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/6d5a954a-6895-4c7c-b0a2-ed249d06724d)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[OSNet] int8 tflite model - catastrophic accuracy degradation #444](https://github.com/PINTO0309/onnx2tf/issues/444)