### PR TITLE
Negative padding supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.4
+  ghcr.io/pinto0309/onnx2tf:1.16.5
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.4
+  docker.io/pinto0309/onnx2tf:1.16.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.4'
+__version__ = '1.16.5'

--- a/onnx2tf/ops/Pad.py
+++ b/onnx2tf/ops/Pad.py
@@ -251,7 +251,7 @@ def make_node(
                     end_mask=end_mask_,
                 )
         paddings_numpy: np.ndarray = paddings.numpy()
-        paddings_numpy[paddings_numpy == -1] = 0
+        paddings_numpy[paddings_numpy < 0] = 0
         paddings = tf.convert_to_tensor(paddings_numpy)
 
     if mode != 'edge':

--- a/onnx2tf/ops/Pad.py
+++ b/onnx2tf/ops/Pad.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    stridedslice_with_flexing_deterrence,
 )
 
 
@@ -205,6 +206,53 @@ def make_node(
         paddings = tf.cast(tf.convert_to_tensor(paddings), dtype=tf.int32)
     else:
         paddings = tf.cast(paddings, dtype=tf.int32)
+
+    # Support for negative number padding
+    # No relief when paddings are not constants
+    # https://github.com/PINTO0309/onnx2tf/issues/473
+    if input_tensor.shape != tf.TensorShape(None) \
+        and None not in input_tensor.shape \
+        and hasattr(paddings, 'numpy') and (paddings.numpy() < 0).any():
+
+        begin_ = [-1 if padding[0] >=0 else -padding[0].numpy() for padding in paddings]
+        begin_mask_ = tf.convert_to_tensor(sum([2 ** idx if begin == -1 else 0 for idx, begin in enumerate(begin_)]))
+        end_ = [-1 if padding[1] >=0 else -padding[1].numpy() for padding in paddings]
+        end_mask_ = tf.convert_to_tensor(sum([2 ** idx if end == -1 else 0 for idx, end in enumerate(end_)]))
+        begin_ = tf.convert_to_tensor([0 if val == -1 else val for val in begin_])
+        end_ = [0 if val == -1 else input_tensor.shape[idx] - val for idx, val in enumerate(end_)]
+        end_ = tf.convert_to_tensor(end_)
+        strides_ = None
+
+        COMPRESSION_DEFAULT_VALUE = 5
+        input_tensor_rank = len(input_tensor.shape)
+        if input_tensor_rank > COMPRESSION_DEFAULT_VALUE:
+            ignore_axes = [idx for idx in range(input_tensor_rank)]
+            input_tensor = \
+                stridedslice_with_flexing_deterrence(
+                    input_tensor=input_tensor,
+                    begin=begin_,
+                    end=end_,
+                    strides=strides_,
+                    begin_mask=begin_mask_,
+                    end_mask=end_mask_,
+                    ignore_axes=ignore_axes,
+                    compression_defult_value=COMPRESSION_DEFAULT_VALUE,
+                    onnx_slice_dims_count=input_tensor_rank,
+                    **kwargs,
+                )
+        else:
+            input_tensor = \
+                tf.strided_slice(
+                    input_=input_tensor,
+                    begin=begin_,
+                    end=end_,
+                    strides=strides_,
+                    begin_mask=begin_mask_,
+                    end_mask=end_mask_,
+                )
+        paddings_numpy: np.ndarray = paddings.numpy()
+        paddings_numpy[paddings_numpy == -1] = 0
+        paddings = tf.convert_to_tensor(paddings_numpy)
 
     if mode != 'edge':
         # mode != 'edge'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3789,12 +3789,13 @@ def dummy_onnx_inference(
 
     # When exact inference mode is enabled and the total size of the tensor of inference results exceeds approximately 80% of available RAM
     mem_available = psutil.virtual_memory().available * 0.80 // 1024 // 1024 //1024
-    if (not disable_strict_mode and (total_output_size // 1024 // 1024 //1024) > mem_available):
+    total_output_size_gb = (total_output_size // 1024 // 1024 //1024)
+    if (not disable_strict_mode and total_output_size_gb > mem_available):
         if tmp_onnx_path:
             os.remove(tmp_onnx_path)
             os.remove(tmp_onnx_external_weights_path)
         raise Exception(
-            f'The tool skipped dummy inference to avoid SWAP processing because the total size of the tensor of inference results exceeded about {mem_available} GB.'
+            f'The tool skipped dummy inference to avoid SWAP processing because the total size of the tensor of inference results exceeded about {mem_available} GB. (results: {total_output_size_gb} GB)'
         )
 
     outputs = onnx_session.run(None, input_datas)


### PR DESCRIPTION
### 1. Content and background
- `Pad`
  - Negative padding supported. 
  - Force substitution to `Strided_Slice` since the TensorFlow runtime does not support padding of negative numbers.
  - [d3net_dnn_double_44.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12505175/d3net_dnn_double_44.onnx.zip)
    - onnx
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/d6f04e91-27aa-44ec-989c-c46cb8589f1e)
    - tflite
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/f61890b9-b3bd-47d1-b204-a590be5af765)
    - results
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/075ba41b-e854-43bc-84fd-c91ad5e8630d)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[D3Net] Clarification regarding a specific input dimension type #473](https://github.com/PINTO0309/onnx2tf/issues/473)