### PR TITLE
fix unusual pads of conv

### DIFF
--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -227,8 +227,18 @@ def make_node(
     # Check auto_pad nonexistent or NOTSET first
     pad_mode = 'VALID'
     padded = False
+
+    # for onnx pads that diff on the side of axes
+    # for example [3,1] or [3,3,3,1]
+    pads_axes_opposite_same = True
+    for i in range(0, spatial_size):
+        if pads[i * 2] != pads[i * 2 + 1]:
+            pads_axes_opposite_same = False
+            break
+
     if auto_pad == 'NOTSET':
-        if input_tensor_rank >=2 \
+        if pads_axes_opposite_same \
+            and input_tensor_rank >=2 \
             and graph_node.inputs[0].shape is not None \
             and graph_node.inputs[0].shape[2:] == output_tensor_shape[2:]:
             pad_mode = "SAME"

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -231,8 +231,8 @@ def make_node(
     # for onnx pads that diff on the side of axes
     # for example [3,1] or [3,3,3,1]
     pads_axes_opposite_same = True
-    for i in range(0, spatial_size):
-        if pads[i * 2] != pads[i * 2 + 1]:
+    for axis_begin, axis_end in zip(pads[0:spatial_size:1], pads[spatial_size::1]):
+        if axis_begin != axis_end:
             pads_axes_opposite_same = False
             break
 


### PR DESCRIPTION
### 1. Background
     convert a Conv with pads[3,3,3,1] on onnx, than I receive an 'mismatch'

  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/2a428d70-8abb-4faf-a7aa-35af3d4c9c05)

### 2. Summary of corrections
     when there's Asymmetrical pads, consider it as user define params and lead it to 'get_padding_as_op'

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)

### 5. Additional instructions
.This tools is really a great wok.
.English is not my native Language, sorry about that.
.I even do not how to send a model file for picture when PR.
.Hope this may somehow help this great work.
