### PR TITLE
Implement workaround for cases where the input tensor contains multiple undefined dimensions `Resize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.4
+  ghcr.io/pinto0309/onnx2tf:1.19.5
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.4
+  docker.io/pinto0309/onnx2tf:1.19.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.4'
+__version__ = '1.19.5'

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -265,14 +265,25 @@ def make_node(
             else:
                 h_w_scale = scales[1:input_tensor_rank-1]
                 h_w_shape = input_tensor_shape[1:input_tensor_rank-1]
-                new_size = tf.cast(
-                    h_w_scale * tf.cast(
-                        h_w_shape,
-                        NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
-                            if isinstance(scales.dtype, np.dtype) else scales.dtype,
-                    ),
-                    tf.int32,
-                )
+                try:
+                    new_size = tf.cast(
+                        h_w_scale * tf.cast(
+                            h_w_shape,
+                            NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
+                                if isinstance(scales.dtype, np.dtype) else scales.dtype,
+                        ),
+                        tf.int32,
+                    )
+                except:
+                    # Workaround when h_w_shape contains undefined dimensions
+                    new_size = tf.cast(
+                        h_w_scale * tf.cast(
+                            tf.shape(input_tensor)[1:input_tensor_rank-1],
+                            NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
+                                if isinstance(scales.dtype, np.dtype) else scales.dtype,
+                        ),
+                        tf.int32,
+                    )
         else:
             h_w_scale = scales[1:input_tensor_rank-1]
             h_w_shape = input_tensor_shape[1:input_tensor_rank-1]


### PR DESCRIPTION
### 1. Content and background
- `Resize`
  - Implement workaround for cases where the input tensor contains multiple undefined dimensions.
  - Addressed the issue of `Resize` aborting only when resizing by the `scale` parameter, not by the `size` parameter.
  - [fp32.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/13849348/fp32.onnx.zip)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/c93c5ac7-0381-487f-9be5-c818d5d7049b)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- https://github.com/PINTO0309/onnx2tf/issues/563