### PR TITLE
Addressed the issue of missing conversions when multi-dimensional flattening is performed and the batch size of the first dimension is an undefined dimension.

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.9
+  ghcr.io/pinto0309/onnx2tf:1.25.10
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.9
+  docker.io/pinto0309/onnx2tf:1.25.10
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.9'
+__version__ = '1.25.10'

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -91,7 +91,7 @@ def make_node(
         and len(graph_node_output.shape) == 2 \
         and axis == input_tensor_rank - 1 \
         and not isinstance(graph_node_output.shape[0], str):
-        cal_shape = (1, -1)
+        cal_shape = (graph_node_output.shape[0], -1)
     elif graph_node_output.shape is not None \
         and len(graph_node_output.shape) == 2 \
         and axis == input_tensor_rank - 1 \

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -87,8 +87,20 @@ def make_node(
         cal_shape = (1, -1)
     elif axis >= input_tensor_rank:
         cal_shape = (-1, 1)
-    elif graph_node_output.shape is not None and len(graph_node_output.shape) == 2 and axis == input_tensor_rank - 1:
+    elif graph_node_output.shape is not None \
+        and len(graph_node_output.shape) == 2 \
+        and axis == input_tensor_rank - 1 \
+        and not isinstance(graph_node_output.shape[0], str):
         cal_shape = (1, -1)
+    elif graph_node_output.shape is not None \
+        and len(graph_node_output.shape) == 2 \
+        and axis == input_tensor_rank - 1 \
+        and isinstance(graph_node_output.shape[0], str):
+        try:
+            dim_prod = int(np.prod(graph_node_output.shape[1:]))
+            cal_shape = (-1, dim_prod)
+        except:
+            cal_shape = (1, -1)
     elif input_tensor_rank >= 2 \
         and input_tensor_shape[0] is None \
         and len([idx for idx in input_tensor_shape[1:] if idx is not None]) == input_tensor_rank - 1 \


### PR DESCRIPTION
### 1. Content and background
- `Flatten`
  - Addressed the issue of missing conversions when multi-dimensional flattening is performed and the batch size of the first dimension is an undefined dimension.
    |ONNX|TFLite|
    |:-:|:-:|
    |![image](https://github.com/user-attachments/assets/4643dcdc-01c7-4b2a-b77e-537a8b7a256b)|![image](https://github.com/user-attachments/assets/0935573e-ae5f-49d3-89f6-b9baccb69e26)|

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[EfficientNetV2_m] Output size is constant not variable #688](https://github.com/PINTO0309/onnx2tf/issues/688)