### PR TITLE
Fixed to skip accuracy check if one of the multiple input tensors contains `np.ndarray (constant)`

### DIFF
--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -523,7 +523,7 @@ def make_node(
             target_perm = [i for i in range(len(shape_for_validation))]
             acc_proc_flag = True
             for val in values:
-                if hasattr(val, 'shape') and not isinstance(val, np.ndarray):
+                if hasattr(val, 'shape') and not isinstance(val, np.ndarray) and not hasattr(val, 'numpy'):
                     if list(val.shape) == shape_for_validation:
                         pass
                     else:


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Fixed to skip accuracy check if one of the multiple input tensors contains np.ndarray (constant).

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
