### PR TITLE
Fixed the broadcast processing when `x_scale` is 1D 1Elem

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.26.6
+  ghcr.io/pinto0309/onnx2tf:1.26.7
 
   or
 
@@ -315,7 +315,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.26.6
+  docker.io/pinto0309/onnx2tf:1.26.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.26.6'
+__version__ = '1.26.7'

--- a/onnx2tf/ops/DequantizeLinear.py
+++ b/onnx2tf/ops/DequantizeLinear.py
@@ -101,12 +101,14 @@ def make_node(
 
     # Reshape process is needed for per-axis dequantization
     # when scale is a 1-D tensor
-    if x_scale_rank == 1:
+    if x_scale_rank == 1 and x_scale_shape[0] != 1:
         shape_broadcast = list([1 for _ in range(axis)] + [input_tensor_shape[axis]] + [1 for _ in range(axis + 1, input_tensor_rank)])
         x_scale = tf.reshape(
             tensor=x_scale,
             shape=shape_broadcast,
         )
+    elif x_scale_rank == 1 and x_scale_shape[0] == 1:
+        shape_broadcast = [1 for i in range(input_tensor_rank)]
 
     subed_tensor = input_tensor
     if len(graph_node.inputs) >= 3 and input_tensor.dtype != tf.int32:


### PR DESCRIPTION
### 1. Content and background
- `DequantizeLinear`
  - Fixed the broadcast processing when `x_scale` is 1D 1Elem.
  - [best.onnx.zip](https://github.com/user-attachments/files/18505302/best.onnx.zip)
  - `onnx2tf -i best.onnx -ois images:1,3,512,640`
    ![image](https://github.com/user-attachments/assets/dcc845bb-e281-4d34-b720-5ff06c13f4c1)
    ![image](https://github.com/user-attachments/assets/663d52ea-1769-4f67-b158-141bcc640c66)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [DequantizeLinear.py can't compile layer when x_scale_rank == 1 #733](https://github.com/PINTO0309/onnx2tf/issues/733)