### PR TITLE
Improve macOS compatibility via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y \
         nano python3-pip python3-mock libpython3-dev \
-        libpython3-all-dev python-is-python3 wget curl \
+        libpython3-all-dev python-is-python3 wget curl cmake \
         software-properties-common sudo \
     && sed -i 's/# set linenumbers/set linenumbers/g' /etc/nanorc \
     && apt clean \


### PR DESCRIPTION
### 1. Content and background
- Hosted docker image is not compatible for macOS with apple silicon.
  - Running container(`docker run`) works fine with "Rosetta for Linux"(with --platform linux/x86_64). But in container `import tensorflow` in python is failed by illegal instruction. It seems tensorflow build contains x86 specific instruction set.
- Building image(`docker build`) for `linux/arm64/v8` fails with error.
 
### 2. Summary of corrections
- Add `cmake` dependency in `Dockerfile` 

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
