### PR TITLE
Improved propagation of NHWC flags under limited conditions in `Unsqueeze`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.14
+  ghcr.io/pinto0309/onnx2tf:1.15.15
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.14
+  docker.io/pinto0309/onnx2tf:1.15.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.14'
+__version__ = '1.15.15'

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -89,6 +89,14 @@ def make_node(
                     before_op_output_shape_trans=before_op_output_shape_trans,
                 ) for idx in axes
             ]
+        elif not nhwc and tensor_rank <= 2:
+            axes = [
+                convert_axis(
+                    axis=idx,
+                    tensor_rank=tensor_rank+len(axes),
+                    before_op_output_shape_trans=before_op_output_shape_trans,
+                ) for idx in axes
+            ]
         else:
             axes = [idx for idx in axes]
     elif axes is not None and isinstance(axes, np.ndarray) and len(axes.shape) == 0:
@@ -98,6 +106,14 @@ def make_node(
                 tensor_rank=tensor_rank+1,
                 before_op_output_shape_trans=before_op_output_shape_trans,
             )
+        elif not nhwc and tensor_rank <= 2:
+            axes = [
+                convert_axis(
+                    axis=idx,
+                    tensor_rank=tensor_rank+len(axes),
+                    before_op_output_shape_trans=before_op_output_shape_trans,
+                ) for idx in axes
+            ]
         axes = list(axes[np.newaxis])
 
     if axes is not None and isinstance(axes, list) and len(axes) > 0:
@@ -198,6 +214,17 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
             tf.identity(input=input_tensor)
         tf_type = tf.identity
+
+    elif nhwc \
+        and len(axes) == 1 \
+        and not isinstance(axes, int):
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.expand_dims(
+                input=input_tensor,
+                axis=axes[0],
+                name=graph_node.name,
+            )
+        tf_type = tf.expand_dims
 
     elif len(new_shape) >= 2 \
         and len([dim for dim in new_shape if dim is None or dim == -1]) >= 2 \

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -64,6 +64,10 @@ def make_node(
         axes = None
     axes = graph_node.attrs.get('axes', axes)
 
+    nhwc: bool = tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+        if isinstance(graph_node_input_1, gs.Variable) \
+            and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
+
     if input_tensor.shape != tf.TensorShape(None):
         input_tensor_shape = list(input_tensor.shape)
         tensor_rank = len(input_tensor_shape)
@@ -77,19 +81,23 @@ def make_node(
         tensor_rank = len(input_tensor_shape)
 
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
-        axes = [
-            convert_axis(
-                axis=idx,
-                tensor_rank=tensor_rank+len(axes),
-                before_op_output_shape_trans=before_op_output_shape_trans,
-            ) for idx in axes
-        ]
+        if nhwc:
+            axes = [
+                convert_axis(
+                    axis=idx,
+                    tensor_rank=tensor_rank+len(axes),
+                    before_op_output_shape_trans=before_op_output_shape_trans,
+                ) for idx in axes
+            ]
+        else:
+            axes = [idx for idx in axes]
     elif axes is not None and isinstance(axes, np.ndarray) and len(axes.shape) == 0:
-        axes = convert_axis(
-            axis=axes,
-            tensor_rank=tensor_rank+1,
-            before_op_output_shape_trans=before_op_output_shape_trans,
-        )
+        if nhwc:
+            axes = convert_axis(
+                axis=axes,
+                tensor_rank=tensor_rank+1,
+                before_op_output_shape_trans=before_op_output_shape_trans,
+            )
         axes = list(axes[np.newaxis])
 
     if axes is not None and isinstance(axes, list) and len(axes) > 0:
@@ -106,6 +114,8 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if nhwc and len(axes) == 1 and tensor_rank is not None and axes not in [0, -1, tensor_rank] else False
     }
 
     # Param replacement - OP replacement

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -89,7 +89,7 @@ def make_node(
                     before_op_output_shape_trans=before_op_output_shape_trans,
                 ) for idx in axes
             ]
-        elif not nhwc and tensor_rank <= 2:
+        elif not nhwc and (isinstance(axes, list) and len(axes) == 1 or isinstance(axes, np.ndarray) and len(axes.shape) == 1) and axes[0] == -1:
             axes = [
                 convert_axis(
                     axis=idx,
@@ -106,7 +106,7 @@ def make_node(
                 tensor_rank=tensor_rank+1,
                 before_op_output_shape_trans=before_op_output_shape_trans,
             )
-        elif not nhwc and tensor_rank <= 2:
+        elif not nhwc and (isinstance(axes, list) and len(axes) == 1 or isinstance(axes, np.ndarray) and len(axes.shape) == 1) and axes[0] == -1:
             axes = [
                 convert_axis(
                     axis=idx,


### PR DESCRIPTION
### 1. Content and background
- `Unsqueeze`
  - Improved propagation of NHWC flags under limited conditions in `Unsqueeze`.
  - Reduces the frequency of shape unmatch errors in subsequent OPs.
- `common_functions.py`
  - Implemented workarounds to avoid shape mismatch errors in `Mul`, `Sub`, `Div`, and `Mod` to improve overall model transformation stability.

```bash
onnx2tf -i conv_tasnet_dnn.onnx -kat input -cotof
```
![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/56cf380f-c4f1-4bc8-992b-9b2965e44896)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[DNN-based_source_separation] Facing issue in Mul node during conversion #460](https://github.com/PINTO0309/onnx2tf/issues/460)