### PR TITLE
Fixed Abort bug when converting models with `--optimization_for_gpu_delegate`.

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -37,7 +37,7 @@ jobs:
           sudo rm -rf "/usr/share/sbt" || true
           sudo rm -rf "/usr/local/sqlpackage" || true
           docker rmi $(docker image ls -q --filter "reference=node*")
-          docker rmi $(docker image ls -q --filter "reference=buildpack*")
+          docker rmi $(docker image ls -q --filter "reference=moby/buildkit*")
           docker rmi $(docker image ls -q --filter "reference=debian*")
           docker rmi $(docker image ls -q --filter "reference=alpine*")
           docker rmi $(docker image ls -q --filter "reference=ubuntu:20.04")

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.7
+  ghcr.io/pinto0309/onnx2tf:1.19.8
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.7
+  docker.io/pinto0309/onnx2tf:1.19.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.7'
+__version__ = '1.19.8'

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -202,7 +202,7 @@ def make_node(
                 result = tf.convert_to_tensor(alpha) * tf.matmul(x, y) + tf.convert_to_tensor(beta)
 
         else:
-            result = tf.convert_to_tensor(alpha) * tf.matmul(x, y) - (tf.convert_to_tensor(beta) * z) * tf.convert_to_tensor(-1)
+            result = tf.convert_to_tensor(alpha) * tf.matmul(x, y) - (tf.convert_to_tensor(beta) * z) * tf.convert_to_tensor(-1.0, dtype=z.dtype)
 
         if result.dtype != input_tensor_x_dtype:
             tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `Gemm`
  - Fixed Abort bug when converting models with `--optimization_for_gpu_delegate`.

    |onnx|before tflite|after tflite|
    |:-:|:-:|:-:|
    |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/447f448f-1b5e-474f-b91b-97298717e4cd)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/8c3e0baf-ba08-4e27-9a85-64562ae3db87)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/6a07d65a-e4bf-48e7-aee9-a3f80ea4dd48)|

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [pre_explicit_broadcast should not expend scalar tensor #573](https://github.com/PINTO0309/onnx2tf/issues/573)