### PR TITLE
Add type specification, v1.19.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.11
+  ghcr.io/pinto0309/onnx2tf:1.19.12
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.11
+  docker.io/pinto0309/onnx2tf:1.19.12
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.11'
+__version__ = '1.19.12'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1368,7 +1368,7 @@ def convert(
             # Used only when there is only one input OP, a 4D tensor image,
             # and --quant_calib_input_op_name_np_data_path is not specified.
             # Otherwise, calibrate using the data specified in --quant_calib_input_op_name_np_data_path.
-            calib_data_dict = {}
+            calib_data_dict: Dict[str, List[np.ndarray, np.ndarray, np.ndarray]] = {}
             model_input_name_list = [
                 model_input.name for model_input in model.inputs
             ]
@@ -1431,8 +1431,8 @@ def convert(
                     yield_data_dict = {}
                     for model_input_name in model_input_name_list:
                         calib_data, mean, std = calib_data_dict[model_input_name]
-                        normalized_calib_data = (calib_data[idx] - mean) / std
-                        yield_data_dict[model_input_name] = normalized_calib_data.astype('float32')
+                        normalized_calib_data: np.ndarray = (calib_data[idx] - mean) / std
+                        yield_data_dict[model_input_name] = normalized_calib_data.astype(np.float32)
                     yield yield_data_dict
 
             # INT8 Quantization


### PR DESCRIPTION
### 1. Content and background
- Add type specification, v1.19.12

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
