### PR TITLE
Fixed a bug that caused `-nodafsc` processing to be unconditionally skipped.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.0
+  ghcr.io/pinto0309/onnx2tf:1.19.1
 
   or
 
@@ -263,7 +263,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   $ docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.0
+  docker.io/pinto0309/onnx2tf:1.19.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.0'
+__version__ = '1.19.1'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3103,15 +3103,16 @@ def stridedslice_with_flexing_deterrence(
 
     if disable_suppression_flexstridedslice:
         # Normal StridedSlice
-        tensor_after_stridedslice = tf.strided_slice(
-            input_=input_tensor,
-            begin=begin,
-            end=end,
-            strides=strides,
-            begin_mask=begin_mask,
-            end_mask=end_mask,
-            name=name,
-        )
+        tensor_after_stridedslice = \
+            tf.strided_slice(
+                input_=input_tensor,
+                begin=begin,
+                end=end,
+                strides=strides,
+                begin_mask=begin_mask,
+                end_mask=end_mask,
+                name=name,
+            )
     else:
         # Special StridedSlice
         # Get dimension with 1 element
@@ -3199,15 +3200,16 @@ def stridedslice_with_flexing_deterrence(
                     )
             else:
                 # Normal StridedSlice
-                tensor_after_stridedslice = tf.strided_slice(
-                    input_=input_tensor,
-                    begin=begin,
-                    end=end,
-                    strides=strides,
-                    begin_mask=begin_mask,
-                    end_mask=end_mask,
-                    name=name,
-                )
+                tensor_after_stridedslice = \
+                    tf.strided_slice(
+                        input_=input_tensor,
+                        begin=begin,
+                        end=end,
+                        strides=strides,
+                        begin_mask=begin_mask,
+                        end_mask=end_mask,
+                        name=name,
+                    )
 
         elif onnx_slice_dims_count == 1 \
             and \
@@ -3584,15 +3586,16 @@ def stridedslice_with_flexing_deterrence(
 
         else:
             # Normal StridedSlice
-            tensor_after_stridedslice = tf.strided_slice(
-                input_=input_tensor,
-                begin=begin,
-                end=end,
-                strides=strides,
-                begin_mask=begin_mask,
-                end_mask=end_mask,
-                name=name,
-            )
+            tensor_after_stridedslice = \
+                tf.strided_slice(
+                    input_=input_tensor,
+                    begin=begin,
+                    end=end,
+                    strides=strides,
+                    begin_mask=begin_mask,
+                    end_mask=end_mask,
+                    name=name,
+                )
 
     return tensor_after_stridedslice
 


### PR DESCRIPTION
### 1. Content and background
- Fixed a bug that caused `-nodafsc` processing to be unconditionally skipped.
- https://github.com/PINTO0309/onnx2tf/issues/557
- [best_float32.tflite.zip](https://github.com/PINTO0309/onnx2tf/files/13686419/best_float32.tflite.zip)

```
onnx2tf -i best.onnx -nodafsc 4
```

![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/b482450e-ab48-4a1b-872b-f24d084ad3a7)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
