### PR TITLE
Fixed a critical bug in `Reshape`, `LayerNormalization` accuracy correction process

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.7
+  ghcr.io/pinto0309/onnx2tf:1.18.8
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.7
+  docker.io/pinto0309/onnx2tf:1.18.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.7'
+__version__ = '1.18.8'

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -1,3 +1,5 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
@@ -13,7 +15,11 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    onnx_tf_tensor_validation,
+    get_tf_model_inputs,
 )
+from typing import Any, Dict
 
 
 @print_node_info
@@ -82,14 +88,6 @@ def make_node(
     shape = graph_node_output_1.shape
     dtype = graph_node_output_1.dtype
 
-    # graph_node_output_2: gs.Variable = None
-    # if len(graph_node.outputs) >= 2:
-    #     graph_node_output_2: gs.Variable = graph_node.outputs[1]
-    # graph_node_output_3: gs.Variable = None
-    # if len(graph_node.outputs) >= 3:
-    #     graph_node_output_3: gs.Variable = graph_node.outputs[2]
-
-
     axis = graph_node.attrs.get('axis', -1)
     axis = convert_axis(
         axis=axis,
@@ -109,6 +107,13 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
     # Generation of TF OP
     tf_layers_dict[graph_node_output_1.name]['tf_node'] = \
         tf.keras.layers.LayerNormalization(
@@ -117,6 +122,134 @@ def make_node(
             gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
             beta_initializer=tf.keras.initializers.constant(bias) if bias is not None else 'zeros',
         )(input_tensor)
+
+    # Detect conversion errors in axis and identify the axis
+    # with the smallest possible error and replace it.
+    min_abs_err = sys.maxsize
+    min_abs_err_axis: int = axis
+
+    if not disable_strict_mode:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+        val_model = None
+        if not isinstance(input_tensor, np.ndarray):
+            val_model = tf.keras.Model(
+                inputs=tf_model_inputs,
+                outputs=[
+                    input_tensor,
+                ],
+            )
+        else:
+            pass
+
+        # TF dummy inference
+        #   Get the output tensor of the previous layer of MatMul
+        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+        tf_pre_tensor_infos = {}
+        try:
+            tf_pre_tensor_infos: Dict[Any] = \
+                dummy_tf_inference(
+                    model=val_model,
+                    inputs=tf_model_inputs,
+                    test_data_nhwc=test_data_nhwc,
+                    custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                )
+        except:
+            pass
+
+        # Get np.ndarray for validation
+        if len(tf_pre_tensor_infos) == 1:
+            if not isinstance(input_tensor, np.ndarray):
+                validation_data = list(tf_pre_tensor_infos.values())[0]
+            else:
+                validation_data = copy.deepcopy(input_tensor)
+
+        # Get ONNX inference results
+        onnx_tensor_infos = None
+        if onnx_tensor_infos_for_validation is not None:
+            onnx_tensor_infos = {
+                graph_node_output_1.name:
+                onnx_tensor_infos_for_validation[graph_node_output_1.name]
+            }
+            del onnx_tensor_infos_for_validation
+
+        if onnx_tensor_infos is not None and validation_data is not None:
+            check_axes = reversed([idx for idx in range(input_tensor_rank)])
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                try:
+                    # Build TF dummy model
+                    input = tf.keras.Input(
+                        shape=validation_data.shape[1:],
+                        batch_size=validation_data.shape[0] \
+                            if isinstance(validation_data.shape[0], int) else None,
+                        name='dummy_input',
+                        dtype=validation_data.dtype,
+                    )
+                    val_model = tf.keras.Model(
+                        inputs=[
+                            input,
+                        ],
+                        outputs=[
+                            tf.keras.layers.LayerNormalization(
+                                axis=[check_axis],
+                                epsilon=epsilon,
+                                gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
+                                beta_initializer=tf.keras.initializers.constant(bias) if bias is not None else 'zeros',
+                            )(input)
+                        ],
+                    )
+                    # TF dummy inference
+                    tf_tensor_infos: Dict[Any] = \
+                        dummy_tf_inference(
+                            model=val_model,
+                            inputs=[
+                                input,
+                            ],
+                            verification_datas=[
+                                validation_data,
+                            ],
+                        )
+                    del input
+                    del val_model
+
+                    # Validation
+                    onnx_tf_output_pairs = {
+                        (oi[0], ti[0]): (oi[1], ti[1]) \
+                            for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                    }
+                    """
+                    check_results: Dict[str, List[np.ndarray, int, float|int]]
+                        {
+                            onnx_output_name: [
+                                onnx_tensor,
+                                matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                max_abs_err,
+                            ]
+                        }
+                    """
+                    check_results = onnx_tf_tensor_validation(
+                        output_pairs=onnx_tf_output_pairs,
+                        rtol=0.0,
+                        atol=0.0,
+                    )
+                    result_err = sum([val[2] for val in check_results.values()])
+                    if result_err < min_abs_err:
+                        min_abs_err = result_err
+                        min_abs_err_axis = check_axis
+                        if min_abs_err < 1e-3:
+                            break
+                except Exception as ex:
+                    pass
+
+            tf_layers_dict[graph_node_output_1.name]['tf_node'] = \
+                tf.keras.layers.LayerNormalization(
+                    axis=[min_abs_err_axis],
+                    epsilon=epsilon,
+                    gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
+                    beta_initializer=tf.keras.initializers.constant(bias) if bias is not None else 'zeros',
+                )(input_tensor)
 
     # Post-process transpose
     tf_layers_dict[graph_node_output_1.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -129,8 +129,8 @@ def make_node(
     # Shape Unmatch Error Mitigation Measures
     # Search for and transpose shapes that do not cause shape unmatch errors
     min_abs_err = sys.maxsize
-    min_abs_err_perm_1: int = [idx for idx in range(len(input_tensor_1.shape))]
-    min_abs_err_perm_2: int = [idx for idx in range(len(input_tensor_2.shape))]
+    min_abs_err_perm_1: List[int] = [idx for idx in range(len(input_tensor_1.shape))]
+    min_abs_err_perm_2: List[int] = [idx for idx in range(len(input_tensor_2.shape))]
 
     def define_matmul(
         *,

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -331,7 +331,7 @@ def make_node(
 
         # Automatic correction of accuracy degradation
         min_abs_err = sys.maxsize
-        min_abs_err_perm_1: int = [idx for idx in range(tensor_rank)]
+        min_abs_err_perm_1: List[int] = [idx for idx in range(tensor_rank)]
 
         if not disable_strict_mode:
             if onnx_tensor_infos is not None and validation_data is not None:

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -248,15 +248,16 @@ def make_node(
                     ],
                 )
                 # TF dummy inference
-                tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                    model=val_model,
-                    inputs=[
-                        input,
-                    ],
-                    verification_datas=[
-                        validation_data,
-                    ],
-                )
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
                 del input
                 del val_model
 


### PR DESCRIPTION
### 1. Content and background
- https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_529/latest.opset17.onnx
- `Reshape`
  - Fixed a critical bug in `Reshape` accuracy correction process.
  - Removed special workaround processing to accommodate ShuffleNet, which is no longer needed.
- `LayerNormalization`
  - Added accuracy correction process.

![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/3b0969b9-ea40-4cb5-ae89-03bfccde68a7)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Reshape Unmatched max abs error when doing ONNX and TF output value validation #478](https://github.com/PINTO0309/onnx2tf/issues/478)