### PR TITLE
Improved stability when handling tensors of any undefined shape. `Reshape`, `Resize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.27.3
+  ghcr.io/pinto0309/onnx2tf:1.27.4
 
   or
 
@@ -317,7 +317,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.27.3
+  docker.io/pinto0309/onnx2tf:1.27.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.27.3'
+__version__ = '1.27.4'

--- a/onnx2tf/ops/Reshape.py
+++ b/onnx2tf/ops/Reshape.py
@@ -136,14 +136,18 @@ def make_node(
             else:
                 transposed_tensor = input_tensor
         except:
-            transposed_tensor = \
-                transpose_with_flexing_deterrence(
-                    input_tensor=input_tensor,
-                    perm=list(perm) if perm is not None else None,
-                    output_shape=transposed_tensor_output_shape if None not in transposed_tensor_output_shape else None,
-                    name=graph_node.name,
-                    **kwargs,
-                )
+            try:
+                transposed_tensor = \
+                    transpose_with_flexing_deterrence(
+                        input_tensor=input_tensor,
+                        perm=list(perm) if perm is not None else None,
+                        output_shape=transposed_tensor_output_shape if None not in transposed_tensor_output_shape else None,
+                        name=graph_node.name,
+                        **kwargs,
+                    )
+            except:
+                transposed_tensor = input_tensor
+
         test_data = None
         if not isinstance(input_tensor, np.ndarray):
             if not isinstance(graph_node_input_1, np.ndarray) \

--- a/onnx2tf/ops/Resize.py
+++ b/onnx2tf/ops/Resize.py
@@ -294,14 +294,25 @@ def make_node(
         else:
             h_w_scale = scales[1:input_tensor_rank-1]
             h_w_shape = input_tensor_shape[1:input_tensor_rank-1]
-            new_size = tf.cast(
-                h_w_scale * tf.cast(
-                    h_w_shape,
-                    NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
-                        if isinstance(scales.dtype, np.dtype) else scales.dtype,
-                ),
-                tf.int32,
-            )
+            if None not in h_w_shape:
+                new_size = tf.cast(
+                    h_w_scale * tf.cast(
+                        h_w_shape,
+                        NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
+                            if isinstance(scales.dtype, np.dtype) else scales.dtype,
+                    ),
+                    tf.int32,
+                )
+            else:
+                h_w_shape = tf.shape(input_tensor)[1:input_tensor_rank-1]
+                new_size = tf.cast(
+                    h_w_scale * tf.cast(
+                        h_w_shape,
+                        NUMPY_DTYPES_TO_TF_DTYPES[scales.dtype] \
+                            if isinstance(scales.dtype, np.dtype) else scales.dtype,
+                    ),
+                    tf.int32,
+                )
 
     if hasattr(new_size, '_inferred_value'):
         new_size_values = new_size._inferred_value


### PR DESCRIPTION
### 1. Content and background
- `Reshape`, `Resize`
  - Improved stability when handling tensors of any undefined shape.
  - However, for operations where the shape changes dynamically, full automatic conversion with onnx2tf is not successful, so manual adjustment of the conversion operation is required. `NonMaxSuppression`, `NonZero`, `If`, `TopK` https://github.com/PINTO0309/onnx2tf#parameter-replacement
  - First of all, the post-processing of mmdetection is catastrophically redundant, so it is highly discouraged to use the official implementation as is.

![image](https://github.com/user-attachments/assets/90ab25e6-5a4d-47fd-acac-2c5b4268a846)

```
ValueError: Exception encountered when calling layer 'tf.math.subtract_2' (type TFOpLambda).

Dimensions must be equal, but are 4 and 2 for '{{node model_79/tf.math.subtract_2/Sub}} = Sub[T=DT_FLOAT](model_79/tf.strided_slice_84/StridedSlice, model_79/tf.tile/Tile)' with input shapes: [1,5,1,4], [1,1,6400,2].

Call arguments received by layer 'tf.math.subtract_2' (type TFOpLambda):
  • x=tf.Tensor(shape=(1, 5, 1, 4), dtype=float32)
  • y=tf.Tensor(shape=(1, 1, 6400, 2), dtype=float32)
```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Unable to convert RTMDet-ins to tflite #761](https://github.com/PINTO0309/onnx2tf/issues/761)
- similar issues: https://github.com/PINTO0309/onnx2tf/issues?q=label%3A%22Dynamic%20batch%20%2F%20Dynamic%20shape%22