### PR TITLE
add output_saved_model flag

### DIFF
--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -62,12 +62,12 @@ def convert(
     input_onnx_file_path: Optional[str] = '',
     onnx_graph: Optional[onnx.ModelProto] = None,
     output_folder_path: Optional[str] = 'saved_model',
-    output_saved_model: Optional[bool] = True,
     output_signaturedefs: Optional[bool] = False,
     output_h5: Optional[bool] = False,
     output_keras_v3: Optional[bool] = False,
     output_tfv1_pb: Optional[bool] = False,
     output_weights: Optional[bool] = False,
+    not_output_saved_model: Optional[bool] = False,
     copy_onnx_input_output_names_to_tflite: Optional[bool] = False,
     output_dynamic_range_quantized_tflite: Optional[bool] = False,
     output_integer_quantized_tflite: Optional[bool] = False,
@@ -147,6 +147,12 @@ def convert(
 
     output_weights: Optional[bool]
         Output weights in hdf5 format.
+
+    not_output_saved_model: Optional[bool]
+        Skip output of the SavedModel format.\n
+        Skipping is useful in cases where only a TFLite model is needed,
+        especially if for some reason (e.g. grouped convolutions) the SavedModel
+        format fails.
 
     copy_onnx_input_output_names_to_tflite: Optional[bool]
         Copy the input/output OP name of ONNX to the input/output OP name of tflite.\n
@@ -1303,7 +1309,7 @@ def convert(
         SIGNATURE_KEY = 'serving_default'
 
         # saved_model
-        if output_saved_model:
+        if not not_output_saved_model:
             try:
                 # concrete_func
                 info(Color.REVERSE(f'saved_model output started'), '=' * 58)

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -2047,6 +2047,16 @@ def main():
             'Output weights in hdf5 format.'
     )
     parser.add_argument(
+        '-nosm',
+        '--not_output_saved_model',
+        action='store_true',
+        help=\
+            'Skip output of the SavedModel format.\n' +
+            'Skipping is useful in cases where only a TFLite model is needed, ' +
+            'especially if for some reason (e.g. grouped convolutions) the SavedModel' +
+            'format fails.'
+    )
+    parser.add_argument(
         '-coion',
         '--copy_onnx_input_output_names_to_tflite',
         action='store_true',
@@ -2618,6 +2628,7 @@ def main():
         output_keras_v3=args.output_keras_v3,
         output_tfv1_pb=args.output_tfv1_pb,
         output_weights=args.output_weights,
+        not_output_saved_model=args.not_output_saved_model,
         copy_onnx_input_output_names_to_tflite=args.copy_onnx_input_output_names_to_tflite,
         output_dynamic_range_quantized_tflite=args.output_dynamic_range_quantized_tflite,
         output_integer_quantized_tflite=args.output_integer_quantized_tflite,


### PR DESCRIPTION
### 1. Content and background

Added `output_saved_model` flag to allow one to optionally only save TFLite models.
The motivation is that on certain models with grouped convolution (namely YOLOv6-Lite) the saved model output fails in a way that prevents conversion from proceeding to the TFLite models. The flag is a simple way to circumvent this.

### 2. Summary of corrections

A simple if/else.

### 3. Before/After (If there is an operating log that can be used as a reference)

TBD
