### PR TITLE
Fixed reference paths for `Lambda` functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.17.5
+  ghcr.io/pinto0309/onnx2tf:1.17.6
 
   or
 
@@ -260,7 +260,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.17.5
+  docker.io/pinto0309/onnx2tf:1.17.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.17.5'
+__version__ = '1.17.6'

--- a/onnx2tf/ops/Bernoulli.py
+++ b/onnx2tf/ops/Bernoulli.py
@@ -3,7 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
-from tensorflow.keras.layers import Lambda # type: ignore
+from tensorflow.python.keras.layers import Lambda
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -4,7 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
-from tensorflow.keras.layers import Lambda # type: ignore
+from tensorflow.python.keras.layers import Lambda
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -15,7 +15,7 @@ import subprocess
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
-from tensorflow.keras.layers import Lambda # type: ignore
+from tensorflow.python.keras.layers import Lambda
 from tensorflow.python.keras.utils import conv_utils
 import onnx
 import onnx_graphsurgeon as gs


### PR DESCRIPTION
### 1. Content and background
- `Bernoulli`, `Resize`, `common_functions.py`
  - Fixed reference paths for `Lambda` functions.
  - This is in preparation for using `proto_splitter`, which will be implemented in TensorFlow v2.15.0 or later.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[Stable Diffusion] Conversion error with stable diffusion model. #424](https://github.com/PINTO0309/onnx2tf/issues/424)
- [[TODO] Implementation of Proto Splitter (breakthrough of 2GB contract for Protocol Buffers) #455](https://github.com/PINTO0309/onnx2tf/issues/455)
