### PR TITLE
Fix unknown Resize 4D

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.1
+  ghcr.io/pinto0309/onnx2tf:1.20.2
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.1
+  docker.io/pinto0309/onnx2tf:1.20.2
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.1'
+__version__ = '1.20.2'

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -243,6 +243,7 @@ def make_node(
             )
             sys.exit(1)
 
+    new_size = None
     if sizes is not None:
         # sizes is defined
         # The number of elements of 'sizes' should be the same as the rank of input 'X'
@@ -255,6 +256,9 @@ def make_node(
             new_size = tf.cast(tf.slice(sizes, [1], [input_tensor_rank-2]), tf.int32)
         elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 2:
             new_size = tf.cast(sizes, tf.int32)
+        elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 4:
+            new_size = tf.cast(sizes[2:], tf.int32)
+
     elif scales is not None:
         # only scales is defined
         if hasattr(graph_node_output, 'shape') \

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -257,7 +257,7 @@ def make_node(
         elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 2:
             new_size = tf.cast(sizes, tf.int32)
         elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 4:
-            new_size = tf.cast(sizes[2:], tf.int32)
+            new_size = tf.cast(sizes[1:3], tf.int32)
 
     elif scales is not None:
         # only scales is defined


### PR DESCRIPTION
### 1. Content and background
- `Resize`
  - Fix unknown Resize 4D
  - Support for resizing to undefined `size` (but only in 4D)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/efae081e-5e25-45bf-b995-3c42f4268ef8)
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/9feff0a8-c7bf-4850-8faa-59930b60c65e)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Resize conversion bug #614](https://github.com/PINTO0309/onnx2tf/issues/614)