### PR TITLE
verup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,19 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install pip -U \
-    && pip install onnx==1.17.0 \
-    && pip install onnxsim==0.4.33 \
-    && pip install onnx_graphsurgeon \
+    && pip install onnx==1.19.0 \
+    && pip install onnxsim==0.4.36 \
+    && pip install onnxoptimizer==0.4.2 \
+    && pip install onnx_graphsurgeon==0.5.8 \
     && pip install onnx2tf \
     && pip install onnx2tf \
-    && pip install simple_onnx_processing_tools \
+    && pip install simple_onnx_processing_tools==1.1.32 \
     && pip install tensorflow==2.19.0 \
     && pip install ai_edge_litert==1.2.0 \
     && pip install protobuf==4.25.5 \
     && pip install h5py==3.11.0 \
     && pip install psutil==5.9.5 \
-    && pip install onnxruntime==1.18.1 \
+    && pip install onnxruntime==1.23.0 \
     && pip install ml_dtypes==0.5.1 \
     && pip install tf-keras==2.19.0 \
     && pip install flatbuffers>=23.5.26

--- a/README.md
+++ b/README.md
@@ -270,10 +270,11 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - Linux / Windows
 - onnx==1.19.0
 - onnxruntime==1.23.0
-- onnx-simplifier==0.4.33 or 0.4.30 `(onnx.onnx_cpp2py_export.shape_inference.InferenceError: [ShapeInferenceError] (op_type:Slice, node name: /xxxx/Slice): [ShapeInferenceError] Inferred shape and existing shape differ in rank: (x) vs (y))`
+- onnxsim==0.4.36
+- onnxoptimizer==0.4.2
 - onnx_graphsurgeon==0.5.8
 - simple_onnx_processing_tools==1.1.32
-- tensorflow==2.19.0, Special bugs: [#436](https://github.com/PINTO0309/onnx2tf/issues/436)
+- tensorflow==2.19.0
 - tf-keras==2.19.0
 - ai-edge-litert==1.2.0
 - psutil==5.9.5
@@ -321,7 +322,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.29.7
+  ghcr.io/pinto0309/onnx2tf:1.29.8
 
   or
 
@@ -329,14 +330,15 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.29.7
+  docker.io/pinto0309/onnx2tf:1.29.8
 
   or
 
   pip install -U onnx==1.19.0 \
   && pip install -U onnx-graphsurgeon==0.5.8 \
   && pip install -U onnxruntime==1.23.0 \
-  && pip install -U onnxsim==0.4.33 \
+  && pip install -U onnxsim==0.4.36 \
+  && pip install -U onnxoptimizer==0.4.2 \
   && pip install -U simple_onnx_processing_tools==1.1.32 \
   && pip install -U sne4onnx>=1.0.13 \
   && pip install -U sng4onnx>=1.0.4 \

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.29.7'
+__version__ = '1.29.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onnx2tf"
-version = "1.29.7"
+version = "1.29.8"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC)."
 readme = "README.md"
 requires-python = "==3.11.12"
@@ -10,7 +10,8 @@ dependencies = [
     "onnx==1.19.0",
     "onnxruntime==1.23.0",
     "opencv-python==4.11.0.86",
-    "onnxsim==0.4.30",
+    "onnxsim==0.4.36",
+    "onnxoptimizer==0.4.2",
     "ai-edge-litert==2.1.0",
     "tensorflow==2.19.0",
     "tf-keras==2.19.0",


### PR DESCRIPTION
### 1. Content and background

- onnxsim `ir_version=10`
  - onnx==1.19.0
  - onnxruntime==1.23.0
  - onnxsim==0.4.36
  - onnxoptimizer==0.4.2
- Not fix: https://github.com/PINTO0309/onnx2tf/issues/436

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
