### PR TITLE
Step 15: Add limited integer quantization support for flatbuffer_direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1671,8 +1671,10 @@ flatbuffer_direct notes:
    weight-only INT8 quantization for `CONV_2D`, `DEPTHWISE_CONV_2D`, `FULLY_CONNECTED`,
    and constant tensor quantization + `DEQUANTIZE` insertion for `ADD`, `SUB`, `MUL`, `DIV`, `CONCATENATION`.
    For kernel weights, `--quant_type per-channel` and `--quant_type per-tensor` are both supported in `flatbuffer_direct`.
-3. Integer quantization (`-oiqt`) is not supported in `flatbuffer_direct` yet.
-4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`.
+3. Integer quantization (`-oiqt`) is supported in a limited form:
+   `*_integer_quant.tflite` and `*_full_integer_quant.tflite` are generated.
+   `*_integer_quant_with_int16_act.tflite` and `*_full_integer_quant_with_int16_act.tflite` are not generated in `flatbuffer_direct`.
+4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`, `DEQUANTIZE`, `QUANTIZE`.
 5. Unsupported OPs fail explicitly with `NotImplementedError`.
 6. `schema.fbs` is fetched from LiteRT by pinned tag by default (`v2.1.2`), and can be overridden by:
    `ONNX2TF_TFLITE_SCHEMA_REPOSITORY`, `ONNX2TF_TFLITE_SCHEMA_TAG`, `ONNX2TF_TFLITE_SCHEMA_RELATIVE_PATH`.
