### PR TITLE
Reduces post-concat accuracy degradation when all axes except batch size have the same value

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.10
+  ghcr.io/pinto0309/onnx2tf:1.16.11
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.10
+  docker.io/pinto0309/onnx2tf:1.16.11
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.10'
+__version__ = '1.16.11'


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Reduces post-concat accuracy degradation when all axes except batch size have the same value.
  - Only supported when there are two input tensors, as the process is redundant.
  - [vttrack.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12537164/vttrack.onnx.zip)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/6a29c2c0-e64a-4134-821b-d237fca773f3)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
