### PR TITLE
fix for float64 error

### DIFF
--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1432,7 +1432,7 @@ def convert(
                     for model_input_name in model_input_name_list:
                         calib_data, mean, std = calib_data_dict[model_input_name]
                         normalized_calib_data = (calib_data[idx] - mean) / std
-                        yield_data_dict[model_input_name] = normalized_calib_data
+                        yield_data_dict[model_input_name] = normalized_calib_data.astype('float32')
                     yield yield_data_dict
 
             # INT8 Quantization


### PR DESCRIPTION
Using converter for full int8 quantization using custom_input_op_name_np_data_path,
when 
np_data = [["images", tmp_file, [[[[0, 0, 0]]]], [[[[255, 255, 255]]]]]]

This is the line in def representative_dataset_gen() function
normalized_calib_data = (calib_data[idx] - mean) / std

dividing by std generates float64 type and tf.convertor expects float32.

Simple fix:

  normalized_calib_data = (calib_data[idx] - mean) / std
  yield_data_dict[model_input_name] = normalized_calib_data**.astype('float32')**


