### PR TITLE
Improved conversion stability of subgraphs of `If` operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.7
+  ghcr.io/pinto0309/onnx2tf:1.20.8
 
   or
 
@@ -278,7 +278,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.7
+  docker.io/pinto0309/onnx2tf:1.20.8
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.7'
+__version__ = '1.20.8'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -559,7 +559,8 @@ def make_node(
 
                 # Get ONNX inference results
                 onnx_tensor_infos = None
-                if onnx_tensor_infos_for_validation is not None:
+                if onnx_tensor_infos_for_validation is not None \
+                    and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                     onnx_tensor_infos = {
                         graph_node_output.name:
                         onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -210,7 +210,8 @@ def make_node(
 
                 # Get ONNX inference results
                 onnx_tensor_infos = None
-                if onnx_tensor_infos_for_validation is not None:
+                if onnx_tensor_infos_for_validation is not None \
+                    and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                     onnx_tensor_infos = {
                         graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
                     }

--- a/onnx2tf/ops/ConvInteger.py
+++ b/onnx2tf/ops/ConvInteger.py
@@ -247,7 +247,8 @@ def make_node(
 
                 # Get ONNX inference results
                 onnx_tensor_infos = None
-                if onnx_tensor_infos_for_validation is not None:
+                if onnx_tensor_infos_for_validation is not None \
+                    and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                     onnx_tensor_infos = {
                         graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
                     }

--- a/onnx2tf/ops/DepthToSpace.py
+++ b/onnx2tf/ops/DepthToSpace.py
@@ -175,7 +175,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
                 }

--- a/onnx2tf/ops/Einsum.py
+++ b/onnx2tf/ops/Einsum.py
@@ -65,6 +65,7 @@ def make_node(
     equation = graph_node.attrs['equation']
     onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
     if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None \
         and graph_node_output.name in onnx_tensor_infos_for_validation:
         onnx_output_shape = list(onnx_tensor_infos_for_validation[graph_node_output.name].shape)
         graph_node_output.shape = onnx_output_shape

--- a/onnx2tf/ops/GroupNorm.py
+++ b/onnx2tf/ops/GroupNorm.py
@@ -164,7 +164,8 @@ def make_node(
 
         # Get ONNX inference results
         onnx_tensor_infos = None
-        if onnx_tensor_infos_for_validation is not None:
+        if onnx_tensor_infos_for_validation is not None \
+            and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
             onnx_tensor_infos = {
                 graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
             }

--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -119,7 +119,8 @@ def make_node(
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(
@@ -164,7 +165,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
                 }

--- a/onnx2tf/ops/LayerNormalization.py
+++ b/onnx2tf/ops/LayerNormalization.py
@@ -186,7 +186,8 @@ def make_node(
 
         # Get ONNX inference results
         onnx_tensor_infos = None
-        if onnx_tensor_infos_for_validation is not None:
+        if onnx_tensor_infos_for_validation is not None \
+            and onnx_tensor_infos_for_validation.get(graph_node_output_1.name, None) is not None:
             onnx_tensor_infos = {
                 graph_node_output_1.name:
                 onnx_tensor_infos_for_validation[graph_node_output_1.name]

--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -100,7 +100,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data_1 = None
     validation_data_2 = None
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         onnx_tensor_infos, validation_data_1, validation_data_2 = \
             acquisition_of_validation_data(
                 input_tensor_1=input_tensor_1,

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -115,7 +115,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -154,7 +155,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -115,7 +115,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -154,7 +155,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -115,7 +115,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -154,7 +155,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -115,7 +115,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -154,7 +155,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -122,7 +122,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -161,7 +162,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -116,7 +116,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -155,7 +156,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -116,7 +116,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -155,7 +156,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -116,7 +116,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -155,7 +156,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -115,7 +115,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -154,7 +155,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/ReduceSumSquare.py
+++ b/onnx2tf/ops/ReduceSumSquare.py
@@ -116,7 +116,8 @@ def make_node(
     onnx_tensor_infos = None
     validation_data = None
 
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -155,7 +156,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -385,7 +385,8 @@ def make_node(
 
                     # Get ONNX inference results
                     onnx_tensor_infos = None
-                    if onnx_tensor_infos_for_validation is not None:
+                    if onnx_tensor_infos_for_validation is not None \
+                        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                         onnx_tensor_infos = {
                             graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
                         }

--- a/onnx2tf/ops/Softmax.py
+++ b/onnx2tf/ops/Softmax.py
@@ -138,7 +138,9 @@ def make_node(
             and onnx_input_shapes[pre_convert_axis] == tf_input_shapes[axis]:
             acc_check_pass_flg = True
 
-    if onnx_tensor_infos_for_validation is not None and not acc_check_pass_flg:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None \
+        and not acc_check_pass_flg:
         # Get the output tensor of one previous OP of TensorFlow only once
         if not disable_strict_mode:
             tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
@@ -180,7 +182,8 @@ def make_node(
 
             # Get ONNX inference results
             onnx_tensor_infos = None
-            if onnx_tensor_infos_for_validation is not None:
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
                 onnx_tensor_infos = {
                     graph_node_output.name:
                     onnx_tensor_infos_for_validation[graph_node_output.name]

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -5660,7 +5660,8 @@ def acquisition_of_validation_data(
 
     # Get ONNX inference results
     onnx_tensor_infos = {}
-    if onnx_tensor_infos_for_validation is not None:
+    if onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
         onnx_tensor_infos = {
             graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
         }


### PR DESCRIPTION
### 1. Content and background
- `If`
  - Improved conversion stability of subgraphs of `If` operations.
  - https://github.com/onnx/onnx-tensorflow/issues/1056
  - https://github.com/PINTO0309/onnx2tf/releases/download/1.20.7/maskrcnn_resnet50_fpn.onnx

```
onnx2tf \
-i maskrcnn_resnet50_fpn.onnx \
-onimc boxes.55 onnx::Shape_3316 3315 onnx::Loop_3751
```
![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/c68e9cfe-154b-43c2-9c32-5741e885783a)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
