### PR TITLE
Created a custom wrapper class for Keras as a preliminary step to support TF v2.15.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.18.14
+  ghcr.io/pinto0309/onnx2tf:1.18.15
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.18.14
+  docker.io/pinto0309/onnx2tf:1.18.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.18.14'
+__version__ = '1.18.15'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3836,9 +3836,8 @@ def dummy_onnx_inference(
             f'The tool skipped dummy inference to avoid SWAP processing because the total size of the tensor of inference results exceeded about {mem_available} GB. (results: {total_output_size_gb} GB)'
         )
 
-    outputs = None
-    if not disable_strict_mode:
-        outputs = onnx_session.run(None, input_datas)
+    outputs = onnx_session.run(None, input_datas)
+
     if tmp_onnx_path:
         os.remove(tmp_onnx_path)
         os.remove(tmp_onnx_external_weights_path)

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3836,7 +3836,9 @@ def dummy_onnx_inference(
             f'The tool skipped dummy inference to avoid SWAP processing because the total size of the tensor of inference results exceeded about {mem_available} GB. (results: {total_output_size_gb} GB)'
         )
 
-    outputs = onnx_session.run(None, input_datas)
+    outputs = None
+    if not disable_strict_mode:
+        outputs = onnx_session.run(None, input_datas)
     if tmp_onnx_path:
         os.remove(tmp_onnx_path)
         os.remove(tmp_onnx_external_weights_path)
@@ -5913,3 +5915,39 @@ def shape_is_equal_ignore_order(
     shape_list_1 = [-1 if isinstance(s, str) or s is None else s for s in shape_list_1]
     shape_list_2 = [-1 if isinstance(s, str) or s is None else s for s in shape_list_2]
     return sorted(shape_list_1) == sorted(shape_list_2)
+
+
+class KLayer(tf.keras.layers.Layer):
+    """Keras wrapper class for tf.xxx
+    """
+    def __init__(self):
+        super(KLayer, self).__init__()
+
+    def call(self, tf_fn, x, **kwargs):
+        """Running tf.xxx via a Keras class.
+
+        Parameters
+        ----------
+        tf_fn:
+            tf.xxx function
+
+        x:
+            input layer or input data
+
+        kwargs:
+            Various parameters to initialize tf.xxx in Dict format
+
+        e.g.\n
+        output = \\\n
+            KLayer()(\n
+                tf_fn=tf.reshape,\n
+                x=input_tensor,\n
+                shape=new_shape,\n
+                name=graph_node.name,\n
+            )\n
+
+        Returns
+        -------
+        Result of executing various tf.xxx functions
+        """
+        return tf_fn(x, **kwargs)


### PR DESCRIPTION
### 1. Content and background
- Created a custom wrapper class for Keras as a preliminary step to support TF v2.15.0.
  - [TensorFlow v2.15.0 での破壊的変更への対応 (You can only use it as input to a Keras layer or a Keras operation)](https://zenn.dev/pinto0309/scraps/7ced3549770937)

```
ValueError: A KerasTensor cannot be used as input to a TensorFlow function.
A KerasTensor is a symbolic placeholder for a shape and dtype,
used when constructing Keras Functional models or Keras Functions.
You can only use it as input to a Keras layer or a Keras operation
(from the namespaces `keras.layers` and `keras.operations`).
You are likely doing something like:

x = Input(...)
tf_fn(x)  # Invalid.

What you should do instead is wrap `tf_fn` in a layer:

class MyLayer(Layer):
    def call(self, x):
        return tf_fn(x)

x = MyLayer()(x)
```
```python
class KLayer(tf.keras.layers.Layer):
    def __init__(self):
        super(KLayer, self).__init__()

    def call(self, tf_fn, x, **kwargs):
        return tf_fn(x, **kwargs)

output = \
    KLayer()(
        tf_fn=tf.reshape,
        x=input_tensor,
        shape=new_shape,
        name=graph_node.name,
    )
```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
