### PR TITLE
Step 14: Wire quant_type into flatbuffer_direct dynamic-range quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,6 +1670,7 @@ flatbuffer_direct notes:
 2. Dynamic range quantization (`-odrqt`) is supported in a limited form:
    weight-only INT8 quantization for `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED`,
    and constant tensor quantization + `DEQUANTIZE` insertion for `ADD`, `SUB`, `MUL`, `DIV`, `CONCATENATION`.
+   For kernel weights, `--quant_type per-channel` and `--quant_type per-tensor` are both supported in `flatbuffer_direct`.
 3. Integer quantization (`-oiqt`) is not supported in `flatbuffer_direct` yet.
 4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`.
 5. Unsupported OPs fail explicitly with `NotImplementedError`.

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -2768,6 +2768,7 @@ def convert(
                 output_folder_path=output_folder_path,
                 output_file_name=output_file_name,
                 output_weights=output_weights,
+                quant_type=quant_type,
                 output_dynamic_range_quantized_tflite=output_dynamic_range_quantized_tflite,
                 output_integer_quantized_tflite=output_integer_quantized_tflite,
             )

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -26,6 +26,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
     output_file_name = kwargs.get("output_file_name", "model")
     onnx_graph = kwargs.get("onnx_graph", None)
     output_weights = bool(kwargs.get("output_weights", False))
+    quant_type = kwargs.get("quant_type", "per-channel")
     output_dynamic_range_quantized_tflite = bool(
         kwargs.get("output_dynamic_range_quantized_tflite", False)
     )
@@ -60,7 +61,10 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
 
     dynamic_range_path = None
     if output_dynamic_range_quantized_tflite:
-        dynamic_model_ir = build_dynamic_range_quantized_model_ir(model_ir)
+        dynamic_model_ir = build_dynamic_range_quantized_model_ir(
+            model_ir,
+            quant_type=str(quant_type),
+        )
         dynamic_range_path = os.path.join(
             output_folder_path,
             f"{output_file_name}_dynamic_range_quant.tflite",


### PR DESCRIPTION
## Summary
- implement Step 14: wire `quant_type` into `flatbuffer_direct` dynamic-range quantization path
- add `quant_type` handoff from `onnx2tf.convert()` to flatbuffer direct exporter
- support `per-channel` and `per-tensor` kernel weight quantization for `-odrqt`
- keep constant-op quantization (`ADD/SUB/MUL/DIV/CONCATENATION`) in per-tensor mode for compatibility
- update README and `update-builder.md` status
- add tests that verify scale-length behavior changes between `per-channel` and `per-tensor`

## Validation
- `python -m py_compile onnx2tf/tflite_builder/quantization.py onnx2tf/tflite_builder/__init__.py onnx2tf/onnx2tf.py tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_builder_direct.py` (8 passed)
