### PR TITLE
[experimental] tensorflow==2.16.1, Keras 3.0

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -105,6 +105,7 @@ jobs:
         pip install sng4onnx
         pip install onnxruntime==1.17.1
         pip install ml_dtypes==0.3.2
+        pip install tf-keras~=2.16
         pip install -e .
     - name: Download models
       run: |

--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -97,14 +97,14 @@ jobs:
         pip install cmake==3.26.4
         pip install psutil==5.9.5
         pip install onnx==1.15.0
-        pip install tensorflow==2.15.0
+        pip install tensorflow==2.16.1
         pip install nvidia-pyindex
         pip install onnx-graphsurgeon
         pip install protobuf==3.20.3
         pip install onnxsim==0.4.33
         pip install sng4onnx
         pip install onnxruntime==1.17.1
-        pip install ml_dtypes==0.2.0
+        pip install ml_dtypes==0.3.2
         pip install -e .
     - name: Download models
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN pip install pip -U \
     && pip install h5py==3.11.0 \
     && pip install psutil==5.9.5 \
     && pip install onnxruntime==1.17.1 \
-    && pip install ml_dtypes==0.3.2
+    && pip install ml_dtypes==0.3.2 \
+    && pip install tf-keras~=2.16
 
 # Re-release flatc with some customizations of our own to address
 # the lack of arithmetic precision of the quantization parameters

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN pip install pip -U \
     && pip install onnx2tf \
     && pip install onnx2tf \
     && pip install simple_onnx_processing_tools \
-    && pip install tensorflow==2.15.0 \
+    && pip install tensorflow==2.16.1 \
     && pip install protobuf==3.20.3 \
-    && pip install h5py==3.7.0 \
+    && pip install h5py==3.11.0 \
     && pip install psutil==5.9.5 \
     && pip install onnxruntime==1.17.1 \
-    && pip install ml_dtypes==0.2.0
+    && pip install ml_dtypes==0.3.2
 
 # Re-release flatc with some customizations of our own to address
 # the lack of arithmetic precision of the quantization parameters

--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U onnx2tf \
   && pip install -U h5py==3.11.0 \
   && pip install -U psutil==5.9.5 \
-  && pip install -U ml_dtypes==0.3.2
+  && pip install -U ml_dtypes==0.3.2 \
+  && pip install -U tf-keras~=2.16
 
   or
 
@@ -310,7 +311,8 @@ or
     && pip install -U protobuf==3.20.3 \
     && pip install -U h5py==3.11.0 \
     && pip install -U psutil==5.9.5 \
-    && pip install -U ml_dtypes==0.3.2
+    && pip install -U ml_dtypes==0.3.2 \
+    && pip install -U tf-keras~=2.16
   ```
 
 ### 2. Run test

--- a/README.md
+++ b/README.md
@@ -224,9 +224,9 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - onnx-simplifier==0.4.33 or 0.4.30 `(onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] (op_type:Slice, node name: /xxxx/Slice): [ShapeInferenceError] Inferred shape and existing shape differ in rank: (x) vs (y))`
 - onnx_graphsurgeon
 - simple_onnx_processing_tools
-- tensorflow==2.15.0, Note: [#515](https://github.com/PINTO0309/onnx2tf/issues/515), Special bugs: [#436](https://github.com/PINTO0309/onnx2tf/issues/436)
+- tensorflow==2.16.1, Note: [#515](https://github.com/PINTO0309/onnx2tf/issues/515), Special bugs: [#436](https://github.com/PINTO0309/onnx2tf/issues/436)
 - psutil==5.9.5
-- ml_dtypes==0.2.0
+- ml_dtypes==0.3.2
 - flatbuffers-compiler (Optional, Only when using the `-coion` option. Executable file named `flatc`.)
   ```bash
   # Custom flatc v23.5.26 binary for Ubuntu 20.04+
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.19.16
+  ghcr.io/pinto0309/onnx2tf:1.20.0
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.19.16
+  docker.io/pinto0309/onnx2tf:1.20.0
 
   or
 
@@ -275,12 +275,12 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U onnxruntime==1.17.1 \
   && pip install -U onnxsim==0.4.33 \
   && pip install -U simple_onnx_processing_tools \
-  && pip install -U tensorflow==2.15.0 \
+  && pip install -U tensorflow==2.16.1 \
   && pip install -U protobuf==3.20.3 \
   && pip install -U onnx2tf \
-  && pip install -U h5py==3.7.0 \
+  && pip install -U h5py==3.11.0 \
   && pip install -U psutil==5.9.5 \
-  && pip install -U ml_dtypes==0.2.0
+  && pip install -U ml_dtypes==0.3.2
 
   or
 
@@ -299,7 +299,7 @@ or
     && sudo chmod +x flatc \
     && sudo mv flatc /usr/bin/
   !pip install -U pip \
-    && pip install tensorflow==2.15.0.post1 \
+    && pip install tensorflow==2.16.1 \
     && pip install -U onnx==1.15.0 \
     && python -m pip install onnx_graphsurgeon \
           --index-url https://pypi.ngc.nvidia.com \
@@ -308,9 +308,9 @@ or
     && pip install -U simple_onnx_processing_tools \
     && pip install -U onnx2tf \
     && pip install -U protobuf==3.20.3 \
-    && pip install -U h5py==3.7.0 \
+    && pip install -U h5py==3.11.0 \
     && pip install -U psutil==5.9.5 \
-    && pip install -U ml_dtypes==0.2.0
+    && pip install -U ml_dtypes==0.3.2
   ```
 
 ### 2. Run test

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.19.16'
+__version__ = '1.20.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -22,6 +22,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+os.environ["TF_USE_LEGACY_KERAS"]="1"
 import tensorflow as tf
 tf.random.set_seed(0)
 tf.keras.utils.set_random_seed(0)

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -22,7 +22,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-os.environ["TF_USE_LEGACY_KERAS"]="1"
+os.environ["TF_USE_LEGACY_KERAS"] = '1'
 import tensorflow as tf
 tf.random.set_seed(0)
 tf.keras.utils.set_random_seed(0)


### PR DESCRIPTION
### 1. Content and background
- `TensorFlow==2.16.1`, `Keras 3.0`
- https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1
  - Keras 3.0 will be the default Keras version. You may need to update your script to use Keras 3.0.
  - Please refer to the new Keras documentation for Keras 3.0 (https://keras.io/keras_3).
- This pull request is to experimentally verify the upgrade to `TensorFlow==2.16.1`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
