### PR TITLE
Improved `Concat` conversion stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.29.16
+  ghcr.io/pinto0309/onnx2tf:1.29.17
 
   or
 
@@ -330,7 +330,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.29.16
+  docker.io/pinto0309/onnx2tf:1.29.17
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.29.16'
+__version__ = '1.29.17'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "1.29.16"
+version = "1.29.17"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.10.12"


### PR DESCRIPTION
### 1. Content and background

- `Concat`
  - Improved `Concat` conversion stability.
  - In 4D, the maximum number of attempts introduced by the new search logic is roughly bounded as:
    ```
    4 * P^N
    ```
  - `4` is the number of candidate axes (0–3).
  - `P` is the number of permutation candidates per input.
  - `N` is the number of input tensors.
  
  Permutation count `P`:
  - Full search: `P = 24` (all 4D permutations).
  - If `24^N` exceeds the guard threshold (20,000), the search switches to a limited set, so `P = 3`.
  
  Worst-case attempts:
  - `N=2`: `4 * 24^2 = 2,304`
  - `N=3`: `4 * 24^3 = 55,296`
  - `N=4`: `24^4` exceeds the threshold, so limited mode: `4 * 3^4 = 324`

These are hard upper bounds; in practice the actual attempts are typically much fewer because shape-incompatible candidates are pruned before `tf.concat`, and the search stops early once the ONNX output shape matches.

- `e2pose`
  <img width="1556" height="478" alt="image" src="https://github.com/user-attachments/assets/2b92266c-bbc5-4178-b56f-2542f8386669" />


### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
