### PR TITLE
Improved `MatMul`/`BatchMatMul` conversion stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.29.11
+  ghcr.io/pinto0309/onnx2tf:1.29.12
 
   or
 
@@ -330,7 +330,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.29.11
+  docker.io/pinto0309/onnx2tf:1.29.12
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.29.11'
+__version__ = '1.29.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "1.29.11"
+version = "1.29.12"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.10.12"


### PR DESCRIPTION
### 1. Content and background

- `MatMul`
  - I adjusted the MatMul post‑processing to handle cases where the ONNX output rank is smaller than the TF matmul result by squeezing unit dims before attempting a transpose. This prevents the invalid perm=['0'] call that caused the Dimension must be 2 but is 1 error. 
  - Added a small shape‑match helper and a squeeze step for trailing or leading 1 dims when ONNX output rank is smaller.
  Recomputed shape after squeeze and only transpose when the perm length matches the tensor rank.

```bash
onnx2tf -i rtdetrv4_s.onnx -cotof
```

<img width="1171" height="424" alt="image" src="https://github.com/user-attachments/assets/f3420029-af0a-426b-bbdb-29b331458f33" />

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- https://github.com/PINTO0309/onnx2tf/issues/815