### PR TITLE
Delete GroupConv warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.27.2
+  ghcr.io/pinto0309/onnx2tf:1.27.3
 
   or
 
@@ -317,7 +317,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.27.2
+  docker.io/pinto0309/onnx2tf:1.27.3
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.27.2'
+__version__ = '1.27.3'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1259,11 +1259,6 @@ def convert(
                 if len(msg_list) > 0:
                     for s in msg_list:
                         if 'Unable to serialize VariableSpec' in s:
-                            warn(
-                                f'This model contains GroupConvolution and is automatically optimized for TFLite, ' +
-                                f'but is not output because h5 does not support GroupConvolution. ' +
-                                f'If h5 is needed, specify --disable_group_convolution to retransform the model.'
-                            )
                             break
                 else:
                     error(e)
@@ -1285,11 +1280,6 @@ def convert(
                 if len(msg_list) > 0:
                     for s in msg_list:
                         if 'Unable to serialize VariableSpec' in s:
-                            warn(
-                                f'This model contains GroupConvolution and is automatically optimized for TFLite, ' +
-                                f'but is not output because keras_v3 does not support GroupConvolution. ' +
-                                f'If keras_v3 is needed, specify --disable_group_convolution to retransform the model.'
-                            )
                             break
                 else:
                     error(e)
@@ -1404,10 +1394,7 @@ def convert(
                 )
                 info(Color.GREEN(f'TFv1 .pb output complete!'))
             except KeyError as e:
-                warn(
-                    f'Probably due to GroupConvolution, saved_model could not be generated successfully, ' +
-                    f'so onnx2tf skip the output of TensorFlow v1 pb.'
-                )
+                pass
             except Exception as e:
                 error(e)
                 import traceback

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -468,12 +468,6 @@ def make_node(
                 error_check_tf_op_type = 'conv_bias'
 
             else:
-                if kernel_size in (1, 2, 3) and not disable_group_convolution:
-                    warn(
-                        f'This model contains GroupConvolution and is automatically optimized for TFLite, ' +
-                        f'but is not output because saved_model does not support GroupConvolution. ' +
-                        f'If saved_model is needed, specify --disable_group_convolution to retransform the model.'
-                    )
                 # GroupedConvolution - Conv1D, Conv2D, Conv3D - Bias Add
                 if kernel_size == 1 and not disable_group_convolution:
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \
@@ -571,12 +565,6 @@ def make_node(
                 error_check_tf_op_type = 'conv_nobias'
 
             else:
-                if kernel_size in (1, 2, 3) and not disable_group_convolution:
-                    warn(
-                        f'This model contains GroupConvolution and is automatically optimized for TFLite, ' +
-                        f'but is not output because saved_model does not support GroupConvolution. ' +
-                        f'If saved_model is needed, specify --disable_group_convolution to retransform the model.'
-                    )
                 # GroupedConvolution - Conv1D, Conv2D, Conv3D - No Bias
                 if kernel_size == 1 and not disable_group_convolution:
                     tf_layers_dict[graph_node_output.name]['tf_node'] = \

--- a/onnx2tf/ops/ConvInteger.py
+++ b/onnx2tf/ops/ConvInteger.py
@@ -417,12 +417,6 @@ def make_node(
             error_check_tf_op_type = 'conv_nobias'
 
         else:
-            if kernel_size in (1, 2, 3) and not disable_group_convolution:
-                warn(
-                    f'This model contains GroupConvolution and is automatically optimized for TFLite, ' +
-                    f'but is not output because saved_model does not support GroupConvolution. ' +
-                    f'If saved_model is needed, specify --disable_group_convolution to retransform the model.'
-                )
             # GroupedConvolution - Conv1D, Conv2D, Conv3D - No Bias
             if kernel_size == 1 and not disable_group_convolution:
                 tf_layers_dict[graph_node_output.name]['tf_node'] = \


### PR DESCRIPTION
### 1. Content and background
- `Conv`, `GroupConvolution`
  - Delete warning message
  - Since Keras v2 supports output of `saved_model` containing `GroupConvolution`, the warning message is no longer necessary.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [FlexConv2d generated due to dynamic input shape? #759](https://github.com/PINTO0309/onnx2tf/issues/759)