### PR TITLE
Improved stability of `ScatterND` and `Where` conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.11
+  ghcr.io/pinto0309/onnx2tf:1.16.12
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.11
+  docker.io/pinto0309/onnx2tf:1.16.12
 
   or
 

--- a/json_samples/replace_alike.json
+++ b/json_samples/replace_alike.json
@@ -6,36 +6,6 @@
       "op_name": "/Unsqueeze",
       "param_target": "op",
       "new_shape": [1,192,320,1]
-    },
-    {
-      "op_name": "/dkd/Where_2",
-      "param_target": "outputs",
-      "param_name": "/dkd/Where_2_output_0",
-      "post_process_transpose_perm": [0,3,1,2]
-    },
-    {
-      "op_name": "/dkd/ScatterND",
-      "param_target": "inputs",
-      "param_name": "/dkd/Concat_output_0",
-      "pre_process_transpose_perm": [0,1,2,3,4]
-    },
-    {
-      "op_name": "/dkd/ScatterND_1",
-      "param_target": "inputs",
-      "param_name": "/dkd/Concat_2_output_0",
-      "pre_process_transpose_perm": [0,1,2,3,4]
-    },
-    {
-      "op_name": "/dkd/ScatterND_2",
-      "param_target": "inputs",
-      "param_name": "/dkd/Concat_4_output_0",
-      "pre_process_transpose_perm": [0,1,2,3,4]
-    },
-    {
-      "op_name": "/dkd/ScatterND_3",
-      "param_target": "inputs",
-      "param_name": "/dkd/Concat_6_output_0",
-      "pre_process_transpose_perm": [0,1,2,3,4]
     }
   ]
 }

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.11'
+__version__ = '1.16.12'

--- a/onnx2tf/ops/ScatterND.py
+++ b/onnx2tf/ops/ScatterND.py
@@ -217,6 +217,8 @@ def make_node(
                                 else tf.convert_to_tensor(updates_tensor),
                         name=graph_node.name,
                     )
+            else:
+                raise
         except:
             raise
 

--- a/onnx2tf/ops/ScatterND.py
+++ b/onnx2tf/ops/ScatterND.py
@@ -123,6 +123,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     # Pre-process transpose
@@ -172,19 +175,50 @@ def make_node(
             indices=indices_tensor,
         )
 
-    tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.tensor_scatter_nd_update(
-            tensor=input_tensor \
-                if not isinstance(input_tensor, np.ndarray) \
-                    else tf.convert_to_tensor(input_tensor),
-            indices=indices_tensor \
-                if not isinstance(indices_tensor, np.ndarray) \
-                    else tf.convert_to_tensor(indices_tensor),
-            updates=updates_tensor \
-                if not isinstance(updates_tensor, np.ndarray) \
-                    else tf.convert_to_tensor(updates_tensor),
-            name=graph_node.name,
-        )
+    try:
+        # normal scatter_nd_update
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.tensor_scatter_nd_update(
+                tensor=input_tensor \
+                    if not isinstance(input_tensor, np.ndarray) \
+                        else tf.convert_to_tensor(input_tensor),
+                indices=indices_tensor \
+                    if not isinstance(indices_tensor, np.ndarray) \
+                        else tf.convert_to_tensor(indices_tensor),
+                updates=updates_tensor \
+                    if not isinstance(updates_tensor, np.ndarray) \
+                        else tf.convert_to_tensor(updates_tensor),
+                name=graph_node.name,
+            )
+    except:
+        # Workaround to estimate the successful shape in the event of a shape error
+        try:
+            nhwc = bool(tf_layers_dict[graph_node_output.name].get('nhwc', False))
+            indices_tensor_shape = indices_tensor.shape
+            update_tensor_shape = updates_tensor.shape
+            if nhwc \
+                and len(indices_tensor_shape) - 1 == len(update_tensor_shape) \
+                and indices_tensor_shape[:len(update_tensor_shape)-1] == update_tensor_shape[:len(update_tensor_shape)-1] \
+                and indices_tensor_shape[-1] == update_tensor_shape[-1]:
+                # Try replacing only the last two axes of indicies
+                indices_tensor = indices_tensor if not isinstance(indices_tensor, np.ndarray) else tf.convert_to_tensor(indices_tensor)
+                perm = [idx for idx in range(len(update_tensor_shape)-1)] + [len(update_tensor_shape)] + [len(update_tensor_shape)-1]
+                indices_tensor = tf.transpose(a=indices_tensor, perm=perm)
+                tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                    tf.tensor_scatter_nd_update(
+                        tensor=input_tensor \
+                            if not isinstance(input_tensor, np.ndarray) \
+                                else tf.convert_to_tensor(input_tensor),
+                        indices=indices_tensor \
+                            if not isinstance(indices_tensor, np.ndarray) \
+                                else tf.convert_to_tensor(indices_tensor),
+                        updates=updates_tensor \
+                            if not isinstance(updates_tensor, np.ndarray) \
+                                else tf.convert_to_tensor(updates_tensor),
+                        name=graph_node.name,
+                    )
+        except:
+            raise
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Where.py
+++ b/onnx2tf/ops/Where.py
@@ -12,6 +12,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -73,6 +74,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_2,
+                graph_node_input_2=graph_node_input_3,
+                tf_layers_dict=tf_layers_dict
+            )
     }
 
     # Pre-process transpose


### PR DESCRIPTION
### 1. Content and background
- `ScatterND`
  - Fixed to determine if the trailing index needs to be transposed and force transposition and retry if necessary.
- `Where`
  - Improved NHWC information to be passed on to subsequent tensors.
- [yolox_nano_ti_lite_26p1_41p8.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12543304/yolox_nano_ti_lite_26p1_41p8.onnx.zip)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/89fa0a15-db5e-4d33-82af-49be8853bbc8)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
