### PR TITLE
PReLU slope conversion bug fixed again

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -97,14 +97,14 @@ jobs:
         pip install pip -U
         pip install cmake==3.22.5
         pip install psutil==5.9.5
-        pip install onnx==1.13.1
+        pip install onnx==1.14.0
         pip install tensorflow==2.13.0
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon
         pip install protobuf==3.20.3
         pip install onnxsim==0.4.33
         pip install sng4onnx
-        pip install onnxruntime==1.15.0
+        pip install onnxruntime==1.15.1
         pip install -e .
     - name: Download models
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install pip -U \
-    && pip install onnx==1.13.1 \
+    && pip install onnx==1.14.0 \
     && pip install onnxsim==0.4.33 \
     && pip install nvidia-pyindex \
     && pip install onnx_graphsurgeon \
@@ -23,7 +23,7 @@ RUN pip install pip -U \
     && pip install protobuf==3.20.3 \
     && pip install h5py==3.7.0 \
     && pip install psutil==5.9.5 \
-    && pip install onnxruntime==1.15.0
+    && pip install onnxruntime==1.15.1
 
 # Re-release flatc with some customizations of our own to address
 # the lack of arithmetic precision of the quantization parameters

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 
 ## Environment
 - Linux / Windows
-- onnx==1.13.1
-- onnxruntime==1.15.0
+- onnx==1.14.0
+- onnxruntime==1.15.1
 - onnx-simplifier==0.4.33
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
@@ -267,10 +267,10 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 
   or
 
-  $ pip install -U onnx==1.13.1 \
+  $ pip install -U onnx==1.14.0 \
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
-  && pip install -U onnxruntime==1.15.0 \
+  && pip install -U onnxruntime==1.15.1 \
   && pip install -U onnxsim==0.4.33 \
   && pip install -U simple_onnx_processing_tools \
   && pip install -U onnx2tf \
@@ -295,10 +295,10 @@ or
     && sudo mv flatc /usr/bin/
   !pip install -U pip \
     && pip install tensorflow==2.13.0 \
-    && pip install -U onnx==1.13.1 \
+    && pip install -U onnx==1.14.0 \
     && python -m pip install onnx_graphsurgeon \
           --index-url https://pypi.ngc.nvidia.com \
-    && pip install -U onnxruntime==1.15.0 \
+    && pip install -U onnxruntime==1.15.1 \
     && pip install -U onnxsim==0.4.33 \
     && pip install -U simple_onnx_processing_tools \
     && pip install -U onnx2tf \

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.1
+  ghcr.io/pinto0309/onnx2tf:1.16.2
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.1
+  docker.io/pinto0309/onnx2tf:1.16.2
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.1'
+__version__ = '1.16.2'

--- a/onnx2tf/ops/PRelu.py
+++ b/onnx2tf/ops/PRelu.py
@@ -92,16 +92,17 @@ def make_node(
         )
 
     # input_tensor: [1, 4, 4, 4]
-    # slope: [4, 1, 1] -> [1, 4, 1, 1]
+    # slope: [4, 1, 1] -> [1, 4, 1, 1] -> [1, 1, 1, 4]
     # https://github.com/PINTO0309/onnx2tf/issues/418
     if tf_layers_dict[graph_node_output.name]['nhwc'] == True \
         and input_tensor_shape is not None \
         and input_tensor_rank >= 3 \
         and sum([1 if isinstance(s, int) and s == input_tensor_shape[1] else 0 for s in input_tensor_shape]) == input_tensor_rank - 1 \
         and slope.shape is not None \
-        and len(slope.shape) == 3 \
+        and len(slope.shape) >= 3 \
         and input_tensor_rank == len(slope.shape) \
-        and isinstance(slope, np.ndarray):
+        and isinstance(slope, np.ndarray) \
+        and slope.shape[-1] == 1:
         convertion_table = [0] + [i for i in range(2, input_tensor_rank)] + [1]
         slope = slope.transpose(convertion_table)
 


### PR DESCRIPTION
### 1. Content and background
- `PReLU`
  - `slope` conversion bug fixed again
- onnx==1.13.1 -> onnx==1.14.0
- onnxruntime==1.15.0 -> onnxruntime==1.15.1

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
