### PR TITLE
Step 10-12: Add limited dynamic-range quantization for flatbuffer_direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1666,11 +1666,12 @@ optional arguments:
     "flatbuffer_direct": Use direct FlatBuffer builder path (limited OP/quantization support).
 
 flatbuffer_direct notes:
-1. Direct export currently supports FP32/FP16 `.tflite` generation only.
-2. Dynamic range quantization (`-odrqt`) and integer quantization (`-oiqt`) are not supported.
-3. Supported builtin OP set (first implementation): `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`.
-4. Unsupported OPs fail explicitly with `NotImplementedError`.
-5. `schema.fbs` is fetched from LiteRT by pinned tag by default (`v2.1.2`), and can be overridden by:
+1. Direct export supports FP32/FP16 `.tflite` generation.
+2. Dynamic range quantization (`-odrqt`) is supported in a limited form: weight-only INT8 quantization for `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED`.
+3. Integer quantization (`-oiqt`) is not supported in `flatbuffer_direct` yet.
+4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`.
+5. Unsupported OPs fail explicitly with `NotImplementedError`.
+6. `schema.fbs` is fetched from LiteRT by pinned tag by default (`v2.1.2`), and can be overridden by:
    `ONNX2TF_TFLITE_SCHEMA_REPOSITORY`, `ONNX2TF_TFLITE_SCHEMA_TAG`, `ONNX2TF_TFLITE_SCHEMA_RELATIVE_PATH`.
 
   -qt {per-channel,per-tensor}, --quant_type {per-channel,per-tensor}
@@ -2237,7 +2238,8 @@ convert(
       TFLite generation backend.
       "tf_converter"(default): Use TensorFlow Lite Converter.
       "flatbuffer_direct": Use direct FlatBuffer builder path.
-      Note: "flatbuffer_direct" supports a limited builtin OP set and FP32/FP16 only.
+      Note: "flatbuffer_direct" supports a limited builtin OP set,
+      FP32/FP16 export, and limited dynamic-range quantization.
 
     quant_norm_mean: Optional[str]
         Normalized average value during quantization.

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -739,7 +739,8 @@ def convert(
         TFLite generation backend.\n
         "tf_converter"(default): Use TensorFlow Lite Converter.\n
         "flatbuffer_direct": Use direct FlatBuffer builder path.\n
-        Note: "flatbuffer_direct" supports a limited builtin OP set and FP32/FP16 only.\n
+        Note: "flatbuffer_direct" supports a limited builtin OP set,\n
+        FP32/FP16 export, and limited dynamic-range quantization.\n
 
     quant_norm_mean: Optional[str]
         Normalized average value during quantization.\n
@@ -2772,6 +2773,17 @@ def convert(
             )
             info(Color.GREEN(f'Float32 tflite output complete! ({direct_outputs["float32_tflite_path"]})'))
             info(Color.GREEN(f'Float16 tflite output complete! ({direct_outputs["float16_tflite_path"]})'))
+            if output_dynamic_range_quantized_tflite:
+                if 'dynamic_range_quant_tflite_path' not in direct_outputs:
+                    raise RuntimeError(
+                        'flatbuffer_direct dynamic-range quantization was requested but no output was generated.'
+                    )
+                info(
+                    Color.GREEN(
+                        f'Dynamic range quantized tflite output complete! '
+                        f'({direct_outputs["dynamic_range_quant_tflite_path"]})'
+                    )
+                )
             if copy_onnx_input_output_names_to_tflite:
                 info(
                     'Input/Output tensor names are directly written from ONNX graph in flatbuffer_direct backend.'

--- a/onnx2tf/tflite_builder/quantization.py
+++ b/onnx2tf/tflite_builder/quantization.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+import numpy as np
+
+from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, QuantParamIR, TensorIR
+
+
+_DYNAMIC_RANGE_TARGET_OPS = {
+    "CONV_2D",
+    "DEPTHWISE_CONV_2D",
+    "FULLY_CONNECTED",
+}
+
+
+def _clone_model_ir(model_ir: ModelIR) -> ModelIR:
+    clone = ModelIR(
+        name=model_ir.name,
+        description=model_ir.description,
+    )
+    clone.inputs = list(model_ir.inputs)
+    clone.outputs = list(model_ir.outputs)
+    clone.operators = [
+        OperatorIR(
+            op_type=op.op_type,
+            inputs=list(op.inputs),
+            outputs=list(op.outputs),
+            options=dict(op.options),
+            version=op.version,
+        )
+        for op in model_ir.operators
+    ]
+    for name, tensor in model_ir.tensors.items():
+        clone.tensors[name] = TensorIR(
+            name=tensor.name,
+            dtype=tensor.dtype,
+            shape=list(tensor.shape),
+            shape_signature=list(tensor.shape_signature)
+            if tensor.shape_signature is not None
+            else None,
+            data=tensor.data.copy() if isinstance(tensor.data, np.ndarray) else tensor.data,
+            is_variable=tensor.is_variable,
+            quantization=(
+                dict(tensor.quantization)
+                if isinstance(tensor.quantization, dict)
+                else QuantParamIR(
+                    scale=list(tensor.quantization.scale),
+                    zero_point=list(tensor.quantization.zero_point),
+                    quantized_dimension=int(tensor.quantization.quantized_dimension),
+                    min=list(tensor.quantization.min)
+                    if tensor.quantization.min is not None
+                    else None,
+                    max=list(tensor.quantization.max)
+                    if tensor.quantization.max is not None
+                    else None,
+                )
+                if isinstance(tensor.quantization, QuantParamIR)
+                else tensor.quantization
+            ),
+        )
+    return clone
+
+
+def _symmetric_int8_quantize(data: np.ndarray) -> tuple[np.ndarray, float]:
+    data = np.asarray(data, dtype=np.float32)
+    max_abs = float(np.max(np.abs(data))) if data.size > 0 else 0.0
+    if max_abs == 0.0:
+        scale = 1.0
+        q = np.zeros_like(data, dtype=np.int8)
+        return q, scale
+    scale = max_abs / 127.0
+    q = np.round(data / scale)
+    q = np.clip(q, -127, 127).astype(np.int8)
+    return q, float(scale)
+
+
+def build_dynamic_range_quantized_model_ir(model_ir: ModelIR) -> ModelIR:
+    clone = _clone_model_ir(model_ir)
+
+    quantized_weight_names: List[str] = []
+    for op in clone.operators:
+        if op.op_type not in _DYNAMIC_RANGE_TARGET_OPS:
+            continue
+        if len(op.inputs) < 2:
+            continue
+        weight_name = op.inputs[1]
+        if weight_name not in clone.tensors:
+            continue
+        tensor = clone.tensors[weight_name]
+        if tensor.dtype != "FLOAT32":
+            continue
+        if not isinstance(tensor.data, np.ndarray):
+            continue
+
+        q_data, scale = _symmetric_int8_quantize(tensor.data)
+        tensor.dtype = "INT8"
+        tensor.data = q_data
+        tensor.quantization = QuantParamIR(
+            scale=[float(scale)],
+            zero_point=[0],
+            min=[float(np.min(tensor.data.astype(np.float32) * scale))],
+            max=[float(np.max(tensor.data.astype(np.float32) * scale))],
+            quantized_dimension=0,
+        )
+        quantized_weight_names.append(weight_name)
+
+    if len(quantized_weight_names) == 0:
+        raise NotImplementedError(
+            "flatbuffer_direct dynamic-range quantization requires at least one supported weight tensor "
+            "(CONV_2D/DEPTHWISE_CONV_2D/FULLY_CONNECTED)."
+        )
+
+    clone.description = f"{clone.description} (dynamic_range_quantized)"
+    return clone


### PR DESCRIPTION
## Summary
- add M5 Stage1 extension steps to `update-builder.md`
- implement limited dynamic-range quantization (`-odrqt`) in `flatbuffer_direct`
- keep `-oiqt` unsupported with explicit error
- add `QuantParamIR` and write tensor quantization parameters to FlatBuffer
- extend tests with dynamic-range quantization smoke case
- update README constraints and support notes

## Validation
- `pytest -q tests/test_tflite_builder_direct.py` (5 passed)
- `python -m py_compile onnx2tf/tflite_builder/*.py onnx2tf/tflite_builder/op_builders/*.py`
