### PR TITLE
Added `Float32` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.26.0
+  ghcr.io/pinto0309/onnx2tf:1.26.1
 
   or
 
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.26.0
+  docker.io/pinto0309/onnx2tf:1.26.1
 
   or
 
@@ -1674,11 +1674,11 @@ optional arguments:
 
   -iqd {int8,uint8,float32}, --input_quant_dtype {int8,uint8,float32}
     Input dtypes when doing Full INT8 Quantization.
-    "int8"(default) or "uint8"
+    "int8"(default) or "uint8" or "float32"
 
   -oqd {int8,uint8,float32}, --output_quant_dtype {int8,uint8,float32}
     Output dtypes when doing Full INT8 Quantization.
-    "int8"(default) or "uint8"
+    "int8"(default) or "uint8" or "float32"
 
   -nuo, --not_use_onnxsim
     No optimization by onnx-simplifier is performed.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.26.0'
+__version__ = '1.26.1'


### PR DESCRIPTION
### 1. Content and background
- `README`
  - Added `Float32` option.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Fixed mistake of #710 #711](https://github.com/PINTO0309/onnx2tf/pull/711)