### PR TITLE
Dealing with garbage-like broken structures in ONNX

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.12
+  ghcr.io/pinto0309/onnx2tf:1.25.13
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.12
+  docker.io/pinto0309/onnx2tf:1.25.13
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.12'
+__version__ = '1.25.13'

--- a/onnx2tf/ops/ArgMax.py
+++ b/onnx2tf/ops/ArgMax.py
@@ -60,11 +60,15 @@ def make_node(
     replace_argmax_to_fused_argmax_and_indices_is_float32 = \
         kwargs['replace_argmax_to_fused_argmax_and_indices_is_float32']
 
+    # Generation of TF OP
+    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
+        if isinstance(graph_node_input, gs.Variable) else graph_node_input
+
     axis = graph_node.attrs.get('axis', 0)
     # NCHW->NHWC, NCDHW->NDHWC
     axis = convert_axis(
         axis=axis,
-        tensor_rank=len(graph_node_input.shape),
+        tensor_rank=len(graph_node_input.shape) if graph_node_input.shape is not None else len(input_tensor.shape),
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
 
@@ -83,10 +87,6 @@ def make_node(
             if isinstance(graph_node_input, gs.Variable) \
                 and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() else False
     }
-
-    # Generation of TF OP
-    input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
-        if isinstance(graph_node_input, gs.Variable) else graph_node_input
 
     # Pre-process transpose
     input_tensor = pre_process_transpose(

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -115,6 +115,12 @@ def make_node(
         and axis == 1:
         # Use Keras Flatten() if there are two or more undefined dimensions
         cal_shape = None
+    elif input_tensor_rank >= 2 \
+        and input_tensor_shape[0] is None \
+        and len([idx for idx in input_tensor_shape[1:] if idx is not None]) != input_tensor_rank - 1 \
+        and axis == 2:
+        # Use Keras Flatten() if there are two or more undefined dimensions
+        cal_shape = None
     else:
         cal_shape = (
             tf.reduce_prod(input_tensor_shape[0:axis]),


### PR DESCRIPTION
### 1. Content and background
- `ArgMax`, `Faltten`
  - Dealing with garbage-like broken structures in ONNX.
    ![image](https://github.com/user-attachments/assets/7548a385-7e6b-4a19-ab5a-ef76cfc1104d)
    ![image](https://github.com/user-attachments/assets/04092ee2-6c05-4815-ac2f-7689e122c742)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [[YOLOv7] None in graph_node_input.shape #694](https://github.com/PINTO0309/onnx2tf/issues/694)