### PR TITLE
Op MatMul improved resource usage for matrix shape compatibility check

### DIFF
--- a/onnx2tf/ops/MatMul.py
+++ b/onnx2tf/ops/MatMul.py
@@ -254,7 +254,7 @@ def make_node(
                         dummy_np_2 = np.ones(list(input_tensor_2.shape), dtype=np.float32).transpose(tensor_2_candidate_for_transposition)
 
                         actual_output_shape = _matmul_output_shape(dummy_np_1.shape, dummy_np_2.shape)
-                        if expected_output_shape is None:
+                        if actual_output_shape is None:
                             dummy_np_result: np.ndarray = np.matmul(dummy_np_1, dummy_np_2)
                             actual_output_shape = dummy_np_result.shape
                             


### PR DESCRIPTION
### 1. Content and background
The MatMul op converter tries to numerically optimize operation M=A*B. To only optimize compatible shapes, a check is present. The current check uses np.matmul on dummy matrices to verify the output shape is compatible with expected shape. For some of the compatible shapes (due to broadcasting), this can consume significant resources both in compute time and memory. 

### 2. Summary of corrections
Add a function to compute shape returned via np.matmul without actually running the np.matmul. In case the function fails (incompatible shapes) and returns None, use current implementation with np.matmul to verify the result (based on my internal unit tests it seems np.matmul can be safely removed, but I left it as it no longer poses threat of high resource usage). 

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
https://github.com/PINTO0309/onnx2tf/issues/679
