### PR TITLE
Gather - keep output dimensions

### DIFF
--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -228,7 +228,8 @@ def make_node(
         tf_layers_dict[graph_node_output.name]['simple_resize'] = True
         tf_layers_dict[graph_node_output.name]['simple_resize_shape_op'] = tf_layers_dict[graph_node_input_1.name]['simple_resize_shape_op']
         tf_type = tf.identity
-    elif unsqueeze_count == consumer_count \
+    elif unsqueeze_count > 0 \
+        and unsqueeze_count == consumer_count \
         and before_cast_indices is not None:
         # Replace
         ind = before_cast_indices
@@ -247,34 +248,16 @@ def make_node(
             ]
         )
         end_mask_ = begin_mask_
-        reshaped_shape = list(input_tensor.shape)[:axis] + list(input_tensor.shape)[axis+1:]
-        
-        if reshaped_shape == shape:
-            # the original layer changed output shape, so we change it too
-            tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                tf.reshape(
-                    tensor=tf.strided_slice(
-                    input_=input_tensor \
-                        if not isinstance(input_tensor, np.ndarray) \
-                            else tf.convert_to_tensor(input_tensor),
-                    begin=begin_,
-                    end=end_,
-                    begin_mask=begin_mask_,
-                    end_mask=end_mask_,
-                    ),
-                    shape=reshaped_shape
-                )
-        else:
-            tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                tf.strided_slice(
-                    input_=input_tensor \
-                        if not isinstance(input_tensor, np.ndarray) \
-                            else tf.convert_to_tensor(input_tensor),
-                    begin=begin_,
-                    end=end_,
-                    begin_mask=begin_mask_,
-                    end_mask=end_mask_,
-                )
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.strided_slice(
+                input_=input_tensor \
+                    if not isinstance(input_tensor, np.ndarray) \
+                        else tf.convert_to_tensor(input_tensor),
+                begin=begin_,
+                end=end_,
+                begin_mask=begin_mask_,
+                end_mask=end_mask_,
+            )
         tf_layers_dict[graph_node_output.name]['unnecessary_gather'] = True
         tf_type = tf.strided_slice
     elif \

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -247,16 +247,34 @@ def make_node(
             ]
         )
         end_mask_ = begin_mask_
-        tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.strided_slice(
-                input_=input_tensor \
-                    if not isinstance(input_tensor, np.ndarray) \
-                        else tf.convert_to_tensor(input_tensor),
-                begin=begin_,
-                end=end_,
-                begin_mask=begin_mask_,
-                end_mask=end_mask_,
-            )
+        reshaped_shape = list(input_tensor.shape)[:axis] + list(input_tensor.shape)[axis+1:]
+        
+        if reshaped_shape == shape:
+            # the original layer changed output shape, so we change it too
+            tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                tf.reshape(
+                    tensor=tf.strided_slice(
+                    input_=input_tensor \
+                        if not isinstance(input_tensor, np.ndarray) \
+                            else tf.convert_to_tensor(input_tensor),
+                    begin=begin_,
+                    end=end_,
+                    begin_mask=begin_mask_,
+                    end_mask=end_mask_,
+                    ),
+                    shape=reshaped_shape
+                )
+        else:
+            tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                tf.strided_slice(
+                    input_=input_tensor \
+                        if not isinstance(input_tensor, np.ndarray) \
+                            else tf.convert_to_tensor(input_tensor),
+                    begin=begin_,
+                    end=end_,
+                    begin_mask=begin_mask_,
+                    end_mask=end_mask_,
+                )
         tf_layers_dict[graph_node_output.name]['unnecessary_gather'] = True
         tf_type = tf.strided_slice
     elif \


### PR DESCRIPTION
ONNX Gather changes output shape by removing the singled out dimension. When converting to TF using strided_slice, the extra dimension is kept. Fix to remove the extra dimension using reshape.

Example: 
ONNX: [1,50,768]->Gather(index=0)->[1,768]
TF: [1,50,768]->StridedSlice(...)->[1,1,768]

### 3. Before/After (If there is an operating log that can be used as a reference)
![image](https://github.com/PINTO0309/onnx2tf/assets/17670772/6959f7f8-573b-43e7-b19b-98760f3908bb)

