### PR TITLE
Fix arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,15 +37,18 @@ RUN wget https://github.com/PINTO0309/onnx2tf/releases/download/1.16.31/flatc.ta
     && mv flatc /usr/bin/
 
 ENV USERNAME=user
+ARG WKDIR=/workdir
+
 RUN echo "root:root" | chpasswd \
     && adduser --disabled-password --gecos "" "${USERNAME}" \
     && echo "${USERNAME}:${USERNAME}" | chpasswd \
     && echo "%${USERNAME}    ALL=(ALL)   NOPASSWD:    ALL" >> /etc/sudoers.d/${USERNAME} \
-    && chmod 0440 /etc/sudoers.d/${USERNAME}
+    && chmod 0440 /etc/sudoers.d/${USERNAME} \
+    && mkdir -p ${WKDIR} \
+    && chown ${USERNAME}:${USERNAME} ${WKDIR}
+
 USER ${USERNAME}
-ARG WKDIR=/workdir
 WORKDIR ${WKDIR}
-RUN sudo chown ${USERNAME}:${USERNAME} ${WKDIR}
 
 RUN echo 'export CUDA_VISIBLE_DEVICES=-1' >> ${HOME}/.bashrc \
     && echo 'export TF_CPP_MIN_LOG_LEVEL=3' >> ${HOME}/.bashrc

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.23.0
+  ghcr.io/pinto0309/onnx2tf:1.23.1
 
   or
 
@@ -301,7 +301,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.23.0
+  docker.io/pinto0309/onnx2tf:1.23.1
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.23.0'
+__version__ = '1.23.1'


### PR DESCRIPTION
### 1. Content and background
- Fix arm64 test

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[CI] GitHub Actions fails to build ARM64/aarch64 docker image #653](https://github.com/PINTO0309/onnx2tf/issues/653)
- [Error when without -dgc: onnx2tf.py -i shufflenet-9.onnx -oiqt #657](https://github.com/PINTO0309/onnx2tf/issues/657)