### PR TITLE
Step 16-17: Improve quantization precision controls and add int16-act direct outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1672,12 +1672,18 @@ flatbuffer_direct notes:
    and constant tensor quantization + `DEQUANTIZE` insertion for `ADD`, `SUB`, `MUL`, `DIV`, `CONCATENATION`.
    For kernel weights, `--quant_type per-channel` and `--quant_type per-tensor` are both supported in `flatbuffer_direct`.
 3. Integer quantization (`-oiqt`) is supported in a limited form:
-   `*_integer_quant.tflite` and `*_full_integer_quant.tflite` are generated.
-   `*_integer_quant_with_int16_act.tflite` and `*_full_integer_quant_with_int16_act.tflite` are not generated in `flatbuffer_direct`.
+   `*_integer_quant.tflite`, `*_full_integer_quant.tflite`,
+   `*_integer_quant_with_int16_act.tflite`, `*_full_integer_quant_with_int16_act.tflite` are generated.
 4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`, `DEQUANTIZE`, `QUANTIZE`.
 5. Unsupported OPs fail explicitly with `NotImplementedError`.
 6. `schema.fbs` is fetched from LiteRT by pinned tag by default (`v2.1.2`), and can be overridden by:
    `ONNX2TF_TFLITE_SCHEMA_REPOSITORY`, `ONNX2TF_TFLITE_SCHEMA_TAG`, `ONNX2TF_TFLITE_SCHEMA_RELATIVE_PATH`.
+7. flatbuffer_direct quantization precision controls are configurable via environment variables:
+   `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_METHOD` (`max` or `percentile`),
+   `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_PERCENTILE` (e.g. `99.99`),
+   `ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_NUMEL`,
+   `ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_ABS_MAX`,
+   `ONNX2TF_FLATBUFFER_DIRECT_QUANT_SCALE_FLOOR`.
 
   -qt {per-channel,per-tensor}, --quant_type {per-channel,per-tensor}
     Selects whether "per-channel" or "per-tensor" quantization is used.
@@ -2245,7 +2251,7 @@ convert(
       "flatbuffer_direct": Use direct FlatBuffer builder path.
       Note: "flatbuffer_direct" supports a limited builtin OP set,
       FP32/FP16 export, limited dynamic-range quantization,
-      and limited integer quantization.
+      limited integer quantization, and limited int16-activation variants.
 
     quant_norm_mean: Optional[str]
         Normalized average value during quantization.

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -741,7 +741,7 @@ def convert(
         "flatbuffer_direct": Use direct FlatBuffer builder path.\n
         Note: "flatbuffer_direct" supports a limited builtin OP set,\n
         FP32/FP16 export, limited dynamic-range quantization,\n
-        and limited integer quantization.\n
+        limited integer quantization, and limited int16-activation variants.\n
 
     quant_norm_mean: Optional[str]
         Normalized average value during quantization.\n
@@ -2798,6 +2798,14 @@ def convert(
                     raise RuntimeError(
                         'flatbuffer_direct full integer quantization was requested but no output was generated.'
                     )
+                if 'integer_quant_with_int16_act_tflite_path' not in direct_outputs:
+                    raise RuntimeError(
+                        'flatbuffer_direct integer quantization with int16 activations was requested but no output was generated.'
+                    )
+                if 'full_integer_quant_with_int16_act_tflite_path' not in direct_outputs:
+                    raise RuntimeError(
+                        'flatbuffer_direct full integer quantization with int16 activations was requested but no output was generated.'
+                    )
                 info(
                     Color.GREEN(
                         f'INT8 Quantization tflite output complete! '
@@ -2808,6 +2816,18 @@ def convert(
                     Color.GREEN(
                         f'Full INT8 Quantization tflite output complete! '
                         f'({direct_outputs["full_integer_quant_tflite_path"]})'
+                    )
+                )
+                info(
+                    Color.GREEN(
+                        f'INT8 Quantization with int16 activations tflite output complete! '
+                        f'({direct_outputs["integer_quant_with_int16_act_tflite_path"]})'
+                    )
+                )
+                info(
+                    Color.GREEN(
+                        f'Full INT8 Quantization with int16 activations tflite output complete! '
+                        f'({direct_outputs["full_integer_quant_with_int16_act_tflite_path"]})'
                     )
                 )
             if copy_onnx_input_output_names_to_tflite:


### PR DESCRIPTION
## Summary
- implement Step 16 precision improvements for flatbuffer_direct quantization
- expand per-channel target coverage to eligible constant inputs in ADD/SUB/MUL/DIV/CONCATENATION
- add threshold controls and calibration strategy options for quantization
  - `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_METHOD` (`max` / `percentile`)
  - `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_PERCENTILE`
  - `ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_NUMEL`
  - `ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_ABS_MAX`
  - `ONNX2TF_FLATBUFFER_DIRECT_QUANT_SCALE_FLOOR`
- implement Step 17 direct builder support for:
  - `*_integer_quant_with_int16_act.tflite`
  - `*_full_integer_quant_with_int16_act.tflite`
- update README and update-builder progress/status
- add tests for int16-act outputs and quantization control behavior

## Validation
- `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py onnx2tf/tflite_builder/quantization.py onnx2tf/tflite_builder/model_writer.py tests/test_tflite_builder_direct.py`
- `python -m py_compile onnx2tf/tflite_builder/*.py onnx2tf/tflite_builder/op_builders/*.py`
- `pytest -q tests/test_tflite_builder_direct.py` (11 passed)
