### PR TITLE
Improve stability of `axes` conversion when an unknown dimension order other than NCHW is input to `ReduceXXX`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.2
+  ghcr.io/pinto0309/onnx2tf:1.20.3
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.2
+  docker.io/pinto0309/onnx2tf:1.20.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.2'
+__version__ = '1.20.3'

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -1,7 +1,10 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -14,8 +17,13 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -95,9 +103,169 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceL1',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
+
 
     # Param replacement
     axes = replace_parameter(

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -1,7 +1,10 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -14,8 +17,13 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -95,9 +103,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceLogSum',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Param replacement
     axes = replace_parameter(

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -1,7 +1,10 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -14,8 +17,13 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -95,9 +103,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceLogSumExp',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Param replacement
     axes = replace_parameter(

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -1,7 +1,10 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -14,8 +17,13 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -73,6 +81,12 @@ def make_node(
             f'TensorFlow does not support noop_with_empty_axes=1 (True).'
         print(error_msg)
         assert not noop_with_empty_axes, error_msg
+
+    pre_convert_axes: List[int] = None
+    if isinstance(axes, list):
+        pre_convert_axes = axes
+    elif isinstance(axes, np.ndarray):
+        pre_convert_axes = list(axes)
 
     # NCHW->NHWC, NCDHW->NDHWC
     if isinstance(axes, list) or (isinstance(axes, np.ndarray) and len(axes.shape) > 0):
@@ -96,9 +110,169 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceMax',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
+
 
     # Generation of TF OP
 

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -1,21 +1,29 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     replace_parameter,
-    convert_axis,
     get_constant_or_variable,
+    convert_axis,
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -96,9 +104,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceMean',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Generation of TF OP
 

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -1,21 +1,29 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     replace_parameter,
-    convert_axis,
     get_constant_or_variable,
+    convert_axis,
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -96,9 +104,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceMin',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Generation of TF OP
 

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -1,21 +1,29 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     replace_parameter,
-    convert_axis,
     get_constant_or_variable,
+    convert_axis,
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -96,9 +104,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceProd',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Generation of TF OP
 

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -1,7 +1,10 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -14,8 +17,13 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -95,9 +103,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceSum',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Param replacement
     axes = replace_parameter(

--- a/onnx2tf/ops/ReduceSumSquare.py
+++ b/onnx2tf/ops/ReduceSumSquare.py
@@ -1,21 +1,29 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     replace_parameter,
     get_constant_or_variable,
+    convert_axis,
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
-    convert_axis,
     pre_process_transpose,
     post_process_transpose,
+    dummy_tf_inference,
+    get_tf_model_inputs,
+    onnx_tf_tensor_validation,
+    define_reduceXXX,
 )
 from onnx2tf.utils.logging import *
+from typing import Any, Dict, List, Tuple
 
 
 @print_node_info
@@ -53,7 +61,7 @@ def make_node(
             before_op_output_shape_trans,
         )
     graph_node_output: gs.Variable = graph_node.outputs[0]
-    shape = graph_node_output.shape
+    onnx_output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
@@ -96,9 +104,168 @@ def make_node(
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
-        'shape': shape,
+        'shape': onnx_output_shape,
         'dtype': dtype,
     }
+
+    onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+    onnx_tensor_infos = None
+    validation_data = None
+
+    if onnx_tensor_infos_for_validation is not None:
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf.keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except:
+                pass
+
+        # Get np.ndarray for validation
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name:
+                    onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+    if not disable_strict_mode:
+        if onnx_tensor_infos is not None and validation_data is not None:
+            # Shape Unmatch Error Mitigation Measures
+            # Search for and transpose shapes that do not cause shape unmatch errors
+            min_abs_err = sys.maxsize
+            min_abs_err_axes: List[int] = None
+            if isinstance(axes, list):
+                min_abs_err_axes = copy.deepcopy(axes)
+            elif isinstance(axes, int):
+                min_abs_err_axes = [axes]
+            elif isinstance(axes, np.ndarray):
+                min_abs_err_axes = list(axes)
+            else:
+                min_abs_err_axes = axes
+
+            check_axes_tuples: List[Tuple] = list(itertools.combinations(list(range(tensor_rank)), len(axes)))
+            if tuple(axes) in check_axes_tuples:
+                check_axes_tuples.remove(tuple(axes))
+                check_axes_tuples.insert(0, tuple(axes))
+            check_axes = [list(check_axes_tuple) for check_axes_tuple in check_axes_tuples]
+
+            # Verify that the output shape matches that of ONNX
+            # If the combination of each value of a dimension is not correct,
+            # invalidate the normal processing judgment.
+            if graph_node.outputs[0].name is not None \
+                and graph_node.outputs[0].name != '' \
+                and graph_node.outputs[0].name in onnx_tensor_infos:
+                target_onnx_output: np.ndarray = onnx_tensor_infos[graph_node.outputs[0].name]
+                target_onnx_output_shape = target_onnx_output.shape
+            else:
+                target_onnx_output_shape = onnx_output_shape
+
+            # Search for the axis with the smallest error
+            for check_axis in check_axes:
+                # Build TF dummy model
+                input = tf.keras.Input(
+                    shape=validation_data.shape[1:],
+                    batch_size=validation_data.shape[0] \
+                        if isinstance(validation_data.shape[0], int) else None,
+                    name='dummy_input',
+                    dtype=validation_data.dtype,
+                )
+                val_model = tf.keras.Model(
+                    inputs=[
+                        input,
+                    ],
+                    outputs=[
+                        define_reduceXXX(
+                            tf_func='ReduceSumSquare',
+                            target_input_tensor=input,
+                            target_axes=check_axis,
+                            target_keepdims=keepdims,
+                        )
+                    ],
+                )
+
+                onnx_output_shape_prod = np.prod([dim if not isinstance(dim, str) else -1 for dim in target_onnx_output_shape])
+                val_model_output_shapes = list(val_model.output.shape)
+                val_model_output_shape_prod = np.prod([dim if dim is not None else -1 for dim in val_model_output_shapes])
+                if onnx_output_shape_prod != val_model_output_shape_prod:
+                    del input
+                    del val_model
+                    continue
+
+                # TF dummy inference
+                tf_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=[
+                            input,
+                        ],
+                        verification_datas=[
+                            validation_data,
+                        ],
+                    )
+                del input
+                del val_model
+
+                # Validation
+                onnx_tf_output_pairs = {
+                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                }
+                """
+                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                    {
+                        onnx_output_name: [
+                            onnx_tensor,
+                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                            max_abs_err,
+                        ]
+                    }
+                """
+                check_results = onnx_tf_tensor_validation(
+                    output_pairs=onnx_tf_output_pairs,
+                    rtol=0.0,
+                    atol=0.0,
+                )
+                result_err = sum([val[2] for val in check_results.values()])
+                if result_err < min_abs_err:
+                    min_abs_err = result_err
+                    min_abs_err_axes = check_axis
+                    if min_abs_err < 1e-3:
+                        break
+            axes = min_abs_err_axes
 
     # Param replacement
     axes = replace_parameter(

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -121,7 +121,7 @@ def make_node(
     validation_data = None
 
     # If all axes are of different sizes and the axis sizes specified in axis are the same
-    # in onnx and sensorflow, skip the accuracy check.
+    # in onnx and Tensorflow, skip the accuracy check.
     acc_check_pass_flg = False
     if graph_node.inputs[0].shape is not None \
         and input_tensor.shape is not None:

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5931,3 +5931,90 @@ def shape_is_equal_ignore_order(
     shape_list_1 = [-1 if isinstance(s, str) or s is None else s for s in shape_list_1]
     shape_list_2 = [-1 if isinstance(s, str) or s is None else s for s in shape_list_2]
     return sorted(shape_list_1) == sorted(shape_list_2)
+
+# ReduceL1
+# ReduceL2
+# ReduceLogSum
+# ReduceLogSumExp
+# ReduceMax
+# ReduceMean
+# ReduceMin
+# ReduceProd
+# ReduceSum
+# ReduceSumSquare
+def define_reduceXXX(
+    *,
+    tf_func: str,
+    target_input_tensor: Any,
+    target_axes: List[int],
+    target_keepdims: bool,
+):
+    reduced_tensor = None
+    axes = target_axes if len(target_axes) > 1 else target_axes[0] if target_axes is not None else None
+
+    if tf_func == 'ReduceL1':
+        reduced_tensor = tf.norm(
+            tensor=target_input_tensor,
+            ord=1,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceL2':
+        reduced_tensor = tf.norm(
+            tensor=target_input_tensor,
+            ord=2,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceLogSum':
+        reduced_tensor = \
+            tf.math.log(
+                x=tf.reduce_sum(
+                    input_tensor=target_input_tensor,
+                    axis=axes,
+                    keepdims=target_keepdims,
+                )
+            )
+    elif tf_func == 'ReduceLogSumExp':
+        reduced_tensor = tf.math.reduce_logsumexp(
+            input_tensor=target_input_tensor,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceMax':
+        reduced_tensor = tf.math.reduce_max(
+            input_tensor=target_input_tensor,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceMean':
+        reduced_tensor = tf.math.reduce_mean(
+            input_tensor=target_input_tensor,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceMin':
+        reduced_tensor = tf.math.reduce_min(
+            input_tensor=target_input_tensor,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceProd':
+        reduced_tensor = tf.math.reduce_prod(
+            input_tensor=target_input_tensor,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceSum':
+        reduced_tensor = tf.reduce_sum(
+            input_tensor=target_input_tensor,
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    elif tf_func == 'ReduceSumSquare':
+        reduced_tensor = tf.reduce_sum(
+            input_tensor=tf.square(x=target_input_tensor),
+            axis=axes,
+            keepdims=target_keepdims,
+        )
+    return reduced_tensor


### PR DESCRIPTION
### 1. Content and background
- `ReduceL1`, `ReduceL2`, `ReduceLogSum`, `ReduceLogSumExp`, `ReduceMax`, `ReduceMean`, `ReduceMin`, `ReduceProd`, `ReduceSum`, `ReduceSumSquare`
  - Improve stability of `axes` conversion when an unknown dimension order other than NCHW is input to `ReduceXXX`.
  - Automatically compensates for mistakes in `axes` dimensional transpositions.

- Error
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/4d11a255-a417-49e8-841e-c0dde12cab9f)
  
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/a26a4edd-bb47-4d0a-a0e6-793b940fb7d8)

- Fixed
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/593e0431-b8ed-41e7-80f8-2f25a35b1520)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Op Error about "Transpose" #616](https://github.com/PINTO0309/onnx2tf/issues/616)