### PR TITLE
Generation of `saved_model` with `GroupConvolution` and Full Integer Quantization without `--dgc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.22.6
+  ghcr.io/pinto0309/onnx2tf:1.23.0
 
   or
 
@@ -301,7 +301,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.22.6
+  docker.io/pinto0309/onnx2tf:1.23.0
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.22.6'
+__version__ = '1.23.0'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1421,7 +1421,7 @@ def convert(
             output_dtypes = [v.dtype for v in loaded_saved_model.structured_outputs.values()]
 
             print('')
-            info(Color.BLUE(f'Input signature information for quantization'))
+            info(Color.BLUE(f'Signature information for quantization'))
             info(Color.BLUE(f'signature_name') + f': {SIGNATURE_KEY}')
             for idx, (input_key, input_shape, input_dtype) in enumerate(zip(input_keys, input_shapes, input_dtypes)):
                 info(


### PR DESCRIPTION
### 1. Content and background
- Generation of `saved_model` with `GroupConvolution` and Full Integer Quantization without `-dgc`, `-osd`.
- Improved stability of Full Integer Quantization.
- YOLOv9 with `GroupConvolution` + `Dynamic Input [1, None, None, 3]`
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/adca768b-9d76-460a-8f72-df010b101048)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/3ae8309d-eee9-42a8-94a4-71ed09a42bd8)
  ![image](https://github.com/PINTO0309/onnx2tf/assets/33194443/551c33c5-a892-446c-8f5f-db7278a63d9c)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
