### PR TITLE
Added ability to optimize patterns with consecutive `ReLU` and `ReLU6`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.3
+  ghcr.io/pinto0309/onnx2tf:1.19.4
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.3
+  docker.io/pinto0309/onnx2tf:1.19.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.3'
+__version__ = '1.19.4'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -811,6 +811,7 @@ def convert(
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
         'output_integer_quantized_tflite': output_integer_quantized_tflite,
         'gelu_replace_op_names': {},
+        'relu_relu6_merge_op_names': {},
         'mul_div_replace_op_names': {},
         'use_cuda': use_cuda,
     }


### PR DESCRIPTION
### 1. Content and background
- Added ability to optimize patterns with consecutive `ReLU` and `ReLU6`
  
  |ONNX|TFLite (Unoptimized)|TFLite (Optimized)|
  |:-:|:-:|:-:|
  |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/50b39a46-0f20-459f-99bb-5bc2d286cf04)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/0eb69dae-171f-4431-8099-118cbec3bc11)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/491d89bc-b6e4-4cac-9551-ea2cb081f32d)|

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
