### PR TITLE
Much stricter accuracy correction conditions for `Reshape`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.8
+  ghcr.io/pinto0309/onnx2tf:1.18.9
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.8
+  docker.io/pinto0309/onnx2tf:1.18.9
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.8'
+__version__ = '1.18.9'

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -260,11 +260,11 @@ def make_node(
     # Input: [1, 20, 20, 20], Output: [1, 800, 10]
     # https://github.com/PINTO0309/onnx2tf/issues/478
     # latest.opset17.onnx
+    # mobileformer.onnx
     graph_node_input_1_shape = graph_node_input_1.shape
     if graph_node_input_1_shape is not None \
         and len(graph_node_input_1_shape) >= 3 \
-        and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_1_shape]) == 0 \
-        and len(set(graph_node_input_1_shape[1:])) == 1:
+        and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_1_shape]) == 0:
 
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
@@ -336,10 +336,6 @@ def make_node(
         if not disable_strict_mode:
             if onnx_tensor_infos is not None and validation_data is not None:
                 tensor_1_candidate_for_transpositions = list(itertools.permutations(range(tensor_rank)))
-                tensor_1_candidate_for_transpositions = [
-                    trans_perm for trans_perm in tensor_1_candidate_for_transpositions \
-                        if trans_perm[0] == 0
-                ]
                 # Search for the axis with the smallest error
                 for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
                     try:


### PR DESCRIPTION
### 1. Content and background
- `Reshape`
  - Much stricter accuracy correction conditions for `Reshape`.
  - The conversion speed is greatly reduced at the cost of not causing accuracy degradation.
  - [mobileformer.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/12782257/mobileformer.onnx.zip)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/0b46105e-727b-4792-8bdf-d2e948798bde)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
