### PR TITLE
Add arm64 docker image

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,11 +38,17 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false  # do not cancel even if any platform fails.
+      matrix:
+        platform: [linux/amd64,linux/arm64]
     steps:
       - name: Git checkout
         uses: actions/checkout@v3
       - name: Enable buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
@@ -59,6 +65,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta_gh.outputs.tags }}
           labels: ${{ steps.meta_gh.outputs.labels }}
@@ -78,6 +85,7 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
+          platforms: ${{ matrix.platform }}
           push: true
           tags: ${{ steps.meta_dh.outputs.tags }}
           labels: ${{ steps.meta_dh.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update \
     && apt-get install -y \
         nano python3-pip python3-mock libpython3-dev \
         libpython3-all-dev python-is-python3 wget curl cmake \
-        software-properties-common sudo \
+        software-properties-common sudo pkg-config libhdf5-dev \
     && sed -i 's/# set linenumbers/set linenumbers/g' /etc/nanorc \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### 1. Content and background

Distributed docker image is not compatible with ARM environments such as Apple Silicon Mac.
Although Docker offers emulation for x86/amd64 environments,  onnx2tf within this emulation mode results in an error, as shown below:

```bash
$ root@39d07181ce27:/# onnx2tf -h
> Illegal instruction
```
This issue is suspected to be caused by the dependency of PyPI TensorFlow on x86-specific instruction sets.

To address this,
 I've augmented the release process with GitHub Actions to include building and pushing Docker images for Arm64 architecture. This make it possible to execute onnx2tf with docker on Arm64 hosts.

### 2. Summary of corrections
- Update Dockerfile
  - Extra dependencies (pkg-config and libhdf5-dev) are required to install h5py for arm64 docker build.
- Add Arm64 build and push in GitHub Actions
  - Referenced the following URL for guidance: https://docs.docker.com/build/ci/github-actions/multi-platform/

New workflow is tested on my repo, built and push successfully. Also I checked some test command can work on it.
My test workflow: https://github.com/ysohma/onnx2tf/actions/runs/9138403803

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
