### PR TITLE
Improve `GridSample`

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.29.5
+  ghcr.io/pinto0309/onnx2tf:1.29.7
 
   or
 
@@ -329,7 +329,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.29.5
+  docker.io/pinto0309/onnx2tf:1.29.7
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.29.6'
+__version__ = '1.29.7'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onnx2tf"
-version = "1.29.6"
+version = "1.29.7"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC)."
 readme = "README.md"
 requires-python = "==3.11.12"


### PR DESCRIPTION
### 1. Content and background
- `GridSample`
  - Modes: `linear`, `nearest`, and `cubic` (the legacy `bilinear` string is mapped to `linear`).
  - Padding modes: `zeros`, `border`, and `reflection`.
  - Dimensionality: 1D, 2D, and 3D inputs are supported with N-linear, N-nearest, and N-cubic behavior.
  - Cubic interpolation uses a Catmull-Rom kernel (a = -0.75). 2D uses 4x4 samples, 3D uses 4x4x4 samples.
  - Performance: linear-index gather (`tf.gather`) is used for 2D/3D to reduce `gather_nd` overhead.
  - Dtype: interpolation runs in float, then casts back to the original input dtype.
    - `string` inputs are allowed only with `nearest` mode.

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [Improved grid_sample #544](https://github.com/PINTO0309/onnx2tf/issues/544)