### PR TITLE
Fixed NHWC flag judgment bug in Transpose of ViT for 3D tensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.4
+  ghcr.io/pinto0309/onnx2tf:1.25.5
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.4
+  docker.io/pinto0309/onnx2tf:1.25.5
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.4'
+__version__ = '1.25.5'

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -166,7 +166,7 @@ def make_node(
     elif isinstance(graph_node_input, gs.Variable) \
         and 'nhwc' in tf_layers_dict[graph_node_input.name].keys():
         nhwc = tf_layers_dict[graph_node_input.name]['nhwc']
-        if nhwc and perm == [i for i in range(len(input_tensor_shape))]:
+        if nhwc and not before_op_output_shape_trans and perm == [i for i in range(len(input_tensor_shape))]:
             nhwc = True
         else:
             nhwc = False


### PR DESCRIPTION
### 1. Content and background
- `Transpose`
  - Fixed NHWC flag judgment bug in `Transpose` of ViT for 3D tensor

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
