### PR TITLE
Step 20: Operationalize ONNX-TFLite evaluation for CLI/CI

### DIFF
--- a/update-builder.md
+++ b/update-builder.md
@@ -56,6 +56,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 17 実装（`integer_quant_with_int16_act` / `full_integer_quant_with_int16_act` の direct builder 対応を追加）
 - Step 18 実装（追加要件の仕様固定: 精度評価・1GB分割・全OP本格実装の境界条件とCLI方針を明文化）
 - Step 19 実装（ONNX Runtime/TFLite 共通推論ラッパーと指標算出を追加し、`*_accuracy_report.json` を生成）
+- Step 20 実装（評価用CLIオプション拡張、量子化モデル向け dequant/raw 比較モード、閾値超過時の失敗制御を追加）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`
@@ -64,7 +65,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - `tflite_backend='tf_converter'` で従来どおり変換可能なこと
 - `python -m py_compile onnx2tf/tflite_builder/*.py onnx2tf/tflite_builder/op_builders/*.py`
 - 小規模 ONNX モデル（Add/Reshape/Conv/AveragePool/Gemm）で `flatbuffer_direct` 出力を生成し `Interpreter.allocate_tensors()` が通ること
-- `pytest -q tests/test_tflite_builder_direct.py` が通過（12 passed）
+- `pytest -q tests/test_tflite_builder_direct.py` が通過（14 passed）
 - `-odrqt` 指定で `*_dynamic_range_quant.tflite` が生成され、Gemm小規模モデルで `Interpreter.allocate_tensors()` および `invoke()` が通ること
 - `-odrqt` 指定で Add(constant) 小規模モデルも `Interpreter.invoke()` まで通ること
 - `-odrqt` + `--quant_type per-channel/per-tensor` でFCモデルの量子化 scale 形状が切り替わること（テストで検証）
@@ -73,9 +74,12 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_METHOD=percentile` 指定時でも `-odrqt` 変換が通ること
 - `ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_ABS_MAX` による量子化しきい値制御で非量子化ケースが明示失敗すること
 - `eval_with_onnx=True` 指定で `*_accuracy_report.json` が生成され、`max_abs/mean_abs/rmse/cosine_similarity` が出力されること
+- `python -m onnx2tf.onnx2tf -h` に `--eval_with_onnx`, `--eval_num_samples`, `--eval_rtol`, `--eval_atol`, `--eval_fail_on_threshold`, `--eval_target_tflite`, `--eval_compare_mode` が表示されること
+- `full_integer_quant` を評価対象にした `eval_compare_mode=dequant/raw` の双方で評価レポート出力できること
+- `eval_fail_on_threshold=True` かつ閾値超過時に変換を失敗終了できること
 
 3. 未着手:
-- 追加要件 Step 20-28（精度評価機能運用化、1GB近傍自動分割、全OP本格実装）
+- 追加要件 Step 21-28（1GB近傍自動分割、全OP本格実装）
 
 ## 拡張ステージ（M5-Stage1: Dynamic Range Quant 最小対応）
 ### Step 10: 拡張仕様固定（限定解禁）
@@ -186,7 +190,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - 未対応は沈黙せず理由付き例外 + 機械可読レポートに出力
 
 4. CLI設計方針（追加予定）:
-- 精度評価: `--eval_with_onnx`, `--eval_num_samples`, `--eval_rtol`, `--eval_atol`, `--eval_fail_on_threshold`
+- 精度評価: `--eval_with_onnx`, `--eval_num_samples`, `--eval_rtol`, `--eval_atol`, `--eval_fail_on_threshold`, `--eval_target_tflite`, `--eval_compare_mode`
 - 分割: `--auto_split_tflite_by_size`, `--tflite_split_max_bytes`, `--tflite_split_target_bytes`
 - OPカバレッジ: `--report_op_coverage`
 
@@ -450,8 +454,8 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 17. `[x] Step 16 完了`
 18. `[x] Step 17 完了`
 19. `[x] Step 18 完了`
-20. `[ ] Step 19 完了`
-21. `[ ] Step 20 完了`
+20. `[x] Step 19 完了`
+21. `[x] Step 20 完了`
 22. `[ ] Step 21 完了`
 23. `[ ] Step 22 完了`
 24. `[ ] Step 23 完了`


### PR DESCRIPTION
## Summary
- add evaluation operation options to conversion and CLI: `eval_rtol`, `eval_atol`, `eval_fail_on_threshold`, `eval_target_tflite`, `eval_compare_mode`
- extend evaluator to support quantized comparison modes (`raw` / `dequant` / `auto`)
- add threshold judgement and `evaluation_pass` diagnostics into `*_accuracy_report.json`
- enforce failure exit path when `eval_fail_on_threshold=True` and evaluation does not pass
- update tests and progress tracking in `update-builder.md`

## Validation
- `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/accuracy_evaluator.py tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_builder_direct.py` (14 passed)
- `python -m onnx2tf.onnx2tf -h` includes new `--eval_*` options
