### PR TITLE
Fixed an error when the input tensor was 1-dimensional during `Concat` accuracy correction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.9
+  ghcr.io/pinto0309/onnx2tf:1.18.10
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.9
+  docker.io/pinto0309/onnx2tf:1.18.10
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.9'
+__version__ = '1.18.10'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -568,7 +568,7 @@ def make_node(
                 min_abs_err = sys.maxsize
                 min_abs_err_axis: int = axis
 
-                if onnx_tensor_infos is not None and validation_datas is not None:
+                if onnx_tensor_infos is not None and validation_datas is not None and validation_datas != []:
                     check_axes = reversed([idx for idx in range(len(shape_for_validation))])
                     # Search for the axis with the smallest error
                     # Build TF dummy model

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -399,6 +399,8 @@ def make_node(
                         if result_err < min_abs_err:
                             min_abs_err = result_err
                             min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                            if min_abs_err < 1e-3:
+                                break
                     except Exception as ex:
                         pass
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `Concat`
  - Fixed an error when the input tensor was 1-dimensional during `Concat` accuracy correction.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