@@ -2242,7 +2244,8 @@ convert(
       "tf_converter"(default): Use TensorFlow Lite Converter.
       "flatbuffer_direct": Use direct FlatBuffer builder path.
       Note: "flatbuffer_direct" supports a limited builtin OP set,
-      FP32/FP16 export, and limited dynamic-range quantization.
+      FP32/FP16 export, limited dynamic-range quantization,
+      and limited integer quantization.
 
     quant_norm_mean: Optional[str]
         Normalized average value during quantization.

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -740,7 +740,8 @@ def convert(
         "tf_converter"(default): Use TensorFlow Lite Converter.\n
         "flatbuffer_direct": Use direct FlatBuffer builder path.\n
         Note: "flatbuffer_direct" supports a limited builtin OP set,\n
-        FP32/FP16 export, and limited dynamic-range quantization.\n
+        FP32/FP16 export, limited dynamic-range quantization,\n
+        and limited integer quantization.\n
 
     quant_norm_mean: Optional[str]
         Normalized average value during quantization.\n
@@ -2202,6 +2203,7 @@ def convert(
             """
             # AUTO calib 4D check
             if output_integer_quantized_tflite \
+                and tflite_backend == 'tf_converter' \
                 and custom_input_op_name_np_data_path is None \
                 and (graph_input.dtype != np.float32 or len(graph_input.shape) != 4):
                 error(
@@ -2769,6 +2771,8 @@ def convert(
                 output_file_name=output_file_name,
                 output_weights=output_weights,
                 quant_type=quant_type,
+                input_quant_dtype=input_quant_dtype,
+                output_quant_dtype=output_quant_dtype,
                 output_dynamic_range_quantized_tflite=output_dynamic_range_quantized_tflite,
                 output_integer_quantized_tflite=output_integer_quantized_tflite,
             )
@@ -2783,6 +2787,27 @@ def convert(
                     Color.GREEN(
                         f'Dynamic range quantized tflite output complete! '
                         f'({direct_outputs["dynamic_range_quant_tflite_path"]})'
+                    )
+                )
+            if output_integer_quantized_tflite:
+                if 'integer_quant_tflite_path' not in direct_outputs:
+                    raise RuntimeError(
+                        'flatbuffer_direct integer quantization was requested but no output was generated.'
+                    )
+                if 'full_integer_quant_tflite_path' not in direct_outputs:
+                    raise RuntimeError(
+                        'flatbuffer_direct full integer quantization was requested but no output was generated.'
+                    )
+                info(
+                    Color.GREEN(
+                        f'INT8 Quantization tflite output complete! '
+                        f'({direct_outputs["integer_quant_tflite_path"]})'
+                    )
+                )
+                info(
+                    Color.GREEN(
+                        f'Full INT8 Quantization tflite output complete! '
+                        f'({direct_outputs["full_integer_quant_tflite_path"]})'
                     )
                 )
             if copy_onnx_input_output_names_to_tflite:

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -6,17 +6,17 @@ from typing import Any, Dict
 from onnx2tf.tflite_builder.ir import clone_model_ir_with_float16
 from onnx2tf.tflite_builder.lower_from_onnx2tf import lower_onnx_to_ir
 from onnx2tf.tflite_builder.model_writer import write_model_file
-from onnx2tf.tflite_builder.quantization import build_dynamic_range_quantized_model_ir
+from onnx2tf.tflite_builder.quantization import (
+    build_dynamic_range_quantized_model_ir,
+    build_full_integer_quantized_model_ir,
+    build_integer_quantized_model_ir,
+)
 from onnx2tf.tflite_builder.schema_loader import load_schema_module
 from onnx2tf.utils.common_functions import weights_export
 
 
 def _reject_unsupported_quantization(**kwargs: Any) -> None:
-    if kwargs.get("output_integer_quantized_tflite", False):
-        raise NotImplementedError(
-            "flatbuffer_direct does not support integer-quantized tflite yet. "
-            "Use tflite_backend='tf_converter' for quantized export."
-        )
+    return
 
 
 def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
@@ -27,8 +27,13 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
     onnx_graph = kwargs.get("onnx_graph", None)
     output_weights = bool(kwargs.get("output_weights", False))
     quant_type = kwargs.get("quant_type", "per-channel")
+    input_quant_dtype = kwargs.get("input_quant_dtype", "int8")
+    output_quant_dtype = kwargs.get("output_quant_dtype", "int8")
     output_dynamic_range_quantized_tflite = bool(
         kwargs.get("output_dynamic_range_quantized_tflite", False)
+    )
+    output_integer_quantized_tflite = bool(
+        kwargs.get("output_integer_quantized_tflite", False)
     )
 
     if onnx_graph is None:
@@ -75,6 +80,39 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
             output_tflite_path=dynamic_range_path,
         )
 
+    integer_quant_path = None
+    full_integer_quant_path = None
+    if output_integer_quantized_tflite:
+        integer_model_ir = build_integer_quantized_model_ir(
+            model_ir,
+            quant_type=str(quant_type),
+        )
+        integer_quant_path = os.path.join(
+            output_folder_path,
+            f"{output_file_name}_integer_quant.tflite",
+        )
+        write_model_file(
+            schema_tflite=schema_tflite,
+            model_ir=integer_model_ir,
+            output_tflite_path=integer_quant_path,
+        )
+
+        full_integer_model_ir = build_full_integer_quantized_model_ir(
+            model_ir,
+            quant_type=str(quant_type),
+            input_quant_dtype=str(input_quant_dtype),
+            output_quant_dtype=str(output_quant_dtype),
+        )
+        full_integer_quant_path = os.path.join(
+            output_folder_path,
+            f"{output_file_name}_full_integer_quant.tflite",
+        )
+        write_model_file(
+            schema_tflite=schema_tflite,
+            model_ir=full_integer_model_ir,
+            output_tflite_path=full_integer_quant_path,
+        )
+
     if output_weights:
         weights_export(
             extract_target_tflite_file_path=float32_path,
@@ -98,6 +136,22 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
                     f"{output_file_name}_dynamic_range_quant_weights.h5",
                 ),
             )
+        if integer_quant_path is not None:
+            weights_export(
+                extract_target_tflite_file_path=integer_quant_path,
+                output_weights_file_path=os.path.join(
+                    output_folder_path,
+                    f"{output_file_name}_integer_quant_weights.h5",
+                ),
+            )
+        if full_integer_quant_path is not None:
+            weights_export(
+                extract_target_tflite_file_path=full_integer_quant_path,
+                output_weights_file_path=os.path.join(
+                    output_folder_path,
+                    f"{output_file_name}_full_integer_quant_weights.h5",
+                ),
+            )
 
     outputs: Dict[str, str] = {
         "float32_tflite_path": float32_path,
@@ -105,4 +159,8 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, str]:
     }
     if dynamic_range_path is not None:
         outputs["dynamic_range_quant_tflite_path"] = dynamic_range_path
+    if integer_quant_path is not None:
+        outputs["integer_quant_tflite_path"] = integer_quant_path
+    if full_integer_quant_path is not None:
+        outputs["full_integer_quant_tflite_path"] = full_integer_quant_path
     return outputs

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -147,7 +147,7 @@ def _build_builtin_options(
         return _build_pool2d_options(schema_tflite, op)
     if op.op_type == "FULLY_CONNECTED":
         return _build_fully_connected_options(schema_tflite, op)
-    if op.op_type in ["LOGISTIC", "DEQUANTIZE"]:
+    if op.op_type in ["LOGISTIC", "DEQUANTIZE", "QUANTIZE"]:
         return _enum(schema_tflite, "BuiltinOptions", "NONE"), None
     raise NotImplementedError(
         f"BuiltinOptions mapping is not implemented for op_type={op.op_type}"

--- a/update-builder.md
+++ b/update-builder.md
@@ -50,6 +50,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 10-12 実装（`flatbuffer_direct` に限定 dynamic range quantization を追加、`QuantParamIR`/quantization 書き込み対応、`-oiqt` は未対応のまま明示エラー）
 - Step 13 実装（`-odrqt` 対象拡張: 定数入力を使う `ADD/SUB/MUL/DIV/CONCATENATION` に対して定数INT8化 + `DEQUANTIZE` 挿入を追加）
 - Step 14 実装（`-odrqt` の `quant_type` 連携: kernel weight に `per-channel` / `per-tensor` を反映）
+- Step 15 実装（`-oiqt` 最小対応: `*_integer_quant.tflite` と `*_full_integer_quant.tflite` を生成。`QUANTIZE/DEQUANTIZE` による限定I/O量子化を追加）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`
@@ -58,14 +59,15 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - `tflite_backend='tf_converter'` で従来どおり変換可能なこと
 - `python -m py_compile onnx2tf/tflite_builder/*.py onnx2tf/tflite_builder/op_builders/*.py`
 - 小規模 ONNX モデル（Add/Reshape/Conv/AveragePool/Gemm）で `flatbuffer_direct` 出力を生成し `Interpreter.allocate_tensors()` が通ること
-- `pytest -q tests/test_tflite_builder_direct.py` が通過（8 passed）
+- `pytest -q tests/test_tflite_builder_direct.py` が通過（9 passed）
 - `-odrqt` 指定で `*_dynamic_range_quant.tflite` が生成され、Gemm小規模モデルで `Interpreter.allocate_tensors()` および `invoke()` が通ること
 - `-odrqt` 指定で Add(constant) 小規模モデルも `Interpreter.invoke()` まで通ること
 - `-odrqt` + `--quant_type per-channel/per-tensor` でFCモデルの量子化 scale 形状が切り替わること（テストで検証）
+- `-oiqt` 指定で `*_integer_quant.tflite` と `*_full_integer_quant.tflite` が生成され、両方 `Interpreter.invoke()` まで通ること
 
 3. 未着手:
-- `-oiqt`（full/integer quantization）対応
 - dynamic range quantization の精度強化（例: per-channel の対象拡張、しきい値制御、校正戦略）
+- `integer_quant_with_int16_act` / `full_integer_quant_with_int16_act` の direct builder 対応
 
 ## 拡張ステージ（M5-Stage1: Dynamic Range Quant 最小対応）
 ### Step 10: 拡張仕様固定（限定解禁）
@@ -112,6 +114,16 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 完了条件:
 1. `-odrqt --quant_type per-channel` と `per-tensor` の双方で変換・推論が可能。
 2. FC系小規模モデルで scale 長が切り替わることをテストで確認できる。
+
+### Step 15: Integer Quantization 最小対応
+1. `flatbuffer_direct` で `-oiqt` 指定時に `*_integer_quant.tflite` と `*_full_integer_quant.tflite` を生成する。
+2. `integer_quant` は既存 dynamic-range 相当の量子化済み重み経路を利用する。
+3. `full_integer_quant` は量子化I/Oラッパー（`DEQUANTIZE`/`QUANTIZE`）を挿入して `input_quant_dtype` / `output_quant_dtype` を反映する。
+4. `integer_quant_with_int16_act` 系はこの段階では対象外とする。
+
+完了条件:
+1. `-oiqt` 指定で integer/full-integer の2ファイルが生成される。
+2. 小規模FCモデルで変換後に推論実行可能である。
 
 ## 作業ステップ
 
@@ -279,3 +291,4 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 13. `[x] Step 12 完了`
 14. `[x] Step 13 完了`
 15. `[x] Step 14 完了`
+16. `[x] Step 15 完了`


### PR DESCRIPTION
## Summary
- implement Step 15: limited `-oiqt` support in `flatbuffer_direct`
- generate `*_integer_quant.tflite` and `*_full_integer_quant.tflite` on `-oiqt`
- reuse dynamic-range quantized IR for integer-quant baseline path
- add limited full-integer IO adaptation using `DEQUANTIZE` (input) and `QUANTIZE` (output)
- wire `input_quant_dtype` and `output_quant_dtype` into direct builder path
- keep `*_integer_quant_with_int16_act.tflite` and `*_full_integer_quant_with_int16_act.tflite` out of scope for direct builder
- update README and `update-builder.md`
- add tests for integer/full-integer generation and inference

## Validation
- `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/quantization.py onnx2tf/tflite_builder/__init__.py onnx2tf/tflite_builder/model_writer.py tests/test_tflite_builder_direct.py`
- `python -m py_compile onnx2tf/tflite_builder/*.py onnx2tf/tflite_builder/op_builders/*.py`
- `pytest -q tests/test_tflite_builder_direct.py` (9 passed)
