### PR TITLE
Optimization of `Selu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.16.23
+  ghcr.io/pinto0309/onnx2tf:1.16.24
 
   or
 
@@ -264,7 +264,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.16.23
+  docker.io/pinto0309/onnx2tf:1.16.24
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.16.23'
+__version__ = '1.16.24'

--- a/onnx2tf/ops/Selu.py
+++ b/onnx2tf/ops/Selu.py
@@ -80,19 +80,9 @@ def make_node(
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.clip_by_value(
-            input_tensor,
-            0,
-            tf.reduce_max(input_tensor)) * gamma + \
-                (
-                    tf.exp(
-                        tf.clip_by_value(
-                            input_tensor,
-                            tf.reduce_min(input_tensor),
-                            0
-                        )
-                    ) - 1
-                ) * (alpha * gamma)
+        tf.keras.layers.ELU(
+            alpha=alpha,
+        )(input_tensor) * gamma
 
     # Post-process transpose
     before_trans_shape = tf_layers_dict[graph_node_output.name]['tf_node'].shape


### PR DESCRIPTION
### 1. Content and background
- `Selu`
  - Optimization of `Selu`.
  - [selu.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12619352/selu.onnx.zip)
    |Before|After|
    |:-:|:-:|
    |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/549beeb4-194c-47f2-8632-e79390c5287b)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/412a71f7-ceb1-4e14-b101-5f52e7211401)|

    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/4b198fa8-bbc1-4370-8ec3-a55029eedb04)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Fails to export BatchNorm1d layers from Pytorch #5590](https://github.com/onnx/onnx/issues/5590)