### PR TITLE
Fix boolean parameter replacement

### DIFF
--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -97,7 +97,7 @@ def replace_parameter(
                     bool(replace_value) if isinstance(replace_value, int) and replace_value in [0, 1] else \
                     bool(int(replace_value)) if isinstance(replace_value, str) and replace_value in ["0", "1"] else \
                     False if isinstance(replace_value, str) and replace_value.lower() == "false" else \
-                    True if isinstance(replace_value, str) and replace_value.lower() == "True" else \
+                    True if isinstance(replace_value, str) and replace_value.lower() == "true" else \
                     replace_value
             elif isinstance(value_before_replacement, int):
                 replace_value = int(replace_value)


### PR DESCRIPTION
### 1. Content and background
The `replace_parameter` function converts parameter values from JSON replacement files into appropriate Python types during ONNX model conversion. A case-sensitivity bug prevented proper conversion of the capitalized boolean string `"True"`, causing it to remain as a string instead of being converted to boolean `True`, which affects both the parameter replacement feature and the new auto-JSON generation feature. 

### 2. Summary of corrections
The bug occurred because the code called `.lower()` on the input string (converting `"True"` → `"true"`) but then compared against `"True"` (capital T), so `"true" == "True"` returned `False` and conversion failed. The fix was to change the comparison from `replace_value.lower() == "True"` to `replace_value.lower() == "true"`. Note that `"False"` was not affected as it correctly compared against `"false"`.

### 3. Before/After (If there is an operating log that can be used as a reference)
Use the following program to test it:
```python
import sys
from onnx2tf.utils.common_functions import replace_parameter

result = replace_parameter(
    value_before_replacement=False,
    param_target='test',
    param_name='test', 
    op_rep_params=[{'param_target': 'test', 'param_name': 'test', 'values': 'True'}]
)

print(f'Output: {result} (type: {type(result).__name__})')
```

### 4. Issue number (only if there is a related issue)
