### PR TITLE
Fixed to force switch between `X` and `Y` when X: `np.ndarray`, Y: `Tensor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.25.14
+  ghcr.io/pinto0309/onnx2tf:1.25.15
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.25.14
+  docker.io/pinto0309/onnx2tf:1.25.15
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.25.14'
+__version__ = '1.25.15'

--- a/onnx2tf/ops/Add.py
+++ b/onnx2tf/ops/Add.py
@@ -92,6 +92,10 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    # issue: https://github.com/PINTO0309/onnx2tf/issues/698
+    if isinstance(input_tensor_1, np.ndarray) and not isinstance(input_tensor_2, np.ndarray):
+        input_tensor_1, input_tensor_2 = input_tensor_2, input_tensor_1
+
     disable_strict_mode: bool = kwargs['disable_strict_mode']
     gelu_replace_op_names: dict = kwargs['gelu_replace_op_names']
 

--- a/onnx2tf/ops/Mul.py
+++ b/onnx2tf/ops/Mul.py
@@ -84,6 +84,10 @@ def make_node(
     input_tensor_2 = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
 
+    # issue: https://github.com/PINTO0309/onnx2tf/issues/698
+    if isinstance(input_tensor_1, np.ndarray) and not isinstance(input_tensor_2, np.ndarray):
+        input_tensor_1, input_tensor_2 = input_tensor_2, input_tensor_1
+
     disable_strict_mode: bool = kwargs['disable_strict_mode']
     gelu_replace_op_names: dict = kwargs['gelu_replace_op_names']
 


### PR DESCRIPTION
### 1. Content and background
- `Mul`, `Add`
  - Fixed to force switch between `X` and `Y` when X: `np.ndarray`, Y: `Tensor`
    ```
    onnx2tf -i 1005_s0_nonar_text_decoder.onnx -cotof
    ```
    ![image](https://github.com/user-attachments/assets/b21e9e7f-a594-4bd5-a082-7b116f2474e4)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Error by broadcasting in tf.math.Multiply Operation #698](https://github.com/PINTO0309/onnx2tf/issues/698)