### PR TITLE
Addition of automatic INT8 calibration process for RGBA 4-channel images

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.3
+  ghcr.io/pinto0309/onnx2tf:1.25.4
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.3
+  docker.io/pinto0309/onnx2tf:1.25.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.3'
+__version__ = '1.25.4'


### PR DESCRIPTION
### 1. Content and background
- Addition of automatic INT8 calibration process for RGBA 4-channel images.
- It should be noted that the MS-COCO image set does not include an alpha channel, so this auto-calibration does not allow for decent quantization.
- There is no correlation between the channel being 4 and the input data being an image. Therefore, if the model to be converted is data other than a 4-channel image, automatic calibration should not be used.
  - The following means and standard deviations are used as fixed values.
    ```python
    mean = np.asarray([[[[0.485, 0.456, 0.406, 0.000]]]], dtype=np.float32)
    std = np.asarray([[[[0.229, 0.224, 0.225, 1.000]]]], dtype=np.float32)
    ```
  - Also, use a fixed value of 0.5 for the alpha channel of the calibration data.
    ```python
    new_element_array = np.full((*calib_data.shape[:-1], 1), 0.500, dtype=np.float32)
    ```
- [magic_touch.onnx.zip](https://github.com/user-attachments/files/16257725/magic_touch.onnx.zip)
  ![image](https://github.com/user-attachments/assets/530d796c-78aa-45c8-8501-0db7f6524551)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[TODO] Add 4 channels of image data to the sample data for quantization #411](https://github.com/PINTO0309/onnx2tf/issues/411)