### PR TITLE
Improved log display during dummy inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.27.6
+  ghcr.io/pinto0309/onnx2tf:1.27.7
 
   or
 
@@ -317,7 +317,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.27.6
+  docker.io/pinto0309/onnx2tf:1.27.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.27.6'
+__version__ = '1.27.7'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1947,6 +1947,8 @@ def convert(
                     validated_onnx_tensor: np.ndarray = checked_value[0]
                     matched_flg: int = checked_value[1]
                     max_abs_err: Any = checked_value[2]
+                    onnx_shape_tf_shape: str = checked_value[3]
+
                     message = ''
                     if matched_flg == 0:
                         message = \
@@ -1960,11 +1962,11 @@ def convert(
                     elif matched_flg == 2:
                         message = \
                             Color.GREEN(f'validate_result') + ': ' +\
-                            Color.REVERSE(f'{Color.BLUE} Skipped (Deleted or Shape Unmatched) ')
+                            Color.REVERSE(f'{Color.BLUE} Skipped (Deleted or Shape Unmatched) {onnx_shape_tf_shape}')
                     print(
                         Color.GREEN(f'INFO:') + ' '+
                         Color.GREEN(f'onnx_output_name') + f': {onnx_output_name} '+
-                        Color.GREEN(f'tf_output_name') + f': {tf_output_name} '+
+                        # Color.GREEN(f'tf_output_name') + f': {tf_output_name} '+
                         Color.GREEN(f'shape') + f': {validated_onnx_tensor.shape} '+
                         Color.GREEN(f'dtype') + f': {validated_onnx_tensor.dtype} '+
                         f'{message}'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1965,7 +1965,7 @@ def convert(
                             Color.REVERSE(f'{Color.BLUE} Skipped (Deleted or Shape Unmatched) {onnx_shape_tf_shape}')
                     print(
                         Color.GREEN(f'INFO:') + ' '+
-                        Color.GREEN(f'onnx_output_name') + f': {onnx_output_name} '+
+                        Color.GREEN(f'onnx_output_name') + f': {re.sub("^wa/", "/", onnx_output_name)} '+
                         # Color.GREEN(f'tf_output_name') + f': {tf_output_name} '+
                         Color.GREEN(f'shape') + f': {validated_onnx_tensor.shape} '+
                         Color.GREEN(f'dtype') + f': {validated_onnx_tensor.dtype} '+

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -4033,18 +4033,19 @@ def onnx_tf_tensor_validation(
 
     Returns
     ----------
-    check_results: Dict[str, List[np.ndarray, int, float|int]]
+    check_results: Dict[str, List[np.ndarray, int, float|int], str]
         Tensor Comparison Results
         {
             onnx_output_name: [
                 onnx_tensor,
                 matched_flg, <--- 0: Unmatched, 1: Matched, 2: Skipped (Deleted or Shape Unmatched),
                 max_abs_err,
+                onnx_shape_tf_shape,
             ]
         }
     """
     check_results = {
-        k: [v[0], False, 0.0] \
+        k: [v[0], False, 0.0, ""] \
             for k, v in output_pairs.items()
     }
 
@@ -4120,9 +4121,12 @@ def onnx_tf_tensor_validation(
             # If there was no match between ONNX and TensorFlow output shapes.
             check_results[names_pair][1] = 2
             check_results[names_pair][2] = max_abs_err
+            check_results[names_pair][3] = \
+                f"onnx.shape:{onnx_tensor.shape if hasattr(onnx_tensor, 'shape') else 'None'}/tf.shape:{tf_tensor.shape if hasattr(tf_tensor, 'shape') else 'None'}"
         else:
             check_results[names_pair][1] = validate_result
             check_results[names_pair][2] = max_abs_err
+            check_results[names_pair][3] = ""
 
     return check_results
 

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -1,6 +1,7 @@
 import math
 import os
 import io
+import re
 import sys
 import copy
 import json
@@ -280,7 +281,7 @@ def print_node_info(func):
             if graph_input is not None:
                 debug(
                     Color.GREEN(f'INFO:') + ' '+
-                    Color.GREEN(f'input_op_name') + f': {graph_input.name} '+
+                    Color.GREEN(f'input_op_name') + f': {re.sub("^wa/", "/", graph_input.name)} '+
                     Color.GREEN(f'shape') + f': {graph_input.shape} '+
                     Color.GREEN(f'dtype') + f': {graph_input.dtype}'
                 )
@@ -294,18 +295,18 @@ def print_node_info(func):
                 )
                 debug(
                     Color.GREEN(f'INFO:') + ' ' + Color.MAGENTA(f'onnx_op_type') + ': '+
-                    f'{graph_node.op}' + Color.MAGENTA(' onnx_op_name') + f': {graph_node.name}')
+                    f'{graph_node.op}' + Color.MAGENTA(' onnx_op_name') + f': {re.sub("^wa/", "/", graph_node.name)}')
                 for idx, graph_node_input in enumerate(graph_node.inputs):
                     debug(
                         Color.GREEN(f'INFO:') + ' '+
-                        Color.CYAN(f' input_name.{idx+1}') + f': {graph_node_input.name} '+
+                        Color.CYAN(f' input_name.{idx+1}') + f': {re.sub("^wa/", "/", graph_node_input.name)} '+
                         Color.CYAN(f'shape') + f': {graph_node_input.shape} '+
                         Color.CYAN(f'dtype') + f': {graph_node_input.dtype}'
                     )
                 for idx, graph_node_output in enumerate(graph_node.outputs):
                     debug(
                         Color.GREEN(f'INFO:') + ' '+
-                        Color.CYAN(f' output_name.{idx+1}') + f': {graph_node_output.name} '+
+                        Color.CYAN(f' output_name.{idx+1}') + f': {re.sub("^wa/", "/", graph_node_output.name)} '+
                         Color.CYAN(f'shape') + f': {graph_node_output.shape} '+
                         Color.CYAN(f'dtype') + f': {graph_node_output.dtype}'
                     )


### PR DESCRIPTION
### 1. Content and background
- `onnx2tf.py`, `common_functions.py`
  - Improved log display during dummy inference
    1. Remove display of tensorflow output OP names
    2. Add display of onnx and tensorflow tensor shapes when `Skipped (Deleted or Shape Unmatched)` occurs.
    3. Remove `wa/`.
  - This is mainly for debugging purposes when converting dynamic tensors. 

![image](https://github.com/user-attachments/assets/baaefc23-bbc3-4193-aac7-8f3926aec83c)

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [FlexConv2d generated due to dynamic input shape? #759](https://github.com/PINTO0309/onnx2tf/issues/759)
- [Unable to convert RTMDet-ins to tflite #761](https://github.com/PINTO0309/onnx2tf/issues/761)