### PR TITLE
fix-shape_unmatched_special_avoidance_workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.3
+  ghcr.io/pinto0309/onnx2tf:2.0.4
 
   or
 
@@ -334,7 +334,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.3
+  docker.io/pinto0309/onnx2tf:2.0.4
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.3'
+__version__ = '2.0.4'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.3"
+version = "2.0.4"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Change Summary (Current Fix)

## Background
- Running `onnx2tf.py -i densenet-12.onnx -cotof` failed at `Mul` (`sng_Mul_1`) with a broadcast shape mismatch.
- Actual TF shapes at failure:
  - `x`: `(1, 112, 112, 64)`
  - `y`: `(1, 64, 1, 1)` (channel-first style)

## Root Cause
- In `shape_unmatched_special_avoidance_workaround`, some transpose paths converted constant `np.ndarray` inputs into `tf.Tensor`.
- After this conversion, downstream `explicit_broadcast` behavior changed and the constant was no longer normalized to NHWC-compatible shape.
- As a result, the constant remained `(1, 64, 1, 1)` instead of `(1, 1, 1, 64)`, causing `tf.math.multiply` to fail.

## Implemented Fix
- File: `onnx2tf/utils/common_functions.py`
- Function: `shape_unmatched_special_avoidance_workaround`
- Added helper:
  - `_transpose_preserve_array(tensor, perm)`
  - Uses `np.transpose` when `tensor` is `np.ndarray`
  - Uses existing `transpose_with_flexing_deterrence` for tensor-like inputs
- Replaced internal transpose call sites in this function with `_transpose_preserve_array` so constants keep `np.ndarray` type through alignment.

## Effect
- Constant layout alignment now preserves array semantics and allows `explicit_broadcast` to correctly reshape constants to channel-last form when needed.
- For the failing case, `y` is now normalized to `(1, 1, 1, 64)`, and `Mul` executes successfully.

## Validation
- Reproduced and re-ran:
  - `python onnx2tf/onnx2tf.py -i densenet-12.onnx -cotof`
- Result:
  - Conversion completed successfully (`exit code 0`)
  - Validation logs reported matching outputs for the model conversion path.