### PR TITLE
Fix unsqueeze prf

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.27.4
+  ghcr.io/pinto0309/onnx2tf:1.27.5
 
   or
 
@@ -317,7 +317,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.27.4
+  docker.io/pinto0309/onnx2tf:1.27.5
 
   or
 

--- a/json_samples/replace_rtmdet_ins.json
+++ b/json_samples/replace_rtmdet_ins.json
@@ -1,0 +1,47 @@
+{
+  "format_version": 1,
+  "operations": [
+    {
+      "op_name": "Concat_551",
+      "param_target": "attributes",
+      "param_name": "axis",
+      "values": 2
+    },
+    {
+      "op_name": "Gather_560",
+      "param_target": "attributes",
+      "param_name": "axis",
+      "values": 2
+    },
+    {
+      "op_name": "Unsqueeze_655",
+      "param_target": "attributes",
+      "param_name": "axes",
+      "values": [1]
+    },
+    {
+      "op_name": "Slice_657",
+      "param_target": "inputs",
+      "param_name": "2062",
+      "values": [0]
+    },
+    {
+      "op_name": "Slice_657",
+      "param_target": "inputs",
+      "param_name": "2029",
+      "values": [2]
+    },
+    {
+      "op_name": "Slice_657",
+      "param_target": "inputs",
+      "param_name": "1538",
+      "values": [3]
+    },
+    {
+      "op_name": "Slice_657",
+      "param_target": "inputs",
+      "param_name": "2015",
+      "values": [1]
+    }
+  ]
+}

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.27.4'
+__version__ = '1.27.5'

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -14,6 +14,7 @@ from onnx2tf.utils.common_functions import (
     convert_axis,
     replace_max_values_negative_values,
     get_replacement_parameter,
+    replace_parameter,
     pre_process_transpose,
     post_process_transpose,
     stridedslice_with_flexing_deterrence,
@@ -278,6 +279,43 @@ def make_node(
                 )
                 sys.exit(1)
 
+    # Param replacement - starts
+    if len(graph_node.inputs) >= 2:
+        starts = replace_parameter(
+            value_before_replacement=starts,
+            param_target='inputs',
+            param_name=graph_node.inputs[1].name,
+            **kwargs,
+        )
+    starts = tf.convert_to_tensor(starts)
+    # Param replacement - ends
+    if len(graph_node.inputs) >= 3:
+        ends = replace_parameter(
+            value_before_replacement=ends,
+            param_target='inputs',
+            param_name=graph_node.inputs[2].name,
+            **kwargs,
+        )
+        ends = tf.convert_to_tensor(ends)
+    # Param replacement - axes
+    if len(graph_node.inputs) >= 4:
+        axes = replace_parameter(
+            value_before_replacement=axes,
+            param_target='inputs',
+            param_name=graph_node.inputs[3].name,
+            **kwargs,
+        )
+        axes = tf.convert_to_tensor(axes)
+    # Param replacement - steps
+    if len(graph_node.inputs) >= 5:
+        steps = replace_parameter(
+            value_before_replacement=steps,
+            param_target='inputs',
+            param_name=graph_node.inputs[4].name,
+            **kwargs,
+        )
+        steps = tf.convert_to_tensor(steps)
+
     # Generation of TF OP
     tf_type = None
     if isinstance(graph_node_input, gs.Variable) \
@@ -409,7 +447,7 @@ def make_node(
             )
             if hasattr(end_mask_, '_inferred_value') and end_mask_._inferred_value == [None]:
                 end_mask_ = 0
-
+            a=0
             # strided_slice
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.strided_slice(

--- a/onnx2tf/ops/Slice.py
+++ b/onnx2tf/ops/Slice.py
@@ -447,7 +447,7 @@ def make_node(
             )
             if hasattr(end_mask_, '_inferred_value') and end_mask_._inferred_value == [None]:
                 end_mask_ = 0
-            a=0
+
             # strided_slice
             tf_layers_dict[graph_node_output.name]['tf_node'] = \
                 tf.strided_slice(

--- a/onnx2tf/ops/Unsqueeze.py
+++ b/onnx2tf/ops/Unsqueeze.py
@@ -7,6 +7,7 @@ import tensorflow as tf
 import onnx_graphsurgeon as gs
 from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
+    replace_parameter,
     get_constant_or_variable,
     convert_axis,
     print_node_info,
@@ -118,6 +119,14 @@ def make_node(
 
     if axes is not None and isinstance(axes, list) and len(axes) > 0:
         axes.sort()
+
+    # Param replacement - axes
+    axes = replace_parameter(
+        value_before_replacement=axes,
+        param_target='attributes',
+        param_name='axes',
+        **kwargs,
+    )
 
     new_shape = copy.deepcopy(input_tensor_shape)
     for idx in axes:


### PR DESCRIPTION
### 1. Content and background
- `Unsqueeze`, `Slice`
  - Supports individual parameter replacement for `Unsqueeze` and `Slice`
  - e.g.
    ![image](https://github.com/user-attachments/assets/e6d11394-4061-4d5c-baec-0f59c36f5e2a)
    ![image](https://github.com/user-attachments/assets/bf6b0a0c-0eec-47b7-bdd6-2ded79e8ad96)
    ```json
    {
      "format_version": 1,
      "operations": [
        {
          "op_name": "Concat_551",
          "param_target": "attributes",
          "param_name": "axis",
          "values": 2
        },
        {
          "op_name": "Gather_560",
          "param_target": "attributes",
          "param_name": "axis",
          "values": 2
        },
        {
          "op_name": "Unsqueeze_655",
          "param_target": "attributes",
          "param_name": "axes",
          "values": [1]
        },
        {
          "op_name": "Slice_657",
          "param_target": "inputs",
          "param_name": "2062",
          "values": [0]
        },
        {
          "op_name": "Slice_657",
          "param_target": "inputs",
          "param_name": "2029",
          "values": [2]
        },
        {
          "op_name": "Slice_657",
          "param_target": "inputs",
          "param_name": "1538",
          "values": [3]
        },
        {
          "op_name": "Slice_657",
          "param_target": "inputs",
          "param_name": "2015",
          "values": [1]
        }
      ]
    }
    ```

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Unable to convert RTMDet-ins to tflite #761](https://github.com/PINTO0309/onnx2tf/issues/761)