### PR TITLE
Fixed the logic to avoid a TensorFlow bug that caused the output tensor of `tf.norm()` to be `(None, None, None, None)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.26.8
+  ghcr.io/pinto0309/onnx2tf:1.26.9
 
   or
 
@@ -315,7 +315,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.26.8
+  docker.io/pinto0309/onnx2tf:1.26.9
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.26.8'
+__version__ = '1.26.9'

--- a/onnx2tf/ops/ReduceL1.py
+++ b/onnx2tf/ops/ReduceL1.py
@@ -298,12 +298,10 @@ def make_node(
     # Generation of TF OP
     axes = list(axes) if axes is not None else None
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.norm(
-            tensor=input_tensor,
-            ord=1,
+        tf.reduce_sum(
+            tf.abs(input_tensor),
             axis=axes if len(axes) > 1 else axes[0],
             keepdims=keepdims,
-            name=graph_node.name,
         )
 
     # Post-process transpose

--- a/onnx2tf/ops/ReduceL2.py
+++ b/onnx2tf/ops/ReduceL2.py
@@ -297,12 +297,12 @@ def make_node(
     # Generation of TF OP
     axes = list(axes) if axes is not None else None
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        tf.norm(
-            tensor=input_tensor,
-            ord=2,
-            axis=axes if len(axes) > 1 else axes[0],
-            keepdims=keepdims,
-            name=graph_node.name,
+        tf.sqrt(
+            tf.reduce_sum(
+                tf.square(input_tensor),
+                axis=axes,
+                keepdims=keepdims
+            )
         )
 
     # Post-process transpose


### PR DESCRIPTION
### 1. Content and background
- Fixed the logic to avoid a TensorFlow bug that caused the output tensor of `tf.norm()` to be `(None, None, None, None)`.
- TensorFlow bugs when converting a model that includes `ReduceL1` or `ReduceL2`.
  ```
  INFO: 20 / 819
  INFO: onnx_op_type: ReduceL2 onnx_op_name: wa/model/stages/stages.0/blocks/blocks.0/mlp/grn/ReduceL2
  INFO:  input_name.1: wa/model/stages/stages.0/blocks/blocks.0/mlp/act/Mul_1_output_0 shape: [1, 56, 56, 512] dtype: float32
  INFO:  output_name.1: wa/model/stages/stages.0/blocks/blocks.0/mlp/grn/ReduceL2_output_0 shape: [1, 1, 1, 512] dtype: float32
  INFO: tf_op_type: l2_normalize
  INFO:  input.1.x: name: tf.math.multiply_8/Mul:0 shape: (1, 56, 56, 512) dtype: <dtype: 'float32'> 
  INFO:  input.2.axis: val: [1, 2] 
  INFO:  output.1.output: name: tf.compat.v1.norm_6/norm/transpose_1:0 shape: (None, None, None, None) dtype: <dtype: 'float32'> 
  ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [convnextv2_base timm model conversion fails #742](https://github.com/PINTO0309/onnx2tf/issues/742)