### PR TITLE
Bugfix in MatMul.py

### DIFF
--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -87,7 +87,7 @@ def make_node(
     input_tensor_2_is_one_d = False
     if input_tensor_1.shape is not None \
         and len(input_tensor_1.shape) == 1:
-        input_tensor_1 = tf.expand_dims(input_tensor_2, axis=0)
+        input_tensor_1 = tf.expand_dims(input_tensor_1, axis=0)
         input_tensor_1_is_one_d = True
     elif input_tensor_2.shape is not None \
             and len(input_tensor_2.shape) == 1:


### PR DESCRIPTION
Fix incorrect tensor expansion in MatMul operation

### 1. Content and background
The MatMul operation was incorrectly handling 1-dimensional tensors by expanding
the wrong input tensor. When handling a 1D `input tensor (shape [256])`, it was 
erroneously expanding `input_tensor_2 (shape [256, 254])` instead of `input_tensor_1`,
leading to incorrect shape transformations.

### 2. Summary of corrections
Changed:
```python
input_tensor_1 = tf.expand_dims(input_tensor_2, axis=0)
```
to 
```python
input_tensor_1 = tf.expand_dims(input_tensor_1, axis=0)
```

This ensures the correct tensor is expanded when handling 1D inputs.


### 3. Before/After
Before:
```
Input1 shape: [256] -> incorrectly became [1,256,254]
Input2 shape: [256,254] remained unchanged
```
After:
```
Input1 shape: [256] -> correctly becomes [1,256]
Input2 shape: [256,254] remains unchanged
```