### PR TITLE
Workaround to the problem of TensorFlow corrupting the FlatBuffer input/output order during INT8 quantization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.22.4
+  ghcr.io/pinto0309/onnx2tf:1.22.5
 
   or
 
@@ -301,7 +301,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.22.4
+  docker.io/pinto0309/onnx2tf:1.22.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.22.4'
+__version__ = '1.22.5'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -856,6 +856,12 @@ def convert(
         onnx_graph_output_names: List[str] = [
             outputop.name for outputop in graph.outputs
         ]
+        onnx_graph_input_shapes: List[List[int | str]] = [
+            inputop.shape for inputop in graph.inputs
+        ]
+        onnx_graph_output_shapes: List[List[int | str]] = [
+            outputop.shape for outputop in graph.outputs
+        ]
 
         # Inputs
         for graph_input in graph.inputs:
@@ -1298,6 +1304,8 @@ def convert(
                 tflite_file_name=f'{output_file_name}_float32.tflite',
                 onnx_input_names=onnx_graph_input_names,
                 onnx_output_names=onnx_graph_output_names,
+                onnx_graph_input_shapes=onnx_graph_input_shapes,
+                onnx_graph_output_shapes=onnx_graph_output_shapes,
             )
         if output_weights:
             weights_export(
@@ -1325,6 +1333,8 @@ def convert(
                 tflite_file_name=f'{output_file_name}_float16.tflite',
                 onnx_input_names=onnx_graph_input_names,
                 onnx_output_names=onnx_graph_output_names,
+                onnx_graph_input_shapes=onnx_graph_input_shapes,
+                onnx_graph_output_shapes=onnx_graph_output_shapes,
             )
         if output_weights:
             weights_export(
@@ -1372,6 +1382,8 @@ def convert(
                         tflite_file_name=f'{output_file_name}_dynamic_range_quant.tflite',
                         onnx_input_names=onnx_graph_input_names,
                         onnx_output_names=onnx_graph_output_names,
+                        onnx_graph_input_shapes=onnx_graph_input_shapes,
+                        onnx_graph_output_shapes=onnx_graph_output_shapes,
                     )
                 if output_weights:
                     weights_export(
@@ -1501,6 +1513,8 @@ def convert(
                         tflite_file_name=f'{output_file_name}_integer_quant.tflite',
                         onnx_input_names=onnx_graph_input_names,
                         onnx_output_names=onnx_graph_output_names,
+                        onnx_graph_input_shapes=onnx_graph_input_shapes,
+                        onnx_graph_output_shapes=onnx_graph_output_shapes,
                     )
                 if output_weights:
                     weights_export(
@@ -1536,6 +1550,8 @@ def convert(
                         tflite_file_name=f'{output_file_name}_full_integer_quant.tflite',
                         onnx_input_names=onnx_graph_input_names,
                         onnx_output_names=onnx_graph_output_names,
+                        onnx_graph_input_shapes=onnx_graph_input_shapes,
+                        onnx_graph_output_shapes=onnx_graph_output_shapes,
                     )
                 if output_weights:
                     weights_export(
@@ -1572,6 +1588,8 @@ def convert(
                         tflite_file_name=f'{output_file_name}_integer_quant_with_int16_act.tflite',
                         onnx_input_names=onnx_graph_input_names,
                         onnx_output_names=onnx_graph_output_names,
+                        onnx_graph_input_shapes=onnx_graph_input_shapes,
+                        onnx_graph_output_shapes=onnx_graph_output_shapes,
                     )
                 info(Color.GREEN(f'INT8 Quantization with int16 activations tflite output complete!'))
             except RuntimeError as ex:
@@ -1603,6 +1621,8 @@ def convert(
                         tflite_file_name=f'{output_file_name}_full_integer_quant_with_int16_act.tflite',
                         onnx_input_names=onnx_graph_input_names,
                         onnx_output_names=onnx_graph_output_names,
+                        onnx_graph_input_shapes=onnx_graph_input_shapes,
+                        onnx_graph_output_shapes=onnx_graph_output_shapes,
                     )
                 info(Color.GREEN(f'Full INT8 Quantization with int16 activations tflite output complete!'))
             except RuntimeError as ex:


### PR DESCRIPTION
### 1. Content and background
- Workaround to the problem of TensorFlow corrupting the FlatBuffer input/output order during INT8 quantization.
- Determination of the number of inputs/outputs of the same shape.
- Correct name discrepancies based on shape if multiple inputs/outputs shapes do not overlap.
- However, if there are inputs/outputs containing undefined dimensions, workaround is skipped because correction is not possible.

  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/4c7fe29f-655f-4953-b5b6-f1ee40161d0f)

  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/2452ee4a-fb7f-4d10-b903-2f7975a8cd24)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Input and Output Name Order Swapping with -coion option #650](https://github.com/PINTO0309/onnx2tf/issues/650)