### PR TITLE
Bring constant layers unconnected to the model into the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.21.0
+  ghcr.io/pinto0309/onnx2tf:1.21.1
 
   or
 
@@ -278,7 +278,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.21.0
+  docker.io/pinto0309/onnx2tf:1.21.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.21.0'
+__version__ = '1.21.1'


### PR DESCRIPTION
### 1. Content and background
- `Constant`
  - Bring `Constant` layers unconnected to the model into the model.
  - It is assumed that the `-nuo` option is specified because running `onnxsim` will remove constants from the ONNX file.
  - Wrap constants in a `Lambda` layer and force them into the model.
  - [toy_with_constant.onnx.zip](https://github.com/PINTO0309/onnx2tf/files/15292126/toy_with_constant.onnx.zip)
  - Convert test
    ```bash
    onnx2tf -i toy_with_constant.onnx -nuo -cotof
    ```
    |ONNX|TFLite|
    |:-:|:-:|
    |![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/ab2260bd-aa41-4522-ad4b-83567d094edf)|![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/7efc5d4d-ec6f-4b16-8d28-b1389a469df7)|
    
    ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/f8d336f0-e99e-4125-b8f1-bed3960aef7e)

  - Inference test
    ```python
    import tensorflow as tf
    import numpy as np
    from pprint import pprint
    
    interpreter = tf.lite.Interpreter(model_path="saved_model/toy_with_constant_float32.tflite")
    interpreter.allocate_tensors()
    
    input_details = interpreter.get_input_details()
    output_details = interpreter.get_output_details()
    
    interpreter.set_tensor(
        tensor_index=input_details[0]['index'],
        value=np.ones(tuple(input_details[0]['shape']), dtype=np.float32)
    )
    interpreter.invoke()
    
    variable_output = interpreter.get_tensor(output_details[0]['index'])
    constant_output = interpreter.get_tensor(output_details[1]['index'])
    
    print("=================")
    print("Variable Output:")
    pprint(variable_output)
    print("=================")
    print("Constant Output:")
    pprint(constant_output)
    ```
    ```
    =================
    Variable Output:
    array([[-0.02787317, -0.05505124,  0.05421712,  0.03526559, -0.14131774,
             0.0019211 ,  0.08399964,  0.00433664, -0.00984338, -0.03370604]],
          dtype=float32)
    =================
    Constant Output:
    array([1., 2., 3., 4., 5.], dtype=float32)
    ```
  
### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Constant outputs removed from ONNX during conversion #627](https://github.com/PINTO0309/onnx2tf/issues/627)