### PR TITLE
Significantly improved conversion stability by reducing the frequency of SWAPs due to lack of RAM for large models, and improved processing stability of `InstanceNormalization`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.3
+  ghcr.io/pinto0309/onnx2tf:1.16.4
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.3
+  docker.io/pinto0309/onnx2tf:1.16.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.3'
+__version__ = '1.16.4'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -7,7 +7,7 @@ with open(os.path.join(__path__[0], '__init__.py')) as f:
     init_text = f.read()
     __version__ = re.search(r'__version__\s*=\s*[\'\"](.+?)[\'\"]', init_text).group(1)
 import sys
-sys.setrecursionlimit(10000)
+sys.setrecursionlimit(2147483647) # C int maximum
 import ast
 import json
 import logging
@@ -879,7 +879,7 @@ def convert(
                     custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
                     tf_layers_dict=tf_layers_dict,
                     use_cuda=use_cuda,
-
+                    disable_strict_mode=disable_strict_mode,
                 )
             """
             onnx_tensor_infos_for_validation:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3787,14 +3787,14 @@ def dummy_onnx_inference(
         # Total bytes
         total_output_size += op_output_size * dtype_sizes.get(gs_graph_output.dtype, 4)
 
-    # When exact inference mode is enabled and the total size of the tensor of inference results exceeds approximately 96 GB
-    STRICT_MAXIMUM_OUTPUT_SIZE = 96
-    if (not disable_strict_mode and (total_output_size // 1024 // 1024 //1024) > STRICT_MAXIMUM_OUTPUT_SIZE):
+    # When exact inference mode is enabled and the total size of the tensor of inference results exceeds approximately 80% of available RAM
+    mem_available = psutil.virtual_memory().available * 0.80 // 1024 // 1024 //1024
+    if (not disable_strict_mode and (total_output_size // 1024 // 1024 //1024) > mem_available):
         if tmp_onnx_path:
             os.remove(tmp_onnx_path)
             os.remove(tmp_onnx_external_weights_path)
         raise Exception(
-            f'The tool skipped dummy inference to avoid SWAP processing because the total size of the tensor of inference results exceeded about {STRICT_MAXIMUM_OUTPUT_SIZE} GB.'
+            f'The tool skipped dummy inference to avoid SWAP processing because the total size of the tensor of inference results exceeded about {mem_available} GB.'
         )
 
     outputs = onnx_session.run(None, input_datas)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3787,12 +3787,9 @@ def dummy_onnx_inference(
         # Total bytes
         total_output_size += op_output_size * dtype_sizes.get(gs_graph_output.dtype, 4)
 
-    # 1. When exact inference mode is enabled and the total size of the tensor of inference results exceeds approximately 96 GB
-    # 2. If exact inference mode is disabled and the total size of the tensor of inference results exceeds about 2 GB
+    # When exact inference mode is enabled and the total size of the tensor of inference results exceeds approximately 96 GB
     STRICT_MAXIMUM_OUTPUT_SIZE = 96
-    NOT_STRICT_MAXIMUM_OUTPUT_SIZE = 2
-    if (not disable_strict_mode and (total_output_size // 1024 // 1024 //1024) > STRICT_MAXIMUM_OUTPUT_SIZE) \
-        or (disable_strict_mode and (total_output_size // 1024 // 1024 //1024) > NOT_STRICT_MAXIMUM_OUTPUT_SIZE):
+    if (not disable_strict_mode and (total_output_size // 1024 // 1024 //1024) > STRICT_MAXIMUM_OUTPUT_SIZE):
         if tmp_onnx_path:
             os.remove(tmp_onnx_path)
             os.remove(tmp_onnx_external_weights_path)


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf.py`, `common_functions.py`
  - Significantly improved conversion stability by reducing the frequency of SWAPs due to lack of RAM for large models
  - Change the maximum number of recursions in Python to the maximum number of recursions. For Python to abort when the model structure is too large.
    ```python
    sys.setrecursionlimit(2147483647) # C int maximum
    ```
- `InstanceNormalization`
  - Workaround for inconsistent `C` position.
  - Improved processing stability of `InstanceNormalization`.
- `Stable Diffusion v1.5`
  - https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_430/stable_diffusion_v1.5.tar.gz

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Stable Diffusion] Conversion error with stable diffusion model. #424](https://github.com/PINTO0309/onnx2tf/issues/424)
- [[TODO] Switch to a mode that performs inference in slow delay shape estimation mode during very large size transformations such as diffusion models #430](https://github.com/PINTO0309/onnx2tf/issues/430)