### PR TITLE
ir_version=10, kernel_shape handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.28.6
+  ghcr.io/pinto0309/onnx2tf:1.28.7
 
   or
 
@@ -317,7 +317,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.28.6
+  docker.io/pinto0309/onnx2tf:1.28.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.28.6'
+__version__ = '1.28.7'

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -62,7 +62,7 @@ def make_node(
         before_op_output_shape_trans,
     )
     kernel_shape = graph_node.attrs.get('kernel_shape', [])
-    kernel_size = len(kernel_shape)
+    kernel_size = len(kernel_shape) if kernel_shape != [] else len(graph_node.inputs[1].shape) - 2
     try:
         input_weights = get_weights_constant_or_variable(
             const_or_var=graph_node.inputs[1] \


### PR DESCRIPTION
### 1. Content and background

- `Conv`
  - Support for ir_version=10, where `kernel_shape` was deleted

    <img width="1504" height="367" alt="image" src="https://github.com/user-attachments/assets/f775555c-d202-488f-afa8-9710b7181121" />

    <img width="1079" height="502" alt="image" src="https://github.com/user-attachments/assets/4a7b466b-7173-495e-a7cf-458ff50309e9" />


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)

- [axes don't match array, input Conv : [ Torch -> ONNX -> TFLite ] #797](https://github.com/PINTO0309/onnx2tf/issues/797)