### PR TITLE
Transformation stability has been significantly improved for models with many dynamic tensors containing `NonZero` OPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.29.13
+  ghcr.io/pinto0309/onnx2tf:1.29.14
 
   or
 
@@ -330,7 +330,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.29.13
+  docker.io/pinto0309/onnx2tf:1.29.14
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.29.13'
+__version__ = '1.29.14'

--- a/onnx2tf/ops/Flatten.py
+++ b/onnx2tf/ops/Flatten.py
@@ -1,6 +1,7 @@
 import random
 random.seed(0)
 import numpy as np
+import itertools
 np.random.seed(0)
 import tensorflow as tf
 import tf_keras
@@ -13,6 +14,8 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    dummy_tf_inference,
+    get_tf_model_inputs,
     pre_process_transpose,
     post_process_transpose,
     transpose_with_flexing_deterrence,
@@ -84,6 +87,109 @@ def make_node(
         **kwargs,
     )
 
+    # Param replacement
+    input_tensor = replace_parameter(
+        value_before_replacement=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
+    # Pre-process transpose
+    input_tensor = pre_process_transpose(
+        value_before_transpose=input_tensor,
+        param_target='inputs',
+        param_name=graph_node.inputs[0].name,
+        **kwargs,
+    )
+
+    perm = [
+        convert_axis(
+            axis=idx,
+            tensor_rank=input_tensor_rank,
+            before_op_output_shape_trans=before_op_output_shape_trans,
+        ) for idx in range(input_tensor_rank)
+    ]
+
+    # Brute-force transpose to match ONNX dummy inference outputs when available.
+    onnx_tensor_infos_for_validation = kwargs.get('onnx_tensor_infos_for_validation', None)
+    test_data_nhwc: np.ndarray = kwargs.get('test_data_nhwc', None)
+    custom_input_op_name_np_data_path: str = kwargs.get('custom_input_op_name_np_data_path', None)
+    disable_strict_mode: bool = kwargs.get('disable_strict_mode', False)
+    if not disable_strict_mode \
+        and onnx_tensor_infos_for_validation is not None \
+        and onnx_tensor_infos_for_validation.get(graph_node_output.name, None) is not None:
+        validation_input = None
+        if isinstance(input_tensor, np.ndarray):
+            validation_input = input_tensor
+        elif hasattr(input_tensor, 'numpy'):
+            try:
+                validation_input = input_tensor.numpy()
+            except Exception:
+                validation_input = None
+        else:
+            try:
+                tf_model_inputs = get_tf_model_inputs(tf_layers_dict=tf_layers_dict)
+                val_model = tf_keras.Model(
+                    inputs=tf_model_inputs,
+                    outputs=[input_tensor],
+                )
+                tf_pre_tensor_infos = dummy_tf_inference(
+                    model=val_model,
+                    inputs=tf_model_inputs,
+                    test_data_nhwc=test_data_nhwc,
+                    custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                )
+                if len(tf_pre_tensor_infos) >= 1:
+                    validation_input = list(tf_pre_tensor_infos.values())[0]
+                del val_model
+            except Exception:
+                validation_input = None
+        if validation_input is None:
+            onnx_input_name = graph_node.inputs[0].name
+            if onnx_tensor_infos_for_validation.get(onnx_input_name, None) is not None:
+                validation_input = onnx_tensor_infos_for_validation[onnx_input_name]
+
+        onnx_output = onnx_tensor_infos_for_validation.get(graph_node_output.name, None)
+        if validation_input is not None and onnx_output is not None:
+            rank = len(validation_input.shape)
+            if rank <= 6:
+                perm_candidates = itertools.permutations(range(rank))
+            else:
+                perm_candidates = [perm]
+
+            def _flatten_np(arr, axis):
+                if axis == 0:
+                    return arr.reshape(1, -1)
+                if axis >= arr.ndim:
+                    return arr.reshape(-1, 1)
+                return arr.reshape(
+                    int(np.prod(arr.shape[:axis])),
+                    int(np.prod(arr.shape[axis:])),
+                )
+
+            matched_perm = None
+            matched_axis = None
+            for cand in perm_candidates:
+                try:
+                    cand_arr = np.transpose(validation_input, cand)
+                    for axis_candidate in range(0, rank + 1):
+                        cand_flat = _flatten_np(cand_arr, axis_candidate)
+                        if cand_flat.shape != onnx_output.shape:
+                            continue
+                        if np.allclose(cand_flat, onnx_output, rtol=0.0, atol=0.0, equal_nan=True):
+                            matched_perm = list(cand)
+                            matched_axis = axis_candidate
+                            break
+                    if matched_perm is not None:
+                        break
+                except Exception:
+                    continue
+            if matched_perm is not None:
+                perm = matched_perm
+                if matched_axis is not None:
+                    axis = matched_axis
+
     # Generation of TF OP
     cal_shape = None
     if axis == 0:
@@ -134,30 +240,6 @@ def make_node(
         has_str_outputshape = True in [True for dim in output_shape if isinstance(dim, str)]
         has_undefined_outputshape = has_none_outputshape or has_str_outputshape
     cal_shape = cal_shape if has_undefined_outputshape else output_shape
-
-    # Param replacement
-    input_tensor = replace_parameter(
-        value_before_replacement=input_tensor,
-        param_target='inputs',
-        param_name=graph_node.inputs[0].name,
-        **kwargs,
-    )
-
-    # Pre-process transpose
-    input_tensor = pre_process_transpose(
-        value_before_transpose=input_tensor,
-        param_target='inputs',
-        param_name=graph_node.inputs[0].name,
-        **kwargs,
-    )
-
-    perm = [
-        convert_axis(
-            axis=idx,
-            tensor_rank=input_tensor_rank,
-            before_op_output_shape_trans=before_op_output_shape_trans,
-        ) for idx in range(input_tensor_rank)
-    ]
     input_tensor = transpose_with_flexing_deterrence(
         input_tensor=input_tensor,
         perm=list(perm) if perm is not None else None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "1.29.13"
+version = "1.29.14"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.10.12"


### PR DESCRIPTION
### 1. Content and background
- Transformation stability has been significantly improved for models with many dynamic tensors containing `NonZero` OPs.
- `NonZero`
  - Added input data capture for ONNX/TF dummy inference to reuse actual input tensors.
  - Implemented `apply_nonzero_passthrough` to store `NonZero` outputs as their input tensors in ONNX dummy outputs (optionally updating graph output shapes).
  - Implemented `apply_nonzero_passthrough_tf` to mirror the same passthrough behavior on TF dummy outputs.
  - Wired both passthroughs into validation (`-coto/-cotof`) and auto-generate-json validation flows.
  - `dummy_onnx_inference`: added `input_datas_for_validation` output hook.
  - `dummy_tf_inference`: added `input_datas_for_validation` output hook.
- Flatten
  - brute-force alignment
  - Added brute-force permutation + axis search in `onnx2tf/ops/Flatten.py` to match ONNX dummy outputs exactly when available.
  - Falls back to ONNX input tensor values if TF-side validation input is not obtainable.
- `explicit_broadcast` now reshapes 1D operands to the last axis when it matches the other operand’s last dimension, avoiding unintended transposes.
- [The input shape broadcasting error of the ADD operator and replace.json cannot resolve the issue #784](https://github.com/PINTO0309/onnx2tf/issues/784)
- model: https://huggingface.co/HuggingFaceTB/SmolVLM-256M-Instruct/blob/main/onnx/vision_encoder.onnx
  ```bash
  onnx2tf \
  -i vision_encoder.onnx \
  -sh pixel_values:1,1,3,512,512 pixel_attention_mask:1,1,512,512
  ```
  <img width="1575" height="506" alt="image" src="https://github.com/user-attachments/assets/595b7249-14fa-4b7d-b613-15916ad8ecec" />
  <img width="807" height="532" alt="image" src="https://github.com/user-attachments/assets/4308a7b9-5f94-4730-8ee2-e93c0ed63f4b" />

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
- [The input shape broadcasting error of the ADD operator and replace.json cannot resolve the issue #784](https://github.com/PINTO0309/onnx2tf/issues/784)