### PR TITLE
Add option for tflite float16 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,9 @@ optional arguments:
     Disable GroupConvolution and replace it with SeparableConvolution for
     output to saved_model format.
 
+  -eatfp16, --enable_accumulation_type_float16 ENABLE_ACCUMULATION_TYPE_FLOAT16
+    Hint for XNNPack fp16 inference on float16 tflite model.
+
   -ebu, --enable_batchmatmul_unfold
     BatchMatMul is separated batch by batch to generate a primitive MatMul.
 
@@ -1838,6 +1841,10 @@ convert(
     disable_group_convolution: Optional[bool]
       Disable GroupConvolution and replace it with SeparableConvolution for
       output to saved_model format.
+
+    enable_accumulation_type_float16: Optional[bool]
+      Hint for XNNPack fp16 inference on float16 tflite model.
+      https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/delegates/xnnpack/README.md#floating-point-ieee-fp16-operators
 
     enable_batchmatmul_unfold: Optional[bool]
       BatchMatMul is separated batch by batch to generate a primitive MatMul.


### PR DESCRIPTION
### 1. Content and background
Native float16 inference in TFLite is introduced in [Tensorflow Blog](https://blog.tensorflow.org/2023/11/half-precision-inference-doubles-on-device-inference-performance.html). 
To enable it, additional flag in TFLiteConverter is required.
```python
converter.target_spec._experimental_supported_accumulation_type = tf.dtypes.float16
```
This PR enable to access this flag.

### 2. Summary of corrections
- Add new option `enable_accumulation_type_float16` that set flag for XNN Pack float16 inference.

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)

I'm not sure new option names are consistent with existing. Please correct them you feel wrong.