### PR TITLE
Implemented a workaround to deal with the problem that padding with the minimum value causes the output error of `MaxPool2D` to be maximized only when quantizing with INT8 quantization. #444

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.9
+  ghcr.io/pinto0309/onnx2tf:1.15.10
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.9
+  docker.io/pinto0309/onnx2tf:1.15.10
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.9'
+__version__ = '1.15.10'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -765,6 +765,7 @@ def convert(
         'mvn_epsilon': mvn_epsilon,
         'output_signaturedefs': output_signaturedefs,
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
+        'output_integer_quantized_tflite': output_integer_quantized_tflite,
         'use_cuda': use_cuda,
     }
 


### PR DESCRIPTION
### 1. Content and background
- `MaxPool`
  - Implemented a workaround to deal with the problem that padding with the minimum value causes the output error of `MaxPool2D` to be maximized only when quantizing with INT8 quantization. #444

    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/e65ceb08-c874-4227-b28f-adca20250673)

    ```
    Float32 model outputs flattened shape: (512,)
    Int8 model outputs flattened shape: (512,)
    Euclidean Distance: 2.0942165851593018
    ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[OSNet] int8 tflite model - catastrophic accuracy degradation #444](https://github.com/PINTO0309/onnx2tf/issues/444)