### PR TITLE
Automatic accuracy compensation `Expand`, `BatchNormalization`, `Gather`

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.6
+  ghcr.io/pinto0309/onnx2tf:1.25.7
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.6
+  docker.io/pinto0309/onnx2tf:1.25.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.6'
+__version__ = '1.25.7'

--- a/onnx2tf/ops/AveragePool.py
+++ b/onnx2tf/ops/AveragePool.py
@@ -268,11 +268,14 @@ def make_node(
             [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
             [[0, 0]]
 
-        padded_tensor = tf.pad(
-            tensor=input_tensor,
-            paddings=tf_pads,
-            mode='CONSTANT',
-        )
+        if spatial_size == 1 and kernel_shape[0] > input_tensor_shape[1]:
+            padded_tensor = input_tensor
+        else:
+            padded_tensor = tf.pad(
+                tensor=input_tensor,
+                paddings=tf_pads,
+                mode='CONSTANT',
+            )
 
     else:
         padded_tensor = input_tensor
@@ -306,11 +309,18 @@ def make_node(
     # Generation of TF OP
     tf_op_type = None
     if len(kernel_shape) == 1:
-        pooled_tensor = AveragePooling1D(
-            pool_size=kernel_shape,
-            strides=strides,
-            padding=tf_pad_mode.upper(),
-        )(padded_tensor)
+        if kernel_shape[0] > padded_tensor.shape[1]:
+            pooled_tensor = AveragePooling1D(
+                pool_size=[padded_tensor.shape[1]],
+                strides=[padded_tensor.shape[1]],
+                padding=tf_pad_mode.upper(),
+            )(padded_tensor)
+        else:
+            pooled_tensor = AveragePooling1D(
+                pool_size=kernel_shape,
+                strides=strides,
+                padding=tf_pad_mode.upper(),
+            )(padded_tensor)
         tf_op_type = AveragePooling1D
 
     elif len(kernel_shape) == 2:

--- a/onnx2tf/ops/BatchNormalization.py
+++ b/onnx2tf/ops/BatchNormalization.py
@@ -1,8 +1,12 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     print_node_info,
@@ -14,7 +18,11 @@ from onnx2tf.utils.common_functions import (
     explicit_broadcast,
     pre_explicit_broadcast,
     transpose_with_flexing_deterrence,
+    get_tf_model_inputs,
+    dummy_tf_inference,
+    onnx_tf_tensor_validation,
 )
+from typing import List, Dict, Any
 
 
 @print_node_info
@@ -85,6 +93,11 @@ def make_node(
     nhwc: bool = tf_layers_dict[X.name]['nhwc'] \
         if isinstance(X, gs.Variable) and 'nhwc' in tf_layers_dict[X.name].keys() else False
 
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
+
     # Preserving Graph Structure (Dict)
     tf_layers_dict[Y.name] = {
         'optype': graph_node.op,
@@ -95,6 +108,7 @@ def make_node(
 
     # Generation of TF OP
     input_tensor = tf_layers_dict[X.name]['tf_node']
+    input_tensor_rank = len(input_tensor.shape)
 
     # Pre-process transpose
     input_tensor = pre_process_transpose(
@@ -123,41 +137,17 @@ def make_node(
             input_tensor_1=input_tensor,
             input_tensor_2=mean,
         )
-        input_tensor, mean = explicit_broadcast(
-            const_or_var_1=input_tensor,
-            const_or_var_2=mean,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
         input_tensor, var = pre_explicit_broadcast(
             input_tensor_1=input_tensor,
             input_tensor_2=var,
-        )
-        input_tensor, var = explicit_broadcast(
-            const_or_var_1=input_tensor,
-            const_or_var_2=var,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
         )
         input_tensor, offset = pre_explicit_broadcast(
             input_tensor_1=input_tensor,
             input_tensor_2=offset,
         )
-        input_tensor, offset = explicit_broadcast(
-            const_or_var_1=input_tensor,
-            const_or_var_2=offset,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
-        )
         input_tensor, scale = pre_explicit_broadcast(
             input_tensor_1=input_tensor,
             input_tensor_2=scale,
-        )
-        input_tensor, scale = explicit_broadcast(
-            const_or_var_1=input_tensor,
-            const_or_var_2=scale,
-            graph_node=graph_node,
-            tf_layers_dict= tf_layers_dict,
         )
 
     try:
@@ -290,6 +280,262 @@ def make_node(
         else:
             raise
 
+    # Automatic accuracy compensation
+    graph_node_input_1_shape = X.shape
+    if graph_node_input_1_shape is not None:
+
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(
+                tf_layers_dict=tf_layers_dict,
+            )
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                val_model = tf_keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ],
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        #   Get the output tensor of the previous layer of MatMul
+        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except Exception as ex:
+                pass
+            del val_model
+
+        # Get np.ndarray for validation
+        validation_data = None
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data = copy.deepcopy(input_tensor)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(Y.name, None) is not None:
+                onnx_tensor_infos = {
+                    Y.name: onnx_tensor_infos_for_validation[Y.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+        # Automatic correction of accuracy degradation
+        min_abs_err = sys.maxsize
+        min_abs_err_perm_1: List[int] = [idx for idx in range(len(mean.shape))]
+
+        if not disable_strict_mode:
+            if onnx_tensor_infos is not None and validation_data is not None:
+                tensor_1_candidate_for_transpositions = list(itertools.permutations(range(len(mean.shape))))
+                # Search for the axis with the smallest error
+                for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
+                    try:
+                        target_validation_data = validation_data
+                        # Build TF dummy model
+                        input = tf_keras.Input(
+                            shape=validation_data.shape[1:],
+                            batch_size=validation_data.shape[0] \
+                                if isinstance(validation_data.shape[0], int) else None,
+                            name='dummy_input',
+                            dtype=validation_data.dtype,
+                        )
+                        val_model = tf_keras.Model(
+                            inputs=[
+                                input,
+                            ],
+                            outputs=[
+                                tf.nn.batch_normalization(
+                                    x=input,
+                                    mean=\
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=mean,
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ) if not isinstance(mean, np.ndarray) else \
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=tf.convert_to_tensor(mean),
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ),
+                                    variance=\
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=var,
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ) if not isinstance(var, np.ndarray) else \
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=tf.convert_to_tensor(var),
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ),
+                                    offset=\
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=offset,
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ) if not isinstance(offset, np.ndarray) else \
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=tf.convert_to_tensor(offset),
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ),
+                                    scale=\
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=scale,
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ) if not isinstance(scale, np.ndarray) else \
+                                        transpose_with_flexing_deterrence(
+                                            input_tensor=tf.convert_to_tensor(scale),
+                                            perm=min_abs_err_perm_1,
+                                            output_shape=Y.shape \
+                                                if None not in Y.shape and Y.shape != [] else None,
+                                            **kwargs,
+                                        ),
+                                    variance_epsilon=epsilon,
+                                )
+                            ],
+                        )
+                        # TF dummy inference
+                        tf_tensor_infos: Dict[Any] = \
+                            dummy_tf_inference(
+                                model=val_model,
+                                inputs=[
+                                    input,
+                                ],
+                                verification_datas=[
+                                    target_validation_data,
+                                ],
+                            )
+                        del input
+                        del val_model
+
+                        # Validation
+                        onnx_tf_output_pairs = {
+                            (oi[0], ti[0]): (oi[1], ti[1]) \
+                                for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                        }
+                        """
+                        check_results: Dict[str, List[np.ndarray, int, float|int]]
+                            {
+                                onnx_output_name: [
+                                    onnx_tensor,
+                                    matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                    max_abs_err,
+                                ]
+                            }
+                        """
+                        check_results = \
+                            onnx_tf_tensor_validation(
+                                output_pairs=onnx_tf_output_pairs,
+                                rtol=0.0,
+                                atol=0.0,
+                            )
+                        result_err = sum([val[2] for val in check_results.values()])
+                        if result_err < min_abs_err:
+                            min_abs_err = result_err
+                            min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                            if min_abs_err < 1e-3:
+                                break
+                    except Exception as ex:
+                        pass
+
+                tf_layers_dict[Y.name]['tf_node'] = \
+                    tf.nn.batch_normalization(
+                        x=input_tensor,
+                        mean=\
+                            transpose_with_flexing_deterrence(
+                                input_tensor=mean,
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ) if not isinstance(mean, np.ndarray) else \
+                            transpose_with_flexing_deterrence(
+                                input_tensor=tf.convert_to_tensor(mean),
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ),
+                        variance=\
+                            transpose_with_flexing_deterrence(
+                                input_tensor=var,
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ) if not isinstance(var, np.ndarray) else \
+                            transpose_with_flexing_deterrence(
+                                input_tensor=tf.convert_to_tensor(var),
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ),
+                        offset=\
+                            transpose_with_flexing_deterrence(
+                                input_tensor=offset,
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ) if not isinstance(offset, np.ndarray) else \
+                            transpose_with_flexing_deterrence(
+                                input_tensor=tf.convert_to_tensor(offset),
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ),
+                        scale=\
+                            transpose_with_flexing_deterrence(
+                                input_tensor=scale,
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ) if not isinstance(scale, np.ndarray) else \
+                            transpose_with_flexing_deterrence(
+                                input_tensor=tf.convert_to_tensor(scale),
+                                perm=min_abs_err_perm_1,
+                                output_shape=Y.shape \
+                                    if None not in Y.shape and Y.shape != [] else None,
+                                **kwargs,
+                            ),
+                        variance_epsilon=epsilon,
+                    )
+                tf_type = tf.nn.batch_normalization
 
     # Post-process transpose
     tf_layers_dict[Y.name]['tf_node'] = post_process_transpose(

--- a/onnx2tf/ops/Expand.py
+++ b/onnx2tf/ops/Expand.py
@@ -1,8 +1,12 @@
+import sys
+import copy
 import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
+import itertools
 import tensorflow as tf
+import tf_keras
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
@@ -13,7 +17,12 @@ from onnx2tf.utils.common_functions import (
     make_tf_node_info,
     pre_process_transpose,
     post_process_transpose,
+    transpose_with_flexing_deterrence,
+    get_tf_model_inputs,
+    dummy_tf_inference,
+    onnx_tf_tensor_validation,
 )
+from typing import List, Dict, Any
 
 
 @print_node_info
@@ -57,8 +66,14 @@ def make_node(
 
     input_tensor = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    input_tensor_rank = len(input_tensor.shape)
     input_tensor_shape = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+
+    onnx_tensor_infos_for_validation: Dict[str: np.ndarray] = kwargs['onnx_tensor_infos_for_validation']
+    test_data_nhwc: np.ndarray = kwargs['test_data_nhwc']
+    custom_input_op_name_np_data_path: str = kwargs['custom_input_op_name_np_data_path']
+    disable_strict_mode: bool = kwargs['disable_strict_mode']
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -118,6 +133,198 @@ def make_node(
             expanded_tensor = input_tensor * ones
         tf_layers_dict[graph_node_output.name]['tf_node'] = expanded_tensor
         tf_type = 'Expand'
+
+    if tf_type == 'Expand':
+        graph_node_input_1_shape = graph_node_input_1.shape
+        graph_node_input_2_shape = graph_node_input_2.shape
+
+        # Get the output tensor of one previous OP of TensorFlow only once
+        if not disable_strict_mode:
+            tf_model_inputs = get_tf_model_inputs(
+                tf_layers_dict=tf_layers_dict,
+            )
+            val_model = None
+            if not isinstance(input_tensor, np.ndarray):
+                expand_shape = []
+                if not isinstance(input_tensor_shape, np.ndarray):
+                    expand_shape = [input_tensor_shape]
+                val_model = tf_keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[
+                        input_tensor,
+                    ] + expand_shape,
+                )
+            else:
+                pass
+
+        # TF dummy inference
+        #   Get the output tensor of the previous layer of MatMul
+        #   If input.1 and input.2 are both layers, tf_pre_tensor_infos is 2 cases
+        #   If one of input.1 or input.2 is np.ndarray, tf_pre_tensor_infos is 1 case
+        tf_pre_tensor_infos = {}
+        if not disable_strict_mode:
+            try:
+                tf_pre_tensor_infos: Dict[Any] = \
+                    dummy_tf_inference(
+                        model=val_model,
+                        inputs=tf_model_inputs,
+                        test_data_nhwc=test_data_nhwc,
+                        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                    )
+            except Exception as ex:
+                pass
+            del val_model
+
+        # Get np.ndarray for validation
+        validation_data_1 = None
+        validation_data_2 = None
+
+        if not disable_strict_mode:
+            if len(tf_pre_tensor_infos) == 1:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data_1 = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data_1 = copy.deepcopy(input_tensor)
+            elif len(tf_pre_tensor_infos) == 2:
+                if not isinstance(input_tensor, np.ndarray):
+                    validation_data_1 = list(tf_pre_tensor_infos.values())[0]
+                else:
+                    validation_data_1 = copy.deepcopy(input_tensor)
+                if not isinstance(input_tensor_shape, np.ndarray):
+                    validation_data_2 = list(tf_pre_tensor_infos.values())[1]
+                else:
+                    validation_data_2 = copy.deepcopy(input_tensor_shape)
+
+            # Get ONNX inference results
+            onnx_tensor_infos = None
+            if onnx_tensor_infos_for_validation is not None \
+                and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
+                onnx_tensor_infos = {
+                    graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
+                }
+                del onnx_tensor_infos_for_validation
+
+        # ONNX   : N,C,W
+        # TF     : N,W,C
+        # TF-axes: [1]
+        #
+        # ONNX: N,C,H,W
+        # TF  : N,H,W,C
+        # TF-axes: [1,2]
+        #
+        # ONNX: N,C,D,H,W
+        # TF  : N,D,H,W,C
+        # TF-axes: [1,2,3]
+
+        # Automatic correction of accuracy degradation
+        min_abs_err = sys.maxsize
+        min_abs_err_perm_1: List[int] = [idx for idx in range(input_tensor_rank)]
+        min_abs_err_perm_2: List[int] = [idx for idx, val in enumerate(input_tensor_shape)]
+
+        if not disable_strict_mode:
+            if onnx_tensor_infos is not None and validation_data_1 is not None and validation_data_2 is not None:
+                tensor_1_candidate_for_transpositions = list(itertools.permutations(range(input_tensor_rank)))
+                tensor_2_candidate_for_transpositions = list(itertools.permutations(range(len(min_abs_err_perm_2))))
+                # Search for the axis with the smallest error
+                for tensor_1_candidate_for_transposition in tensor_1_candidate_for_transpositions:
+                    try:
+                        for tensor_2_candidate_for_transposition in tensor_2_candidate_for_transpositions:
+                            try:
+                                # Build TF dummy model
+                                input_1 = tf_keras.Input(
+                                    shape=validation_data_1.shape[1:],
+                                    batch_size=validation_data_1.shape[0] \
+                                        if isinstance(validation_data_1.shape[0], int) else None,
+                                    name='dummy_input_1',
+                                    dtype=validation_data_1.dtype,
+                                )
+                                expand_shape = [validation_data_2[pos] for pos in tensor_2_candidate_for_transposition]
+                                input_2 = tf_keras.Input(
+                                    shape=[len(expand_shape)],
+                                    batch_size=1,
+                                    name='dummy_input_2',
+                                    dtype=validation_data_2.dtype,
+                                )
+                                a=0
+
+                                ones = tf.ones(input_2[0], dtype=input_tensor.dtype)
+                                expanded_tensor = input_1 * ones
+                                a=0
+
+                                val_model = tf_keras.Model(
+                                    inputs=[
+                                        input_1,
+                                        input_2,
+                                    ],
+                                    outputs=[
+                                        expanded_tensor,
+                                    ],
+                                )
+                                a=0
+                                # TF dummy inference
+                                tf_tensor_infos: Dict[Any] = \
+                                    dummy_tf_inference(
+                                        model=val_model,
+                                        inputs=[
+                                            input_1,
+                                            input_2,
+                                        ],
+                                        verification_datas=[
+                                            validation_data_1,
+                                            tf.convert_to_tensor([expand_shape], dtype=tf.int64) if isinstance(expand_shape, list) else tf.expand_dims(expand_shape, axis=0),
+                                        ],
+                                    )
+                                del input_1
+                                del input_2
+                                del val_model
+
+                                # Validation
+                                onnx_tf_output_pairs = {
+                                    (oi[0], ti[0]): (oi[1], ti[1]) \
+                                        for oi, ti in zip(onnx_tensor_infos.items(), tf_tensor_infos.items())
+                                }
+                                """
+                                check_results: Dict[str, List[np.ndarray, int, float|int]]
+                                    {
+                                        onnx_output_name: [
+                                            onnx_tensor,
+                                            matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched)
+                                            max_abs_err,
+                                        ]
+                                    }
+                                """
+                                check_results = \
+                                    onnx_tf_tensor_validation(
+                                        output_pairs=onnx_tf_output_pairs,
+                                        rtol=0.0,
+                                        atol=0.0,
+                                    )
+                                result_err = sum([val[2] for val in check_results.values()])
+                                if result_err < min_abs_err:
+                                    min_abs_err = result_err
+                                    min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
+                                    min_abs_err_perm_2 = list(tensor_2_candidate_for_transposition)
+                                    if min_abs_err < 1e-3:
+                                        break
+                            except Exception as ex:
+                                pass
+                    except Exception as ex:
+                        pass
+
+                input_tensor = \
+                    transpose_with_flexing_deterrence(
+                        input_tensor=input_tensor,
+                        perm=min_abs_err_perm_1,
+                        output_shape=input_tensor_shape \
+                            if None not in input_tensor.shape and input_tensor.shape != [] else None,
+                        **kwargs,
+                    )
+                input_tensor_shape = [input_tensor_shape[pos] for pos in min_abs_err_perm_2]
+                ones = tf.ones(input_tensor_shape, dtype=input_tensor.dtype)
+                expanded_tensor = input_tensor * ones
+
+                tf_layers_dict[graph_node_output.name]['tf_node'] = expanded_tensor
+                tf_type = tf.expand_dims
 
     # Post-process transpose
     tf_layers_dict[graph_node_output.name]['tf_node'] = post_process_transpose(


### PR DESCRIPTION
### 1. Content and background
- `Expand`, `BatchNormalization`, `Gather`
  - Automatic accuracy compensation.
  - Added the ability to automatically compensate for accuracy degradation due to dimensional transposition errors.
- `AveragePool`
  - Only very few edge cases are supported.
  - The dynamic tensor `AveragePool` is difficult to replace exactly with TensorFlow's `AveragePooling`.
    ```
    INFO: 39 / 1464
    INFO: onnx_op_type: AveragePool onnx_op_name: wa/xvector/block1/tdnnd1/cam_layer/AveragePool
    INFO:  input_name.1: wa/xvector/block1/tdnnd1/nonlinear2/relu/Relu_output_0 shape: [1, 128, 'unk__71'] dtype: float32
    INFO:  output_name.1: wa/xvector/block1/tdnnd1/cam_layer/AveragePool_output_0 shape: [1, 128, 'unk__77'] dtype: float32
    ERROR: The trace log is below.
    Traceback (most recent call last):
      File "/home/xxxxx/git/onnx2tf/onnx2tf/utils/common_functions.py", line 312, in print_wrapper_func
        result = func(*args, **kwargs)
      File "/home/xxxxx/git/onnx2tf/onnx2tf/utils/common_functions.py", line 385, in inverted_operation_enable_disable_wrapper_func
        result = func(*args, **kwargs)
      File "/home/xxxxx/git/onnx2tf/onnx2tf/utils/common_functions.py", line 55, in get_replacement_parameter_wrapper_func
        func(*args, **kwargs)
      File "/home/xxxxx/git/onnx2tf/onnx2tf/ops/AveragePool.py", line 171, in make_node
        output_spatial_shape = [
      File "/home/xxxxx/git/onnx2tf/onnx2tf/ops/AveragePool.py", line 172, in <listcomp>
        func((i + pb + pe - d * (k - 1) - 1) / s + 1)
    TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'
    
    ERROR: input_onnx_file_path: ../cam++_vin.onnx
    ERROR: onnx_op_name: wa/xvector/block1/tdnnd1/cam_layer/AveragePool
    ERROR: Read this and deal with it. https://github.com/PINTO0309/onnx2tf#parameter-replacement
    ERROR: Alternatively, if the input OP has a dynamic dimension, use the -b or -ois option to rewrite it to a static shape and try again.
    ERROR: If the input OP of ONNX before conversion is NHWC or an irregular channel arrangement other than NCHW, use the -kt or -kat option.
    ERROR: Also, for models that include NonMaxSuppression in the post-processing, try the -onwdt option.
    ``` 

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Unable to convert a model with 3d input shape of dynamic length into tflite int8 format #673](https://github.com/PINTO0309/onnx2tf/issues/673)