### PR TITLE
Fix to preserve `domain` and `ir_version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.0
+  ghcr.io/pinto0309/onnx2tf:1.20.1
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.0
+  docker.io/pinto0309/onnx2tf:1.20.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.0'
+__version__ = '1.20.1'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3654,6 +3654,8 @@ def dummy_onnx_inference(
         Results of inference using dummy tensor
     """
     # Separate onnx at specified output_names position
+    domain: str = onnx_graph.domain
+    ir_version: int = onnx_graph.ir_version
     gs_graph = gs.import_onnx(onnx_graph)
 
     # reduce all axes except batch axis
@@ -3706,7 +3708,7 @@ def dummy_onnx_inference(
                 if node_output.dtype is not None:
                     gs_graph.outputs.append(node_output)
 
-    new_onnx_graph = gs.export_onnx(graph=gs_graph, do_type_check=False)
+    new_onnx_graph = gs.export_onnx(graph=gs_graph, do_type_check=False, **{'domain': domain, 'ir_version': ir_version})
     tmp_onnx_path = ''
     tmp_onnx_external_weights_path =''
     try:


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf.py`, `common_functions.py`
  - Fix to preserve `domain` and `ir_version`.
  - Fixed a problem that `domain` and `ir_version` were rewritten to the latest version during model optimization operation.
  - Also modified [sng4onnx](https://github.com/PINTO0309/sng4onnx).

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
