### PR TITLE
Distribute test data files to GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.4
+  ghcr.io/pinto0309/onnx2tf:1.20.5
 
   or
 
@@ -265,7 +265,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.4
+  docker.io/pinto0309/onnx2tf:1.20.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.4'
+__version__ = '1.20.5'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -4168,8 +4168,14 @@ def download_test_image_data() -> np.ndarray:
     LOCAL_FILE_PATH = os.path.join(os.getcwd(), FILE_NAME)
 
     if not os.path.isfile(LOCAL_FILE_PATH):
-        URL = f'https://s3.us-central-1.wasabisys.com/onnx2tf-en/datas/{FILE_NAME}'
-        test_sample_images_npy = requests.get(URL).content
+        URL = f'https://github.com/PINTO0309/onnx2tf/releases/download/1.20.4/{FILE_NAME}'
+        try:
+            # GitHub releases
+            test_sample_images_npy = requests.get(URL, timeout=(1.0, 5.0)).content
+        except requests.exceptions.Timeout:
+            # Wasabi Storage
+            URL = f'https://s3.us-central-1.wasabisys.com/onnx2tf-en/datas/{FILE_NAME}'
+            test_sample_images_npy = requests.get(URL).content
     else:
         with open(LOCAL_FILE_PATH, 'rb') as test_sample_images_npy_file:
             test_sample_images_npy = test_sample_images_npy_file.read()


### PR DESCRIPTION
### 1. Content and background
- Distribute test data files to GitHub releases.
  - `calibration_image_sample_data_20x128x128x3_float32.npy`
  - connection timeout: 1 sec
  - read timeout: 5 sec
- The downstream speed of Wasabi Storage is very slow due to the rapid increase in the number of requests per day.
- Porting to Wasabi Storage if the download from GitHub releases times out.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [onnx2tf download_test_image_data() S3 file connection error #545](https://github.com/PINTO0309/onnx2tf/issues/545)
