### PR TITLE
Add handling of cases where the first or second tensor is 1-dimensional

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.20
+  ghcr.io/pinto0309/onnx2tf:1.16.21
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.20
+  docker.io/pinto0309/onnx2tf:1.16.21
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.20'
+__version__ = '1.16.21'


### PR DESCRIPTION
### 1. Content and background
- `MatMul`
  - Add handling of cases where the first or second tensor is 1-dimensional.
  - https://numpy.org/doc/stable/reference/generated/numpy.matmul.html
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/47eafed7-79fe-4874-bae7-4a3b2c82c747)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
