### PR TITLE
Adjusted behavior when Split assumes splitting into multiple sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.14
+  ghcr.io/pinto0309/onnx2tf:1.19.15
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.14
+  docker.io/pinto0309/onnx2tf:1.19.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.14'
+__version__ = '1.19.15'

--- a/onnx2tf/ops/Split.py
+++ b/onnx2tf/ops/Split.py
@@ -53,7 +53,7 @@ def make_node(
     if len(graph_node.inputs) >= 2:
         graph_node_input_2 = get_constant_or_variable(
             graph_node.inputs[1],
-            before_op_output_shape_trans,
+            before_op_output_shape_trans if isinstance(graph_node_input_2, gs.Variable) else False,
         )
     # graph_node_output: gs.Variable = graph_node.outputs[0]
     graph_node_outputs: List[gs.Variable] = [


### PR DESCRIPTION
### 1. Content and background
- `Split`
 - Adjusted behavior when Split assumes splitting into multiple sizes.
 - Fixed a bug that caused a list of constants to be transposed to NCHW when the tensor is split by multiple irregular constant sizes.

![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/4d463e53-714c-41de-aab7-23165d070d52)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [ONNX Split operation converts to a tf StridedSlice operation with outputs in the wrong order. #588](https://github.com/PINTO0309/onnx2tf/issues/588)