### PR TITLE
Fixed to output all TF, h5, and keras formats when outputting .h5

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.17.0
+  ghcr.io/pinto0309/onnx2tf:1.17.1
 
   or
 
@@ -260,7 +260,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.17.0
+  docker.io/pinto0309/onnx2tf:1.17.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.17.0'
+__version__ = '1.17.1'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1042,6 +1042,32 @@ def convert(
         if output_h5:
             try:
                 info(Color.REVERSE(f'h5 output started'), '=' * 67)
+                # Structure (JSON)
+                try:
+                    open(f'{output_folder_path}/{output_file_name}_float32.json', 'w').write(model.to_json())
+                except:
+                    pass
+                # Weights (h5)
+                try:
+                    model.save_weights(f'{output_folder_path}/{output_file_name}_float32.weights.h5', save_format='h5')
+                except:
+                    pass
+                # Weights (keras)
+                try:
+                    model.save_weights(f'{output_folder_path}/{output_file_name}_float32.weights.keras', save_format='keras')
+                except:
+                    pass
+                # Weights (TF)
+                try:
+                    model.save_weights(f'{output_folder_path}/{output_file_name}_float32.weights.tf', save_format='tf')
+                except:
+                    pass
+                # Monolithic (keras)
+                try:
+                    model.save(f'{output_folder_path}/{output_file_name}_float32.keras', save_format='keras')
+                except:
+                    pass
+                # Monolithic (h5)
                 model.save(f'{output_folder_path}/{output_file_name}_float32.h5', save_format='h5')
                 info(Color.GREEN(f'h5 output complete!'))
             except ValueError as e:
@@ -1068,7 +1094,7 @@ def convert(
         if output_keras_v3:
             try:
                 info(Color.REVERSE(f'keras_v3 output started'), '=' * 61)
-                model.save(f'{output_folder_path}/{output_file_name}_float32.keras', save_format="keras_v3")
+                model.save(f'{output_folder_path}/{output_file_name}_float32_v3.keras', save_format="keras_v3")
                 info(Color.GREEN(f'keras_v3 output complete!'))
             except ValueError as e:
                 msg_list = [s for s in e.args if isinstance(s, str)]


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf.py`
  - Fixed to output all TF, h5, and keras formats when outputting .h5.
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/f68e9acb-2039-4c0f-88f7-d0b3719c956a)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
