### PR TITLE
Fixed so that the URL for downloading the flatc binary is changed for each CPU architecture to be built.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-args: BUILD_ARCH=${{ matrix.platforms }}
           push: true
           labels: ${{ steps.meta_gh.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.lower-repo-1.outputs.repository }},push-by-digest=true,name-canonical=true,push=true
@@ -104,6 +105,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-args: BUILD_ARCH=${{ matrix.platforms }}
           push: true
           labels: ${{ steps.meta_gh.outputs.labels }}
           outputs: type=image,name=${{ env.DOCKER_REGISTRY }}/${{ steps.lower-repo-1.outputs.repository }},push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ARG BUILD_ARCH="linux/amd64"
 
 RUN apt-get update \
     && apt-get install -y \
@@ -31,7 +32,13 @@ RUN pip install pip -U \
 # Re-release flatc with some customizations of our own to address
 # the lack of arithmetic precision of the quantization parameters
 # https://github.com/PINTO0309/onnx2tf/issues/196
-RUN wget https://github.com/PINTO0309/onnx2tf/releases/download/1.16.31/flatc.tar.gz \
+RUN if [ "${BUILD_ARCH}" = "linux/amd64" ]; then \
+        wget -O flatc.tar.gz https://github.com/PINTO0309/onnx2tf/releases/download/1.16.31/flatc.tar.gz; \
+    elif [ "${BUILD_ARCH}" = "linux/arm64" ]; then \
+        wget -O flatc.tar.gz https://github.com/PINTO0309/onnx2tf/releases/download/1.26.6/flatc_arm64.tar.gz; \
+    else \
+        echo "Unsupported architecture: ${BUILD_ARCH}" && exit 1; \
+    fi \
     && tar -zxvf flatc.tar.gz \
     && chmod +x flatc \
     && mv flatc /usr/bin/


### PR DESCRIPTION
### 1. Content and background
- Fixed so that the URL for downloading the flatc binary is changed for each CPU architecture to be built.
- https://github.com/PINTO0309/onnx2tf/pull/734

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
