### PR TITLE
Attempts to force axis correction when the number of axes in the combined tensor do not exactly match

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.5
+  ghcr.io/pinto0309/onnx2tf:1.16.6
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.5
+  docker.io/pinto0309/onnx2tf:1.16.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.5'
+__version__ = '1.16.6'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5803,3 +5803,28 @@ def nhwc_determination_of_output_value_of_binary_input_op(
                 and 'nhwc' in tf_layers_dict[graph_node_input_2.name].keys() else False
 
     return is_output_nhwc_1 or is_output_nhwc_2
+
+
+def shape_is_equal_ignore_order(
+    shape_list_1: List[int],
+    shape_list_2: List[int],
+):
+    """NHWC determination of output value of binary input OP.
+
+    Parameters
+    ----------
+    shape_list_1: List[int]
+        List of shapes to be verified
+
+    shape_list_2: List[int]
+        List of shapes to be verified
+
+    tf_layers_dict: Dict
+        TensorFlow Model Structure Dictionary
+
+    Returns
+    -------
+    True: Matches
+    False: Unmatches
+    """
+    return sorted(shape_list_1) == sorted(shape_list_2)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5827,4 +5827,6 @@ def shape_is_equal_ignore_order(
     True: Matches
     False: Unmatches
     """
+    shape_list_1 = [-1 if isinstance(s, str) or s is None else s for s in shape_list_1]
+    shape_list_2 = [-1 if isinstance(s, str) or s is None else s for s in shape_list_2]
     return sorted(shape_list_1) == sorted(shape_list_2)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5808,8 +5808,8 @@ def nhwc_determination_of_output_value_of_binary_input_op(
 def shape_is_equal_ignore_order(
     shape_list_1: List[int],
     shape_list_2: List[int],
-):
-    """NHWC determination of output value of binary input OP.
+) -> bool:
+    """Verify that all axis size combinations match.
 
     Parameters
     ----------
@@ -5818,9 +5818,6 @@ def shape_is_equal_ignore_order(
 
     shape_list_2: List[int]
         List of shapes to be verified
-
-    tf_layers_dict: Dict
-        TensorFlow Model Structure Dictionary
 
     Returns
     -------


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Attempts to force axis correction when the number of axes in the combined tensor do not exactly match.
    - However, if more than 2 patterns of correct answers exist, give up the correction.
    - This workaround is useful when automatic axis correction is practically difficult, such as when all tensors to be combined originate from `Transpose` or `Reshape`.
    - Under very limited conditions, it is no longer necessary to correct the axis in JSON.
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/bb8e591b-34ed-4e57-a290-0c30f5852431)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[D3Net] Clarification regarding a specific input dimension type #473](https://github.com/PINTO0309/onnx2tf/issues/473)