### PR TITLE
Improve accuracy of NHWC decision in `Concat` and support edge cases in `Slice`

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.16
+  ghcr.io/pinto0309/onnx2tf:1.16.17
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.16
+  docker.io/pinto0309/onnx2tf:1.16.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.16'
+__version__ = '1.16.17'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -174,6 +174,10 @@ def make_node(
             and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() \
             and tf_layers_dict[graph_node_input.name]['nhwc'] == True:
                 nhwc_judge = nhwc_judge and True
+        elif isinstance(graph_node_input, gs.Constant) \
+            and hasattr(graph_node_input, 'values') \
+            and isinstance(graph_node_input.values, np.ndarray):
+                nhwc_judge = nhwc_judge or True
         else:
             nhwc_judge = nhwc_judge and False
 

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -178,7 +178,8 @@ def make_node(
     }
 
     # Determine if the axes are randomly placed on the axes.
-    if (isinstance(axes, np.ndarray) or hasattr(axes, 'numpy')):
+    if (isinstance(axes, np.ndarray) or hasattr(axes, 'numpy')) \
+        and len(axes.shape) > 1:
         base_axes = list(axes) if isinstance(axes, np.ndarray) else list(axes.numpy())
         sorted_axes = list(sorted(axes)) if isinstance(axes, np.ndarray) else list(sorted(axes.numpy()))
         if base_axes != sorted_axes:


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Improve accuracy of NHWC decision in `Concat`.
- `Slice`
  -  Support edge cases in `Slice`.
  - Address a situation where the axes of a `Slice` transformed using tensorflow-onnx are in a disjointed state.
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/09571a59-a7cf-4fc1-b44d-264b685ee18c)
- [face_blendshapes.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12564488/face_blendshapes.onnx.zip)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/05296c84-3bdb-443d-8a8c-b8a5b518affc)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
