### PR TITLE
Implemented the ability to forcibly estimate the shape of `com.microsoft v1` modules for which `onnx.shape_inference.infer_shapes(x)` does not work correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras forma
   import torch
   import torchvision
   import ai_edge_torch
-  
+
   # Use resnet18 with pre-trained weights.
   resnet18 = torchvision.models.resnet18(torchvision.models.ResNet18_Weights.IMAGENET1K_V1)
   sample_inputs = (torch.randn(1, 3, 224, 224),)
-  
+
   # Convert and serialize PyTorch model to a tflite flatbuffer. Note that we
   # are setting the model to evaluation mode prior to conversion.
   edge_model = ai_edge_torch.convert(resnet18.eval(), sample_inputs)
@@ -38,7 +38,7 @@ Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras forma
 - Google for Developers Blog MAY 14, 2024 - AI Edge Torch: High Performance Inference of PyTorch Models on Mobile Devices
 
   https://developers.googleblog.com/en/ai-edge-torch-high-performance-inference-of-pytorch-models-on-mobile-devices/
-  
+
 - Considering the compatibility of Pythonic code with TensorFlow/Keras/TFLite and the beauty of the conversion workflow, [nobuco](https://github.com/AlexanderLutsenko/nobuco) is the most optimal choice going forward.
 - The role of `onnx2tf` will end within the next one to two years. I don't intend to stop the maintenance of `onnx2tf` itself anytime soon, but I will continue to maintain it little by little as long as there is demand for it from everyone. The end of `onnx2tf` will be when `TensorRT` and other runtimes support porting from FX Graph based models.
 
@@ -293,7 +293,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.22.3
+  ghcr.io/pinto0309/onnx2tf:1.22.4
 
   or
 
@@ -301,7 +301,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.22.3
+  docker.io/pinto0309/onnx2tf:1.22.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.22.3'
+__version__ = '1.22.4'

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -242,6 +242,7 @@ def make_node(
         if pads_axes_opposite_same \
             and input_tensor_rank >=2 \
             and graph_node.inputs[0].shape is not None \
+            and output_tensor_shape is not None \
             and graph_node.inputs[0].shape[2:] == output_tensor_shape[2:]:
             pad_mode = "SAME"
         elif pads != [0, 0] * spatial_size:

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -252,7 +252,9 @@ def make_node(
             sizes = sizes.set_shape(input_tensor_shape.shape)
             new_size = tf.cast(sizes[1:input_tensor_rank-1], tf.int32)
         elif isinstance(sizes, np.ndarray):
-            new_size = tf.cast(sizes[1:input_tensor_rank-1], tf.int32)
+            new_size = tf.cast(tf.convert_to_tensor(sizes[1:input_tensor_rank-1]), tf.int32)
+        elif hasattr(sizes, 'numpy'):
+            new_size = tf.cast(tf.convert_to_tensor(sizes.numpy()[1:input_tensor_rank-1]), tf.int32)
         elif tf_keras.backend.is_keras_tensor(sizes) and len(sizes.shape) > 1:
             new_size = tf.cast(tf.slice(sizes, [1], [input_tensor_rank-2]), tf.int32)
         elif tf_keras.backend.is_keras_tensor(sizes) and len(sizes.shape) == 1 and sizes.shape[0] == 2:
@@ -304,6 +306,7 @@ def make_node(
     if hasattr(new_size, '_inferred_value'):
         new_size_values = new_size._inferred_value
         if (new_size_values is None or new_size_values.count(None) == len(new_size_values)) \
+            and graph_node_output.shape is not None \
             and sum([1 if isinstance(s, str) else 0 for s in graph_node_output.shape[1:input_tensor_rank-1]]) == 0:
             tensor_rank = len(graph_node_output.shape)
             convertion_table = [0] + [i for i in range(2, tensor_rank)] + [1]


### PR DESCRIPTION
### 1. Content and background
1. Implemented the ability to forcibly estimate the shape of `com.microsoft v1` modules for which `onnx.shape_inference.infer_shapes(x)` does not work correctly. e.g. `FusedConv`
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/13d4dc63-e4a1-4d07-87f3-1659a0d1e581)
2. Added optimization process for some patterns of `Resize` operations like garbage. (Not perfect, but only for a very few edge cases)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/d8cafccb-6b50-4da1-9ab5-bcfb1612a9bf)

- ONNX
  [lm_model4_opt.onnx.zip](https://github.com/user-attachments/files/15510495/lm_model4_opt.onnx.zip)
- TFLite
  [lm_model4_opt_float32.tflite.zip](https://github.com/user-attachments/files/15513626/lm_model4_opt_float32.tflite.zip)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/1f10103a-b9e7-40dc-97b2-95b6b98a61bb)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [FusedConv error #643](https://github.com/PINTO0309/onnx2tf/issues/643)