### PR TITLE
Significantly faster `Softmax`, `InstanceNormalization`, `Add`, `Sub`, `Div`, `Mul` and `Mod` conversions when converting models too large to perform dummy inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.17.4
+  ghcr.io/pinto0309/onnx2tf:1.17.5
 
   or
 
@@ -260,7 +260,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.17.4
+  docker.io/pinto0309/onnx2tf:1.17.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.17.4'
+__version__ = '1.17.5'

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -105,6 +105,8 @@ def make_node(
     test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
     custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
     disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -116,55 +118,56 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
-    # Get the output tensor of one previous OP of TensorFlow only once
-    if not disable_strict_mode:
-        tf_model_inputs = get_tf_model_inputs(
-            tf_layers_dict=tf_layers_dict,
-        )
-        val_model = None
-        if not isinstance(input_tensor, np.ndarray):
-            val_model = tf.keras.Model(
-                inputs=tf_model_inputs,
-                outputs=[
-                    input_tensor,
-                ],
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(
+                tf_layers_dict=tf_layers_dict,
             )
-        else:
-            pass
-
-    # TF dummy inference
-    #   Get the output tensor of the previous layer of MatMul
-    #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
-    #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
-    tf_pre_tensor_infos = {}
-    if not disable_strict_mode:
-        try:
-            tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
-                model=val_model,
-                inputs=tf_model_inputs,
-                test_data_nhwc=test_data_nhwc,
-                custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
-            )
-        except Exception as ex:
-            pass
-        del val_model
-
-    # Get np.ndarray for validation
-    validation_data = None
-    if not disable_strict_mode:
-        if len(tf_pre_tensor_infos) == 1:
+            val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                validation_data = list(tf_pre_tensor_infos.values())[0]
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
             else:
-                validation_data = copy.deepcopy(input_tensor)
+                pass
 
-        # Get ONNX inference results
-        onnx_tensor_infos = None
-        if onnx_tensor_infos_for_validation is not None:
-            onnx_tensor_infos = {
-                graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
-            }
-            del onnx_tensor_infos_for_validation
+        # TF dummy inference
+        #   Get the output tensor of the previous layer of MatMul
+        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = dummy_tf_inference(
+                    model=val_model,
+                    inputs=tf_model_inputs,
+                    test_data_nhwc=test_data_nhwc,
+                    custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                )
+            except Exception as ex:
+                pass
+            del val_model
+
+        # Get np.ndarray for validation
+        validation_data = None
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
 
     # ONNX   : N,C,W
     # TF     : N,W,C

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5674,6 +5674,14 @@ def correction_process_for_accuracy_errors(
     input_tensor_2: Any
         TensorFlow tensor after accuracy check and accuracy correction
     """
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    onnx_tensor_infos = None
+    validation_data_1 = None
+    validation_data_2 = None
+    if onnx_tensor_infos_for_validation is None:
+        return input_tensor_1, input_tensor_2
+    else:
+        del onnx_tensor_infos_for_validation
     if graph_node_output_shape is not None:
         onnx_output_shape = [dim if not isinstance(dim, str) else -1 for dim in graph_node_output_shape]
         onnx_output_same_shape_counts = collections.Counter(onnx_output_shape)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5634,15 +5634,15 @@ def obtaining_an_inverted_pattern_for_brute_force_validation(
 
 
 def correction_process_for_accuracy_errors(
-        *,
-        input_tensor_1: Any,
-        input_tensor_2: Any,
-        tf_func: Any,
-        np_func: Any,
-        graph_node_output_shape: List,
-        graph_node_output: gs.Variable,
-        tf_layers_dict: Dict,
-        **kwargs,
+    *,
+    input_tensor_1: Any,
+    input_tensor_2: Any,
+    tf_func: Any,
+    np_func: Any,
+    graph_node_output_shape: List,
+    graph_node_output: gs.Variable,
+    tf_layers_dict: Dict,
+    **kwargs,
 ) -> Tuple[Any, Any]:
     """Correction process for accuracy errors.
 


### PR DESCRIPTION
### 1. Content and background
- `Softmax`, `InstanceNormalization`, `Add`, `Sub`, `Div`, `Mul`, `Mod`
  - Significantly faster `Softmax`, `InstanceNormalization`, `Add`, `Sub`, `Div`, `Mul` and `Mod` conversions when converting models too large to perform dummy inference.
  - However, because the size of the model is so large that dummy inference cannot be performed, no accuracy correction is performed and accuracy is not guaranteed.
  - Stable Diffusion - stable-diffusion-v1-5

    https://github.com/PINTO0309/onnx2tf/assets/33194443/98c86e36-9ae1-4b59-b53c-2827502e0532

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Stable Diffusion] Conversion error with stable diffusion model. #424](https://github.com/PINTO0309/onnx2tf/issues/424)