### PR TITLE
Bug fix for `--number_of_dimensions_after_flextranspose_compression` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.12
+  ghcr.io/pinto0309/onnx2tf:1.18.13
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.12
+  docker.io/pinto0309/onnx2tf:1.18.13
 
   or
 
@@ -401,16 +401,16 @@ $ wget https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_readme/Erf_11
 $ onnx2tf -i Erf_11.onnx -rtpo Erf
 
 # High-dimensional Transpose decomposition
-# If you do not like FlexTranspose being generated, try `-nodafc`.
+# If you do not like FlexTranspose being generated, try `-nodaftc`.
 # Suppresses the generation of FlexTranspose by decomposing Transpose
 # to the specified number of dimensions.
 # In TensorFlow v2.12.0 and later, up to 6 dimensions are converted to normal Transpose;
 # in v2.11.0 and earlier, up to 5 dimensions are converted to normal Transpose.
-# Note that specifying `2` for the `-nodafc` option causes all Transpose OPs to disappear
+# Note that specifying `2` for the `-nodaftc` option causes all Transpose OPs to disappear
 # from the model structure.
 # Below is an example of decomposing a Transpose of 5 or more dimensions into a Transpose
 # of 4 dimensions.
-$ onnx2tf -i xxxx.onnx -nodafc 4
+$ onnx2tf -i xxxx.onnx -nodaftc 4
 
 # Parameter replacement (Resize,Transpose,Softmax)
 $ rm replace.json

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.12'
+__version__ = '1.18.13'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2696,6 +2696,10 @@ def transpose_with_flexing_deterrence(
 
     tensor_after_transposition = input_tensor
 
+    # If no transposition is necessary, skip all processing.
+    if (perm is not None and perm == list(range(len(perm)))):
+        return tensor_after_transposition
+
     if disable_suppression_flextranspose:
         # Normal Transpose
         tensor_after_transposition = tf.transpose(
@@ -2750,10 +2754,16 @@ def transpose_with_flexing_deterrence(
                         dim if not isinstance(dim, str) else -1 for dim in output_shape
                     ],
                 )
-        elif input_tensor_rank >= (COMPRESSION_DEFAULT_VALUE + 1) and x_shape_none_dims_count == 0 \
-            or number_of_dimensions_after_flextranspose_compression < COMPRESSION_DEFAULT_VALUE \
-                and number_of_dimensions_after_flextranspose_compression >= 2 \
-                and x_shape_none_dims_count == 0:
+        elif \
+                (
+                    input_tensor_rank >= (COMPRESSION_DEFAULT_VALUE + 1) and x_shape_none_dims_count == 0
+                ) \
+            or \
+                (
+                    number_of_dimensions_after_flextranspose_compression < COMPRESSION_DEFAULT_VALUE \
+                        and number_of_dimensions_after_flextranspose_compression >= 2 \
+                        and x_shape_none_dims_count == 0
+                ):
             # Special Transpose.2
             #   Suppresses as much as possible the conversion of transposes
             #   of 7 or more dimensions into FlexTransposes.


### PR DESCRIPTION
### 1. Content and background
- `Reshape`, `common_functions.py`
  - Bug fix for `--number_of_dimensions_after_flextranspose_compression` option.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
