### PR TITLE
`BatchNormalization` Workaround for inconsistent "C" position

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.13
+  ghcr.io/pinto0309/onnx2tf:1.15.14
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.13
+  docker.io/pinto0309/onnx2tf:1.15.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.13'
+__version__ = '1.15.14'

--- a/onnx2tf/ops/BatchNormalization.py
+++ b/onnx2tf/ops/BatchNormalization.py
@@ -175,7 +175,7 @@ def make_node(
                     else tf.convert_to_tensor(scale),
             variance_epsilon=epsilon,
         )
-    except:
+    except Exception as e:
         # Workaround for inconsistent "C" position
         input_tensor_rank = len(input_tensor.shape)
         if input_tensor_rank >= 3 \
@@ -199,6 +199,8 @@ def make_node(
                         else tf.convert_to_tensor(scale),
                 variance_epsilon=epsilon,
             )
+        else:
+            raise
 
 
     # Post-process transpose

--- a/onnx2tf/ops/BatchNormalization.py
+++ b/onnx2tf/ops/BatchNormalization.py
@@ -158,22 +158,48 @@ def make_node(
             tf_layers_dict= tf_layers_dict,
         )
 
-    tf_layers_dict[Y.name]['tf_node'] = tf.nn.batch_normalization(
-        x=input_tensor,
-        mean=mean \
-            if not isinstance(mean, np.ndarray) \
-                else tf.convert_to_tensor(mean),
-        variance=var \
-            if not isinstance(var, np.ndarray) \
-                else tf.convert_to_tensor(var),
-        offset=offset \
-            if not isinstance(offset, np.ndarray) \
-                else tf.convert_to_tensor(offset),
-        scale=scale \
-            if not isinstance(scale, np.ndarray) \
-                else tf.convert_to_tensor(scale),
-        variance_epsilon=epsilon,
-    )
+    try:
+        tf_layers_dict[Y.name]['tf_node'] = tf.nn.batch_normalization(
+            x=input_tensor,
+            mean=mean \
+                if not isinstance(mean, np.ndarray) \
+                    else tf.convert_to_tensor(mean),
+            variance=var \
+                if not isinstance(var, np.ndarray) \
+                    else tf.convert_to_tensor(var),
+            offset=offset \
+                if not isinstance(offset, np.ndarray) \
+                    else tf.convert_to_tensor(offset),
+            scale=scale \
+                if not isinstance(scale, np.ndarray) \
+                    else tf.convert_to_tensor(scale),
+            variance_epsilon=epsilon,
+        )
+    except:
+        # Workaround for inconsistent "C" position
+        input_tensor_rank = len(input_tensor.shape)
+        if input_tensor_rank >= 3 \
+            and input_tensor.shape[1] is not None \
+            and input_tensor.shape[1] == offset.shape[0]:
+
+            perm = [0] + [i for i in range(2, input_tensor_rank)] + [1]
+            tf_layers_dict[Y.name]['tf_node'] = tf.nn.batch_normalization(
+                x=tf.transpose(input_tensor, perm=perm),
+                mean=mean \
+                    if not isinstance(mean, np.ndarray) \
+                        else tf.convert_to_tensor(mean),
+                variance=var \
+                    if not isinstance(var, np.ndarray) \
+                        else tf.convert_to_tensor(var),
+                offset=offset \
+                    if not isinstance(offset, np.ndarray) \
+                        else tf.convert_to_tensor(offset),
+                scale=scale \
+                    if not isinstance(scale, np.ndarray) \
+                        else tf.convert_to_tensor(scale),
+                variance_epsilon=epsilon,
+            )
+
 
     # Post-process transpose
     tf_layers_dict[Y.name]['tf_node'] = post_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- `BatchNormalization`
  - Workaround for inconsistent `C` position.
  - This is a special optimization measure especially for onnx generated using [tf2onnx (tensorflow-onnx)](https://github.com/onnx/tensorflow-onnx).
  - Reduction of conversion errors caused by missing the position of the `C` when there is a large number of unnecessary `Transpose` just before the `BatchNormalization`.
  - Improved stability of the overall model conversion.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
