### PR TITLE
Fixed to restore metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U onnxruntime==1.17.1 \
   && pip install -U onnxsim==0.4.33 \
   && pip install -U simple_onnx_processing_tools \
-  && pip install -U sng4onnx==1.0.4 \
+  && pip install -U sne4onnx>=1.0.13 \
+  && pip install -U sng4onnx>=1.0.4 \
   && pip install -U tensorflow==2.16.1 \
   && pip install -U protobuf==3.20.3 \
   && pip install -U onnx2tf \
@@ -321,7 +322,6 @@ or
     && pip install -U onnxruntime==1.17.1 \
     && pip install -U onnxsim==0.4.33 \
     && pip install -U simple_onnx_processing_tools \
-    && pip install -U sng4onnx==1.0.4 \
     && pip install -U onnx2tf \
     && pip install -U protobuf==3.20.3 \
     && pip install -U h5py==3.11.0 \

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.20.9
+  ghcr.io/pinto0309/onnx2tf:1.20.10
 
   or
 
@@ -278,7 +278,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.20.9
+  docker.io/pinto0309/onnx2tf:1.20.10
 
   or
 
@@ -288,6 +288,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U onnxruntime==1.17.1 \
   && pip install -U onnxsim==0.4.33 \
   && pip install -U simple_onnx_processing_tools \
+  && pip install -U sng4onnx==1.0.4 \
   && pip install -U tensorflow==2.16.1 \
   && pip install -U protobuf==3.20.3 \
   && pip install -U onnx2tf \
@@ -320,6 +321,7 @@ or
     && pip install -U onnxruntime==1.17.1 \
     && pip install -U onnxsim==0.4.33 \
     && pip install -U simple_onnx_processing_tools \
+    && pip install -U sng4onnx==1.0.4 \
     && pip install -U onnx2tf \
     && pip install -U protobuf==3.20.3 \
     && pip install -U h5py==3.11.0 \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.20.9'
+__version__ = '1.20.10'

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -3657,6 +3657,10 @@ def dummy_onnx_inference(
     # Separate onnx at specified output_names position
     domain: str = onnx_graph.domain
     ir_version: int = onnx_graph.ir_version
+    meta_data = {'domain': domain, 'ir_version': ir_version}
+    metadata_props = None
+    if hasattr(onnx_graph, 'metadata_props'):
+        metadata_props = onnx_graph.metadata_props
     gs_graph = gs.import_onnx(onnx_graph)
 
     # reduce all axes except batch axis
@@ -3709,7 +3713,9 @@ def dummy_onnx_inference(
                 if node_output.dtype is not None:
                     gs_graph.outputs.append(node_output)
 
-    new_onnx_graph = gs.export_onnx(graph=gs_graph, do_type_check=False, **{'domain': domain, 'ir_version': ir_version})
+    new_onnx_graph = gs.export_onnx(graph=gs_graph, do_type_check=False, **meta_data)
+    if metadata_props is not None:
+        new_onnx_graph.metadata_props.extend(metadata_props)
     tmp_onnx_path = ''
     tmp_onnx_external_weights_path =''
     try:


### PR DESCRIPTION
### 1. Content and background
- YOLOv9, YOLOv8 ONNX
- Fixed to restore metadata
- `pip install -U sng4onnx>=1.0.4 sne4onnx>=1.0.13`
  ![image](https://github.com/PINTO0309/sng4onnx/assets/33194443/ca682e94-ae95-4f03-bd1c-3329243c22c0)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
