### PR TITLE
Modified to suppress broadcast when `Gemm` is immediately followed by a scalar `Mul`, `Div`, `Sub`, or `Mod`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.9
+  ghcr.io/pinto0309/onnx2tf:1.19.10
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.9
+  docker.io/pinto0309/onnx2tf:1.19.10
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.9'
+__version__ = '1.19.10'

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -159,19 +159,45 @@ def make_node(
             **kwargs,
         )
 
-    input_tensor_1, input_tensor_2 = \
-        pre_explicit_broadcast(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-        )
+    try:
+        is_scalar_1 = False
+        is_scalar_2 = False
+        is_scalar_1_rank = tf.rank(input_tensor_1) == 0
+        if hasattr(is_scalar_1_rank, 'numpy'):
+            is_scalar_1 = is_scalar_1_rank.numpy()
+        is_scalar_2_rank = tf.rank(input_tensor_2) == 0
+        if hasattr(is_scalar_2_rank, 'numpy'):
+            is_scalar_2 = is_scalar_2_rank.numpy()
+        if (is_scalar_1 or is_scalar_2) and graph_node.i().op == 'Gemm':
+            pass
+        else:
+            input_tensor_1, input_tensor_2 = \
+                pre_explicit_broadcast(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                )
 
-    input_tensor_1, input_tensor_2 = \
-        explicit_broadcast(
-            const_or_var_1=input_tensor_1,
-            const_or_var_2=input_tensor_2,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
+            input_tensor_1, input_tensor_2 = \
+                explicit_broadcast(
+                    const_or_var_1=input_tensor_1,
+                    const_or_var_2=input_tensor_2,
+                    graph_node=graph_node,
+                    tf_layers_dict= tf_layers_dict,
+                )
+    except Exception as ex:
+        input_tensor_1, input_tensor_2 = \
+            pre_explicit_broadcast(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+            )
+
+        input_tensor_1, input_tensor_2 = \
+            explicit_broadcast(
+                const_or_var_1=input_tensor_1,
+                const_or_var_2=input_tensor_2,
+                graph_node=graph_node,
+                tf_layers_dict= tf_layers_dict,
+            )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \

--- a/onnx2tf/ops/Div.py
+++ b/onnx2tf/ops/Div.py
@@ -149,19 +149,45 @@ def make_node(
             **kwargs,
         )
 
-    input_tensor_1, input_tensor_2 = \
-        pre_explicit_broadcast(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-        )
+    try:
+        is_scalar_1 = False
+        is_scalar_2 = False
+        is_scalar_1_rank = tf.rank(input_tensor_1) == 0
+        if hasattr(is_scalar_1_rank, 'numpy'):
+            is_scalar_1 = is_scalar_1_rank.numpy()
+        is_scalar_2_rank = tf.rank(input_tensor_2) == 0
+        if hasattr(is_scalar_2_rank, 'numpy'):
+            is_scalar_2 = is_scalar_2_rank.numpy()
+        if (is_scalar_1 or is_scalar_2) and graph_node.i().op == 'Gemm':
+            pass
+        else:
+            input_tensor_1, input_tensor_2 = \
+                pre_explicit_broadcast(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                )
 
-    input_tensor_1, input_tensor_2 = \
-        explicit_broadcast(
-            const_or_var_1=input_tensor_1,
-            const_or_var_2=input_tensor_2,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
+            input_tensor_1, input_tensor_2 = \
+                explicit_broadcast(
+                    const_or_var_1=input_tensor_1,
+                    const_or_var_2=input_tensor_2,
+                    graph_node=graph_node,
+                    tf_layers_dict= tf_layers_dict,
+                )
+    except Exception as ex:
+        input_tensor_1, input_tensor_2 = \
+            pre_explicit_broadcast(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+            )
+
+        input_tensor_1, input_tensor_2 = \
+            explicit_broadcast(
+                const_or_var_1=input_tensor_1,
+                const_or_var_2=input_tensor_2,
+                graph_node=graph_node,
+                tf_layers_dict= tf_layers_dict,
+            )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \

--- a/onnx2tf/ops/Mod.py
+++ b/onnx2tf/ops/Mod.py
@@ -148,19 +148,45 @@ def make_node(
             **kwargs,
         )
 
-    input_tensor_1, input_tensor_2 = \
-        pre_explicit_broadcast(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-        )
+    try:
+        is_scalar_1 = False
+        is_scalar_2 = False
+        is_scalar_1_rank = tf.rank(input_tensor_1) == 0
+        if hasattr(is_scalar_1_rank, 'numpy'):
+            is_scalar_1 = is_scalar_1_rank.numpy()
+        is_scalar_2_rank = tf.rank(input_tensor_2) == 0
+        if hasattr(is_scalar_2_rank, 'numpy'):
+            is_scalar_2 = is_scalar_2_rank.numpy()
+        if (is_scalar_1 or is_scalar_2) and graph_node.i().op == 'Gemm':
+            pass
+        else:
+            input_tensor_1, input_tensor_2 = \
+                pre_explicit_broadcast(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                )
 
-    input_tensor_1, input_tensor_2 = \
-        explicit_broadcast(
-            const_or_var_1=input_tensor_1,
-            const_or_var_2=input_tensor_2,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
+            input_tensor_1, input_tensor_2 = \
+                explicit_broadcast(
+                    const_or_var_1=input_tensor_1,
+                    const_or_var_2=input_tensor_2,
+                    graph_node=graph_node,
+                    tf_layers_dict= tf_layers_dict,
+                )
+    except Exception as ex:
+        input_tensor_1, input_tensor_2 = \
+            pre_explicit_broadcast(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+            )
+
+        input_tensor_1, input_tensor_2 = \
+            explicit_broadcast(
+                const_or_var_1=input_tensor_1,
+                const_or_var_2=input_tensor_2,
+                graph_node=graph_node,
+                tf_layers_dict= tf_layers_dict,
+            )
 
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -149,19 +149,45 @@ def make_node(
             **kwargs,
         )
 
-    input_tensor_1, input_tensor_2 = \
-        pre_explicit_broadcast(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-        )
+    try:
+        is_scalar_1 = False
+        is_scalar_2 = False
+        is_scalar_1_rank = tf.rank(input_tensor_1) == 0
+        if hasattr(is_scalar_1_rank, 'numpy'):
+            is_scalar_1 = is_scalar_1_rank.numpy()
+        is_scalar_2_rank = tf.rank(input_tensor_2) == 0
+        if hasattr(is_scalar_2_rank, 'numpy'):
+            is_scalar_2 = is_scalar_2_rank.numpy()
+        if (is_scalar_1 or is_scalar_2) and graph_node.i().op == 'Gemm':
+            pass
+        else:
+            input_tensor_1, input_tensor_2 = \
+                pre_explicit_broadcast(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                )
 
-    input_tensor_1, input_tensor_2 = \
-        explicit_broadcast(
-            const_or_var_1=input_tensor_1,
-            const_or_var_2=input_tensor_2,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
+            input_tensor_1, input_tensor_2 = \
+                explicit_broadcast(
+                    const_or_var_1=input_tensor_1,
+                    const_or_var_2=input_tensor_2,
+                    graph_node=graph_node,
+                    tf_layers_dict= tf_layers_dict,
+                )
+    except Exception as ex:
+        input_tensor_1, input_tensor_2 = \
+            pre_explicit_broadcast(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+            )
+
+        input_tensor_1, input_tensor_2 = \
+            explicit_broadcast(
+                const_or_var_1=input_tensor_1,
+                const_or_var_2=input_tensor_2,
+                graph_node=graph_node,
+                tf_layers_dict= tf_layers_dict,
+            )
 
     # broadcast_for_gpu_delegate
     input_tensor_1, input_tensor_2 = \

--- a/onnx2tf/ops/Sub.py
+++ b/onnx2tf/ops/Sub.py
@@ -147,20 +147,45 @@ def make_node(
             **kwargs,
         )
 
-    input_tensor_1, input_tensor_2 = \
-        pre_explicit_broadcast(
-            input_tensor_1=input_tensor_1,
-            input_tensor_2=input_tensor_2,
-        )
+    try:
+        is_scalar_1 = False
+        is_scalar_2 = False
+        is_scalar_1_rank = tf.rank(input_tensor_1) == 0
+        if hasattr(is_scalar_1_rank, 'numpy'):
+            is_scalar_1 = is_scalar_1_rank.numpy()
+        is_scalar_2_rank = tf.rank(input_tensor_2) == 0
+        if hasattr(is_scalar_2_rank, 'numpy'):
+            is_scalar_2 = is_scalar_2_rank.numpy()
+        if (is_scalar_1 or is_scalar_2) and graph_node.i().op == 'Gemm':
+            pass
+        else:
+            input_tensor_1, input_tensor_2 = \
+                pre_explicit_broadcast(
+                    input_tensor_1=input_tensor_1,
+                    input_tensor_2=input_tensor_2,
+                )
 
-    input_tensor_1, input_tensor_2 = \
-        explicit_broadcast(
-            const_or_var_1=input_tensor_1,
-            const_or_var_2=input_tensor_2,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
+            input_tensor_1, input_tensor_2 = \
+                explicit_broadcast(
+                    const_or_var_1=input_tensor_1,
+                    const_or_var_2=input_tensor_2,
+                    graph_node=graph_node,
+                    tf_layers_dict= tf_layers_dict,
+                )
+    except Exception as ex:
+        input_tensor_1, input_tensor_2 = \
+            pre_explicit_broadcast(
+                input_tensor_1=input_tensor_1,
+                input_tensor_2=input_tensor_2,
+            )
 
+        input_tensor_1, input_tensor_2 = \
+            explicit_broadcast(
+                const_or_var_1=input_tensor_1,
+                const_or_var_2=input_tensor_2,
+                graph_node=graph_node,
+                tf_layers_dict= tf_layers_dict,
+            )
     # Deterring shape corruption due to broadcast
     input_tensor_1, input_tensor_2 = \
         deterring_shape_corruption_due_to_broadcast(


### PR DESCRIPTION
### 1. Content and background
- `Mul`, `Div`, `Sub`, or `Mod`
  - Modified to suppress broadcast when `Gemm` is immediately followed by a scalar `Mul`, `Div`, `Sub`, or `Mod`.
  - This is a very specific workaround for the special specifications of NNAPI.
  - Address the issue of NNAPI not allowing multi-dimensional bias.
  - The problem is not reproducible for variable batch sizes.
  - The problem reproduces only when changing to a fixed batch size.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [pre_explicit_broadcast should not expend scalar tensor #573](https://github.com/PINTO0309/onnx2tf/issues/573)