### PR TITLE
[experimental] Prevents `Mul` -> `Div` patterns from creating redundant `Mul` -> `Mul` operation sets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.2
+  ghcr.io/pinto0309/onnx2tf:1.16.3
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.2
+  docker.io/pinto0309/onnx2tf:1.16.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.2'
+__version__ = '1.16.3'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -767,6 +767,7 @@ def convert(
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
         'output_integer_quantized_tflite': output_integer_quantized_tflite,
         'gelu_replace_op_names': {},
+        'mul_div_replace_op_names': {},
         'use_cuda': use_cuda,
     }
 

--- a/onnx2tf/ops/And.py
+++ b/onnx2tf/ops/And.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -131,26 +131,29 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
-    input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-    )
+    input_tensor_1, input_tensor_2 = \
+        pre_explicit_broadcast(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+        )
 
-    input_tensor_1, input_tensor_2 = explicit_broadcast(
-        const_or_var_1=input_tensor_1,
-        const_or_var_2=input_tensor_2,
-        graph_node=graph_node,
-        tf_layers_dict= tf_layers_dict,
-    )
+    input_tensor_1, input_tensor_2 = \
+        explicit_broadcast(
+            const_or_var_1=input_tensor_1,
+            const_or_var_2=input_tensor_2,
+            graph_node=graph_node,
+            tf_layers_dict= tf_layers_dict,
+        )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \
@@ -162,16 +165,17 @@ def make_node(
 
     # Correction process for accuracy errors
     if not disable_strict_mode:
-        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-            tf_func=tf.math.divide,
-            np_func=np.divide,
-            graph_node_output_shape=graph_node_output_shape,
-            graph_node_output=graph_node_output,
-            tf_layers_dict=tf_layers_dict,
-            **kwargs,
-        )
+        input_tensor_1, input_tensor_2 = \
+            correction_process_for_accuracy_errors(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+                tf_func=tf.math.divide,
+                np_func=np.divide,
+                graph_node_output_shape=graph_node_output_shape,
+                graph_node_output=graph_node_output,
+                tf_layers_dict=tf_layers_dict,
+                **kwargs,
+            )
 
     # Generation of TF OP
     target_cast_dtype = [

--- a/onnx2tf/ops/Equal.py
+++ b/onnx2tf/ops/Equal.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/Greater.py
+++ b/onnx2tf/ops/Greater.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/GreaterOrEqual.py
+++ b/onnx2tf/ops/GreaterOrEqual.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/Less.py
+++ b/onnx2tf/ops/Less.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/LessOrEqual.py
+++ b/onnx2tf/ops/LessOrEqual.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -129,26 +129,29 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
-    input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-    )
+    input_tensor_1, input_tensor_2 = \
+        pre_explicit_broadcast(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+        )
 
-    input_tensor_1, input_tensor_2 = explicit_broadcast(
-        const_or_var_1=input_tensor_1,
-        const_or_var_2=input_tensor_2,
-        graph_node=graph_node,
-        tf_layers_dict= tf_layers_dict,
-    )
+    input_tensor_1, input_tensor_2 = \
+        explicit_broadcast(
+            const_or_var_1=input_tensor_1,
+            const_or_var_2=input_tensor_2,
+            graph_node=graph_node,
+            tf_layers_dict= tf_layers_dict,
+        )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \
@@ -160,16 +163,17 @@ def make_node(
 
     # Correction process for accuracy errors
     if not disable_strict_mode:
-        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-            tf_func=tf.math.mod,
-            np_func=np.mod,
-            graph_node_output_shape=graph_node_output_shape,
-            graph_node_output=graph_node_output,
-            tf_layers_dict=tf_layers_dict,
-            **kwargs,
-        )
+        input_tensor_1, input_tensor_2 = \
+            correction_process_for_accuracy_errors(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+                tf_func=tf.math.mod,
+                np_func=np.mod,
+                graph_node_output_shape=graph_node_output_shape,
+                graph_node_output=graph_node_output,
+                tf_layers_dict=tf_layers_dict,
+                **kwargs,
+            )
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \

--- a/onnx2tf/ops/Or.py
+++ b/onnx2tf/ops/Or.py
@@ -79,14 +79,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -129,26 +129,29 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
-    input_tensor_1, input_tensor_2 = pre_explicit_broadcast(
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-    )
+    input_tensor_1, input_tensor_2 = \
+        pre_explicit_broadcast(
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+        )
 
-    input_tensor_1, input_tensor_2 = explicit_broadcast(
-        const_or_var_1=input_tensor_1,
-        const_or_var_2=input_tensor_2,
-        graph_node=graph_node,
-        tf_layers_dict= tf_layers_dict,
-    )
+    input_tensor_1, input_tensor_2 = \
+        explicit_broadcast(
+            const_or_var_1=input_tensor_1,
+            const_or_var_2=input_tensor_2,
+            graph_node=graph_node,
+            tf_layers_dict= tf_layers_dict,
+        )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \
@@ -160,16 +163,17 @@ def make_node(
 
     # Correction process for accuracy errors
     if not disable_strict_mode:
-        input_tensor_1, input_tensor_2 = correction_process_for_accuracy_errors(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-            tf_func=tf.math.subtract,
-            np_func=np.subtract,
-            graph_node_output_shape=graph_node_output_shape,
-            graph_node_output=graph_node_output,
-            tf_layers_dict=tf_layers_dict,
-            **kwargs,
-        )
+        input_tensor_1, input_tensor_2 = \
+            correction_process_for_accuracy_errors(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+                tf_func=tf.math.subtract,
+                np_func=np.subtract,
+                graph_node_output_shape=graph_node_output_shape,
+                graph_node_output=graph_node_output,
+                tf_layers_dict=tf_layers_dict,
+                **kwargs,
+            )
 
     # Generation of TF OP
     # Merge two consecutive identical OPs into one

--- a/onnx2tf/ops/Xor.py
+++ b/onnx2tf/ops/Xor.py
@@ -80,14 +80,15 @@ def make_node(
     # At least one True value for same_input_shape_as_onnx
     # At least one True value in nhwc_flags
     # same_input_shape_as_onnx == True and nhwc_flags == False and 3D or 4D or 5D tensor is NHWC transposed
-    input_tensor_1, input_tensor_2 = shape_unmatched_special_avoidance_workaround(
-        graph_node_input_1=graph_node_input_1,
-        graph_node_input_2=graph_node_input_2,
-        input_tensor_1=input_tensor_1,
-        input_tensor_2=input_tensor_2,
-        tf_layers_dict=tf_layers_dict,
-        **kwargs,
-    )
+    input_tensor_1, input_tensor_2 = \
+        shape_unmatched_special_avoidance_workaround(
+            graph_node_input_1=graph_node_input_1,
+            graph_node_input_2=graph_node_input_2,
+            input_tensor_1=input_tensor_1,
+            input_tensor_2=input_tensor_2,
+            tf_layers_dict=tf_layers_dict,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor_1 = pre_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- `Mul`, `Div`
  - Prevents `Mul` -> `Div` patterns from creating redundant `Mul` -> `Mul` operation sets.
  - This optimization improves the overall computational efficiency of the model just a little bit.
    |onnx|tflite|
    |:-:|:-:|
    |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/500c4c05-b36a-4db3-a2b0-7ecfd127e930)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/a9c2b4a7-83a9-4c6b-b559-8a48b085d101)|

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Demucs] Issue while converting demucs model from onnx to tflite in conv2d_transpose #470](https://github.com/PINTO0309/onnx2tf/issues/470)