### PR TITLE
Workaround for bug in TensorFlow quantization logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.15
+  ghcr.io/pinto0309/onnx2tf:1.19.16
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.15
+  docker.io/pinto0309/onnx2tf:1.19.16
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.15'
+__version__ = '1.19.16'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -29,6 +29,7 @@ tf.config.experimental.enable_op_determinism()
 tf.get_logger().setLevel('INFO')
 tf.autograph.set_verbosity(0)
 tf.get_logger().setLevel(logging.FATAL)
+tf.experimental.numpy.experimental_enable_numpy_behavior()
 from absl import logging as absl_logging
 absl_logging.set_verbosity(absl_logging.ERROR)
 

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -29,7 +29,6 @@ tf.config.experimental.enable_op_determinism()
 tf.get_logger().setLevel('INFO')
 tf.autograph.set_verbosity(0)
 tf.get_logger().setLevel(logging.FATAL)
-tf.experimental.numpy.experimental_enable_numpy_behavior()
 from absl import logging as absl_logging
 absl_logging.set_verbosity(absl_logging.ERROR)
 
@@ -1433,7 +1432,7 @@ def convert(
                     for model_input_name in model_input_name_list:
                         calib_data, mean, std = calib_data_dict[model_input_name]
                         normalized_calib_data: np.ndarray = (calib_data[idx] - mean) / std
-                        yield_data_dict[model_input_name] = normalized_calib_data.astype(np.float32)
+                        yield_data_dict[model_input_name] = tf.cast(tf.convert_to_tensor(normalized_calib_data), tf.float32)
                     yield yield_data_dict
 
             # INT8 Quantization


### PR DESCRIPTION
### 1. Content and background
- Workaround for bug in TensorFlow quantization logic
- Quantization behavior is clearly broken since `TensorFlow==2.15.0` or `TensorFlow==2.15.0.post1`.

```python
# representative_dataset_gen
def representative_dataset_gen():
    for idx in range(data_count):
        yield_data_dict = {}
        for model_input_name in model_input_name_list:
            calib_data, mean, std = calib_data_dict[model_input_name]
            normalized_calib_data: np.ndarray = (calib_data[idx] - mean) / std
            yield_data_dict[model_input_name] = tf.cast(tf.convert_to_tensor(normalized_calib_data), tf.float32)
        yield yield_data_dict
```

```
EagerTensor object has no attribute 'astype'. 
        If you are looking for numpy-related methods, please run the following:
        tf.experimental.numpy.experimental_enable_numpy_behavior()
      
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/python/framework/tensor.py", line 256, in __getattr__
    raise AttributeError(
  File "/home/b920405/git/onnx2tf/onnx2tf/onnx2tf.py", line 1436, in representative_dataset_gen
    yield_data_dict[model_input_name] = normalized_calib_data.astype(np.float32)
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/optimize/calibrator.py", line 101, in _feed_tensors
    for sample in dataset_gen():
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/optimize/calibrator.py", line 254, in calibrate
    self._feed_tensors(dataset_gen, resize_input=True)
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/convert_phase.py", line 215, in wrapper
    raise error from None  # Re-throws the exception.
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/convert_phase.py", line 215, in wrapper
    raise error from None  # Re-throws the exception.
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/lite.py", line 735, in _quantize
    calibrated = calibrate_quantize.calibrate(
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/lite.py", line 1037, in _optimize_tflite_model
    model = self._quantize(
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/convert_phase.py", line 215, in wrapper
    raise error from None  # Re-throws the exception.
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/convert_phase.py", line 215, in wrapper
    raise error from None  # Re-throws the exception.
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/lite.py", line 1332, in _convert_from_saved_model
    return self._optimize_tflite_model(
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/lite.py", line 1465, in convert
    return self._convert_from_saved_model(graph_def)
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/lite.py", line 1093, in _convert_and_export_metrics
    result = convert_func(self, *args, **kwargs)
  File "/home/b920405/.local/lib/python3.10/site-packages/tensorflow/lite/python/lite.py", line 1139, in wrapper
    return self._convert_and_export_metrics(convert_func, *args, **kwargs)
  File "/home/b920405/git/onnx2tf/onnx2tf/onnx2tf.py", line 1449, in convert
    tflite_model = converter.convert()
  File "/home/b920405/git/onnx2tf/onnx2tf/onnx2tf.py", line 2327, in main
    model = convert(
  File "/home/b920405/git/onnx2tf/onnx2tf/onnx2tf.py", line 2381, in <module>
    main()
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main (Current frame)
    return _run_code(code, main_globals, None,
AttributeError: EagerTensor object has no attribute 'astype'. 
        If you are looking for numpy-related methods, please run the following:
        tf.experimental.numpy.experimental_enable_numpy_behavior()
```

If the modifications are made as suggested by the error message, the main flow of model transformation will be significantly disrupted. The following sentence shall not be added to the logic

```python
tf.experimental.numpy.experimental_enable_numpy_behavior()
```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Resize operation fails (['unk__0', 'unk__1', 'unk__2', 'unk__3']) and raises UnboundLocalError: local variable 'new_size' referenced before assignment #607](https://github.com/PINTO0309/onnx2tf/issues/607)