### PR TITLE
Disable arm64/aarch64 containers and fix `-GroupConvolution` conversion bug on `-osd` and `-oiqt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.23.2
+  ghcr.io/pinto0309/onnx2tf:1.23.3
 
   or
 
@@ -301,7 +301,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.23.2
+  docker.io/pinto0309/onnx2tf:1.23.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.23.2'
+__version__ = '1.23.3'


### PR DESCRIPTION
### 1. Content and background
1. Disable arm64/aarch64 containers
2. Fix `-GroupConvolution` conversion bug on `-osd` and `-oiqt`.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Error when without -dgc: onnx2tf.py -i shufflenet-9.onnx -oiqt #657](https://github.com/PINTO0309/onnx2tf/issues/657)
- [[CI] GitHub Actions fails to build ARM64/aarch64 docker image #653](https://github.com/PINTO0309/onnx2tf/issues/653)