### PR TITLE
Bug fix for `Celu`, onnxruntime==1.17.1

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -103,7 +103,7 @@ jobs:
         pip install protobuf==3.20.3
         pip install onnxsim==0.4.33
         pip install sng4onnx
-        pip install onnxruntime==1.16.3
+        pip install onnxruntime==1.17.1
         pip install ml_dtypes==0.2.0
         pip install -e .
     - name: Download models

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN pip install pip -U \
     && pip install protobuf==3.20.3 \
     && pip install h5py==3.7.0 \
     && pip install psutil==5.9.5 \
-    && pip install onnxruntime==1.16.3 \
+    && pip install onnxruntime==1.17.1 \
     && pip install ml_dtypes==0.2.0
 
 # Re-release flatc with some customizations of our own to address

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 ## Environment
 - Linux / Windows
 - onnx==1.15.0
-- onnxruntime==1.16.3
+- onnxruntime==1.17.1
 - onnx-simplifier==0.4.33 or 0.4.30 `(onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] (op_type:Slice, node name: /xxxx/Slice): [ShapeInferenceError] Inferred shape and existing shape differ in rank: (x) vs (y))`
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.13
+  ghcr.io/pinto0309/onnx2tf:1.19.14
 
   or
 
@@ -265,14 +265,14 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.13
+  docker.io/pinto0309/onnx2tf:1.19.14
 
   or
 
   pip install -U onnx==1.15.0 \
   && pip install -U nvidia-pyindex \
   && pip install -U onnx-graphsurgeon \
-  && pip install -U onnxruntime==1.16.3 \
+  && pip install -U onnxruntime==1.17.1 \
   && pip install -U onnxsim==0.4.33 \
   && pip install -U simple_onnx_processing_tools \
   && pip install -U tensorflow==2.15.0 \
@@ -303,7 +303,7 @@ or
     && pip install -U onnx==1.15.0 \
     && python -m pip install onnx_graphsurgeon \
           --index-url https://pypi.ngc.nvidia.com \
-    && pip install -U onnxruntime==1.16.3 \
+    && pip install -U onnxruntime==1.17.1 \
     && pip install -U onnxsim==0.4.33 \
     && pip install -U simple_onnx_processing_tools \
     && pip install -U onnx2tf \


### PR DESCRIPTION
### 1. Content and background
- `Celu`
  - Fixed a bug that caused very few elements to diverge to `Nan`, resulting in inconsistent output.
    ```
    onnx_tensor[0, 3, 1, 26]
    97.723495

    tf_transposed_tensor[0, 3, 1, 26]
    nan
    ```
  - [poc.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/14975764/poc.onnx.zip)

### 2. Summary of corrections

TensorFlow operator combinations were reviewed.

```
onnx2tf -i poc.onnx -cotof
```

![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/c9430e75-4687-4ded-948c-82c77bc10bbd)

![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/0589bf32-690b-436d-84cd-bbd4d2741e67)

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [There are discrepancies between the outputs of the ONNX model and converted TensorFlow models. #602](https://github.com/PINTO0309/onnx2tf/issues/602)