### PR TITLE
support suppressing flex ops for MatMulInteger

### DIFF
--- a/.github/workflows/test-models.yml
+++ b/.github/workflows/test-models.yml
@@ -106,6 +106,7 @@ jobs:
         pip install onnxruntime==1.17.1
         pip install ml_dtypes==0.3.2
         pip install tf-keras~=2.16
+        pip install flatbuffers>=23.5.26
         pip install -e .
     - name: Download models
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN pip install pip -U \
     && pip install psutil==5.9.5 \
     && pip install onnxruntime==1.17.1 \
     && pip install ml_dtypes==0.3.2 \
-    && pip install tf-keras~=2.16
+    && pip install tf-keras~=2.16 \
+    && pip install flatbuffers>=23.5.26
 
 # Re-release flatc with some customizations of our own to address
 # the lack of arithmetic precision of the quantization parameters

--- a/README.md
+++ b/README.md
@@ -1350,6 +1350,9 @@ optional arguments:
     Therefore, it is strongly discouraged to use it on large models of hundreds
     of megabytes or more.
 
+  -odrqt, --output_dynamic_range_quantized_tflite
+    Output of dynamic range quantized tflite.
+
   -oiqt, --output_integer_quantized_tflite
     Output of integer quantized tflite.
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.21.1
+  ghcr.io/pinto0309/onnx2tf:1.21.2
 
   or
 
@@ -278,7 +278,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.21.1
+  docker.io/pinto0309/onnx2tf:1.21.2
 
   or
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.21.3
+  ghcr.io/pinto0309/onnx2tf:1.21.4
 
   or
 
@@ -279,7 +279,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.21.3
+  docker.io/pinto0309/onnx2tf:1.21.4
 
   or
 

--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ onnx2tf -i emotion-ferplus-8.onnx -oiqt -qt per-tensor
 onnx2tf -i resnet18-v1-7.onnx -onimc resnetv15_stage2_conv1_fwd resnetv15_stage2_conv2_fwd
 
 # Suppress generation of Flex OP and replace with Pseudo-Function
-# [Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU]
+# [Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU, MatMulInteger]
 # Below is a sample of replacing Erf with another set of operations.
 wget https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_readme/Erf_11.onnx
 onnx2tf -i Erf_11.onnx -rtpo Erf
@@ -1596,7 +1596,7 @@ optional arguments:
     Replace list of operators to pseudo operators.
     Full name of the target operators should be given.
     Currently supported operators :
-    Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU
+    Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU, MatMulInteger
 
   -me, --mvn_epsilon
     For MeanVarianceNormalization.
@@ -2069,7 +2069,7 @@ convert(
       Replace list of operators to pseudo operators.
       Full name of the target operators should be given.
       Currently supported operators :
-      Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU
+      Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU, MatMulInteger
 
     mvn_epsilon: Optional[float]
       For MeanVarianceNormalization.

--- a/README.md
+++ b/README.md
@@ -1149,7 +1149,7 @@ onnx2tf -i sjy_fused_static_spo.onnx
 ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/35adb529-58cc-4f10-96b3-f6ecf4f31db1)
 
 ### 16. Add constant outputs to the model that are not connected to the model body
