### PR TITLE
Optimization of `torch.nn.PixelUnshuffle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.6
+  ghcr.io/pinto0309/onnx2tf:1.20.7
 
   or
 
@@ -278,7 +278,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.6
+  docker.io/pinto0309/onnx2tf:1.20.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.6'
+__version__ = '1.20.7'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -820,6 +820,7 @@ def convert(
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
         'output_integer_quantized_tflite': output_integer_quantized_tflite,
         'gelu_replace_op_names': {},
+        'space_to_depth_replace_op_names': {},
         'relu_relu6_merge_op_names': {},
         'mul_div_replace_op_names': {},
         'use_cuda': use_cuda,

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -162,7 +162,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -162,7 +162,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -162,7 +162,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -162,7 +162,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -169,7 +169,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -163,7 +163,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -163,7 +163,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -163,7 +163,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -162,7 +162,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/ReduceSumSquare.py
+++ b/onnx2tf/ops/ReduceSumSquare.py
@@ -163,7 +163,7 @@ def make_node(
                 del onnx_tensor_infos_for_validation
 
     if not disable_strict_mode:
-        if onnx_tensor_infos is not None and validation_data is not None:
+        if onnx_tensor_infos is not None and validation_data is not None and axes is not None:
             # Shape Unmatch Error Mitigation Measures
             # Search for and transpose shapes that do not cause shape unmatch errors
             min_abs_err = sys.maxsize

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -98,22 +98,42 @@ def make_node(
         'dtype': dtype,
     }
 
-    # Generation of TF OP
-    # NWC->NCW, NHWC->NCHW, NDHWC->NCDHW Transpose
-    perm = [
-        convert_axis(
-            axis=idx,
-            tensor_rank=tensor_rank,
-            before_op_output_shape_trans=before_op_output_shape_trans,
-        ) for idx in range(tensor_rank)
-    ]
+    space_to_depth_replace_op_names: dict = kwargs['space_to_depth_replace_op_names']
+    space_to_depth_op_names = [op_name for op_names in space_to_depth_replace_op_names.values() for op_name in op_names]
+    enable_skip_op = graph_node.name in space_to_depth_op_names
 
-    # NHWC -> NCHW
-    transposed_tensor_output_shape = \
-        list(tf.transpose(a=input_tensor, perm=list(perm)).shape) \
-            if tf.transpose(a=input_tensor, perm=list(perm)).shape is not None else [None]
-    try:
-        if graph_node.i().op not in ['LSTM', 'RNN', 'GRU']:
+    perm = []
+    tf_type = None
+    enable_space_to_depth = False
+
+    if not enable_skip_op:
+        # Generation of TF OP
+        # NWC->NCW, NHWC->NCHW, NDHWC->NCDHW Transpose
+        perm = [
+            convert_axis(
+                axis=idx,
+                tensor_rank=tensor_rank,
+                before_op_output_shape_trans=before_op_output_shape_trans,
+            ) for idx in range(tensor_rank)
+        ]
+
+        # NHWC -> NCHW
+        transposed_tensor_output_shape = \
+            list(tf.transpose(a=input_tensor, perm=list(perm)).shape) \
+                if tf.transpose(a=input_tensor, perm=list(perm)).shape is not None else [None]
+        try:
+            if graph_node.i().op not in ['LSTM', 'RNN', 'GRU']:
+                transposed_tensor = \
+                    transpose_with_flexing_deterrence(
+                        input_tensor=input_tensor,
+                        perm=list(perm) if perm is not None else None,
+                        output_shape=transposed_tensor_output_shape if None not in transposed_tensor_output_shape else None,
+                        name=graph_node.name,
+                        **kwargs,
+                    )
+            else:
+                transposed_tensor = input_tensor
+        except:
             transposed_tensor = \
                 transpose_with_flexing_deterrence(
                     input_tensor=input_tensor,
@@ -122,304 +142,391 @@ def make_node(
                     name=graph_node.name,
                     **kwargs,
                 )
+        test_data = None
+        if not isinstance(input_tensor, np.ndarray):
+            if not isinstance(graph_node_input_1, np.ndarray) \
+                and graph_node_input_1.name in tf_layers_dict \
+                and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
+                test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
+                test_data = test_data.transpose(list(perm) if perm is not None else None)
+            elif isinstance(graph_node_input_1, np.ndarray):
+                test_data: np.ndarray = input_tensor
+                test_data = test_data.transpose(list(perm) if perm is not None else None)
+            else:
+                test_data = None
         else:
-            transposed_tensor = input_tensor
-    except:
-        transposed_tensor = \
-            transpose_with_flexing_deterrence(
-                input_tensor=input_tensor,
-                perm=list(perm) if perm is not None else None,
-                output_shape=transposed_tensor_output_shape if None not in transposed_tensor_output_shape else None,
-                name=graph_node.name,
-                **kwargs,
-            )
-    test_data = None
-    if not isinstance(input_tensor, np.ndarray):
-        if not isinstance(graph_node_input_1, np.ndarray) \
-            and graph_node_input_1.name in tf_layers_dict \
-            and 'verification_data' in tf_layers_dict[graph_node_input_1.name].keys():
-            test_data: np.ndarray = tf_layers_dict[graph_node_input_1.name]['verification_data']
-            test_data = test_data.transpose(list(perm) if perm is not None else None)
-        elif isinstance(graph_node_input_1, np.ndarray):
-            test_data: np.ndarray = input_tensor
-            test_data = test_data.transpose(list(perm) if perm is not None else None)
-        else:
-            test_data = None
-    else:
-        test_data = input_tensor.transpose(list(perm) if perm is not None else None)
+            test_data = input_tensor.transpose(list(perm) if perm is not None else None)
 
-    if isinstance(reshape_shape, np.ndarray):
-        perm_shape = [
-            convert_axis(
-                axis=idx,
-                tensor_rank=len(reshape_shape),
-                before_op_output_shape_trans=before_op_output_shape_trans,
-            ) for idx in range(len(reshape_shape))
-        ]
-        transposed_reshape_shape = list(reshape_shape)
-        if before_op_output_shape_trans:
-            transposed_reshape_shape = [
-                transposed_reshape_shape[perm_shape_dim] for perm_shape_dim in list(perm_shape)
+        if isinstance(reshape_shape, np.ndarray):
+            perm_shape = [
+                convert_axis(
+                    axis=idx,
+                    tensor_rank=len(reshape_shape),
+                    before_op_output_shape_trans=before_op_output_shape_trans,
+                ) for idx in range(len(reshape_shape))
             ]
-    else:
-        transposed_reshape_shape = reshape_shape
+            transposed_reshape_shape = list(reshape_shape)
+            if before_op_output_shape_trans:
+                transposed_reshape_shape = [
+                    transposed_reshape_shape[perm_shape_dim] for perm_shape_dim in list(perm_shape)
+                ]
+        else:
+            transposed_reshape_shape = reshape_shape
 
-    # Param replacement
-    transposed_tensor = replace_parameter(
-        value_before_replacement=transposed_tensor,
-        param_target='inputs',
-        param_name=graph_node.inputs[0].name,
-        **kwargs,
-    )
-    replaced_shape = replace_parameter(
-        value_before_replacement=transposed_reshape_shape,
-        param_target='inputs',
-        param_name=graph_node.inputs[1].name,
-        **kwargs,
-    )
-    shape_replaced_flg = False
-    if ((isinstance(transposed_reshape_shape, list) and isinstance(replaced_shape, list)) \
-        or (isinstance(transposed_reshape_shape, np.ndarray) and isinstance(replaced_shape, np.ndarray))) \
-        and transposed_reshape_shape != replaced_shape:
-        shape_replaced_flg = True
-    elif (not isinstance(transposed_reshape_shape, list) and not isinstance(transposed_reshape_shape, np.ndarray)) \
-        and tf_keras.backend.is_keras_tensor(transposed_reshape_shape) \
-        and (isinstance(replaced_shape, list) or isinstance(replaced_shape, np.ndarray)):
-        shape_replaced_flg = True
-    if shape_replaced_flg:
-        transposed_reshape_shape = replaced_shape
+        # Param replacement
+        transposed_tensor = replace_parameter(
+            value_before_replacement=transposed_tensor,
+            param_target='inputs',
+            param_name=graph_node.inputs[0].name,
+            **kwargs,
+        )
+        replaced_shape = replace_parameter(
+            value_before_replacement=transposed_reshape_shape,
+            param_target='inputs',
+            param_name=graph_node.inputs[1].name,
+            **kwargs,
+        )
+        shape_replaced_flg = False
+        if ((isinstance(transposed_reshape_shape, list) and isinstance(replaced_shape, list)) \
+            or (isinstance(transposed_reshape_shape, np.ndarray) and isinstance(replaced_shape, np.ndarray))) \
+            and transposed_reshape_shape != replaced_shape:
+            shape_replaced_flg = True
+        elif (not isinstance(transposed_reshape_shape, list) and not isinstance(transposed_reshape_shape, np.ndarray)) \
+            and tf_keras.backend.is_keras_tensor(transposed_reshape_shape) \
+            and (isinstance(replaced_shape, list) or isinstance(replaced_shape, np.ndarray)):
+            shape_replaced_flg = True
+        if shape_replaced_flg:
+            transposed_reshape_shape = replaced_shape
 
-    # Pre-process transpose
-    transposed_tensor = pre_process_transpose(
-        value_before_transpose=transposed_tensor,
-        param_target='inputs',
-        param_name=graph_node.inputs[0].name,
-        **kwargs,
-    )
-
-    # Reshape
-    has_undefined_outputshape = output_shape is None
-    if not has_undefined_outputshape:
-        has_none_outputshape = None in output_shape
-        has_str_outputshape = True in [True for dim in output_shape if isinstance(dim, str)]
-        has_undefined_outputshape = has_none_outputshape or has_str_outputshape
-    final_shape = transposed_reshape_shape \
-        if (has_undefined_outputshape or shape_replaced_flg) else output_shape
-    final_shape = final_shape \
-        if not isinstance(final_shape, np.ndarray) \
-            else tf.convert_to_tensor(final_shape)
-
-
-    # Elimination of unnecessary OP sequential processing
-    # [1,81,52,52] -> Reshape [81,52,52] -> Expand [1,81,52,52]
-    # [1,81,52,52] -> Reshape [81,52,52] -> Unsqueeze [1,81,52,52]
-    # [81,52,52] -> Reshape [1,81,52,52] -> Squeeze [81,52,52]
-    consumer_count = 0
-    consumer_nodes: List[gs.Node] = []
-    while True:
-        try:
-            consumer_node =  graph_node.o(consumer_count, 0)
-            consumer_nodes.append(consumer_node)
-            consumer_count += 1
-        except:
-            break
-    expand_count = 0
-    unsqueeze_count = 0
-    squeeze_count = 0
-    for consumer_node in consumer_nodes:
-        if consumer_node.op == 'Expand' \
-            and consumer_node.outputs[0].shape is not None \
-            and consumer_node.outputs[0].shape == transposed_tensor.shape:
-            expand_count += 1
-
-        elif consumer_node.op == 'Unsqueeze' \
-            and consumer_node.outputs[0].shape is not None \
-            and consumer_node.outputs[0].shape == transposed_tensor.shape:
-            unsqueeze_count += 1
-
-        elif consumer_node.op == 'Squeeze' \
-            and consumer_node.outputs[0].shape is not None \
-            and consumer_node.outputs[0].shape == transposed_tensor.shape:
-            squeeze_count += 1
-    if (expand_count > 0 and expand_count == consumer_count) \
-        or (unsqueeze_count > 0 and unsqueeze_count == consumer_count) \
-        or (squeeze_count > 0 and squeeze_count == consumer_count):
-        # Replace
-        final_shape = consumer_nodes[0].outputs[0].shape
-        tf_layers_dict[graph_node_output.name]['unnecessary_reshape'] = True
-    else:
-        # No-replace
-        pass
-
-    tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.reshape(
-            tensor=transposed_tensor,
-            shape=final_shape,
-            name=graph_node.name,
+        # Pre-process transpose
+        transposed_tensor = pre_process_transpose(
+            value_before_transpose=transposed_tensor,
+            param_target='inputs',
+            param_name=graph_node.inputs[0].name,
+            **kwargs,
         )
 
-    # Workaround to special patterns with wrong transposition when all axes except batch size have the same value.
-    # Examine which combination of axis configurations reduces the error in output values the most,
-    # and apply the transposition with the best performance.
-    # Input: [1, 20, 20, 20], Output: [1, 800, 10]
-    # https://github.com/PINTO0309/onnx2tf/issues/478
-    # latest.opset17.onnx
-    # mobileformer.onnx
-    graph_node_input_1_shape = graph_node_input_1.shape
-    if graph_node_input_1_shape is not None \
-        and len(graph_node_input_1_shape) >= 3 \
-        and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_1_shape]) == 0:
+        # Reshape
+        has_undefined_outputshape = output_shape is None
+        if not has_undefined_outputshape:
+            has_none_outputshape = None in output_shape
+            has_str_outputshape = True in [True for dim in output_shape if isinstance(dim, str)]
+            has_undefined_outputshape = has_none_outputshape or has_str_outputshape
+        final_shape = transposed_reshape_shape \
+            if (has_undefined_outputshape or shape_replaced_flg) else output_shape
+        final_shape = final_shape \
+            if not isinstance(final_shape, np.ndarray) \
+                else tf.convert_to_tensor(final_shape)
 
-        # Get the output tensor of one previous OP of TensorFlow only once
-        if not disable_strict_mode:
-            tf_model_inputs = get_tf_model_inputs(
-                tf_layers_dict=tf_layers_dict,
-            )
-            val_model = None
-            if not isinstance(transposed_tensor, np.ndarray):
-                val_model = tf_keras.Model(
-                    inputs=tf_model_inputs,
-                    outputs=[
-                        transposed_tensor,
-                    ],
-                )
-            else:
-                pass
 
-        # TF dummy inference
-        #   Get the output tensor of the previous layer of MatMul
-        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
-        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
-        tf_pre_tensor_infos = {}
-        if not disable_strict_mode:
+        # Elimination of unnecessary OP sequential processing
+        # [1,81,52,52] -> Reshape [81,52,52] -> Expand [1,81,52,52]
+        # [1,81,52,52] -> Reshape [81,52,52] -> Unsqueeze [1,81,52,52]
+        # [81,52,52] -> Reshape [1,81,52,52] -> Squeeze [81,52,52]
+        consumer_count = 0
+        consumer_nodes: List[gs.Node] = []
+        while True:
             try:
-                tf_pre_tensor_infos: Dict[Any] = \
-                    dummy_tf_inference(
-                        model=val_model,
-                        inputs=tf_model_inputs,
-                        test_data_nhwc=test_data_nhwc,
-                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                consumer_node = graph_node.o(consumer_count, 0)
+                consumer_nodes.append(consumer_node)
+                consumer_count += 1
+            except:
+                break
+        expand_count = 0
+        unsqueeze_count = 0
+        squeeze_count = 0
+        for consumer_node in consumer_nodes:
+            if consumer_node.op == 'Expand' \
+                and consumer_node.outputs[0].shape is not None \
+                and consumer_node.outputs[0].shape == transposed_tensor.shape:
+                expand_count += 1
+
+            elif consumer_node.op == 'Unsqueeze' \
+                and consumer_node.outputs[0].shape is not None \
+                and consumer_node.outputs[0].shape == transposed_tensor.shape:
+                unsqueeze_count += 1
+
+            elif consumer_node.op == 'Squeeze' \
+                and consumer_node.outputs[0].shape is not None \
+                and consumer_node.outputs[0].shape == transposed_tensor.shape:
+                squeeze_count += 1
+        if (expand_count > 0 and expand_count == consumer_count) \
+            or (unsqueeze_count > 0 and unsqueeze_count == consumer_count) \
+            or (squeeze_count > 0 and squeeze_count == consumer_count):
+            # Replace
+            final_shape = consumer_nodes[0].outputs[0].shape
+            tf_layers_dict[graph_node_output.name]['unnecessary_reshape'] = True
+        else:
+            # No-replace
+            pass
+
+        # SpaceToDepth
+        block_size = 1
+        spase_to_depth_final_shape = []
+        if not tf_layers_dict[graph_node_output.name].get('unnecessary_reshape', False):
+            if len(final_shape) == 6:
+                channel_size = final_shape[1] if isinstance(final_shape[1], int) else None
+                block_size = final_shape[3] if isinstance(final_shape[3], int) else None
+
+                if channel_size is not None \
+                    and block_size == final_shape[5]:
+
+                    transpose_node: gs.Node = None
+                    reshape_node: gs.Node = None
+                    consumer_count = 0
+                    while True:
+                        try:
+                            transpose_node = graph_node.o(consumer_count, 0)
+                            consumer_count += 1
+                        except:
+                            break
+
+                    if consumer_count == 1:
+                        if transpose_node.op == 'Transpose':
+                            perm: List[int] = transpose_node.attrs.get('perm', [])
+                            if perm == [0, 1, 3, 5, 2, 4]:
+
+                                consumer_count = 0
+                                while True:
+                                    try:
+                                        reshape_node = transpose_node.o(consumer_count, 0)
+                                        consumer_count += 1
+                                    except:
+                                        break
+
+                                if consumer_count == 1:
+                                    if reshape_node.op == 'Reshape' \
+                                        and reshape_node.outputs[0].shape is not None \
+                                        and len(reshape_node.outputs[0].shape) == 4 \
+                                        and isinstance(reshape_node.outputs[0].shape[1], int) \
+                                        and sum([0 if isinstance(dim, int) else 1 for dim in reshape_node.outputs[0].shape]) == 0 \
+                                        and channel_size * block_size ** 2 == reshape_node.outputs[0].shape[1]:
+
+                                        # Save the name of the OP set to be replaced to SpaceToDepth
+                                        # Transpose, Reshape
+                                        spase_to_depth_final_shape = [
+                                            reshape_node.outputs[0].shape[0],
+                                            reshape_node.outputs[0].shape[2],
+                                            reshape_node.outputs[0].shape[3],
+                                            reshape_node.outputs[0].shape[1],
+                                        ]
+                                        if 'space_to_depth_replace_op_names' not in kwargs:
+                                            kwargs['space_to_depth_replace_op_names'] = {}
+                                        kwargs['space_to_depth_replace_op_names'][graph_node.name] = [
+                                            transpose_node.name,
+                                            reshape_node.name,
+                                        ]
+                                        enable_space_to_depth = True
+
+        if not enable_space_to_depth:
+            # Reshape
+            tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                tf.reshape(
+                    tensor=transposed_tensor,
+                    shape=final_shape,
+                    name=graph_node.name,
+                )
+
+            # Workaround to special patterns with wrong transposition when all axes except batch size have the same value.
+            # Examine which combination of axis configurations reduces the error in output values the most,
+            # and apply the transposition with the best performance.
+            # Input: [1, 20, 20, 20], Output: [1, 800, 10]
+            # https://github.com/PINTO0309/onnx2tf/issues/478
+            # latest.opset17.onnx
+            # mobileformer.onnx
+            graph_node_input_1_shape = graph_node_input_1.shape
+            if graph_node_input_1_shape is not None \
+                and len(graph_node_input_1_shape) >= 3 \
+                and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_1_shape]) == 0:
+
+                # Get the output tensor of one previous OP of TensorFlow only once
+                if not disable_strict_mode:
+                    tf_model_inputs = get_tf_model_inputs(
+                        tf_layers_dict=tf_layers_dict,
                     )
-            except Exception as ex:
-                pass
-            del val_model
-
-        # Get np.ndarray for validation
-        validation_data = None
-        if not disable_strict_mode:
-            if len(tf_pre_tensor_infos) == 1:
-                if not isinstance(transposed_tensor, np.ndarray):
-                    validation_data = list(tf_pre_tensor_infos.values())[0]
-                else:
-                    validation_data = copy.deepcopy(transposed_tensor)
-
-            # Get ONNX inference results
-            onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
-                onnx_tensor_infos = {
-                    graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
-                }
-                del onnx_tensor_infos_for_validation
-
-        # ONNX   : N,C,W
-        # TF     : N,W,C
-        # TF-axes: [1]
-        #
-        # ONNX: N,C,H,W
-        # TF  : N,H,W,C
-        # TF-axes: [1,2]
-        #
-        # ONNX: N,C,D,H,W
-        # TF  : N,D,H,W,C
-        # TF-axes: [1,2,3]
-
-        # Automatic correction of accuracy degradation
-        min_abs_err = sys.maxsize
-        min_abs_err_perm_1: List[int] = [idx for idx in range(tensor_rank)]
-
-        if not disable_strict_mode:
-            if onnx_tensor_infos is not None and validation_data is not None:
-                tensor_1_candidate_for_transpositions = list(itertools.permutations(range(tensor_rank)))
-                # Search for the axis with the smallest error
-                for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
-                    try:
-                        target_validation_data = validation_data
-                        # Build TF dummy model
-                        input = tf_keras.Input(
-                            shape=validation_data.shape[1:],
-                            batch_size=validation_data.shape[0] \
-                                if isinstance(validation_data.shape[0], int) else None,
-                            name='dummy_input',
-                            dtype=validation_data.dtype,
-                        )
+                    val_model = None
+                    if not isinstance(transposed_tensor, np.ndarray):
                         val_model = tf_keras.Model(
-                            inputs=[
-                                input,
-                            ],
+                            inputs=tf_model_inputs,
                             outputs=[
-                                tf.reshape(
-                                    tensor=tf.transpose(a=input, perm=tensor_1_candidate_for_transposition),
-                                    shape=final_shape,
-                                    name=graph_node.name,
-                                )
+                                transposed_tensor,
                             ],
                         )
-                        # TF dummy inference
-                        tf_tensor_infos: Dict[Any] = \
+                    else:
+                        pass
+
+                # TF dummy inference
+                #   Get the output tensor of the previous layer of MatMul
+                #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+                #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+                tf_pre_tensor_infos = {}
+                if not disable_strict_mode:
+                    try:
+                        tf_pre_tensor_infos: Dict[Any] = \
                             dummy_tf_inference(
                                 model=val_model,
-                                inputs=[
-                                    input,
-                                ],
-                                verification_datas=[
-                                    target_validation_data,
-                                ],
+                                inputs=tf_model_inputs,
+                                test_data_nhwc=test_data_nhwc,
+                                custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
                             )
-                        del input
-                        del val_model
-
-                        # Validation
-                        onnx_tf_output_pairs = {
-                            (oi[0], ti[0]): (oi[1], ti[1]) \
-                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
-                        }
-                        """
-                        check_results: Dict[str, List[np.ndarray, int, float|int]]
-                            {
-                                onnx_output_name: [
-                                    onnx_tensor,
-                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
-                                    max_abs_err,
-                                ]
-                            }
-                        """
-                        check_results = \
-                            onnx_tf_tensor_validation(
-                                output_pairs=onnx_tf_output_pairs,
-                                rtol=0.0,
-                                atol=0.0,
-                            )
-                        result_err = sum([val[2] for val in check_results.values()])
-                        if result_err < min_abs_err:
-                            min_abs_err = result_err
-                            min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
-                            if min_abs_err < 1e-3:
-                                break
                     except Exception as ex:
                         pass
-                transposed_tensor_shape = list(tf.transpose(a=transposed_tensor, perm=min_abs_err_perm_1).shape)
-                tf_layers_dict[graph_node_output.name]['tf_node'] = \
-                    tf.reshape(
-                        tensor=transpose_with_flexing_deterrence(
-                            input_tensor=transposed_tensor,
-                            perm=min_abs_err_perm_1,
-                            output_shape=transposed_tensor_shape \
-                                if None not in transposed_tensor_shape and transposed_tensor_shape != [] else None,
-                            **kwargs,
-                        ),
-                        shape=final_shape,
-                        name=graph_node.name,
-                    )
+                    del val_model
+
+                # Get np.ndarray for validation
+                validation_data = None
+                if not disable_strict_mode:
+                    if len(tf_pre_tensor_infos) == 1:
+                        if not isinstance(transposed_tensor, np.ndarray):
+                            validation_data = list(tf_pre_tensor_infos.values())[0]
+                        else:
+                            validation_data = copy.deepcopy(transposed_tensor)
+
+                    # Get ONNX inference results
+                    onnx_tensor_infos = None
+                    if onnx_tensor_infos_for_validation is not None:
+                        onnx_tensor_infos = {
+                            graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+                        }
+                        del onnx_tensor_infos_for_validation
+
+                # ONNX   : N,C,W
+                # TF     : N,W,C
+                # TF-axes: [1]
+                #
+                # ONNX: N,C,H,W
+                # TF  : N,H,W,C
+                # TF-axes: [1,2]
+                #
+                # ONNX: N,C,D,H,W
+                # TF  : N,D,H,W,C
+                # TF-axes: [1,2,3]
+
+                # Automatic correction of accuracy degradation
+                min_abs_err = sys.maxsize
+                min_abs_err_perm_1: List[int] = [idx for idx in range(tensor_rank)]
+
+                if not disable_strict_mode:
+                    if onnx_tensor_infos is not None and validation_data is not None:
+                        tensor_1_candidate_for_transpositions = list(itertools.permutations(range(tensor_rank)))
+                        # Search for the axis with the smallest error
+                        for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
+                            try:
+                                target_validation_data = validation_data
+                                # Build TF dummy model
+                                input = tf_keras.Input(
+                                    shape=validation_data.shape[1:],
+                                    batch_size=validation_data.shape[0] \
+                                        if isinstance(validation_data.shape[0], int) else None,
+                                    name='dummy_input',
+                                    dtype=validation_data.dtype,
+                                )
+                                val_model = tf_keras.Model(
+                                    inputs=[
+                                        input,
+                                    ],
+                                    outputs=[
+                                        tf.reshape(
+                                            tensor=tf.transpose(a=input, perm=tensor_1_candidate_for_transposition),
+                                            shape=final_shape,
+                                            name=graph_node.name,
+                                        )
+                                    ],
+                                )
+                                # TF dummy inference
+                                tf_tensor_infos: Dict[Any] = \
+                                    dummy_tf_inference(
+                                        model=val_model,
+                                        inputs=[
+                                            input,
+                                        ],
+                                        verification_datas=[
+                                            target_validation_data,
+                                        ],
+                                    )
+                                del input
+                                del val_model
+
+                                # Validation
+                                onnx_tf_output_pairs = {
+                                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                                }
+                                """
+                                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                                    {
+                                        onnx_output_name: [
+                                            onnx_tensor,
+                                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                            max_abs_err,
+                                        ]
+                                    }
+                                """
+                                check_results = \
+                                    onnx_tf_tensor_validation(
+                                        output_pairs=onnx_tf_output_pairs,
+                                        rtol=0.0,
+                                        atol=0.0,
+                                    )
+                                result_err = sum([val[2] for val in check_results.values()])
+                                if result_err < min_abs_err:
+                                    min_abs_err = result_err
+                                    min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                                    if min_abs_err < 1e-3:
+                                        break
+                            except Exception as ex:
+                                pass
+                        transposed_tensor_shape = list(tf.transpose(a=transposed_tensor, perm=min_abs_err_perm_1).shape)
+                        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                            tf.reshape(
+                                tensor=transpose_with_flexing_deterrence(
+                                    input_tensor=transposed_tensor,
+                                    perm=min_abs_err_perm_1,
+                                    output_shape=transposed_tensor_shape \
+                                        if None not in transposed_tensor_shape and transposed_tensor_shape != [] else None,
+                                    **kwargs,
+                                ),
+                                shape=final_shape,
+                                name=graph_node.name,
+                            )
+                        tf_type = tf.reshape
+
+        else:
+            # SpaceToDepth
+            # ONNX: 1,3,32,4,32,4 -> 1,3,4,4,32,32 -> 1,48,32,32
+            # TF  : 1,32,4,32,4,3 -> 1,32,32,4,4,3 -> 1,32,32,48
+            input_tensor = tf.reshape(
+                tensor=input_tensor,
+                shape=[
+                    final_shape[0],
+                    final_shape[2],
+                    final_shape[3],
+                    final_shape[4],
+                    final_shape[5],
+                    final_shape[1],
+                ],
+                name=graph_node.name,
+            )
+            input_tensor = tf.transpose(a=input_tensor, perm=[0,1,3,5,2,4])
+            tf_layers_dict[graph_node_output.name]['tf_node'] = \
+                tf.reshape(
+                    tensor=input_tensor,
+                    shape=spase_to_depth_final_shape,
+                    name=graph_node.name,
+                )
+            tf_type = tf.nn.space_to_depth
+
+    else:
+        # Identity
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.identity(
+                input=input_tensor,
+                name=graph_node.name,
+            )
+        tf_type = tf.identity
+        transposed_tensor = input_tensor
+        transposed_reshape_shape = input_tensor.shape
+
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(
@@ -433,10 +540,10 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.reshape,
+                'tf_op_type': tf_type,
                 'tf_inputs': {
-                    'tensor': transposed_tensor,
-                    'shape': transposed_reshape_shape,
+                    'tensor': transposed_tensor if not enable_space_to_depth else input_tensor,
+                    'shape': transposed_reshape_shape if not enable_space_to_depth else input_tensor.shape,
                 },
                 'tf_outputs': {
                     'output': tf_layers_dict[graph_node_output.name]['tf_node'],

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -264,7 +264,8 @@ def make_node(
         block_size = 1
         spase_to_depth_final_shape = []
         if not tf_layers_dict[graph_node_output.name].get('unnecessary_reshape', False):
-            if len(final_shape) == 6:
+            if (isinstance(final_shape, np.ndarray) or isinstance(final_shape, list)) \
+                and len(final_shape) == 6:
                 channel_size = final_shape[1] if isinstance(final_shape[1], int) else None
                 block_size = final_shape[3] if isinstance(final_shape[3], int) else None
 

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -54,20 +54,36 @@ def make_node(
     tensor_rank = len(input_tensor_shape)
 
     perm = graph_node.attrs.get('perm', [idx for idx in reversed(range(tensor_rank))])
+
     if not isinstance(graph_node_input, np.ndarray) \
         and 'nwc_nhwc_ndhwc_keep' in tf_layers_dict[graph_node_input.name] \
         and tf_layers_dict[graph_node_input.name]['nwc_nhwc_ndhwc_keep'] == True:
         perm = [i for i in range(tensor_rank)]
 
+    space_to_depth_replace_op_names: dict = kwargs['space_to_depth_replace_op_names']
+    space_to_depth_op_names = [op_name for op_names in space_to_depth_replace_op_names.values() for op_name in op_names]
+    enable_space_to_depth = graph_node.name in space_to_depth_op_names
+
+    tf_type = None
     nwc_nhwc_ndhwc_keep = False
-    if isinstance(perm, list) or (isinstance(perm, np.ndarray) and len(perm.shape) > 0):
-        if perm[0] == 0:
-            try:
-                if graph_node.o().op == 'Softmax' \
-                    and graph_node.o().inputs[0].shape == input_tensor_shape:
-                    perm = [idx for idx in range(tensor_rank)]
-                    nwc_nhwc_ndhwc_keep = True
-                else:
+
+    if not enable_space_to_depth:
+        if isinstance(perm, list) or (isinstance(perm, np.ndarray) and len(perm.shape) > 0):
+            if perm[0] == 0:
+                try:
+                    if graph_node.o().op == 'Softmax' \
+                        and graph_node.o().inputs[0].shape == input_tensor_shape:
+                        perm = [idx for idx in range(tensor_rank)]
+                        nwc_nhwc_ndhwc_keep = True
+                    else:
+                        perm = [
+                            convert_axis(
+                                axis=idx,
+                                tensor_rank=tensor_rank,
+                                before_op_output_shape_trans=before_op_output_shape_trans,
+                            ) for idx in perm
+                        ]
+                except:
                     perm = [
                         convert_axis(
                             axis=idx,
@@ -75,81 +91,73 @@ def make_node(
                             before_op_output_shape_trans=before_op_output_shape_trans,
                         ) for idx in perm
                     ]
-            except:
-                perm = [
-                    convert_axis(
-                        axis=idx,
-                        tensor_rank=tensor_rank,
-                        before_op_output_shape_trans=before_op_output_shape_trans,
-                    ) for idx in perm
-                ]
-        elif output_shape is not None:
-            # When a zero-dimensional transposition occurs, compare the shape
-            # of the final output tensor of ONNX with the shape
-            # of the input tensor of TF and transpose to match the shape
-            # of the final output tensor on the ONNX side
-            onnx_output_shape = [s if not isinstance(s, str) else None for s in output_shape]
-            onnx_output_shape_none_count = onnx_output_shape.count(None)
-            tf_input_shape = input_tensor_shape
-            tf_input_shape_none_count = [s for s in tf_input_shape].count(None)
-            new_perm = [-1] * len(onnx_output_shape)
-            if onnx_output_shape_none_count > 0 and tf_input_shape_none_count == 0:
-                pass
-            else:
-                for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
-                    matched_idxs = [
-                        idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
-                            if onnx_shape_value == tf_shape_value
-                    ]
-                    if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
-                        new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
-                    elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
-                        new_perm = perm
-                    elif len(matched_idxs) == 1:
-                        new_perm[matched_idxs[0]] = tf_shape_idx
-                    else:
-                        for matched_idx in matched_idxs:
-                            if new_perm[matched_idx] == -1:
-                                new_perm[matched_idx] = tf_shape_idx
-                                break
-                perm = new_perm
+            elif output_shape is not None:
+                # When a zero-dimensional transposition occurs, compare the shape
+                # of the final output tensor of ONNX with the shape
+                # of the input tensor of TF and transpose to match the shape
+                # of the final output tensor on the ONNX side
+                onnx_output_shape = [s if not isinstance(s, str) else None for s in output_shape]
+                onnx_output_shape_none_count = onnx_output_shape.count(None)
+                tf_input_shape = input_tensor_shape
+                tf_input_shape_none_count = [s for s in tf_input_shape].count(None)
+                new_perm = [-1] * len(onnx_output_shape)
+                if onnx_output_shape_none_count > 0 and tf_input_shape_none_count == 0:
+                    pass
+                else:
+                    for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
+                        matched_idxs = [
+                            idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
+                                if onnx_shape_value == tf_shape_value
+                        ]
+                        if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
+                            new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
+                        elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
+                            new_perm = perm
+                        elif len(matched_idxs) == 1:
+                            new_perm[matched_idxs[0]] = tf_shape_idx
+                        else:
+                            for matched_idx in matched_idxs:
+                                if new_perm[matched_idx] == -1:
+                                    new_perm[matched_idx] = tf_shape_idx
+                                    break
+                    perm = new_perm
 
-    elif perm is not None and isinstance(perm, np.ndarray) and len(perm.shape) == 0:
-        if perm[0] == 0:
-            perm = convert_axis(
-                axis=perm,
-                tensor_rank=tensor_rank,
-                before_op_output_shape_trans=before_op_output_shape_trans,
-            )
-        elif output_shape is not None:
-            # When a zero-dimensional transposition occurs, compare the shape
-            # of the final output tensor of ONNX with the shape of the input tensor
-            # of TF and transpose to match the shape of the final output tensor on the ONNX side
-            onnx_output_shape = [s if not isinstance(s, str) else None for s in output_shape]
-            onnx_output_shape_none_count = onnx_output_shape.count(None)
-            tf_input_shape = input_tensor_shape
-            tf_input_shape_none_count = [s for s in tf_input_shape].count(None)
-            new_perm = [-1] * len(onnx_output_shape)
-            if onnx_output_shape_none_count > 0 and tf_input_shape_none_count == 0:
-                pass
-            else:
-                for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
-                    matched_idxs = [
-                        idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
-                            if onnx_shape_value == tf_shape_value
-                    ]
-                    if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
-                        new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
-                    elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
-                        new_perm = perm
-                    elif len(matched_idxs) == 1:
-                        new_perm[matched_idxs[0]] = tf_shape_idx
-                    else:
-                        for matched_idx in matched_idxs:
-                            if new_perm[matched_idx] == -1:
-                                new_perm[matched_idx] = tf_shape_idx
-                                break
-                perm = new_perm
+        elif perm is not None and isinstance(perm, np.ndarray) and len(perm.shape) == 0:
+            if perm[0] == 0:
+                perm = convert_axis(
+                    axis=perm,
+                    tensor_rank=tensor_rank,
+                    before_op_output_shape_trans=before_op_output_shape_trans,
+                )
+            elif output_shape is not None:
+                # When a zero-dimensional transposition occurs, compare the shape
+                # of the final output tensor of ONNX with the shape of the input tensor
+                # of TF and transpose to match the shape of the final output tensor on the ONNX side
+                onnx_output_shape = [s if not isinstance(s, str) else None for s in output_shape]
+                onnx_output_shape_none_count = onnx_output_shape.count(None)
+                tf_input_shape = input_tensor_shape
+                tf_input_shape_none_count = [s for s in tf_input_shape].count(None)
+                new_perm = [-1] * len(onnx_output_shape)
+                if onnx_output_shape_none_count > 0 and tf_input_shape_none_count == 0:
+                    pass
+                else:
+                    for tf_shape_idx, tf_shape_value in enumerate(tf_input_shape):
+                        matched_idxs = [
+                            idx for idx, onnx_shape_value in enumerate(onnx_output_shape) \
+                                if onnx_shape_value == tf_shape_value
+                        ]
+                        if len(matched_idxs) == 0 and onnx_output_shape_none_count <= 1:
+                            new_perm[tf_shape_idx] = onnx_output_shape.index(tf_shape_value)
+                        elif len(matched_idxs) == 0 and onnx_output_shape_none_count > 1:
+                            new_perm = perm
+                        elif len(matched_idxs) == 1:
+                            new_perm[matched_idxs[0]] = tf_shape_idx
+                        else:
+                            for matched_idx in matched_idxs:
+                                if new_perm[matched_idx] == -1:
+                                    new_perm[matched_idx] = tf_shape_idx
+                                    break
+                    perm = new_perm
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -161,37 +169,48 @@ def make_node(
 
     perm = list(perm) if perm is not None else None
 
-    # Param replacement
-    input_tensor = replace_parameter(
-        value_before_replacement=input_tensor,
-        param_target='inputs',
-        param_name=graph_node.inputs[0].name,
-        **kwargs,
-    )
-    perm = replace_parameter(
-        value_before_replacement=perm,
-        param_target='attributes',
-        param_name='perm',
-        **kwargs,
-    )
-
-    # Generation of TF OP
-    tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        transpose_with_flexing_deterrence(
-            input_tensor=input_tensor,
-            perm=perm \
-                if not isinstance(perm, np.ndarray) \
-                    else tf.convert_to_tensor(perm),
-            output_shape=output_shape,
-            name=graph_node.name,
+    if not enable_space_to_depth:
+        # Transpose
+        # Param replacement
+        input_tensor = replace_parameter(
+            value_before_replacement=input_tensor,
+            param_target='inputs',
+            param_name=graph_node.inputs[0].name,
             **kwargs,
         )
+        perm = replace_parameter(
+            value_before_replacement=perm,
+            param_target='attributes',
+            param_name='perm',
+            **kwargs,
+        )
+
+        # Generation of TF OP
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            transpose_with_flexing_deterrence(
+                input_tensor=input_tensor,
+                perm=perm \
+                    if not isinstance(perm, np.ndarray) \
+                        else tf.convert_to_tensor(perm),
+                output_shape=output_shape,
+                name=graph_node.name,
+                **kwargs,
+            )
+        tf_type = tf.transpose
+    else:
+        # SpaceToDepth
+        tf_layers_dict[graph_node_output.name]['tf_node'] = \
+            tf.identity(
+                input=input_tensor,
+                name=graph_node.name,
+            )
+        tf_type = tf.identity
 
     # Generation of Debug Info
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.transpose,
+                'tf_op_type': tf_type,
                 'tf_inputs': {
                     'a': input_tensor,
                     'perm': perm,


### PR DESCRIPTION
### 1. Content and background
- Optimization of `torch.nn.PixelUnshuffle`.
  - https://pytorch.org/docs/stable/generated/torch.nn.PixelUnshuffle.html
  - https://www.tensorflow.org/api_docs/python/tf/nn/space_to_depth
  - This implementation is inspired by the valuable knowledge of [AlexanderLutsenko / nobuco](https://github.com/AlexanderLutsenko/nobuco). Thank you very much.
    - https://github.com/AlexanderLutsenko/nobuco?tab=readme-ov-file#implementation-mismatch-pick-your-poison
  - Unlike PyTorch's method of replacing internal processing, a similar process is implemented from a frozen ONNX graph with the minimum number of operations required.

  |ONNX|Before<br>tflite|After<br>tflite|
  |:-:|:-:|:-:|
  |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/f39b4e8b-7fed-4ca5-af6a-e4e48f9e7adc)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/a9da56c5-b582-4c7a-aaf5-35f78d0b529c)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/b1d16985-614c-42dd-b040-49886b2da9b6)|

- Bug fix. `ReduceL1`, `ReduceL2`, `ReduceLogSum`, `ReduceLogSumExp`, `ReduceMax`, `ReduceMean`, `ReduceMin`, `ReduceProd`, `ReduceSum`, `ReduceSumSquare`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)

