### PR TITLE
Bug fixes in `Trilu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.13
+  ghcr.io/pinto0309/onnx2tf:1.18.14
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.13
+  docker.io/pinto0309/onnx2tf:1.18.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.13'
+__version__ = '1.18.14'

--- a/onnx2tf/ops/Trilu.py
+++ b/onnx2tf/ops/Trilu.py
@@ -73,9 +73,8 @@ def make_node(
             k = 0 - tensor_shape[-2]
     else:
         k = tf.constant(0, dtype=tf.int64)
-    k_dtype = NUMPY_DTYPES_TO_TF_DTYPES[k.dtype] \
-        if isinstance(k.dtype, np.dtype) else k.dtype
-    keep_triangle = tf.constant(-1, dtype=k_dtype)
+    k = tf.convert_to_tensor(k, dtype=tf.int64)
+    keep_triangle = tf.constant(-1, dtype=k.dtype)
 
     upper = bool(graph_node.attrs.get('upper', 1))
 


### PR DESCRIPTION
### 1. Content and background
- `Trilu`
  - Fixed a problem with conversion abort when `K` is set to a primitive integer.
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/2a35def2-8988-4679-9ad6-616eea3338f0)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
  - [Trilu dtype error when using k greater than tensor dimension. #538](https://github.com/PINTO0309/onnx2tf/issues/538)