-Sometimes you want to always output constants that are not connected to the model body.　See: [https://github.com/PINTO0309/onnx2tf/issues/627](https://github.com/PINTO0309/onnx2tf/issues/627). For example, in the case of ONNX as shown in the figure below. For example, you may want to keep scaling parameters and other parameters as fixed values inside the model and always include the same value in the output.
+Sometimes you want to always output constants that are not connected to the model body. See: [https://github.com/PINTO0309/onnx2tf/issues/627](https://github.com/PINTO0309/onnx2tf/issues/627). For example, in the case of ONNX as shown in the figure below. You may want to keep scaling parameters and other parameters as fixed values inside the model and always include the same value in the output.
 
 ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/38080d00-8048-4a2e-8df4-90378487cebc)
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - psutil==5.9.5
 - ml_dtypes==0.3.2
 - flatbuffers-compiler (Optional, Only when using the `-coion` option. Executable file named `flatc`.)
+- flatbuffers>=23.5.26
   ```bash
   # Custom flatc v23.5.26 binary for Ubuntu 20.04+
   # https://github.com/PINTO0309/onnx2tf/issues/196
@@ -270,7 +271,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.21.2
+  ghcr.io/pinto0309/onnx2tf:1.21.3
 
   or
 
@@ -278,7 +279,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.21.2
+  docker.io/pinto0309/onnx2tf:1.21.3
 
   or
 
@@ -296,7 +297,8 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   && pip install -U h5py==3.11.0 \
   && pip install -U psutil==5.9.5 \
   && pip install -U ml_dtypes==0.3.2 \
-  && pip install -U tf-keras~=2.16
+  && pip install -U tf-keras~=2.16 \
+  && pip install flatbuffers>=23.5.26
 
   or
 
@@ -327,7 +329,8 @@ or
     && pip install -U h5py==3.11.0 \
     && pip install -U psutil==5.9.5 \
     && pip install -U ml_dtypes==0.3.2 \
-    && pip install -U tf-keras~=2.16
+    && pip install -U tf-keras~=2.16 \
+    && pip install flatbuffers>=23.5.26
   ```
 
 ### 2. Run test

--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,7 @@ usage: onnx2tf
 [-otfv1pb]
 [-ow]
 [-coion]
+[-odrqt]
 [-oiqt]
 [-qt {per-channel,per-tensor}]
 [-cind INPUT_NAME NUMPY_FILE_PATH MEAN STD]

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.21.3'
+__version__ = '1.21.4'

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.21.1'
+__version__ = '1.21.2'

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.21.2'
+__version__ = '1.21.3'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -382,7 +382,7 @@ def convert(
         Replace list of operators to pseudo operators. \n
         Full name of the target operators should be given. \n
         Currently supported operators : \n
-        Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU
+        Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU, MatMulInteger
 
     mvn_epsilon: Optional[float]
         For MeanVarianceNormalization.\n
@@ -2223,7 +2223,7 @@ def main():
             'Replace list of operators to pseudo operators. \n ' +
             'Full name of the target operators should be given. \n ' +
             'Currently supported operators : \n' +
-            'Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU'
+            'Asin, Acos, Atan, Abs, PReLU, LeakyReLU, Power, GatherND, Neg, HardSwish, Erf, GeLU, MatMulInteger'
     )
     parser.add_argument(
         '-me',

--- a/onnx2tf/ops/GatherElements.py
+++ b/onnx2tf/ops/GatherElements.py
@@ -1,8 +1,12 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_constant_or_variable,
@@ -15,7 +19,11 @@ from onnx2tf.utils.common_functions import (
     pre_process_transpose,
     post_process_transpose,
     transpose_with_flexing_deterrence,
+    get_tf_model_inputs,
+    dummy_tf_inference,
+    onnx_tf_tensor_validation,
 )
+from typing import List, Dict, Any
 
 
 @print_node_info
@@ -85,6 +93,11 @@ def make_node(
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
 
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
@@ -105,51 +118,244 @@ def make_node(
         indices=indices_tensor,
     )
 
-    if axis == 0:
-        axis_perm = tf.range(tf.rank(input_tensor))
-        data_swaped = input_tensor
-        index_swaped = indices_tensor
-    else:
-        axis_perm = tf.tensor_scatter_nd_update(
-            tf.range(tf.rank(input_tensor)),
-            tf.constant([[0], [axis]]),
-            tf.constant([axis, 0])
-        )
-        data_swaped = transpose_with_flexing_deterrence(
-            input_tensor=input_tensor,
-            perm=axis_perm,
-            **kwargs,
-        )
-        index_swaped = transpose_with_flexing_deterrence(
-            input_tensor=indices_tensor,
-            perm=axis_perm,
-            **kwargs,
-        )
+    def define_gather_elements(axis: int, target_tensor, target_indices):
+        if axis == 0:
+            axis_perm = tf.range(tf.rank(target_tensor))
+            data_swaped = target_tensor
+            index_swaped = target_indices
+        else:
+            axis_perm = tf.tensor_scatter_nd_update(
+                tf.range(tf.rank(target_tensor)),
+                tf.constant([[0], [axis]]),
+                tf.constant([axis, 0])
+            )
+            data_swaped = transpose_with_flexing_deterrence(
+                input_tensor=target_tensor,
+                perm=axis_perm,
+                **kwargs,
+            )
+            index_swaped = transpose_with_flexing_deterrence(
+                input_tensor=target_indices,
+                perm=axis_perm,
+                **kwargs,
+            )
 
-    idx_tensors_per_axis = [
-        tf.range(tf.shape(index_swaped, index_swaped.dtype)[i]) \
-            for i in range(index_swaped.shape.rank)
-    ]
+        idx_tensors_per_axis = [
+            tf.range(tf.shape(index_swaped, index_swaped.dtype)[i]) \
+                for i in range(index_swaped.shape.rank)
+        ]
 
-    idx_tensors_per_axis = tf.meshgrid(
-        *idx_tensors_per_axis,
-        indexing='ij',
-    )
-    idx_tensors_per_axis[0] = index_swaped
-    dim_expanded_idx_tensors_per_axis = [
-        tf.expand_dims(idx_tensor, axis=-1)
-        for idx_tensor in idx_tensors_per_axis
-    ]
-    index_expanded = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+        idx_tensors_per_axis = tf.meshgrid(
+            *idx_tensors_per_axis,
+            indexing='ij',
+        )
+        idx_tensors_per_axis[0] = index_swaped
+        dim_expanded_idx_tensors_per_axis = [
+            tf.expand_dims(idx_tensor, axis=-1)
+            for idx_tensor in idx_tensors_per_axis
+        ]
+        index_expanded = tf.concat(dim_expanded_idx_tensors_per_axis, axis=-1)
+        gathered = tf.gather_nd(data_swaped, index_expanded)
+        transposed = \
+            transpose_with_flexing_deterrence(
+                input_tensor=gathered,
+                perm=axis_perm,
+                **kwargs,
+            )
+        return transposed
 
-    gathered = tf.gather_nd(data_swaped, index_expanded)
+    # Workaround to special patterns with wrong transposition when all axes except batch size have the same value.
+    # Examine which combination of axis configurations reduces the error in output values the most,
+    # and apply the transposition with the best performance.
+    # https://github.com/PINTO0309/onnx2tf/issues/629
+    # convnext-det.onnx
+    graph_node_input_1_shape = graph_node_input_1.shape
+    graph_node_input_2_shape = graph_node_input_2.shape
+    if graph_node_input_1_shape is not None \
+        and graph_node_input_2_shape is not None \
+        and len(graph_node_input_1_shape) >= 3 \
+        and len(graph_node_input_2_shape) >= 2 \
+        and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_1_shape]) == 0 \
+        and sum([1 if isinstance(s, str) else 0 for s in graph_node_input_2_shape]) == 0:
+
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(
+                tf_layers_dict=tf_layers_dict,
+            )
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf_keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                        indices_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        #   Get the output tensor of the previous layer of MatMul
+        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except Exception as ex:
+                pass
+            del val_model
+
+        # Get np.ndarray for validation
+        validation_data_1 = None
+        validation_data_2 = None
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 2:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data_1 = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data_1 = copy.deepcopy(input_tensor)
+                if not isinstance(indices_tensor, np.ndarray):
+                    validation_data_2 = list(tf_pre_tensor_infos.values())[1]
+                else:
+                    validation_data_2 = copy.deepcopy(indices_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+        # ONNX   : N,C,W
+        # TF     : N,W,C
+        # TF-axes: [1]
+        #
+        # ONNX: N,C,H,W
+        # TF  : N,H,W,C
+        # TF-axes: [1,2]
+        #
+        # ONNX: N,C,D,H,W
+        # TF  : N,D,H,W,C
+        # TF-axes: [1,2,3]
+
+        # Automatic correction of accuracy degradation
+        min_abs_err = sys.maxsize
+        indices_tensor_rank = len(graph_node_input_2_shape)
+        min_abs_err_perm_2: List[int] = [idx for idx in range(indices_tensor_rank)]
+
+        if not disable_strict_mode:
+            if onnx_tensor_infos is not None \
+                and validation_data_1 is not None \
+                and validation_data_2 is not None:
+
+                tensor_2_candidate_for_transpositions = list(itertools.permutations(range(indices_tensor_rank)))
+                # Search for the axis with the smallest error
+                for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
+                    try:
+                        target_validation_data_1 = validation_data_1
+                        target_validation_data_2 = validation_data_2
+                        # Build TF dummy model
+                        input_1 = tf_keras.Input(
+                            shape=validation_data_1.shape[1:],
+                            batch_size=validation_data_1.shape[0] \
+                                if isinstance(validation_data_1.shape[0], int) else None,
+                            name='dummy_input_1',
+                            dtype=validation_data_1.dtype,
+                        )
+                        input_2 = tf_keras.Input(
+                            shape=validation_data_2.shape[1:],
+                            batch_size=validation_data_2.shape[0] \
+                                if isinstance(validation_data_2.shape[0], int) else None,
+                            name='dummy_input_2',
+                            dtype=validation_data_2.dtype,
+                        )
+                        val_model = tf_keras.Model(
+                            inputs=[
+                                input_1,
+                                input_2,
+                            ],
+                            outputs=[
+                                define_gather_elements(
+                                    axis=axis,
+                                    target_tensor=input_1,
+                                    target_indices=tf.transpose(a=input_2, perm=tensor_2_candidate_for_transposition),
+                                )
+                            ],
+                        )
+                        # TF dummy inference
+                        tf_tensor_infos: Dict[Any] = \
+                            dummy_tf_inference(
+                                model=val_model,
+                                inputs=[
+                                    input_1,
+                                    input_2,
+                                ],
+                                verification_datas=[
+                                    target_validation_data_1,
+                                    target_validation_data_2,
+                                ],
+                            )
+                        del input_1
+                        del input_2
+                        del val_model
+
+                        # Validation
+                        onnx_tf_output_pairs = {
+                            (oi[0], ti[0]): (oi[1], ti[1]) \
+                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                        }
+                        """
+                        check_results: Dict[str, List[np.ndarray, int, float|int]]
+                            {
+                                onnx_output_name: [
+                                    onnx_tensor,
+                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                    max_abs_err,
+                                ]
+                            }
+                        """
+                        check_results = \
+                            onnx_tf_tensor_validation(
+                                output_pairs=onnx_tf_output_pairs,
+                                rtol=0.0,
+                                atol=0.0,
+                            )
+                        result_err = sum([val[2] for val in check_results.values()])
+                        if result_err < min_abs_err:
+                            min_abs_err = result_err
+                            min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
+                            if min_abs_err < 1e-3:
+                                break
+                    except Exception as ex:
+                        pass
+
+                transposed_tensor_shape = list(tf.transpose(a=indices_tensor, perm=min_abs_err_perm_2).shape)
+                indices_tensor = \
+                    transpose_with_flexing_deterrence(
+                        input_tensor=indices_tensor,
+                        perm=min_abs_err_perm_2,
+                        output_shape=transposed_tensor_shape \
+                            if None not in transposed_tensor_shape and transposed_tensor_shape != [] else None,
+                        **kwargs,
+                    )
 
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        transpose_with_flexing_deterrence(
-            input_tensor=gathered,
-            perm=axis_perm,
-            **kwargs,
+        define_gather_elements(
+            axis=axis,
+            target_tensor=input_tensor,
+            target_indices=indices_tensor,
         )
+
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(


### PR DESCRIPTION
### 1. Content and background
Currently, MatMulInteger is implemented as tf matmul with int32 inputs/outputs, which leads to generation of Flex(Batch)MatMul ops.

### 2. Summary of corrections
When `-rtpo MatMulInteger` is specified, inputs of MatMulInteger are casted to float32 instead, allowing the node to be converted to the builtin FullyConnected or BatchMatMul ops.

### 3. Before/After (If there is an operating log that can be used as a reference)
ONNX input:
![image](https://github.com/PINTO0309/onnx2tf/assets/25856103/25c91c62-1b3e-4ca4-b541-1cd59db7f39b)

Before:
![Screenshot_20240517_202911](https://github.com/PINTO0309/onnx2tf/assets/25856103/dbb7386f-f650-4803-873e-d1517bde445e)

After:
![image](https://github.com/PINTO0309/onnx2tf/assets/25856103/caaf48b0-8385-47c0-a134-5e21d0644df0)

### 4. Issue number (only if there is a related issue)
