### PR TITLE
Addressing edge cases of `PRelu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:1.29.22
+  ghcr.io/pinto0309/onnx2tf:1.29.23
 
   or
 
@@ -331,7 +331,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:1.29.22
+  docker.io/pinto0309/onnx2tf:1.29.23
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '1.29.22'
+__version__ = '1.29.23'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "1.29.22"
+version = "1.29.23"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.10.12"
@@ -56,7 +56,7 @@ Issues = "https://github.com/PINTO0309/onnx2tf/issues"
 
 [tool.uv]
 override-dependencies = [
-    "onnx==1.19.0",
+    "onnx==1.19.1",
     "onnxsim==0.4.36",
     "ml-dtypes==0.5.1",
     "numpy==1.26.4",


### PR DESCRIPTION
## PReLU fallback handling
- Try native `PReLU` first; if it raises an exception, fall back to a pseudo‑PReLU implementation only for that failing op.
- This limits the pseudo‑PReLU path to problematic nodes instead of applying it globally.

## Affected files
- `onnx2tf/ops/PRelu.py`

## Model
- [something.onnx.zip](https://github.com/user-attachments/files/25009414/something.onnx.zip)

- https://github.com/onnx/onnx-tensorflow/issues/1079
