### PR TITLE
Reduce error frequency of `Concat` of two tensors containing constants and disable tensor swapping during `Sub`, `Div` and `Mod`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.9
+  ghcr.io/pinto0309/onnx2tf:1.16.10
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.9
+  docker.io/pinto0309/onnx2tf:1.16.10
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.9'
+__version__ = '1.16.10'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -112,7 +112,7 @@ def make_node(
         values = new_values
 
     elif len(values) == 2 \
-        and (not isinstance(values[0], np.ndarray) and isinstance(values[1], np.ndarray)) or (isinstance(values[0], np.ndarray) and not isinstance(values[1], np.ndarray)) \
+        and ((not isinstance(values[0], np.ndarray) and isinstance(values[1], np.ndarray)) or (isinstance(values[0], np.ndarray) and not isinstance(values[1], np.ndarray))) \
         and sum([f for f in nhwc_flags]) == 0:
 
         variable_tensor = values[0] if not isinstance(values[0], np.ndarray) else values[1]

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -950,7 +950,7 @@ def explicit_broadcast(
 
     # Swap: len(const_or_var_1.shape) > len(const_or_var_2.shape)
     swapped = 0
-    if len(const_or_var_1.shape) < len(const_or_var_2.shape):
+    if len(const_or_var_1.shape) < len(const_or_var_2.shape) and not graph_node.op in ['Sub', 'Div', 'Mod']:
         const_or_var_1, const_or_var_2 = const_or_var_2, const_or_var_1
         graph_node_input_name1, graph_node_input_name2 = graph_node_input_name2, graph_node_input_name1
         graph_node_input_shape1, graph_node_input_shape2 = graph_node_input_shape2, graph_node_input_shape1


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Reduce error frequency of `Concat` of two tensors containing constants.
  - It is a simple correction and does not cover all patterns.
- `common_functions.py`
  - Disable tensor swapping during `Sub`, `Div` and `Mod`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
