### PR TITLE
Fix `Gather` parameter substitution logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.1
+  ghcr.io/pinto0309/onnx2tf:1.18.2
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.1
+  docker.io/pinto0309/onnx2tf:1.18.2
 
   or
 

--- a/json_samples/replace_retinaface_dynamic_shape.json
+++ b/json_samples/replace_retinaface_dynamic_shape.json
@@ -1,0 +1,29 @@
+{
+  "format_version": 1,
+  "operations": [
+    {
+      "op_name": "/fpn/Gather",
+      "param_target": "inputs",
+      "param_name": "/fpn/Constant_output_0",
+      "values": 1
+    },
+    {
+      "op_name": "/fpn/Gather_1",
+      "param_target": "inputs",
+      "param_name": "/fpn/Constant_1_output_0",
+      "values": 2
+    },
+    {
+      "op_name": "/fpn/Gather_2",
+      "param_target": "inputs",
+      "param_name": "/fpn/Constant_output_0",
+      "values": 1
+    },
+    {
+      "op_name": "/fpn/Gather_3",
+      "param_target": "inputs",
+      "param_name": "/fpn/Constant_1_output_0",
+      "values": 2
+    }
+  ]
+}

--- a/json_samples/replace_retinaface_dynamic_shape.json
+++ b/json_samples/replace_retinaface_dynamic_shape.json
@@ -14,6 +14,14 @@
       "values": 2
     },
     {
+      "op_name": "/fpn/Concat_1",
+      "param_target": "outputs",
+      "param_name": "/fpn/Concat_1_output_0",
+      "post_process_transpose_perm": [0,2,3,1]
+    },
+
+
+    {
       "op_name": "/fpn/Gather_2",
       "param_target": "inputs",
       "param_name": "/fpn/Constant_output_0",
@@ -24,6 +32,12 @@
       "param_target": "inputs",
       "param_name": "/fpn/Constant_1_output_0",
       "values": 2
+    },
+    {
+      "op_name": "/fpn/Concat_3",
+      "param_target": "outputs",
+      "param_name": "/fpn/Concat_3_output_0",
+      "post_process_transpose_perm": [0,2,3,1]
     }
   ]
 }

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.1'
+__version__ = '1.18.2'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -564,6 +564,7 @@ def convert(
                     operations['op_name'] = operations['op_name'].replace(':','_')
                     if output_signaturedefs or output_integer_quantized_tflite:
                         operations['op_name'] = re.sub('^/', 'wa/', operations['op_name'])
+                        operations['param_name'] = re.sub('^/', 'wa/', operations['param_name'])
         except json.decoder.JSONDecodeError as ex:
             error(
                 f'The file specified in param_replacement_file is not in JSON format. \n' +
@@ -694,6 +695,12 @@ def convert(
                         o._name = o._name.replace(':','__')
             if output_signaturedefs or output_integer_quantized_tflite:
                 node.name = re.sub('^/', 'wa/', node.name)
+                if hasattr(node, 'inputs'):
+                    for i in node.inputs:
+                        if hasattr(i, 'name'):
+                            i.name = re.sub('^/', 'wa/', i.name)
+                        elif hasattr(i, '_name'):
+                            i._name = re.sub('^/', 'wa/', i._name)
                 if hasattr(node, 'outputs'):
                     for o in node.outputs:
                         if hasattr(o, 'name'):
@@ -710,6 +717,12 @@ def convert(
                         o._name = o._name.replace(':','__')
             if output_signaturedefs or output_integer_quantized_tflite:
                 node._name = re.sub('^/', 'wa/', node._name)
+                if hasattr(node, 'inputs'):
+                    for i in node.inputs:
+                        if hasattr(i, 'name'):
+                            i.name = re.sub('^/', 'wa/', i.name)
+                        elif hasattr(i, '_name'):
+                            i._name = re.sub('^/', 'wa/', i._name)
                 if hasattr(node, 'outputs'):
                     for o in node.outputs:
                         if hasattr(o, 'name'):

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -497,6 +497,7 @@ def make_node(
         value_before_transpose=tf_layers_dict[graph_node_output.name]['tf_node'],
         param_target='outputs',
         param_name=graph_node.outputs[0].name,
+        graph_node=graph_node,
         **kwargs,
     )
 

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -158,7 +158,7 @@ def make_node(
         param_name=graph_node.inputs[1].name,
         **kwargs,
     )
-    if simple_indices:
+    if simple_indices is not None:
         simple_indices = replace_parameter(
             value_before_replacement=simple_indices,
             param_target='inputs',

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -158,6 +158,13 @@ def make_node(
         param_name=graph_node.inputs[1].name,
         **kwargs,
     )
+    if simple_indices:
+        simple_indices = replace_parameter(
+            value_before_replacement=simple_indices,
+            param_target='inputs',
+            param_name=graph_node.inputs[1].name,
+            **kwargs,
+        )
 
     # Pre-process transpose
     input_tensor = pre_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- Improved conversion stability when multiple undefined dimensions exist in the input tensor.
- `Gather`
  - Fix parameter substitution logic.
  - [retinaface_onnx_dynamic.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12758261/retinaface_onnx_dynamic.onnx.zip)
  - [json_samples/replace_retinaface_dynamic_shape.json](https://github.com/PINTO0309/onnx2tf/pull/522/files#diff-7aab958b007b2197a4f8f83457d2337cf95a15c303fb6d7468a7fe08ed292c42)
    |onnx|tflite|
    |:-:|:-:|
    |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/398bb85d-296f-4b52-8a44-443e8586c808)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/2200049c-4d32-4817-ba47-ff690eaa5a67)|
- `onnx2tf.py`
  - Fix parameter replacement logic.
- `Concat`, `common_functions.py`
  - Added the ability to swap axes using `Gather` instead of `Transpose` when the tensor to be concatenated is a 1D tensor.

![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/655c9f4f-bf0f-48c0-9dc8-b9dc61255fe6)


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Cannot use converted model with dynamic input shape #521](https://github.com/PINTO0309/onnx2tf/issues/521)