### PR TITLE
[experimental, Breaking change] `tf.keras` -> `tf_keras`

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.3
+  ghcr.io/pinto0309/onnx2tf:1.20.4
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.3
+  docker.io/pinto0309/onnx2tf:1.20.4
 
   or
 

--- a/README.md
+++ b/README.md
@@ -2111,7 +2111,7 @@ convert(
 
     Returns
     ----------
-    model: tf.keras.Model
+    model: tf_keras.Model
       Model
 ```
 
@@ -2386,7 +2386,7 @@ ONNX file for testing. https://github.com/PINTO0309/onnx2tf/releases/tag/1.1.28
 
   https://user-images.githubusercontent.com/33194443/197319770-e7ef7174-66cd-4bc2-84be-59e1a251151d.mp4
 
-- [x] All OPs are decomposed into primitive operations as much as possible. This is beneficial for lateral deployment of models to frameworks other than TFLite. Therefore, OPs belonging to `tf.keras.layers` are almost never used, and the tool consists only of `tf.xxx`. (except for a very few OPs)
+- [x] All OPs are decomposed into primitive operations as much as possible. This is beneficial for lateral deployment of models to frameworks other than TFLite. Therefore, OPs belonging to `tf_keras.layers` are almost never used, and the tool consists only of `tf.xxx`. (except for a very few OPs)
 - [x] As I do not want to add more dependent packages, I do not use `tensorflow_addons (tfa)`, but replace it with the standard OP of tensorflow.
 - [x] Not only does it handle conversions of 4-dimensional inputs, such as `NCHW` to `NHWC`, but also the number of input dimensions in 3, 5, or even more dimensions. For example, `NCDHW` to `NDHWC`, etc. However, since 1-D, 2-D, 3-D and 6-D input may produce patterns that are mechanically difficult to convert, it should be possible to give parameters to externally modify the tool's behavior. See [Parameter replacement](#parameter-replacement)
 - [x] If there are undefined dimensions in the input OP, the model structure is not fully optimized and conversion errors are very likely to occur.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.3'
+__version__ = '1.20.4'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -25,7 +25,8 @@ os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 os.environ["TF_USE_LEGACY_KERAS"] = '1'
 import tensorflow as tf
 tf.random.set_seed(0)
-tf.keras.utils.set_random_seed(0)
+import tf_keras
+tf_keras.utils.set_random_seed(0)
 tf.config.experimental.enable_op_determinism()
 tf.get_logger().setLevel('INFO')
 tf.autograph.set_verbosity(0)
@@ -107,7 +108,7 @@ def convert(
     disable_model_save: Optional[bool] = False,
     non_verbose: Optional[bool] = False,
     verbosity: Optional[str] = 'debug',
-) -> tf.keras.Model:
+) -> tf_keras.Model:
     """Convert ONNX to TensorFlow models.
 
     Parameters
@@ -447,7 +448,7 @@ def convert(
 
     Returns
     ----------
-    model: tf.keras.Model
+    model: tf_keras.Model
         Model
     """
 
@@ -1056,7 +1057,7 @@ def convert(
                 if output_signaturedefs or output_integer_quantized_tflite:
                     output.node.layer._name = re.sub('^/', '', output.node.layer._name)
 
-        model = tf.keras.Model(inputs=inputs, outputs=outputs)
+        model = tf_keras.Model(inputs=inputs, outputs=outputs)
         # if get_log_level() <= LOG_LEVELS['debug']:
         #     debug('')
         #     model.summary(line_length=140)
@@ -1633,7 +1634,7 @@ def convert(
                         if opname in ops_output_names \
                             and hasattr(layer_info['tf_node'], 'numpy')
             ]
-            model = tf.keras.Model(inputs=inputs, outputs=outputs)
+            model = tf_keras.Model(inputs=inputs, outputs=outputs)
 
             # Exclude output OPs not subject to validation
             ops_output_names = [

--- a/onnx2tf/ops/Col2Im.py
+++ b/onnx2tf/ops/Col2Im.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -15,7 +16,7 @@ from onnx2tf.utils.common_functions import (
 )
 
 
-class Col2ImLayer(tf.keras.layers.Layer):
+class Col2ImLayer(tf_keras.layers.Layer):
     def __init__(self):
         super(Col2ImLayer, self).__init__()
 

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -398,14 +399,14 @@ def make_node(
                 for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
                     try:
                         # Build TF dummy model
-                        input_1 = tf.keras.Input(
+                        input_1 = tf_keras.Input(
                             shape=validation_data_1.shape[1:],
                             batch_size=validation_data_1.shape[0] \
                                 if isinstance(validation_data_1.shape[0], int) else None,
                             name='dummy_input_1',
                             dtype=validation_data_1.dtype,
                         )
-                        input_2 = tf.keras.Input(
+                        input_2 = tf_keras.Input(
                             shape=validation_data_2.shape[1:],
                             batch_size=validation_data_2.shape[0] \
                                 if isinstance(validation_data_2.shape[0], int) else None,
@@ -438,7 +439,7 @@ def make_node(
                         if onnx_tensor_infos:
                             try:
                                 # Search for the axis with the smallest error
-                                val_model = tf.keras.Model(
+                                val_model = tf_keras.Model(
                                     inputs=[
                                         input_1,
                                         input_2,
@@ -535,7 +536,7 @@ def make_node(
             if acc_proc_flag:
                 # Get the output tensor of one previous OP of TensorFlow only once
                 tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=values,
                 )
@@ -573,7 +574,7 @@ def make_node(
                     # Search for the axis with the smallest error
                     # Build TF dummy model
                     inputs = [
-                        tf.keras.Input(
+                        tf_keras.Input(
                             shape=validation_data.shape[1:],
                             batch_size=validation_data.shape[0] \
                                 if isinstance(validation_data.shape[0], int) else None,
@@ -582,7 +583,7 @@ def make_node(
                         ) for idx, validation_data in enumerate(validation_datas)
                     ]
                     for check_axis in check_axes:
-                        val_model = tf.keras.Model(
+                        val_model = tf_keras.Model(
                             inputs=inputs,
                             outputs=[
                                 define_concat(

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 from tensorflow.python.keras.layers import (
     Conv1D,
     Conv2D,
@@ -172,7 +173,7 @@ def make_node(
                 )
                 val_model = None
                 if not isinstance(input_tensor, np.ndarray):
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=tf_model_inputs,
                         outputs=[
                             input_tensor,
@@ -320,7 +321,7 @@ def make_node(
                     dilation_rate=dilations,
                     groups=group,
                     use_bias=False,
-                    kernel_initializer=tf.keras.initializers.constant(input_weights),
+                    kernel_initializer=tf_keras.initializers.constant(input_weights),
                     name=graph_node.name,
                 )(input_tensor),
                 y=input_bias,
@@ -337,7 +338,7 @@ def make_node(
                     dilation_rate=dilations,
                     groups=group,
                     use_bias=False,
-                    kernel_initializer=tf.keras.initializers.constant(input_weights),
+                    kernel_initializer=tf_keras.initializers.constant(input_weights),
                     name=graph_node.name,
                 )(input_tensor),
                 y=input_bias,
@@ -396,7 +397,7 @@ def make_node(
                 dilation_rate=dilations,
                 groups=group,
                 use_bias=False,
-                kernel_initializer=tf.keras.initializers.constant(input_weights),
+                kernel_initializer=tf_keras.initializers.constant(input_weights),
                 name=graph_node.name,
             )(input_tensor)
 
@@ -410,7 +411,7 @@ def make_node(
                 dilation_rate=dilations,
                 groups=group,
                 use_bias=False,
-                kernel_initializer=tf.keras.initializers.constant(input_weights),
+                kernel_initializer=tf_keras.initializers.constant(input_weights),
                 name=graph_node.name,
             )(input_tensor)
 
@@ -512,7 +513,7 @@ def make_node(
                 #                 dilation_rate=dilations,
                 #                 groups=group,
                 #                 use_bias=False,
-                #                 kernel_initializer=tf.keras.initializers.constant(input_weights),
+                #                 kernel_initializer=tf_keras.initializers.constant(input_weights),
                 #                 name=graph_node.name,
                 #             )(input_tensor),
                 #             y=input_bias,
@@ -612,7 +613,7 @@ def make_node(
                 #             dilation_rate=dilations,
                 #             groups=group,
                 #             use_bias=False,
-                #             kernel_initializer=tf.keras.initializers.constant(input_weights),
+                #             kernel_initializer=tf_keras.initializers.constant(input_weights),
                 #             name=graph_node.name,
                 #         )(input_tensor)
                 #     tf_op_type = 'GroupedConvolution3D'
@@ -661,7 +662,7 @@ def make_node(
                 try:
                     target_validation_data = validation_data.transpose(tensor_1_candidate_for_transposition)
                     # Build TF dummy model
-                    input = tf.keras.Input(
+                    input = tf_keras.Input(
                         shape=target_validation_data.shape[1:],
                         batch_size=target_validation_data.shape[0] \
                             if isinstance(target_validation_data.shape[0], int) else None,
@@ -774,7 +775,7 @@ def make_node(
                                 dilations,
                             )
                     # define model
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=[
                             input,
                         ],

--- a/onnx2tf/ops/ConvInteger.py
+++ b/onnx2tf/ops/ConvInteger.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 from tensorflow.python.keras.layers import (
     Conv1D,
     Conv2D,
@@ -209,7 +210,7 @@ def make_node(
                 )
                 val_model = None
                 if not isinstance(input_tensor, np.ndarray):
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=tf_model_inputs,
                         outputs=[
                             input_tensor,
@@ -350,7 +351,7 @@ def make_node(
                 dilation_rate=dilations,
                 groups=group,
                 use_bias=False,
-                kernel_initializer=tf.keras.initializers.constant(input_weights),
+                kernel_initializer=tf_keras.initializers.constant(input_weights),
                 name=graph_node.name,
             )(input_tensor)
 
@@ -364,7 +365,7 @@ def make_node(
                 dilation_rate=dilations,
                 groups=group,
                 use_bias=False,
-                kernel_initializer=tf.keras.initializers.constant(input_weights),
+                kernel_initializer=tf_keras.initializers.constant(input_weights),
                 name=graph_node.name,
             )(input_tensor)
 
@@ -462,7 +463,7 @@ def make_node(
             #             dilation_rate=dilations,
             #             groups=group,
             #             use_bias=False,
-            #             kernel_initializer=tf.keras.initializers.constant(input_weights),
+            #             kernel_initializer=tf_keras.initializers.constant(input_weights),
             #             name=graph_node.name,
             #         )(input_tensor)
             #     tf_op_type = 'GroupedConvolution3D'
@@ -511,7 +512,7 @@ def make_node(
                 try:
                     target_validation_data = validation_data.transpose(tensor_1_candidate_for_transposition)
                     # Build TF dummy model
-                    input = tf.keras.Input(
+                    input = tf_keras.Input(
                         shape=target_validation_data.shape[1:],
                         batch_size=target_validation_data.shape[0] \
                             if isinstance(target_validation_data.shape[0], int) else None,
@@ -570,7 +571,7 @@ def make_node(
                                 dilations,
                             )
                     # define model
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=[
                             input,
                         ],

--- a/onnx2tf/ops/DepthToSpace.py
+++ b/onnx2tf/ops/DepthToSpace.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -136,7 +137,7 @@ def make_node(
             )
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -194,7 +195,7 @@ def make_node(
                     try:
                         target_validation_data = validation_data.transpose(tensor_1_candidate_for_transposition)
                         # Build TF dummy model
-                        input = tf.keras.Input(
+                        input = tf_keras.Input(
                             shape=target_validation_data.shape[1:],
                             batch_size=target_validation_data.shape[0] \
                                 if isinstance(target_validation_data.shape[0], int) else None,
@@ -203,7 +204,7 @@ def make_node(
                         )
                         val_model = None
                         if mode == "DCR":
-                            val_model = tf.keras.Model(
+                            val_model = tf_keras.Model(
                                 inputs=[
                                     input,
                                 ],
@@ -229,7 +230,7 @@ def make_node(
                                 perm=[0,1,4,2,5,3],
                                 **kwargs,
                             )
-                            val_model = tf.keras.Model(
+                            val_model = tf_keras.Model(
                                 inputs=[
                                     input,
                                 ],

--- a/onnx2tf/ops/Einsum.py
+++ b/onnx2tf/ops/Einsum.py
@@ -5,6 +5,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -149,14 +150,14 @@ def make_node(
             for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
                 try:
                     # Build TF dummy model
-                    input_1 = tf.keras.Input(
+                    input_1 = tf_keras.Input(
                         shape=validation_data_1.shape[1:],
                         batch_size=validation_data_1.shape[0] \
                             if isinstance(validation_data_1.shape[0], int) else None,
                         name='dummy_input_1',
                         dtype=validation_data_1.dtype,
                     )
-                    input_2 = tf.keras.Input(
+                    input_2 = tf_keras.Input(
                         shape=validation_data_2.shape[1:],
                         batch_size=validation_data_2.shape[0] \
                             if isinstance(validation_data_2.shape[0], int) else None,
@@ -189,7 +190,7 @@ def make_node(
                     if onnx_tensor_infos:
                         try:
                             # Search for the axis with the smallest error
-                            val_model = tf.keras.Model(
+                            val_model = tf_keras.Model(
                                 inputs=[
                                     input_1,
                                     input_2,

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -151,7 +152,7 @@ def make_node(
             )
     else:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.keras.layers.Flatten()(input_tensor)
+            tf_keras.layers.Flatten()(input_tensor)
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/GRU.py
+++ b/onnx2tf/ops/GRU.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     replace_parameter,
@@ -94,7 +95,7 @@ class ThresholdedReLU(Layer):
             if self.alpha != alpha else tf.convert_to_tensor(self.alpha)
 
     def call(self, x):
-        return tf.keras.layers.ThresholdedReLU(theta=self.alpha)(x)
+        return tf_keras.layers.ThresholdedReLU(theta=self.alpha)(x)
 
 class Affine(Layer):
     def __init__(self, alpha: float, beta: float):
@@ -144,7 +145,7 @@ ONNX_ACTIVATION_MAPPING: Dict[str, List] = {
 }
 
 
-class CustomGRUCell(tf.keras.layers.AbstractRNNCell):
+class CustomGRUCell(tf_keras.layers.AbstractRNNCell):
     def __init__(
         self,
         hidden_size,
@@ -352,7 +353,7 @@ class CustomGRU(Layer):
             self.is_bidirectional,
             self.go_backwards,
         )
-        self.rnn = tf.keras.layers.RNN(
+        self.rnn = tf_keras.layers.RNN(
             self.cell,
             return_sequences=self.return_sequences,
             go_backwards=self.go_backwards,
@@ -914,7 +915,7 @@ def make_node(
     tf_layers_dict[graph_node_output1.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.keras.layers.GRU,
+                'tf_op_type': tf_keras.layers.GRU,
                 'tf_inputs': {
                     'direction': direction,
                     'X': X,

--- a/onnx2tf/ops/Gather.py
+++ b/onnx2tf/ops/Gather.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from typing import List
 from onnx2tf.utils.common_functions import (
@@ -322,7 +323,7 @@ def make_node(
             and input_tensor.shape[axis] is not None:
             maximum_number_of_elements = input_tensor.shape[axis]
             indices_values = indices_values + maximum_number_of_elements
-        elif tf.keras.backend.is_keras_tensor(indices_values) \
+        elif tf_keras.backend.is_keras_tensor(indices_values) \
             and indices_values.shape == tf.TensorShape(None):
             indices_values = tf.reshape(indices_values, [-1])
 

--- a/onnx2tf/ops/Gemm.py
+++ b/onnx2tf/ops/Gemm.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     replace_parameter,
@@ -96,7 +97,7 @@ def make_node(
 
     input_tensor_x_dtype = NUMPY_DTYPES_TO_TF_DTYPES[x.dtype] \
         if isinstance(x.dtype, np.dtype) else x.dtype
-    x = tf.keras.layers.Flatten()(x)
+    x = tf_keras.layers.Flatten()(x)
 
     # The Flatten API changes data type from tf.float64 to tf.float32
     # so we need the following line to get the original type back

--- a/onnx2tf/ops/GridSample.py
+++ b/onnx2tf/ops/GridSample.py
@@ -5,6 +5,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -570,14 +571,14 @@ def make_node(
             )
         try:
             # Build TF dummy model
-            input_1 = tf.keras.Input(
+            input_1 = tf_keras.Input(
                 shape=validation_data_1.shape[1:],
                 batch_size=validation_data_1.shape[0] \
                     if isinstance(validation_data_1.shape[0], int) else None,
                 name='dummy_input_1',
                 dtype=validation_data_1.dtype,
             )
-            input_2 = tf.keras.Input(
+            input_2 = tf_keras.Input(
                 shape=validation_data_2.shape[1:],
                 batch_size=validation_data_2.shape[0] \
                     if isinstance(validation_data_2.shape[0], int) else None,
@@ -596,7 +597,7 @@ def make_node(
             if onnx_tensor_infos:
                 try:
                     # Search for the axis with the smallest error
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=[
                             input_1,
                             input_2,

--- a/onnx2tf/ops/GroupNorm.py
+++ b/onnx2tf/ops/GroupNorm.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -126,7 +127,7 @@ def make_node(
         )
         val_model = None
         if not isinstance(input_tensor, np.ndarray):
-            val_model = tf.keras.Model(
+            val_model = tf_keras.Model(
                 inputs=tf_model_inputs,
                 outputs=[
                     input_tensor,
@@ -198,7 +199,7 @@ def make_node(
                 try:
                     target_validation_data = validation_data.transpose(tensor_1_candidate_for_transposition)
                     # Build TF dummy model
-                    input = tf.keras.Input(
+                    input = tf_keras.Input(
                         shape=target_validation_data.shape[1:],
                         batch_size=target_validation_data.shape[0] \
                             if isinstance(target_validation_data.shape[0], int) else None,
@@ -206,7 +207,7 @@ def make_node(
                         dtype=target_validation_data.dtype,
                     )
                     mean, variance = tf.nn.moments(input, axes=axes, keepdims=True)
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=[
                             input,
                         ],
@@ -261,28 +262,28 @@ def make_node(
 
     if activation == 0:
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.keras.layers.GroupNormalization(
+            tf_keras.layers.GroupNormalization(
                 groups=groups,
                 axis=-1,
                 epsilon=epsilon,
                 center=True if B is not None else False, # beta/bias
                 scale=True if scale is not None else False, # gamma/scale
-                beta_initializer=tf.keras.initializers.constant(B) if B is not None else 'zeros',
-                gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
+                beta_initializer=tf_keras.initializers.constant(B) if B is not None else 'zeros',
+                gamma_initializer=tf_keras.initializers.constant(scale) if scale is not None else 'ones',
             )(input_tensor)
     else:
         group_norm = \
-            tf.keras.layers.GroupNormalization(
+            tf_keras.layers.GroupNormalization(
                 groups=groups,
                 axis=-1,
                 epsilon=epsilon,
                 center=True if B is not None else False, # beta/bias
                 scale=True if scale is not None else False, # gamma/scale
-                beta_initializer=tf.keras.initializers.constant(B) if B is not None else 'zeros',
-                gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
+                beta_initializer=tf_keras.initializers.constant(B) if B is not None else 'zeros',
+                gamma_initializer=tf_keras.initializers.constant(scale) if scale is not None else 'ones',
             )(input_tensor)
         tf_layers_dict[graph_node_output.name]['tf_node'] = \
-            tf.keras.activations.swish(group_norm)
+            tf_keras.activations.swish(group_norm)
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
@@ -296,7 +297,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.keras.layers.GroupNormalization,
+                'tf_op_type': tf_keras.layers.GroupNormalization,
                 'tf_inputs': {
                     'x': input_tensor,
                     'groups': groups,

--- a/onnx2tf/ops/Input.py
+++ b/onnx2tf/ops/Input.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from typing import List
 from onnx2tf.utils.logging import *
@@ -113,7 +114,7 @@ def make_node(
         # 3D
         if not ncw_nchw_ncdhw_keep and not nwc_nhwc_ndhwc_keep and not absolutely_keep:
             tf_layers_dict[graph_input_name]['tf_node'] = \
-                tf.keras.Input(
+                tf_keras.Input(
                     shape=[
                         shape[2] if isinstance(shape[2], int) else None,
                         shape[1] if isinstance(shape[1], int) else None,
@@ -130,7 +131,7 @@ def make_node(
             ]
             tf_layers_dict[graph_input_name]['ncw_nchw_ncdhw_perm'] = [0,2,1]
         else:
-            ncw = tf.keras.Input(
+            ncw = tf_keras.Input(
                 shape=[
                     inp if isinstance(inp, int) else None for inp in shape[1:]
                 ],
@@ -161,7 +162,7 @@ def make_node(
         # 4D
         if not ncw_nchw_ncdhw_keep and not nwc_nhwc_ndhwc_keep and not absolutely_keep:
             tf_layers_dict[graph_input_name]['tf_node'] = \
-                tf.keras.Input(
+                tf_keras.Input(
                     shape=[
                         shape[2] if isinstance(shape[2], int) else None,
                         shape[3] if isinstance(shape[3], int) else None,
@@ -180,7 +181,7 @@ def make_node(
             ]
             tf_layers_dict[graph_input_name]['ncw_nchw_ncdhw_perm'] = [0,3,1,2]
         else:
-            nchw = tf.keras.Input(
+            nchw = tf_keras.Input(
                 shape=[
                     inp if isinstance(inp, int) else None for inp in shape[1:]
                 ],
@@ -213,7 +214,7 @@ def make_node(
         # 5D
         if not ncw_nchw_ncdhw_keep and not nwc_nhwc_ndhwc_keep and not absolutely_keep:
             tf_layers_dict[graph_input_name]['tf_node'] = \
-                tf.keras.Input(
+                tf_keras.Input(
                     shape=[
                         shape[2] if isinstance(shape[2], int) else None,
                         shape[3] if isinstance(shape[3], int) else None,
@@ -234,7 +235,7 @@ def make_node(
             ]
             tf_layers_dict[graph_input_name]['ncw_nchw_ncdhw_perm'] = [0,4,1,2,3]
         else:
-            ncdhw = tf.keras.Input(
+            ncdhw = tf_keras.Input(
                 shape=[
                     inp if isinstance(inp, int) else None for inp in shape[1:]
                 ],
@@ -288,7 +289,7 @@ def make_node(
             assert not nwc_nhwc_ndhwc_keep, error_msg
 
         tf_layers_dict[graph_input_name]['tf_node'] = \
-            tf.keras.Input(
+            tf_keras.Input(
                 shape=[
                     inp if isinstance(inp, int) else None for inp in shape[1:]
                 ],
@@ -324,7 +325,7 @@ def make_node(
             assert not nwc_nhwc_ndhwc_keep, error_msg
 
         tf_layers_dict[graph_input_name]['tf_node'] = \
-            tf.keras.Input(
+            tf_keras.Input(
                 shape=shape if graph_input.shape != tf.TensorShape(None) else [None],
                 name=graph_input_name,
                 dtype=dtype,

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -126,7 +127,7 @@ def make_node(
             )
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -198,7 +199,7 @@ def make_node(
                 try:
                     target_validation_data = validation_data.transpose(tensor_1_candidate_for_transposition)
                     # Build TF dummy model
-                    input = tf.keras.Input(
+                    input = tf_keras.Input(
                         shape=target_validation_data.shape[1:],
                         batch_size=target_validation_data.shape[0] \
                             if isinstance(target_validation_data.shape[0], int) else None,
@@ -206,7 +207,7 @@ def make_node(
                         dtype=target_validation_data.dtype,
                     )
                     mean, variance = tf.nn.moments(input, axes=axes, keepdims=True)
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=[
                             input,
                         ],

--- a/onnx2tf/ops/LSTM.py
+++ b/onnx2tf/ops/LSTM.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     replace_parameter,
@@ -94,7 +95,7 @@ class ThresholdedReLU(Layer):
             if self.alpha != alpha else tf.convert_to_tensor(self.alpha)
 
     def call(self, x):
-        return tf.keras.layers.ThresholdedReLU(theta=self.alpha)(x)
+        return tf_keras.layers.ThresholdedReLU(theta=self.alpha)(x)
 
 class Affine(Layer):
     def __init__(self, alpha: float, beta: float):
@@ -143,7 +144,7 @@ ONNX_ACTIVATION_MAPPING: Dict[str, List] = {
 }
 
 
-class CustomLSTMCell(tf.keras.layers.AbstractRNNCell):
+class CustomLSTMCell(tf_keras.layers.AbstractRNNCell):
     def __init__(
         self,
         hidden_size,
@@ -333,7 +334,7 @@ class CustomLSTM(Layer):
             self.is_bidirectional,
             self.go_backwards,
         )
-        self.rnn = tf.keras.layers.RNN(
+        self.rnn = tf_keras.layers.RNN(
             self.cell,
             return_sequences=self.return_sequences,
             go_backwards=self.go_backwards,
@@ -1043,7 +1044,7 @@ def make_node(
     tf_layers_dict[graph_node_output1.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.keras.layers.LSTM,
+                'tf_op_type': tf_keras.layers.LSTM,
                 'tf_inputs': {
                     'direction': direction,
                     'X': X,

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -5,6 +5,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -117,11 +118,11 @@ def make_node(
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output_1.name]['tf_node'] = \
-        tf.keras.layers.LayerNormalization(
+        tf_keras.layers.LayerNormalization(
             axis=[axis],
             epsilon=epsilon,
-            gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
-            beta_initializer=tf.keras.initializers.constant(bias) if bias is not None else 'zeros',
+            gamma_initializer=tf_keras.initializers.constant(scale) if scale is not None else 'ones',
+            beta_initializer=tf_keras.initializers.constant(bias) if bias is not None else 'zeros',
         )(input_tensor)
 
     # Detect conversion errors in axis and identify the axis
@@ -151,7 +152,7 @@ def make_node(
         tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
         val_model = None
         if not isinstance(input_tensor, np.ndarray):
-            val_model = tf.keras.Model(
+            val_model = tf_keras.Model(
                 inputs=tf_model_inputs,
                 outputs=[
                     input_tensor,
@@ -198,23 +199,23 @@ def make_node(
             for check_axis in check_axes:
                 try:
                     # Build TF dummy model
-                    input = tf.keras.Input(
+                    input = tf_keras.Input(
                         shape=validation_data.shape[1:],
                         batch_size=validation_data.shape[0] \
                             if isinstance(validation_data.shape[0], int) else None,
                         name='dummy_input',
                         dtype=validation_data.dtype,
                     )
-                    val_model = tf.keras.Model(
+                    val_model = tf_keras.Model(
                         inputs=[
                             input,
                         ],
                         outputs=[
-                            tf.keras.layers.LayerNormalization(
+                            tf_keras.layers.LayerNormalization(
                                 axis=[check_axis],
                                 epsilon=epsilon,
-                                gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
-                                beta_initializer=tf.keras.initializers.constant(bias) if bias is not None else 'zeros',
+                                gamma_initializer=tf_keras.initializers.constant(scale) if scale is not None else 'ones',
+                                beta_initializer=tf_keras.initializers.constant(bias) if bias is not None else 'zeros',
                             )(input)
                         ],
                     )
@@ -262,11 +263,11 @@ def make_node(
                     pass
 
             tf_layers_dict[graph_node_output_1.name]['tf_node'] = \
-                tf.keras.layers.LayerNormalization(
+                tf_keras.layers.LayerNormalization(
                     axis=[min_abs_err_axis],
                     epsilon=epsilon,
-                    gamma_initializer=tf.keras.initializers.constant(scale) if scale is not None else 'ones',
-                    beta_initializer=tf.keras.initializers.constant(bias) if bias is not None else 'zeros',
+                    gamma_initializer=tf_keras.initializers.constant(scale) if scale is not None else 'ones',
+                    beta_initializer=tf_keras.initializers.constant(bias) if bias is not None else 'zeros',
                 )(input_tensor)
 
     # Post-process transpose

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -5,6 +5,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -196,14 +197,14 @@ def make_node(
                             continue
 
                     # Build TF dummy model
-                    input_1 = tf.keras.Input(
+                    input_1 = tf_keras.Input(
                         shape=validation_data_1.shape[1:],
                         batch_size=validation_data_1.shape[0] \
                             if isinstance(validation_data_1.shape[0], int) else None,
                         name='dummy_input_1',
                         dtype=validation_data_1.dtype,
                     )
-                    input_2 = tf.keras.Input(
+                    input_2 = tf_keras.Input(
                         shape=validation_data_2.shape[1:],
                         batch_size=validation_data_2.shape[0] \
                             if isinstance(validation_data_2.shape[0], int) else None,
@@ -232,7 +233,7 @@ def make_node(
                     # Terminate when the error is less than 1e-3
                     try:
                         # Search for the axis with the smallest error
-                        val_model = tf.keras.Model(
+                        val_model = tf_keras.Model(
                             inputs=[
                                 input_1,
                                 input_2,
@@ -243,17 +244,18 @@ def make_node(
                         )
 
                         # TF dummy inference
-                        tf_tensor_infos: Dict[Any] = dummy_tf_inference(
-                            model=val_model,
-                            inputs=[
-                                input_1,
-                                input_2,
-                            ],
-                            verification_datas=[
-                                validation_data_1,
-                                validation_data_2,
-                            ],
-                        )
+                        tf_tensor_infos: Dict[Any] = \
+                            dummy_tf_inference(
+                                model=val_model,
+                                inputs=[
+                                    input_1,
+                                    input_2,
+                                ],
+                                verification_datas=[
+                                    validation_data_1,
+                                    validation_data_2,
+                                ],
+                            )
                         del input_1
                         del input_2
                         del dummy_matmul

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -345,7 +346,7 @@ def make_node(
                 kernel_shape.insert(0, 1)
             elif kernel_shape is not None and kernel_shape.shape is not None and hasattr(kernel_shape, 'numpy'):
                 kernel_shape = np.insert(arr=kernel_shape.numpy(), obj=1, values=1)
-            elif kernel_shape is not None and kernel_shape.shape is not None and tf.keras.backend.is_keras_tensor(kernel_shape):
+            elif kernel_shape is not None and kernel_shape.shape is not None and tf_keras.backend.is_keras_tensor(kernel_shape):
                 kernel_shape = tf.concat([kernel_shape[:1], [1], kernel_shape[1:]], axis=0)
 
         # MaxPoolWithArgmax

--- a/onnx2tf/ops/NonMaxSuppression.py
+++ b/onnx2tf/ops/NonMaxSuppression.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     replace_parameter,
@@ -23,7 +24,7 @@ from tensorflow.python.ops import gen_image_ops
 from tensorflow.python.util import dispatch
 
 
-class NMSLayer(tf.keras.layers.Layer):
+class NMSLayer(tf_keras.layers.Layer):
     def __init__(self):
         super(NMSLayer, self).__init__()
 

--- a/onnx2tf/ops/OptionalGetElement.py
+++ b/onnx2tf/ops/OptionalGetElement.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -71,7 +72,7 @@ def make_node(
     else:
         converted_tenosr = tf.convert_to_tensor(input_tensor)
         spec = None
-        if tf.keras.backend.is_keras_tensor(converted_tenosr):
+        if tf_keras.backend.is_keras_tensor(converted_tenosr):
             spec = converted_tenosr.type_spec
         else:
             spec = tf.TensorSpec.from_tensor(converted_tenosr)

--- a/onnx2tf/ops/OptionalHasElement.py
+++ b/onnx2tf/ops/OptionalHasElement.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -71,7 +72,7 @@ def make_node(
     else:
         converted_tenosr = tf.convert_to_tensor(input_tensor)
         spec = None
-        if tf.keras.backend.is_keras_tensor(converted_tenosr):
+        if tf_keras.backend.is_keras_tensor(converted_tenosr):
             spec = converted_tenosr.type_spec
         else:
             spec = tf.TensorSpec.from_tensor(converted_tenosr)

--- a/onnx2tf/ops/Pad.py
+++ b/onnx2tf/ops/Pad.py
@@ -5,6 +5,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -166,7 +167,7 @@ def make_node(
             paddings = tf.convert_to_tensor(paddings) \
                 if isinstance(paddings, np.ndarray) else paddings
 
-    elif tf.keras.backend.is_keras_tensor(paddings):
+    elif tf_keras.backend.is_keras_tensor(paddings):
         paddings = \
             tf.transpose(
                 a=tf.reshape(

--- a/onnx2tf/ops/RNN.py
+++ b/onnx2tf/ops/RNN.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     replace_parameter,
@@ -94,7 +95,7 @@ class ThresholdedReLU(Layer):
             if self.alpha != alpha else tf.convert_to_tensor(self.alpha)
 
     def call(self, x):
-        return tf.keras.layers.ThresholdedReLU(theta=self.alpha)(x)
+        return tf_keras.layers.ThresholdedReLU(theta=self.alpha)(x)
 
 class Affine(Layer):
     def __init__(self, alpha: float, beta: float):
@@ -143,7 +144,7 @@ ONNX_ACTIVATION_MAPPING: Dict[str, List] = {
 }
 
 
-class CustomRNNCell(tf.keras.layers.AbstractRNNCell):
+class CustomRNNCell(tf_keras.layers.AbstractRNNCell):
     def __init__(
         self,
         hidden_size,
@@ -242,7 +243,7 @@ class CustomRNN(Layer):
             self.is_bidirectional,
             self.go_backwards,
         )
-        self.rnn = tf.keras.layers.RNN(
+        self.rnn = tf_keras.layers.RNN(
             self.cell,
             return_sequences=self.return_sequences,
             go_backwards=self.go_backwards,
@@ -740,7 +741,7 @@ def make_node(
     tf_layers_dict[graph_node_output1.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.keras.layers.RNN,
+                'tf_op_type': tf_keras.layers.RNN,
                 'tf_inputs': {
                     'direction': direction,
                     'X': X,

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -120,7 +121,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -195,14 +196,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -120,7 +121,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -195,14 +196,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -120,7 +121,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -195,14 +196,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -120,7 +121,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -195,14 +196,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -127,7 +128,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -202,14 +203,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -121,7 +122,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -196,14 +197,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -121,7 +122,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -196,14 +197,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -121,7 +122,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -196,14 +197,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -120,7 +121,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -195,14 +196,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/ReduceSumSquare.py
+++ b/onnx2tf/ops/ReduceSumSquare.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -121,7 +122,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -196,14 +197,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -6,6 +6,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -182,7 +183,7 @@ def make_node(
         and transposed_reshape_shape != replaced_shape:
         shape_replaced_flg = True
     elif (not isinstance(transposed_reshape_shape, list) and not isinstance(transposed_reshape_shape, np.ndarray)) \
-        and tf.keras.backend.is_keras_tensor(transposed_reshape_shape) \
+        and tf_keras.backend.is_keras_tensor(transposed_reshape_shape) \
         and (isinstance(replaced_shape, list) or isinstance(replaced_shape, np.ndarray)):
         shape_replaced_flg = True
     if shape_replaced_flg:
@@ -276,7 +277,7 @@ def make_node(
             )
             val_model = None
             if not isinstance(transposed_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         transposed_tensor,
@@ -344,14 +345,14 @@ def make_node(
                     try:
                         target_validation_data = validation_data
                         # Build TF dummy model
-                        input = tf.keras.Input(
+                        input = tf_keras.Input(
                             shape=validation_data.shape[1:],
                             batch_size=validation_data.shape[0] \
                                 if isinstance(validation_data.shape[0], int) else None,
                             name='dummy_input',
                             dtype=validation_data.dtype,
                         )
-                        val_model = tf.keras.Model(
+                        val_model = tf_keras.Model(
                             inputs=[
                                 input,
                             ],

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 from tensorflow.python.keras.layers import Lambda
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
@@ -192,14 +193,14 @@ def make_node(
             sizes = np.insert(arr=sizes, obj=1, values=1)
         elif sizes is not None and sizes.shape is not None and hasattr(sizes, 'numpy'):
             sizes = np.insert(arr=sizes.numpy(), obj=1, values=1)
-        elif sizes is not None and sizes.shape is not None and tf.keras.backend.is_keras_tensor(sizes):
+        elif sizes is not None and sizes.shape is not None and tf_keras.backend.is_keras_tensor(sizes):
             sizes = tf.concat([sizes[:1], [1], sizes[1:]], axis=0)
 
         if isinstance(scales, np.ndarray):
             scales = np.insert(arr=scales, obj=1, values=1)
         elif scales is not None and scales.shape is not None and hasattr(scales, 'numpy'):
             scales = np.insert(arr=scales.numpy(), obj=1, values=1)
-        elif scales is not None and scales.shape is not None and tf.keras.backend.is_keras_tensor(scales):
+        elif scales is not None and scales.shape is not None and tf_keras.backend.is_keras_tensor(scales):
             scales = tf.concat([scales[:1], [1], scales[1:]], axis=0)
 
     # Generation of TF OP
@@ -252,11 +253,11 @@ def make_node(
             new_size = tf.cast(sizes[1:input_tensor_rank-1], tf.int32)
         elif isinstance(sizes, np.ndarray):
             new_size = tf.cast(sizes[1:input_tensor_rank-1], tf.int32)
-        elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) > 1:
+        elif tf_keras.backend.is_keras_tensor(sizes) and len(sizes.shape) > 1:
             new_size = tf.cast(tf.slice(sizes, [1], [input_tensor_rank-2]), tf.int32)
-        elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 2:
+        elif tf_keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 2:
             new_size = tf.cast(sizes, tf.int32)
-        elif tf.keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 4:
+        elif tf_keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 4:
             new_size = tf.cast(sizes[1:3], tf.int32)
 
     elif scales is not None:

--- a/onnx2tf/ops/ScaleAndTranslate.py
+++ b/onnx2tf/ops/ScaleAndTranslate.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -168,7 +169,7 @@ def make_node(
             new_size = tf.cast(sizes[1:input_tensor_rank-1], tf.int32)
         elif isinstance(sizes, np.ndarray):
             new_size = tf.cast(sizes, tf.int32)
-        elif tf.keras.backend.is_keras_tensor(sizes):
+        elif tf_keras.backend.is_keras_tensor(sizes):
             new_size = tf.cast(tf.slice(sizes, [1], [input_tensor_rank-2]), tf.int32)
     elif scales is not None:
         # only scales is defined

--- a/onnx2tf/ops/Selu.py
+++ b/onnx2tf/ops/Selu.py
@@ -3,6 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -80,7 +81,7 @@ def make_node(
 
     # Generation of TF OP
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.keras.layers.ELU(
+        tf_keras.layers.ELU(
             alpha=alpha,
         )(input_tensor) * gamma
 

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -4,6 +4,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -282,14 +283,14 @@ def make_node(
         ##### begin
         if isinstance(starts, tf.Tensor) and hasattr(starts, "numpy"):
             begin_ = [dim for dim in starts.numpy()]
-        elif not isinstance(starts, np.ndarray) and tf.keras.backend.is_keras_tensor(starts):
+        elif not isinstance(starts, np.ndarray) and tf_keras.backend.is_keras_tensor(starts):
             begin_ = starts
         else:
             begin_ = [dim for dim in starts]
         ##### end
         if isinstance(ends, tf.Tensor) and hasattr(ends, "numpy"):
             end_ = [dim for dim in ends.numpy()]
-        elif not isinstance(ends, np.ndarray) and tf.keras.backend.is_keras_tensor(ends):
+        elif not isinstance(ends, np.ndarray) and tf_keras.backend.is_keras_tensor(ends):
             end_ = ends
         else:
             end_ = [dim for dim in ends]
@@ -298,7 +299,7 @@ def make_node(
         if steps is not None:
             if isinstance(steps, tf.Tensor) and hasattr(steps, "numpy"):
                 strides_ = [dim for dim in steps.numpy()]
-            elif not isinstance(steps, np.ndarray) and tf.keras.backend.is_keras_tensor(steps):
+            elif not isinstance(steps, np.ndarray) and tf_keras.backend.is_keras_tensor(steps):
                 strides_ = steps
             else:
                 strides_ = [dim for dim in steps]
@@ -422,7 +423,7 @@ def make_node(
                     onnx_slice_dims_count = len(starts.numpy())
                 elif isinstance(starts, int):
                     onnx_slice_dims_count = 1
-                elif tf.keras.backend.is_keras_tensor(starts):
+                elif tf_keras.backend.is_keras_tensor(starts):
                     onnx_slice_dims_count = len(starts.shape)
                 else:
                     onnx_slice_dims_count = len(starts)
@@ -488,7 +489,7 @@ def make_node(
                 onnx_slice_dims_count = len(starts.numpy())
             elif isinstance(starts, int):
                 onnx_slice_dims_count = 1
-            elif tf.keras.backend.is_keras_tensor(starts):
+            elif tf_keras.backend.is_keras_tensor(starts):
                 onnx_slice_dims_count = len(starts.shape)
             else:
                 onnx_slice_dims_count = len(starts)

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -5,6 +5,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     replace_parameter,
@@ -143,7 +144,7 @@ def make_node(
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
             val_model = None
             if not isinstance(input_tensor, np.ndarray):
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=tf_model_inputs,
                     outputs=[
                         input_tensor,
@@ -245,14 +246,14 @@ def make_node(
             # Search for the axis with the smallest error
             for check_axis in check_axes:
                 # Build TF dummy model
-                input = tf.keras.Input(
+                input = tf_keras.Input(
                     shape=validation_data.shape[1:],
                     batch_size=validation_data.shape[0] \
                         if isinstance(validation_data.shape[0], int) else None,
                     name='dummy_input',
                     dtype=validation_data.dtype,
                 )
-                val_model = tf.keras.Model(
+                val_model = tf_keras.Model(
                     inputs=[
                         input,
                     ],

--- a/onnx2tf/ops/StringNormalizer.py
+++ b/onnx2tf/ops/StringNormalizer.py
@@ -3,7 +3,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
-# import tensorflow_text as text
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -17,7 +17,7 @@ from onnx2tf.utils.common_functions import (
 from onnx2tf.utils.logging import *
 
 
-class StringNormalizer(tf.keras.layers.Layer):
+class StringNormalizer(tf_keras.layers.Layer):
     def __init__(
         self,
         case_change_action=None,

--- a/onnx2tf/ops/Tile.py
+++ b/onnx2tf/ops/Tile.py
@@ -5,6 +5,7 @@ import numpy as np
 np.random.seed(0)
 import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -160,7 +161,7 @@ def make_node(
         for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
             try:
                 # Build TF dummy model
-                input_1 = tf.keras.Input(
+                input_1 = tf_keras.Input(
                     shape=validation_data_1.shape[1:],
                     batch_size=validation_data_1.shape[0] \
                         if isinstance(validation_data_1.shape[0], int) else None,
@@ -193,7 +194,7 @@ def make_node(
                 if onnx_tensor_infos:
                     try:
                         # Search for the axis with the smallest error
-                        val_model = tf.keras.Model(
+                        val_model = tf_keras.Model(
                             inputs=[
                                 input_1,
                             ],

--- a/onnx2tf/ops/Unique.py
+++ b/onnx2tf/ops/Unique.py
@@ -3,9 +3,9 @@ from typing import List
 
 random.seed(0)
 import numpy as np
-
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -18,7 +18,7 @@ from onnx2tf.utils.common_functions import (
 from onnx2tf.utils.logging import Color
 
 
-class tfUnique(tf.keras.layers.Layer):
+class tfUnique(tf_keras.layers.Layer):
 
     def __init__(self):
         super(tfUnique, self).__init__()

--- a/onnx2tf/ops/_Loop.py
+++ b/onnx2tf/ops/_Loop.py
@@ -5,6 +5,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -17,7 +18,7 @@ import importlib
 from onnx2tf.utils.logging import *
 
 
-class While_Loop_CustomLayer(tf.keras.layers.Layer):
+class While_Loop_CustomLayer(tf_keras.layers.Layer):
     def __init__(self):
         super(While_Loop_CustomLayer, self).__init__()
 

--- a/onnx2tf/ops/__Loop.py
+++ b/onnx2tf/ops/__Loop.py
@@ -5,6 +5,7 @@ random.seed(0)
 import numpy as np
 np.random.seed(0)
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -17,7 +18,7 @@ import importlib
 from onnx2tf.utils.logging import *
 
 
-class While_Loop_CustomLayer(tf.keras.layers.Layer):
+class While_Loop_CustomLayer(tf_keras.layers.Layer):
     def __init__(self):
         super(While_Loop_CustomLayer, self).__init__()
 


### PR DESCRIPTION
### 1. Content and background
- [experimental, Breaking change] `tf.keras` -> `tf_keras`
- `pip install tf-keras~=2.16`
- Because the API path for `tf.keras` is obsolete.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
