### PR TITLE
Improved conversion stability when `H`, `W` and `D` of `MaxPool` and `AveragePool` contain undefined dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.5
+  ghcr.io/pinto0309/onnx2tf:1.20.6
 
   or
 
@@ -278,7 +278,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.5
+  docker.io/pinto0309/onnx2tf:1.20.6
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.5'
+__version__ = '1.20.6'

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -163,7 +163,8 @@ def make_node(
     tf_pads = calc_tf_pooling_pads(
         input_shape=input_tensor_shape,
         kernel=kernel_shape,
-        strides=strides
+        strides=strides,
+        input_tensor=input_tensor
     )
 
     func = math.ceil if ceil_mode else math.floor

--- a/onnx2tf/ops/MaxPool.py
+++ b/onnx2tf/ops/MaxPool.py
@@ -162,7 +162,8 @@ def make_node(
     tf_pads = calc_tf_pooling_pads(
         input_shape=input_tensor_shape,
         kernel=dilated_kernel_shape,
-        strides=strides
+        strides=strides,
+        input_tensor=input_tensor,
     )
 
     # onnx padding value is ignored if auto_pad is not 'NOTSET'


### PR DESCRIPTION
### 1. Content and background
- `MaxPool`, `AveragePool`
  - Improved conversion stability when `H`, `W` and `D` of `MaxPool` and `AveragePool` contain undefined dimensions.
  - The accuracy of the converted model is not always accurate.
  - e.g. YOLOv8n dynamic inputs `[N, 3, H, W]`
  - YOLOv8 has been modified only to avoid a situation where the conversion aborts, although this is undoubtedly not good for the design of the model, as fixed parameters such as the number of classes are embedded in the backward `Split` operation with fixed values.
  - Concatenating dimensions that have completely different meanings is also a major problem.
  - Unless you replace the PyTorch implementation with `Slice`, you won't be able to do proper inferencing.
    - ONNX
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/cacbec18-2c57-4005-9567-37360ee3699f)
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/363ff05e-fe56-4a44-a0a2-d712252edad4)
    - TFLite
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/6e337b7d-e709-4895-85fd-72be778c7d04)
      ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/a05b5017-90b0-4fb5-9781-b9e6282b889e)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
