### PR TITLE
Fix combine_fixes arguments

### DIFF
--- a/onnx2tf/utils/json_auto_generator.py
+++ b/onnx2tf/utils/json_auto_generator.py
@@ -1417,7 +1417,7 @@ def generate_auto_replacement_json(
                 info(f"Generated {len(candidate_fixes)} candidate fixes")
                 
                 # Generate fix combinations
-                fix_combinations = combine_fixes(candidate_fixes, max_combinations=5)
+                fix_combinations = combine_fixes(candidate_fixes)
                 
                 # In a real implementation, we would test each combination
                 # For now, we'll use heuristics to select the best combination


### PR DESCRIPTION
### 1. Content and background
When `onnx2tf.convert` is invoked with with `check_onnx_tf_outputs_elementwise_close_full = True` it crashes, because combine_fixes is called with invalid arguments

### 2. Summary of corrections
Remove max_combinations from call.

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
