### PR TITLE
`Split` now supports input of dynamically sized tensors, improving conversion stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.27.1
+  ghcr.io/pinto0309/onnx2tf:1.27.2
 
   or
 
@@ -317,7 +317,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.27.1
+  docker.io/pinto0309/onnx2tf:1.27.2
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.27.1'
+__version__ = '1.27.2'


### PR DESCRIPTION
### 1. Content and background
- `Split`
  - `Split` now supports input of dynamically sized tensors, improving conversion stability
    ![image](https://github.com/user-attachments/assets/3898c3bf-6b9e-46eb-b75d-9b97f8004965)
    ![image](https://github.com/user-attachments/assets/3486444b-baea-440b-ab53-b751d233a356)
  - yolo11x-obb for oriented bounding boxes
  - yolo11x-obb-dynamic.onnx

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Cannot convert Yolo11x-obb to saved_model with dynamic batch size #751](https://github.com/PINTO0309/onnx2tf/issues/751)