### PR TITLE
Reduction of transposition errors when all axis values except batch size are the same

### DIFF
--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -61,41 +61,6 @@ def make_node(
     input_tensor_shape = input_tensor.shape
     input_tensor_rank = len(input_tensor_shape)
 
-    # # layer_norm の scale と bias は少し特殊な転置を施す
-    # # [c,w] -> [w,c]
-    # # [c,h,w] -> [h,w,c]
-    # # [c,d,h,w] -> [d,h,w,c]
-    # # [c,d,d,h,w] -> [d,d,h,w,c]
-    # graph_node_input_2 = None
-    # if hasattr(graph_node.inputs[1], 'values'):
-    #     values = graph_node.inputs[1].values
-    #     values_rank = values.ndim
-    #     if values_rank > 1:
-    #         perm = [i for i in range(1, values_rank)] + [0]
-    #         graph_node_input_2 = values.transpose(perm)
-    #     else:
-    #         scale_shape_idx = list(input_tensor_shape).index(values.shape[0])
-    #         scale_shape = [1] * input_tensor_rank
-    #         scale_shape[scale_shape_idx] = values.shape[0]
-    #         graph_node_input_2 = values.reshape(scale_shape)
-    # else:
-    #     graph_node_input_2 = graph_node.inputs[1]
-    # graph_node_input_3 = None
-    # if len(graph_node.inputs) >= 3:
-    #     if hasattr(graph_node.inputs[2], 'values'):
-    #         values = graph_node.inputs[2].values
-    #         values_rank = values.ndim
-    #         if values_rank > 1:
-    #             perm = [i for i in range(1, values_rank)] + [0]
-    #             graph_node_input_3 = values.transpose(perm)
-    #         else:
-    #             bias_shape_idx = list(input_tensor_shape).index(values.shape[0])
-    #             bias_shape = [1] * input_tensor_rank
-    #             bias_shape[bias_shape_idx] = values.shape[0]
-    #             graph_node_input_3 = values.reshape(bias_shape)
-    #     else:
-    #         graph_node_input_3 = graph_node.inputs[2]
-
     graph_node_input_2 = None
     if hasattr(graph_node.inputs[1], 'values'):
         graph_node_input_2 = graph_node.inputs[1].values
@@ -117,12 +82,12 @@ def make_node(
     shape = graph_node_output_1.shape
     dtype = graph_node_output_1.dtype
 
-    graph_node_output_2: gs.Variable = None
-    if len(graph_node.outputs) >= 2:
-        graph_node_output_2: gs.Variable = graph_node.outputs[1]
-    graph_node_output_3: gs.Variable = None
-    if len(graph_node.outputs) >= 3:
-        graph_node_output_3: gs.Variable = graph_node.outputs[2]
+    # graph_node_output_2: gs.Variable = None
+    # if len(graph_node.outputs) >= 2:
+    #     graph_node_output_2: gs.Variable = graph_node.outputs[1]
+    # graph_node_output_3: gs.Variable = None
+    # if len(graph_node.outputs) >= 3:
+    #     graph_node_output_3: gs.Variable = graph_node.outputs[2]
 
 
     axis = graph_node.attrs.get('axis', -1)
@@ -145,50 +110,6 @@ def make_node(
     }
 
     # Generation of TF OP
-    # reduce_meaned_1 = tf.reduce_mean(
-    #     input_tensor=input_tensor,
-    #     axis=[axis],
-    #     keepdims=True,
-    # )
-    # subed = tf.math.subtract(
-    #     x=input_tensor,
-    #     y=reduce_meaned_1,
-    # )
-
-    # squared = tf.math.multiply(
-    #     x=subed,
-    #     y=subed,
-    # )
-    # reduce_meaned_2 = tf.reduce_mean(
-    #     input_tensor=squared,
-    #     axis=[axis],
-    #     keepdims=True,
-    # )
-    # added = tf.math.add(
-    #     x=reduce_meaned_2,
-    #     y=epsilon,
-    # )
-    # sqrted = tf.math.sqrt(x=added)
-
-    # divided = tf.math.divide(
-    #     x=subed,
-    #     y=sqrted,
-    # )
-    # sacaled = tf.math.multiply(
-    #     x=divided,
-    #     y=scale,
-    # )
-    # bias_added = None
-    # if bias is not None:
-    #     bias_added = tf.math.add(
-    #         x=sacaled,
-    #         y=bias,
-    #     )
-    # else:
-    #     bias_added = sacaled
-
-    # tf_layers_dict[graph_node_output_1.name]['tf_node'] = bias_added
-
     tf_layers_dict[graph_node_output_1.name]['tf_node'] = \
         tf.keras.layers.LayerNormalization(
             axis=[axis],

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -1,7 +1,10 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -15,8 +18,11 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
     transpose_with_flexing_deterrence,
+    get_tf_model_inputs,
+    dummy_tf_inference,
+    onnx_tf_tensor_validation,
 )
-from typing import List
+from typing import List, Dict, Any
 
 
 @print_node_info
@@ -78,6 +84,11 @@ def make_node(
     elif isinstance(reshape_shape, np.ndarray) and np.count_nonzero(reshape_shape == 0) > 0:
         new_shape = [-1 if isinstance(s, str) else int(s) for s in output_shape]
         reshape_shape = new_shape
+
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -276,6 +287,166 @@ def make_node(
                 pass
     except:
         pass
+
+
+    # Workaround to special patterns with wrong transposition when all axes except batch size have the same value.
+    # Examine which combination of axis configurations reduces the error in output values the most,
+    # and apply the transposition with the best performance.
+    # Input: [1, 20, 20, 20], Output: [1, 800, 10]
+    # https://github.com/PINTO0309/onnx2tf/issues/478
+    graph_node_input_1_shape = graph_node_input_1.shape
+    if graph_node_input_1_shape is not None \
+        and len(graph_node_input_1_shape) >= 3 \
+        and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_1_shape]) == 0 \
+        and len(set(graph_node_input_1_shape[1:])) == 1:
+
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(
+                tf_layers_dict=tf_layers_dict,
+            )
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        #   Get the output tensor of the previous layer of MatMul
+        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except Exception as ex:
+                pass
+            del val_model
+
+        # Get np.ndarray for validation
+        validation_data = None
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+        # ONNX   : N,C,W
+        # TF     : N,W,C
+        # TF-axes: [1]
+        #
+        # ONNX: N,C,H,W
+        # TF  : N,H,W,C
+        # TF-axes: [1,2]
+        #
+        # ONNX: N,C,D,H,W
+        # TF  : N,D,H,W,C
+        # TF-axes: [1,2,3]
+
+        # Automatic correction of accuracy degradation
+        min_abs_err = sys.maxsize
+        min_abs_err_perm_1: int = [idx for idx in range(tensor_rank)]
+
+        if not disable_strict_mode:
+            if onnx_tensor_infos is not None:
+                tensor_1_candidate_for_transpositions = list(itertools.permutations(range(tensor_rank)))
+                tensor_1_candidate_for_transpositions = [
+                    trans_perm for trans_perm in tensor_1_candidate_for_transpositions \
+                        if trans_perm[0] == 0
+                ]
+                # Search for the axis with the smallest error
+                for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
+                    try:
+                        target_validation_data = validation_data.transpose(tensor_1_candidate_for_transposition)
+                        # Build TF dummy model
+                        input = tf.keras.Input(
+                            shape=target_validation_data.shape[1:],
+                            batch_size=target_validation_data.shape[0] \
+                                if isinstance(target_validation_data.shape[0], int) else None,
+                            name='dummy_input',
+                            dtype=target_validation_data.dtype,
+                        )
+                        val_model = tf.keras.Model(
+                            inputs=[
+                                input,
+                            ],
+                            outputs=[
+                                tf.reshape(
+                                    tensor=tf.transpose(a=input, perm=tensor_1_candidate_for_transposition),
+                                    shape=final_shape,
+                                    name=graph_node.name,
+                                )
+                            ],
+                        )
+                        # TF dummy inference
+                        tf_tensor_infos: Dict[Any] = \
+                            dummy_tf_inference(
+                                model=val_model,
+                                inputs=[
+                                    input,
+                                ],
+                                verification_datas=[
+                                    target_validation_data,
+                                ],
+                            )
+                        del input
+                        del val_model
+
+                        # Validation
+                        onnx_tf_output_pairs = {
+                            (oi[0], ti[0]): (oi[1], ti[1]) \
+                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                        }
+                        """
+                        check_results: Dict[str, List[np.ndarray, int, float|int]]
+                            {
+                                onnx_output_name: [
+                                    onnx_tensor,
+                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                    max_abs_err,
+                                ]
+                            }
+                        """
+                        check_results = \
+                            onnx_tf_tensor_validation(
+                                output_pairs=onnx_tf_output_pairs,
+                                rtol=0.0,
+                                atol=0.0,
+                            )
+                        result_err = sum([val[2] for val in check_results.values()])
+                        if result_err < min_abs_err:
+                            min_abs_err = result_err
+                            min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                            # if min_abs_err < 1e-3:
+                            #     break
+                    except Exception as ex:
+                        pass
+                tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                    tf.reshape(
+                        tensor=tf.transpose(a=input_tensor, perm=min_abs_err_perm_1),
+                        shape=final_shape,
+                        name=graph_node.name,
+                    )
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- `Reshape`
  - Workaround to special patterns with wrong transposition when all axes except batch size have the same value.
  - Examine which combination of axis configurations reduces the error in output values the most, and apply the transposition with the best performance.
  - Input: [1, 20, 20, 20], Output: [1, 800, 10]
  - [subgraph_model.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12520958/subgraph_model.onnx.zip)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/a4c550e3-135b-42ca-832d-ac7ef8f40cd3)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Reshape Unmatched max abs error when doing ONNX and TF output value validation #478](https://github.com/PINTO0309/onnx2tf/issues/478)