### PR TITLE
Step 13: Expand dynamic-range quantization targets in flatbuffer_direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1667,7 +1667,9 @@ optional arguments:
 
 flatbuffer_direct notes:
 1. Direct export supports FP32/FP16 `.tflite` generation.
-2. Dynamic range quantization (`-odrqt`) is supported in a limited form: weight-only INT8 quantization for `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED`.
+2. Dynamic range quantization (`-odrqt`) is supported in a limited form:
+   weight-only INT8 quantization for `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED`,
+   and constant tensor quantization + `DEQUANTIZE` insertion for `ADD`, `SUB`, `MUL`, `DIV`, `CONCATENATION`.
 3. Integer quantization (`-oiqt`) is not supported in `flatbuffer_direct` yet.
 4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`.
 5. Unsupported OPs fail explicitly with `NotImplementedError`.

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -147,7 +147,7 @@ def _build_builtin_options(
         return _build_pool2d_options(schema_tflite, op)
     if op.op_type == "FULLY_CONNECTED":
         return _build_fully_connected_options(schema_tflite, op)
-    if op.op_type == "LOGISTIC":
+    if op.op_type in ["LOGISTIC", "DEQUANTIZE"]:
         return _enum(schema_tflite, "BuiltinOptions", "NONE"), None
     raise NotImplementedError(
         f"BuiltinOptions mapping is not implemented for op_type={op.op_type}"

--- a/update-builder.md
+++ b/update-builder.md
@@ -48,6 +48,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 8 実装（`tests/test_tflite_builder_direct.py` 追加、backend matrix/Interpreter 実行テスト追加）
 - Step 9 実装（README に backend 制約・対応OP・schemaタグ固定運用を追記）
 - Step 10-12 実装（`flatbuffer_direct` に限定 dynamic range quantization を追加、`QuantParamIR`/quantization 書き込み対応、`-oiqt` は未対応のまま明示エラー）
+- Step 13 実装（`-odrqt` 対象拡張: 定数入力を使う `ADD/SUB/MUL/DIV/CONCATENATION` に対して定数INT8化 + `DEQUANTIZE` 挿入を追加）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`
@@ -56,12 +57,13 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - `tflite_backend='tf_converter'` で従来どおり変換可能なこと
 - `python -m py_compile onnx2tf/tflite_builder/*.py onnx2tf/tflite_builder/op_builders/*.py`
 - 小規模 ONNX モデル（Add/Reshape/Conv/AveragePool/Gemm）で `flatbuffer_direct` 出力を生成し `Interpreter.allocate_tensors()` が通ること
-- `pytest -q tests/test_tflite_builder_direct.py` が通過（5 passed）
+- `pytest -q tests/test_tflite_builder_direct.py` が通過（6 passed）
 - `-odrqt` 指定で `*_dynamic_range_quant.tflite` が生成され、Gemm小規模モデルで `Interpreter.allocate_tensors()` および `invoke()` が通ること
+- `-odrqt` 指定で Add(constant) 小規模モデルも `Interpreter.invoke()` まで通ること
 
 3. 未着手:
 - `-oiqt`（full/integer quantization）対応
-- dynamic range quantization の対象OP拡張（現状: `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED` のweight-only）
+- dynamic range quantization の精度強化（例: per-channel 量子化やしきい値制御）
 
 ## 拡張ステージ（M5-Stage1: Dynamic Range Quant 最小対応）
 ### Step 10: 拡張仕様固定（限定解禁）
@@ -90,6 +92,15 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 完了条件:
 1. `*_dynamic_range_quant.tflite` が生成される。
 2. 小規模モデルで `Interpreter.allocate_tensors()` が通る。
+
+### Step 13: Dynamic Range Quant 対象拡張（定数演算）
+1. `ADD`, `SUB`, `MUL`, `DIV`, `CONCATENATION` の定数入力を量子化対象に追加する。
+2. 上記定数は INT8 化したうえで、演算直前に `DEQUANTIZE` を挿入して互換性を維持する。
+3. 対応外のケースは引き続き明示失敗を維持する。
+
+完了条件:
+1. Add(constant) などの小規模モデルで `-odrqt` が成功し、推論可能である。
+2. 既存 `-odrqt`（Conv/Depthwise/FC weight-only）が回帰しない。
 
 ## 作業ステップ
 
@@ -255,3 +266,4 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 11. `[x] Step 10 完了`
 12. `[x] Step 11 完了`
 13. `[x] Step 12 完了`
+14. `[x] Step 13 完了`


### PR DESCRIPTION
## Summary
- implement Step 13 extension for `flatbuffer_direct` dynamic-range quantization
- expand `-odrqt` target coverage to constant inputs used by `ADD`, `SUB`, `MUL`, `DIV`, `CONCATENATION`
- quantize those constants to INT8 and insert `DEQUANTIZE` ops before consumer ops
- keep existing kernel-weight quantization path for `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED`
- update `model_writer` to support `DEQUANTIZE` builtin options handling
- update `README.md` and `update-builder.md` progress
- add test for Add(constant) dynamic-range quantized inference path

## Validation
- `python -m py_compile onnx2tf/tflite_builder/quantization.py onnx2tf/tflite_builder/model_writer.py tests/test_tflite_builder_direct.py onnx2tf/tflite_builder/ir.py onnx2tf/tflite_builder/tensor_buffer_builder.py onnx2tf/tflite_builder/__init__.py onnx2tf/onnx2tf.py`
- `pytest -q tests/test_tflite_builder_direct.py` (6 passed)
