### PR TITLE
Improved handling when `axis` attribute is not defined and the batch size of the first dimension is undefined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.11
+  ghcr.io/pinto0309/onnx2tf:1.25.12
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.11
+  docker.io/pinto0309/onnx2tf:1.25.12
 
   or
 
@@ -404,7 +404,7 @@ The given SavedModel SignatureDef contains the following input(s):
 The given SavedModel SignatureDef contains the following output(s):
   outputs['output_0'] tensor_info:
       dtype: DT_FLOAT
-      shape: (1, 1000) # <-- Model design bug in resnet18-v1-7.onnx
+      shape: (-1, 1000)
       name: PartitionedCall:0
 Method name is: tensorflow/serving/predict
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.11'
+__version__ = '1.25.12'

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -57,14 +57,17 @@ def make_node(
     output_shape = graph_node_output.shape
     dtype = graph_node_output.dtype
 
-    axis = graph_node.attrs.get("axis", 0)
-    if graph_node_input.shape is not None \
-        and axis < input_tensor_rank:
-        axis = convert_axis(
-            axis=axis,
-            tensor_rank=len(graph_node_input.shape),
-            before_op_output_shape_trans=before_op_output_shape_trans,
-        )
+    axis = graph_node.attrs.get("axis", None)
+    if axis is not None:
+        if graph_node_input.shape is not None \
+            and axis < input_tensor_rank:
+            axis = convert_axis(
+                axis=axis,
+                tensor_rank=len(graph_node_input.shape),
+                before_op_output_shape_trans=before_op_output_shape_trans,
+            )
+    else:
+        axis = input_tensor_rank - 1
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {


### PR DESCRIPTION
### 1. Content and background
- `Flatten`
  - Improved handling when `axis` attribute is not defined and the batch size of the first dimension is undefined.
  - ONNX
    ![image](https://github.com/user-attachments/assets/7fe6000c-834a-41cd-9508-1f8bf13b2f93)
    ```bash
    wget https://github.com/PINTO0309/onnx2tf/releases/download/0.0.2/resnet18-v1-7.onnx
    onnx2tf -i resnet18-v1-7.onnx
    
    ls -lh saved_model/
    
    assets
    fingerprint.pb
    resnet18-v1-7_float16.tflite
    resnet18-v1-7_float32.tflite
    saved_model.pb
    variables
    
    TF_CPP_MIN_LOG_LEVEL=3 \
    saved_model_cli show \
    --dir saved_model \
    --signature_def serving_default \
    --tag_set serve
    
    The given SavedModel SignatureDef contains the following input(s):
      inputs['data'] tensor_info:
          dtype: DT_FLOAT
          shape: (-1, 224, 224, 3)
          name: serving_default_data:0
    The given SavedModel SignatureDef contains the following output(s):
      outputs['output_0'] tensor_info:
          dtype: DT_FLOAT
          shape: (-1, 1000)
          name: PartitionedCall:0
    Method name is: tensorflow/serving/predict
    ```
  - TFLite
    ![image](https://github.com/user-attachments/assets/2da8169a-2272-4f47-957d-7a6416728630)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
