### PR TITLE
Add logic to replace a set of primitive OPs with `GeLU`s to improve overall model processing efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.15.18
+  ghcr.io/pinto0309/onnx2tf:1.16.0
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.15.18
+  docker.io/pinto0309/onnx2tf:1.16.0
 
   or
 
@@ -392,7 +392,7 @@ $ onnx2tf -i emotion-ferplus-8.onnx -oiqt -qt per-tensor
 $ onnx2tf -i resnet18-v1-7.onnx -onimc resnetv15_stage2_conv1_fwd resnetv15_stage2_conv2_fwd
 
 # Suppress generation of Flex OP and replace with Pseudo-Function
-# [Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf]
+# [Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU]
 # Below is a sample of replacing GELU / Erf with another set of operations.
 $ wget https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_readme/gelu_11.onnx
 $ onnx2tf -i gelu_11.onnx -rtpo Erf
@@ -1440,7 +1440,7 @@ optional arguments:
     Replace list of operators to pseudo operators.
     Full name of the target operators should be given.
     Currently supported operators :
-    Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf
+    Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU
 
   -me, --mvn_epsilon
     For MeanVarianceNormalization.
@@ -1907,7 +1907,7 @@ convert(
       Replace list of operators to pseudo operators.
       Full name of the target operators should be given.
       Currently supported operators :
-      Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf
+      Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU
 
     mvn_epsilon: Optional[float]
       For MeanVarianceNormalization.
@@ -2355,6 +2355,7 @@ The above differences often cannot be dealt with by simply converting the model 
 - [x] Add process to replace `Neg` with `pseudo-Neg`.
 - [x] Add process to replace `ArgMax` with `pseudo-ArgMax`.
 - [x] Add process to replace `Erf` with `pseudo-Erf`.
+- [x] Add process to replace `GeLU` with `pseudo-GeLU`.
 - [x] Added option to fix dynamic batch size `N` to a specified number.
 - [x] Added option to overwrite dynamic shape input OPs with static shape. `--overwrite_input_shape`
 - [x] Output in Keras H5 format.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.15.18'
+__version__ = '1.16.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -369,7 +369,7 @@ def convert(
         Replace list of operators to pseudo operators. \n
         Full name of the target operators should be given. \n
         Currently supported operators : \n
-        Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf
+        Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU
 
     mvn_epsilon: Optional[float]
         For MeanVarianceNormalization.\n
@@ -766,6 +766,7 @@ def convert(
         'output_signaturedefs': output_signaturedefs,
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
         'output_integer_quantized_tflite': output_integer_quantized_tflite,
+        'gelu_replace_op_names': {},
         'use_cuda': use_cuda,
     }
 
@@ -2009,7 +2010,7 @@ def main():
             'Replace list of operators to pseudo operators. \n ' +
             'Full name of the target operators should be given. \n ' +
             'Currently supported operators : \n' +
-            'Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf'
+            'Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU'
     )
     parser.add_argument(
         '-me',

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -91,6 +91,7 @@ def make_node(
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
     disable_strict_mode: bool = kwargs['disable_strict_mode']
+    gelu_replace_op_names: dict = kwargs['gelu_replace_op_names']
 
     # Param replacement
     input_tensor_1 = \
@@ -187,34 +188,47 @@ def make_node(
             )
 
     # Generation of TF OP
-    # Merge two consecutive identical OPs into one
-    # https://github.com/PINTO0309/onnx2tf/issues/230
-    #   A constant is calculated in advance only
-    #   when one of the operations of the current OP
-    #   is a constant and one of the operations of
-    #   the next OP is also a constant.
-    # By merging two OPs into one, an accuracy error always occurs
-    # in the merged OP during the accuracy check.
-    # 1. `Mul` -> `Mul` to `Single-Mul` : `10 * 5 * 8 -> 10 * 40`
-    # 2. `Mul` -> `Div` to `Single-Mul` : `10 * 5 / 8 -> 10 * 0.625`
-    # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
-    # 4. `Div` -> `Div` to `Single-Mul` : `10 / 5 / 8 -> 10 * 0.025`
-    # 5. `Sub` -> `Sub` to `Single-Sub` : `10 - 5 - 8 -> 10 - 13`
-    # 6. `Sub` -> `Add` to `Single-Sub` : `10 - 5 + 8 -> 10 + 3`
-    # 7. `Add` -> `Add` to `Single-Add`  : `10 + 5 + 8 -> 10 + 13`
-    # 8. `Add` -> `Sub` to `Single-Add`  : `10 + 5 - 8 -> 10 - 3`
-    _, tf_type = \
-        merge_two_consecutive_identical_ops_into_one(
-            graph_node_input_1=graph_node_input_1,
-            graph_node_input_2=graph_node_input_2,
-            graph_node_output=graph_node_output,
-            before_op_output_shape_trans=before_op_output_shape_trans,
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-            graph_node=graph_node,
-            tf_layers_dict=tf_layers_dict,
-            tf_func='Add'
-        )
+
+    # Replace with GeLU if available.
+    gelu_op_names = [op_name for op_names in gelu_replace_op_names.values() for op_name in op_names]
+    enable_gelu = graph_node.name in gelu_op_names
+
+    if not enable_gelu:
+        # Merge two consecutive identical OPs into one
+        # https://github.com/PINTO0309/onnx2tf/issues/230
+        #   A constant is calculated in advance only
+        #   when one of the operations of the current OP
+        #   is a constant and one of the operations of
+        #   the next OP is also a constant.
+        # By merging two OPs into one, an accuracy error always occurs
+        # in the merged OP during the accuracy check.
+        # 1. `Mul` -> `Mul` to `Single-Mul` : `10 * 5 * 8 -> 10 * 40`
+        # 2. `Mul` -> `Div` to `Single-Mul` : `10 * 5 / 8 -> 10 * 0.625`
+        # 3. `Div` -> `Mul` to `Single-Mul` : `10 / 5 * 8 -> 10 * 1.6`
+        # 4. `Div` -> `Div` to `Single-Mul` : `10 / 5 / 8 -> 10 * 0.025`
+        # 5. `Sub` -> `Sub` to `Single-Sub` : `10 - 5 - 8 -> 10 - 13`
+        # 6. `Sub` -> `Add` to `Single-Sub` : `10 - 5 + 8 -> 10 + 3`
+        # 7. `Add` -> `Add` to `Single-Add`  : `10 + 5 + 8 -> 10 + 13`
+        # 8. `Add` -> `Sub` to `Single-Add`  : `10 + 5 - 8 -> 10 - 3`
+        _, tf_type = \
+            merge_two_consecutive_identical_ops_into_one(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_2,
+                graph_node_output=graph_node_output,
+                before_op_output_shape_trans=before_op_output_shape_trans,
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+                graph_node=graph_node,
+                tf_layers_dict=tf_layers_dict,
+                tf_func='Add'
+            )
+    else:
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.identity(
+                input=input_tensor_1 if graph_node.i(0).name in gelu_op_names else input_tensor_2,
+                name=graph_node.name,
+            )
+        tf_type = tf.identity
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `GeLU`
  - Add logic to replace a set of primitive OPs with GeLUs to improve overall model processing efficiency.
    https://www.tensorflow.org/api_docs/python/tf/keras/activations/gelu
    https://www.tensorflow.org/api_docs/python/tf/nn/gelu
    
  - Automatically detect the range where the following OP combination is valid and replace it with the `GeLU` OP.

    ```
    0.5 * x * (1 + erf(x / sqrt(2.0)))
    
    # sqrt(2) = 1.4142135
    # a = tf.math.sqrt(2.0)
    # a
    # <tf.Tensor: shape=(), dtype=float32, numpy=1.4142135>
    # a == 1.4142135381698608
    # <tf.Tensor: shape=(), dtype=bool, numpy=True>
    ```

  - a. x -> b.`Div (a*1.4142135381698608)` -> c.`Erf (b)` -> d.`Add (c+1.0)` -> e.`Mul (a*d)` -> f.`Mul (f*0.5)`
    ```
    INFO: onnx_op_type: Div onnx_op_name: Div_145
    INFO:  input_name.1: 366 shape: [1, 320, 256] dtype: float32
    INFO:  input_name.2: 277 shape: [] dtype: float32
    INFO:  output_name.1: 368 shape: [1, 320, 256] dtype: float32
    INFO: tf_op_type: divide
    INFO:  input.1.x: name: tf.math.add/Add:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    INFO:  input.2.y: shape: (1, 1, 1) dtype: <dtype: 'float32'> 
    INFO:  output.1.output: name: tf.math.divide/truediv:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    
    INFO: onnx_op_type: Erf onnx_op_name: Erf_146
    INFO:  input_name.1: 368 shape: [1, 320, 256] dtype: float32
    INFO:  output_name.1: 369 shape: [1, 320, 256] dtype: float32
    INFO: tf_op_type: erf
    INFO:  input.1.x: name: tf.math.divide/truediv:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    INFO:  output.1.output: name: tf.math.erf/Erf:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    
    INFO: onnx_op_type: Add onnx_op_name: Add_148
    INFO:  input_name.1: 369 shape: [1, 320, 256] dtype: float32
    INFO:  input_name.2: 280 shape: [] dtype: float32
    INFO:  output_name.1: 371 shape: [1, 320, 256] dtype: float32
    INFO: tf_op_type: add
    INFO:  input.1.x: name: tf.math.erf/Erf:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    INFO:  input.2.y: shape: (1, 1, 1) dtype: <dtype: 'float32'> 
    INFO:  output.1.output: name: tf.math.add_1/Add:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    
    INFO: onnx_op_type: Mul onnx_op_name: Mul_149
    INFO:  input_name.1: 366 shape: [1, 320, 256] dtype: float32
    INFO:  input_name.2: 371 shape: [1, 320, 256] dtype: float32
    INFO:  output_name.1: 372 shape: [1, 320, 256] dtype: float32
    INFO: tf_op_type: multiply
    INFO:  input.1.x: name: tf.math.add/Add:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    INFO:  input.2.y: name: tf.math.add_1/Add:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    INFO:  output.1.output: name: tf.math.multiply_6/Mul:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    
    INFO: onnx_op_type: Mul onnx_op_name: Mul_151
    INFO:  input_name.1: 372 shape: [1, 320, 256] dtype: float32
    INFO:  input_name.2: 283 shape: [] dtype: float32
    INFO:  output_name.1: 374 shape: [1, 320, 256] dtype: float32
    INFO: tf_op_type: multiply
    INFO:  input.1.x: name: tf.math.multiply_6/Mul:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    INFO:  input.2.y: shape: (1, 1, 1) dtype: <dtype: 'float32'> 
    INFO:  output.1.output: name: tf.math.multiply_8/Mul:0 shape: (1, 320, 256) dtype: <dtype: 'float32'> 
    ```

  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/7a480c44-cc78-49b8-94d2-ca36b3d9cb8a)

  An additional `--enable_approximate` option should be implemented to allow the process to be replaced by an approximate calculation. This allows for an increase in overall model performance in exchange for a small degradation in accuracy.
  
  ```
  0.5 * x * (1 + tanh(sqrt(2 / pi) * (x + 0.044715 * x^3)))
  ```
  https://github.com/onnx/onnx/blob/main/docs/Changelog.md#gelu-20
  
  However, as shown below, if 0.5 is pre-multiplied, it is automatically converted to `GeLU`. (The `Transpose` may be ignored.)
  
  |Before (onnx)|After (tflite)|
  |:-:|:-:|
  |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/06674887-833d-483b-96bb-9f5aec165a09)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/3a55d6f7-d2e0-4b56-9313-01b2e5354603)|

- Results
  [gelu.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12450575/gelu.onnx.zip)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/755cf787-9150-4572-a458-88354ac295f9)
  
  |onnx|tflite|
  |:-:|:-:|
  |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/9b2f7a0d-ff76-4e7f-a7e9-60e87cce26b8)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/0944f075-6b0c-462a-a5cb-fe0c986f6f8d)|

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Implemented forced replacement of GeLU processing with standard OP. #465](https://github.com/PINTO0309/onnx2tf/issues/465)