### PR TITLE
If all axes are of different sizes and the axis sizes specified in axis are the same in onnx and TensorFlow, skip the accuracy check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.10
+  ghcr.io/pinto0309/onnx2tf:1.18.11
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.10
+  docker.io/pinto0309/onnx2tf:1.18.11
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.10'
+__version__ = '1.18.11'

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -89,6 +89,7 @@ def make_node(
     dtype = graph_node_output_1.dtype
 
     axis = graph_node.attrs.get('axis', -1)
+    pre_convert_axis = axis
     axis = convert_axis(
         axis=axis,
         tensor_rank=input_tensor_rank,
@@ -128,7 +129,22 @@ def make_node(
     min_abs_err = sys.maxsize
     min_abs_err_axis: int = axis
 
-    if not disable_strict_mode:
+    # If all axes are of different sizes and the axis sizes specified in axis are the same
+    # in onnx and sensorflow, skip the accuracy check.
+    acc_check_pass_flg = False
+    onnx_input_shapes = list(graph_node.inputs[0].shape)
+    tf_input_shapes = list(input_tensor.shape)
+    if onnx_input_shapes is not None \
+        and tf_input_shapes is not None \
+        and len(onnx_input_shapes) >= 1 \
+        and len(tf_input_shapes) >= 1 \
+        and len(onnx_input_shapes) == len(set(onnx_input_shapes)) \
+        and not isinstance(onnx_input_shapes[pre_convert_axis], str) \
+        and tf_input_shapes[axis] is not None \
+        and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
+        acc_check_pass_flg = True
+
+    if not disable_strict_mode and not acc_check_pass_flg:
         # Get the output tensor of one previous OP of TensorFlow only once
         tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
         val_model = None

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -132,17 +132,19 @@ def make_node(
     # If all axes are of different sizes and the axis sizes specified in axis are the same
     # in onnx and sensorflow, skip the accuracy check.
     acc_check_pass_flg = False
-    onnx_input_shapes = list(graph_node.inputs[0].shape)
-    tf_input_shapes = list(input_tensor.shape)
-    if onnx_input_shapes is not None \
-        and tf_input_shapes is not None \
-        and len(onnx_input_shapes) >= 1 \
-        and len(tf_input_shapes) >= 1 \
-        and len(onnx_input_shapes) == len(set(onnx_input_shapes)) \
-        and not isinstance(onnx_input_shapes[pre_convert_axis], str) \
-        and tf_input_shapes[axis] is not None \
-        and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
-        acc_check_pass_flg = True
+    if graph_node.inputs[0].shape is not None \
+        and input_tensor.shape is not None:
+        onnx_input_shapes = list(graph_node.inputs[0].shape)
+        tf_input_shapes = list(input_tensor.shape)
+        if onnx_input_shapes is not None \
+            and tf_input_shapes is not None \
+            and len(onnx_input_shapes) >= 1 \
+            and len(tf_input_shapes) >= 1 \
+            and len(onnx_input_shapes) == len(set(onnx_input_shapes)) \
+            and not isinstance(onnx_input_shapes[pre_convert_axis], str) \
+            and tf_input_shapes[axis] is not None \
+            and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
+            acc_check_pass_flg = True
 
     if not disable_strict_mode and not acc_check_pass_flg:
         # Get the output tensor of one previous OP of TensorFlow only once

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -123,17 +123,19 @@ def make_node(
     # If all axes are of different sizes and the axis sizes specified in axis are the same
     # in onnx and sensorflow, skip the accuracy check.
     acc_check_pass_flg = False
-    onnx_input_shapes = list(graph_node.inputs[0].shape)
-    tf_input_shapes = list(input_tensor.shape)
-    if onnx_input_shapes is not None \
-        and tf_input_shapes is not None \
-        and len(onnx_input_shapes) >= 1 \
-        and len(tf_input_shapes) >= 1 \
-        and len(onnx_input_shapes) == len(set(onnx_input_shapes)) \
-        and not isinstance(onnx_input_shapes[pre_convert_axis], str) \
-        and tf_input_shapes[axis] is not None \
-        and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
-        acc_check_pass_flg = True
+    if graph_node.inputs[0].shape is not None \
+        and input_tensor.shape is not None:
+        onnx_input_shapes = list(graph_node.inputs[0].shape)
+        tf_input_shapes = list(input_tensor.shape)
+        if onnx_input_shapes is not None \
+            and tf_input_shapes is not None \
+            and len(onnx_input_shapes) >= 1 \
+            and len(tf_input_shapes) >= 1 \
+            and len(onnx_input_shapes) == len(set(onnx_input_shapes)) \
+            and not isinstance(onnx_input_shapes[pre_convert_axis], str) \
+            and tf_input_shapes[axis] is not None \
+            and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
+            acc_check_pass_flg = True
 
     if onnx_tensor_infos_for_validation is not None and not acc_check_pass_flg:
         # Get the output tensor of one previous OP of TensorFlow only once

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -92,8 +92,8 @@ def make_node(
     tensor_rank = len(input_tensor.shape)
 
     axis = graph_node.attrs.get('axis', tensor_rank - 1)
-    axis = (axis + tensor_rank) % tensor_rank
     pre_convert_axis = axis
+    axis = (axis + tensor_rank) % tensor_rank
     axis = convert_axis(
         axis=axis,
         tensor_rank=tensor_rank,
@@ -120,7 +120,22 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    # If all axes are of different sizes and the axis sizes specified in axis are the same
+    # in onnx and sensorflow, skip the accuracy check.
+    acc_check_pass_flg = False
+    onnx_input_shapes = list(graph_node.inputs[0].shape)
+    tf_input_shapes = list(input_tensor.shape)
+    if onnx_input_shapes is not None \
+        and tf_input_shapes is not None \
+        and len(onnx_input_shapes) >= 1 \
+        and len(tf_input_shapes) >= 1 \
+        and len(onnx_input_shapes) == len(set(onnx_input_shapes)) \
+        and not isinstance(onnx_input_shapes[pre_convert_axis], str) \
+        and tf_input_shapes[axis] is not None \
+        and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
+        acc_check_pass_flg = True
+
+    if onnx_tensor_infos_for_validation is not None and not acc_check_pass_flg:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -222,7 +237,7 @@ def make_node(
     min_abs_err = sys.maxsize
     min_abs_err_axis: int = axis
 
-    if not disable_strict_mode:
+    if not disable_strict_mode and not acc_check_pass_flg:
         if onnx_tensor_infos is not None and validation_data is not None:
             check_axes = reversed([idx for idx in range(tensor_rank)])
             # Search for the axis with the smallest error


### PR DESCRIPTION
### 1. Content and background
- `Softmax`, `LayerNormalization`
  - If all axes are of different sizes and the axis sizes specified in axis are the same in onnx and TensorFlow, skip the accuracy check.
  - Faster model transformations in some architectures, such as Transformer.
  - OPs with multiple axes of the same size are corrected for accuracy as usual, so the conversion speed is not accelerated.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
