### PR TITLE
Support for onnx==1.15.0

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -96,7 +96,7 @@ jobs:
         pip install pip -U
         pip install cmake==3.26.4
         pip install psutil==5.9.5
-        pip install onnx==1.14.1
+        pip install onnx==1.15.0
         pip install tensorflow==2.15.0
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install pip -U \
-    && pip install onnx==1.14.1 \
+    && pip install onnx==1.15.0 \
     && pip install onnxsim==0.4.33 \
     && pip install nvidia-pyindex \
     && pip install onnx_graphsurgeon \

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 
 ## Environment
 - Linux / Windows
-- onnx==1.14.1
+- onnx==1.15.0
 - onnxruntime==1.16.3
 - onnx-simplifier==0.4.33 or 0.4.30 `(onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] (op_type:Slice, node name: /xxxx/Slice): [ShapeInferenceError] Inferred shape and existing shape differ in rank: (x) vs (y))`
 - onnx_graphsurgeon
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.2
+  ghcr.io/pinto0309/onnx2tf:1.19.3
 
   or
 
@@ -265,11 +265,11 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.2
+  docker.io/pinto0309/onnx2tf:1.19.3
 
   or
 
-  pip install -U onnx==1.14.1 \
+  pip install -U onnx==1.15.0 \
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
   && pip install -U onnxruntime==1.16.3 \
@@ -298,7 +298,7 @@ or
     && sudo mv flatc /usr/bin/
   !pip install -U pip \
     && pip install tensorflow==2.15.0 \
-    && pip install -U onnx==1.14.1 \
+    && pip install -U onnx==1.15.0 \
     && python -m pip install onnx_graphsurgeon \
           --index-url https://pypi.ngc.nvidia.com \
     && pip install -U onnxruntime==1.16.3 \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.2'
+__version__ = '1.19.3'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -18,6 +18,7 @@ import tensorflow as tf
 from tensorflow.python.keras.layers import Lambda
 from tensorflow.python.keras.utils import conv_utils
 import onnx
+from onnx.serialization import ProtoSerializer
 import onnx_graphsurgeon as gs
 try:
     import onnxruntime as ort
@@ -3699,7 +3700,8 @@ def dummy_onnx_inference(
     tmp_onnx_path = ''
     tmp_onnx_external_weights_path =''
     try:
-        serialized_graph = onnx._serialize(new_onnx_graph)
+        serializer: ProtoSerializer = onnx._get_serializer(fmt='protobuf')
+        serialized_graph = serializer.serialize_proto(proto=new_onnx_graph)
     except ValueError as ve:
         tmp_onnx_path = 'tmp.onnx'
         tmp_onnx_external_weights_path ='tmp_external.weights'


### PR DESCRIPTION
### 1. Content and background
- Support for onnx==1.15.0
- Protocol Buffers serialization process was adapted to the new onnx==1.15.0 specification.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
