### PR TITLE
Fixed to disable transposition when bias is one dimensional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.10
+  ghcr.io/pinto0309/onnx2tf:1.15.11
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.10
+  docker.io/pinto0309/onnx2tf:1.15.11
 
   or
 
@@ -625,9 +625,9 @@ The accuracy error rates after quantization for different activation functions a
 
   Therefore, the following two similar examples are equally likely to result in divergent output values for the model after INT8 quantization, with all output values being Nan or zero.
 
-  1. Pattern with fixed value `-255.0` padded on 4 sides of tensor 
+  1. Pattern with fixed value `-255.0` padded on 4 sides of tensor
     ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/5ae0ed5f-7938-48d9-801d-fbab01eb2704)
-  
+
   2. Pattern with fixed value `-128.0` padded on 4 sides of tensor
     ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/35c7d540-b304-4662-894a-af0e053642d7)
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.10'
+__version__ = '1.15.11'


### PR DESCRIPTION
### 1. Content and background
- `Gemm`
  - Fixed to disable transposition when `bias` is one dimensional.
  - Fixed a problem in which tensors were erroneously transposed in the opposite direction when a one-dimensional bias was present.
  - https://github.com/woshidandan/TANet
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/63b71fe1-8c48-44a9-9360-3327ca1b9ff9)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
