### PR TITLE
Implemented workaround for shape correction when final output shapes do not match

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.21
+  ghcr.io/pinto0309/onnx2tf:1.16.22
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.21
+  docker.io/pinto0309/onnx2tf:1.16.22
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.21'
+__version__ = '1.16.22'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -18,7 +18,6 @@ from onnx2tf.utils.common_functions import (
     post_process_transpose,
     transpose_with_flexing_deterrence,
     shape_is_equal_ignore_order,
-    transpose_with_flexing_deterrence,
     dummy_tf_inference,
     onnx_tf_tensor_validation,
     acquisition_of_validation_data,


### PR DESCRIPTION
### 1. Content and background
- `BatchNormalization`
  - Implemented workaround for shape correction when final output shapes do not match.
  - This is a special treatment for unstable onnx files generated using tensorflow-onnx.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
