### PR TITLE
Support for 1D `MaxPoolWithArgmax`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.10
+  ghcr.io/pinto0309/onnx2tf:1.19.11
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.10
+  docker.io/pinto0309/onnx2tf:1.19.11
 
   or
 

--- a/json_samples/replace_um.json
+++ b/json_samples/replace_um.json
@@ -1,0 +1,11 @@
+{
+  "format_version": 1,
+  "operations": [
+    {
+      "op_name": "/Transpose",
+      "param_target": "attributes",
+      "param_name": "perm",
+      "values": [0,2,3,1]
+    }
+  ]
+}

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.10'
+__version__ = '1.19.11'


### PR DESCRIPTION
### 1. Content and background
- `MaxPoolWithArgmax`
  - Support for 1D `MaxPoolWithArgmax`
  - However, TFLite does not support `max_pool_with_argmax` as standard.
  - [UM_best_model.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/14111141/UM_best_model.onnx.zip)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/e0ee2807-d6a4-4057-a852-0eff5d7b8326)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [ValueError in MaxPool Layer during ONNX to TensorFlow Conversion with 3D Input #579](https://github.com/PINTO0309/onnx2tf/issues/579)