### PR TITLE
[experimental] To avoid generating unnecessary `Reshape` as much as possible, the process is terminated early when a simple operation of tensor A and tensor B is established.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.16
+  ghcr.io/pinto0309/onnx2tf:1.15.17
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.16
+  docker.io/pinto0309/onnx2tf:1.15.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.16'
+__version__ = '1.15.17'

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -130,33 +130,37 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
-    input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-    )
+    input_tensor_1, input_tensor_2 = \
+        pre_explicit_broadcast(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+        )
 
-    input_tensor_1, input_tensor_2 = explicit_broadcast(
-        const_or_var_1=input_tensor_1,
-        const_or_var_2=input_tensor_2,
-        graph_node=graph_node,
-        tf_layers_dict= tf_layers_dict,
-    )
+    input_tensor_1, input_tensor_2 = \
+        explicit_broadcast(
+            const_or_var_1=input_tensor_1,
+            const_or_var_2=input_tensor_2,
+            graph_node=graph_node,
+            tf_layers_dict= tf_layers_dict,
+        )
 
     # broadcast_for_gpu_delegate
-    input_tensor_1, input_tensor_2 = broadcast_for_gpu_delegate(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        broadcast_for_gpu_delegate(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            **kwargs,
+        )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \
@@ -168,16 +172,17 @@ def make_node(
 
     # Correction process for accuracy errors
     if not disable_strict_mode:
-        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-            tf_func=tf.math.multiply,
-            np_func=np.multiply,
-            graph_node_output_shape=graph_node_output_shape,
-            graph_node_output=graph_node_output,
-            tf_layers_dict=tf_layers_dict,
-            **kwargs,
-        )
+        input_tensor_1, input_tensor_2 = \
+            correction_process_for_accuracy_errors(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+                tf_func=tf.math.multiply,
+                np_func=np.multiply,
+                graph_node_output_shape=graph_node_output_shape,
+                graph_node_output=graph_node_output,
+                tf_layers_dict=tf_layers_dict,
+                **kwargs,
+            )
 
     # Generation of TF OP
     # TODO: Temporarily Revert due to missing decision conditions

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -104,25 +104,28 @@ def make_node(
         convertion_table = [0] + [i for i in range(2, input_tensor_rank)] + [1]
         slope = slope.transpose(convertion_table)
 
-    input_tensor, slope = pre_explicit_broadcast(
-        input_tensor_1=input_tensor,
-        input_tensor_2=slope,
-    )
-    input_tensor, slope = explicit_broadcast(
-        const_or_var_1=input_tensor,
-        const_or_var_2=slope,
-        graph_node=graph_node,
-        tf_layers_dict= tf_layers_dict,
-    )
+    input_tensor, slope = \
+        pre_explicit_broadcast(
+            input_tensor_1=input_tensor,
+            input_tensor_2=slope,
+        )
+    input_tensor, slope = \
+        explicit_broadcast(
+            const_or_var_1=input_tensor,
+            const_or_var_2=slope,
+            graph_node=graph_node,
+            tf_layers_dict= tf_layers_dict,
+        )
 
     # Pre-process transpose
     before_trans_shape = input_tensor_shape
-    input_tensor = pre_process_transpose(
-        value_before_transpose=input_tensor,
-        param_target='inputs',
-        param_name=graph_node.inputs[0].name,
-        **kwargs,
-    )
+    input_tensor = \
+        pre_process_transpose(
+            value_before_transpose=input_tensor,
+            param_target='inputs',
+            param_name=graph_node.inputs[0].name,
+            **kwargs,
+        )
     after_trans_shape = input_tensor.shape
     if 'nhwc' in tf_layers_dict[graph_node_output.name].keys() \
         and tf_layers_dict[graph_node_output.name]['nhwc'] == True \

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -104,6 +104,17 @@ def make_node(
         convertion_table = [0] + [i for i in range(2, input_tensor_rank)] + [1]
         slope = slope.transpose(convertion_table)
 
+    input_tensor, slope = pre_explicit_broadcast(
+        input_tensor_1=input_tensor,
+        input_tensor_2=slope,
+    )
+    input_tensor, slope = explicit_broadcast(
+        const_or_var_1=input_tensor,
+        const_or_var_2=slope,
+        graph_node=graph_node,
+        tf_layers_dict= tf_layers_dict,
+    )
+
     # Pre-process transpose
     before_trans_shape = input_tensor_shape
     input_tensor = pre_process_transpose(

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -757,6 +757,15 @@ def pre_explicit_broadcast(
         and None not in input_tensor_2.shape \
         and len(input_tensor_1.shape) == len(input_tensor_2.shape):
 
+        # Broadcasting of the operation Checks whether the operation functions normally,
+        # and if so, terminates the process without doing anything.
+        try:
+            dummy_mul = input_tensor_1 * input_tensor_2
+        except Exception as e:
+            pass
+        else:
+            return input_tensor_1, input_tensor_2
+
         input_tensor_2_shape = input_tensor_2.shape
         squeezed_input_tensor_2_shape = [idx for idx in input_tensor_2_shape if idx != 1]
         squeezed_input_tensor_2_shape_rank = len(squeezed_input_tensor_2_shape)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -761,6 +761,9 @@ def pre_explicit_broadcast(
         # and if so, terminates the process without doing anything.
         try:
             dummy_mul = input_tensor_1 * input_tensor_2
+            max_shape_prod = max(np.prod(input_tensor_1.shape), np.prod(input_tensor_2.shape))
+            if np.prod(dummy_mul.shape) <= max_shape_prod:
+                return input_tensor_1, input_tensor_2
         except Exception as e:
             pass
         else:
@@ -895,6 +898,10 @@ def explicit_broadcast(
         i if i is not None else INF_INDEX_VALUE for i in const_or_var_2.shape
     ]
     if np.prod(shape_for_judging_skip_processing_1) == 1 or np.prod(shape_for_judging_skip_processing_2) == 1:
+        return const_or_var_1, const_or_var_2
+
+    # If the two tensors to be processed have exactly the same number of axes, skip the process.
+    if len(const_or_var_1.shape) == len(const_or_var_2.shape):
         return const_or_var_1, const_or_var_2
 
     # Dealing with tricky BatchNormalization


### PR DESCRIPTION
### 1. Content and background
- `common_functions.py`
  - Experimental implementation.
  - To avoid generating unnecessary `Reshape` as much as possible, the process is terminated early when a simple operation of tensor A and tensor B is established.
  - [mobilenetv3_large_pytorch.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12421461/mobilenetv3_large_pytorch.onnx.zip)
    |Before|After|
    |:-:|:-:|
    |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/00338f6c-39d6-4c7e-8ca7-001e7aa896fc)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/7e54e7b4-dfe9-4eb9-892b-9fc53e83bbfe)|

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
