### PR TITLE
Improvements to `ScatterND`, `Transpose` -> `Softmax` -> `Transpose` combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.2
+  ghcr.io/pinto0309/onnx2tf:1.25.3
 
   or
 
@@ -305,7 +305,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.2
+  docker.io/pinto0309/onnx2tf:1.25.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.2'
+__version__ = '1.25.3'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1970,6 +1970,7 @@ def main():
         '-osd',
         '--output_signaturedefs',
         action='store_true',
+        default=True,
         help=\
             'Signature is added to the output for serving or for conversion \n' +
             'to other model formats. However, this can significantly reduce the speed \n' +

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -106,6 +106,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -106,6 +106,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceLogSum.py
+++ b/onnx2tf/ops/ReduceLogSum.py
@@ -106,6 +106,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceLogSumExp.py
+++ b/onnx2tf/ops/ReduceLogSumExp.py
@@ -106,6 +106,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceMax.py
+++ b/onnx2tf/ops/ReduceMax.py
@@ -113,6 +113,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceMean.py
+++ b/onnx2tf/ops/ReduceMean.py
@@ -107,6 +107,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceMin.py
+++ b/onnx2tf/ops/ReduceMin.py
@@ -107,6 +107,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceProd.py
+++ b/onnx2tf/ops/ReduceProd.py
@@ -107,6 +107,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceSum.py
+++ b/onnx2tf/ops/ReduceSum.py
@@ -106,6 +106,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/ReduceSumSquare.py
+++ b/onnx2tf/ops/ReduceSumSquare.py
@@ -107,6 +107,9 @@ def make_node(
         'optype': graph_node.op,
         'shape': onnx_output_shape,
         'dtype': dtype,
+        'nhwc': tf_layers_dict[graph_node_input_1.name]['nhwc'] \
+            if isinstance(graph_node_input_1, gs.Variable) \
+                and 'nhwc' in tf_layers_dict[graph_node_input_1.name].keys() else False
     }
 
     onnx_tensor_infos_for_validation: Dict[str:np.ndarray] = kwargs['onnx_tensor_infos_for_validation']

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -166,6 +166,10 @@ def make_node(
     elif isinstance(graph_node_input, gs.Variable) \
         and 'nhwc' in tf_layers_dict[graph_node_input.name].keys():
         nhwc = tf_layers_dict[graph_node_input.name]['nhwc']
+        if nhwc and perm == [i for i in range(len(input_tensor_shape))]:
+            nhwc = True
+        else:
+            nhwc = False
     else:
         nhwc = False
 

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -160,10 +160,20 @@ def make_node(
                     perm = new_perm
 
     # Preserving Graph Structure (Dict)
+    nwhc = False
+    if nwc_nhwc_ndhwc_keep:
+        nhwc = True
+    elif isinstance(graph_node_input, gs.Variable) \
+        and 'nhwc' in tf_layers_dict[graph_node_input.name].keys():
+        nhwc = tf_layers_dict[graph_node_input.name]['nhwc']
+    else:
+        nhwc = False
+
     tf_layers_dict[graph_node_output.name] = {
         'optype': graph_node.op,
         'shape': output_shape,
         'dtype': dtype,
+        'nhwc': nhwc,
         'nwc_nhwc_ndhwc_keep': nwc_nhwc_ndhwc_keep,
     }
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -2185,7 +2185,7 @@ def process_neg_idx(
             and not isinstance(indices_shape[-1], np.ndarray) \
             and not isinstance(indices_shape[-1], tf.Tensor) \
             and tf_keras.backend.is_keras_tensor(indices_shape[-1]):
-            if data_shape != tf.TensorShape([None]):
+            if tf.TensorShape(None) not in data_shape :
                 max_i = tf.cast(
                     tf.strided_slice(
                         input_=data_shape,


### PR DESCRIPTION
### 1. Content and background
- Improvements to `ScatterND`.
- Improved conversion stability for `Transpose` -> `Softmax` -> `Transpose` combinations.
- Improved error message regarding OP name error when `GroupConvolution` is included.

  ![image](https://github.com/user-attachments/assets/df0af652-a984-4529-932f-b394486745f4)

  ```
  ERROR: Generation of saved_model failed because the OP name does not match the following pattern. ^[A-Za-z0-9.][A-Za-z0-9_.\\/>-]*$
  ERROR: /model.22/cv2.2/cv2.2.2/Conv/kernel
  ERROR: Please convert again with the `-osd` or `--output_signaturedefs` option.
  ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
