### PR TITLE
Step 24: OPレジストリ化とカバレッジレポート導入

### DIFF
--- a/onnx2tf/tflite_builder/dispatcher.py
+++ b/onnx2tf/tflite_builder/dispatcher.py
@@ -2,62 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from onnx2tf.tflite_builder.op_builders import (
-    build_binary_op,
-    build_concat_op,
-    build_conv2d_or_depthwise_op,
-    build_fully_connected_from_gemm_or_matmul,
-    build_identity_op,
-    build_logistic_op,
-    build_pool2d_op,
-    build_reshape_op,
-    build_softmax_op,
-    build_transpose_op,
-)
+from onnx2tf.tflite_builder.op_registry import validate_node_support
 
 
 def dispatch_node(node: Any, ctx: Any) -> None:
-    op = node.op
-    if op == "Add":
-        build_binary_op(node, ctx, "ADD")
-        return
-    if op == "Sub":
-        build_binary_op(node, ctx, "SUB")
-        return
-    if op == "Mul":
-        build_binary_op(node, ctx, "MUL")
-        return
-    if op == "Div":
-        build_binary_op(node, ctx, "DIV")
-        return
-    if op == "Sigmoid":
-        build_logistic_op(node, ctx)
-        return
-    if op == "Softmax":
-        build_softmax_op(node, ctx)
-        return
-    if op == "Reshape":
-        build_reshape_op(node, ctx)
-        return
-    if op == "Transpose":
-        build_transpose_op(node, ctx)
-        return
-    if op == "Concat":
-        build_concat_op(node, ctx)
-        return
-    if op == "Identity":
-        build_identity_op(node, ctx)
-        return
-    if op == "Conv":
-        build_conv2d_or_depthwise_op(node, ctx)
-        return
-    if op == "AveragePool":
-        build_pool2d_op(node, ctx, "AVERAGE_POOL_2D")
-        return
-    if op == "MaxPool":
-        build_pool2d_op(node, ctx, "MAX_POOL_2D")
-        return
-    if op in ["Gemm", "MatMul"]:
-        build_fully_connected_from_gemm_or_matmul(node, ctx)
-        return
-    raise NotImplementedError(f"ONNX op is not supported by flatbuffer_direct: {op} ({node.name})")
+    entry = validate_node_support(node, ctx)
+    entry.builder(node, ctx)

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -7,6 +7,11 @@ import onnx
 from onnx import numpy_helper
 
 from onnx2tf.tflite_builder.dispatcher import dispatch_node
+from onnx2tf.tflite_builder.op_registry import (
+    NodeValidationError,
+    get_supported_onnx_ops,
+    validate_node_support,
+)
 from onnx2tf.tflite_builder.ir import (
     ModelIR,
     OperatorIR,
@@ -170,6 +175,200 @@ class LoweringContext:
         self.model_ir.operators.append(op)
 
 
+class _NodeWrap:
+    def __init__(self, n: onnx.NodeProto):
+        self.name = n.name if n.name else n.op_type
+        self.op = n.op_type
+        self.attrs = {}
+        for a in n.attribute:
+            if a.type == onnx.AttributeProto.INT:
+                self.attrs[a.name] = int(a.i)
+            elif a.type == onnx.AttributeProto.FLOAT:
+                self.attrs[a.name] = float(a.f)
+            elif a.type == onnx.AttributeProto.INTS:
+                self.attrs[a.name] = [int(v) for v in a.ints]
+            elif a.type == onnx.AttributeProto.FLOATS:
+                self.attrs[a.name] = [float(v) for v in a.floats]
+            elif a.type == onnx.AttributeProto.STRING:
+                self.attrs[a.name] = a.s.decode("utf-8")
+            else:
+                pass
+        self.inputs = [type("In", (), {"name": i}) for i in n.input if i != ""]
+        self.outputs = [type("Out", (), {"name": o}) for o in n.output if o != ""]
+
+
+def _collect_schema_ops_for_range(
+    *,
+    opset_min: int = 13,
+    opset_max: int = 18,
+) -> List[str]:
+    schema_ops = set()
+    for schema in onnx.defs.get_all_schemas_with_history():
+        if schema.domain != "":
+            continue
+        if int(schema.since_version) < int(opset_min) or int(schema.since_version) > int(opset_max):
+            continue
+        schema_ops.add(str(schema.name))
+    return sorted(schema_ops)
+
+
+def build_op_coverage_report(
+    *,
+    onnx_graph: onnx.ModelProto,
+    output_file_name: str,
+    opset_min: int = 13,
+    opset_max: int = 18,
+    conversion_error: Optional[str] = None,
+) -> Dict[str, Any]:
+    try:
+        onnx_graph = onnx.shape_inference.infer_shapes(onnx_graph)
+    except Exception:
+        pass
+
+    shape_map, dtype_map = _extract_tensor_info(onnx_graph)
+    constants: Dict[str, np.ndarray] = {}
+    for ini in onnx_graph.graph.initializer:
+        constants[ini.name] = np.asarray(numpy_helper.to_array(ini))
+
+    model_ir = ModelIR(name=output_file_name)
+    ctx = LoweringContext(
+        model_ir=model_ir,
+        shape_map=shape_map,
+        dtype_map=dtype_map,
+        constants=constants,
+    )
+    initializer_names = {ini.name for ini in onnx_graph.graph.initializer}
+    for graph_input in onnx_graph.graph.input:
+        if graph_input.name in initializer_names:
+            continue
+        ctx.ensure_tensor(graph_input.name)
+        model_ir.inputs.append(graph_input.name)
+    for name, value in constants.items():
+        if name not in model_ir.tensors:
+            ctx.add_const_tensor(name, value)
+
+    node_reports: List[Dict[str, Any]] = []
+    unsupported_nodes: List[Dict[str, Any]] = []
+    graph_unique_ops: set = set()
+    for node in onnx_graph.graph.node:
+        node_name = node.name if node.name else node.op_type
+        graph_unique_ops.add(node.op_type)
+        if node.op_type == "Constant":
+            value_attr = None
+            for attr in node.attribute:
+                if attr.name == "value":
+                    value_attr = attr
+                    break
+            if value_attr is not None and len(node.output) > 0:
+                const_array = np.asarray(numpy_helper.to_array(value_attr.t))
+                out_name = node.output[0]
+                if out_name in model_ir.tensors:
+                    t = model_ir.tensors[out_name]
+                    t.data = const_array
+                    t.dtype = tflite_dtype_from_numpy(const_array.dtype)
+                    t.shape, t.shape_signature = normalize_onnx_shape(list(const_array.shape))
+                    constants[out_name] = const_array
+                else:
+                    _added = ctx.add_const_tensor(out_name, const_array)
+                    if _added != out_name:
+                        model_ir.tensors[out_name] = model_ir.tensors.pop(_added)
+                        model_ir.tensors[out_name].name = out_name
+                        constants[out_name] = constants.pop(_added)
+            node_reports.append(
+                {
+                    "node_name": node_name,
+                    "onnx_op": "Constant",
+                    "supported": True,
+                    "reason_code": "handled_inline",
+                    "message": "Constant node is handled inline in lowering pass.",
+                }
+            )
+            continue
+
+        wrapped = _NodeWrap(node)
+        try:
+            validate_node_support(wrapped, ctx)
+            node_reports.append(
+                {
+                    "node_name": node_name,
+                    "onnx_op": node.op_type,
+                    "supported": True,
+                    "reason_code": None,
+                    "message": None,
+                }
+            )
+        except NodeValidationError as ve:
+            issue = ve.to_dict()
+            issue["supported"] = False
+            node_reports.append(issue)
+            unsupported_nodes.append(issue)
+        except Exception as ex:
+            issue = {
+                "node_name": node_name,
+                "onnx_op": node.op_type,
+                "supported": False,
+                "reason_code": "validation_exception",
+                "message": str(ex),
+            }
+            node_reports.append(issue)
+            unsupported_nodes.append(issue)
+
+    supported_registry_ops = set(get_supported_onnx_ops())
+    schema_ops = set(_collect_schema_ops_for_range(opset_min=opset_min, opset_max=opset_max))
+    graph_ops = sorted(graph_unique_ops)
+    supported_graph_ops = sorted(
+        list({r["onnx_op"] for r in node_reports if r["supported"] is True})
+    )
+    unsupported_graph_ops = sorted(
+        list({r["onnx_op"] for r in node_reports if r["supported"] is False})
+    )
+    reason_counts: Dict[str, int] = {}
+    for issue in unsupported_nodes:
+        reason = str(issue.get("reason_code", "unknown"))
+        reason_counts[reason] = int(reason_counts.get(reason, 0) + 1)
+
+    total_nodes = len(node_reports)
+    supported_nodes = len([r for r in node_reports if r["supported"] is True])
+    coverage = float(supported_nodes / total_nodes) if total_nodes > 0 else 1.0
+    report: Dict[str, Any] = {
+        "schema_version": 1,
+        "target_opset_min": int(opset_min),
+        "target_opset_max": int(opset_max),
+        "supported_onnx_ops_registry": sorted(list(supported_registry_ops)),
+        "schema_onnx_ops_target_range": sorted(list(schema_ops)),
+        "registry_missing_from_schema_range": sorted(list(schema_ops - supported_registry_ops)),
+        "registry_extra_outside_schema_range": sorted(list(supported_registry_ops - schema_ops)),
+        "graph_ops": graph_ops,
+        "graph_supported_ops": supported_graph_ops,
+        "graph_unsupported_ops": unsupported_graph_ops,
+        "graph_node_reports": node_reports,
+        "unsupported_nodes": unsupported_nodes,
+        "unsupported_reason_counts": reason_counts,
+        "graph_summary": {
+            "total_nodes": int(total_nodes),
+            "supported_nodes": int(supported_nodes),
+            "unsupported_nodes": int(total_nodes - supported_nodes),
+            "coverage_ratio": float(coverage),
+        },
+        "conversion_error": conversion_error,
+    }
+    return report
+
+
+def write_op_coverage_report(
+    *,
+    report: Dict[str, Any],
+    output_report_path: str,
+) -> str:
+    import json
+    import os
+
+    os.makedirs(os.path.dirname(output_report_path) or ".", exist_ok=True)
+    with open(output_report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+    return output_report_path
+
+
 def lower_onnx_to_ir(
     onnx_graph: onnx.ModelProto,
     output_file_name: str,
@@ -233,30 +432,15 @@ def lower_onnx_to_ir(
                     constants[output_name] = constants.pop(name)
             continue
 
-        # Wrap node API for builder functions with old attribute names.
-        class _NodeWrap:
-            def __init__(self, n):
-                self.name = n.name if n.name else n.op_type
-                self.op = n.op_type
-                self.attrs = {}
-                for a in n.attribute:
-                    if a.type == onnx.AttributeProto.INT:
-                        self.attrs[a.name] = int(a.i)
-                    elif a.type == onnx.AttributeProto.FLOAT:
-                        self.attrs[a.name] = float(a.f)
-                    elif a.type == onnx.AttributeProto.INTS:
-                        self.attrs[a.name] = [int(v) for v in a.ints]
-                    elif a.type == onnx.AttributeProto.FLOATS:
-                        self.attrs[a.name] = [float(v) for v in a.floats]
-                    elif a.type == onnx.AttributeProto.STRING:
-                        self.attrs[a.name] = a.s.decode("utf-8")
-                    else:
-                        # keep unsupported attrs ignored for now.
-                        pass
-                self.inputs = [type("In", (), {"name": i}) for i in n.input if i != ""]
-                self.outputs = [type("Out", (), {"name": o}) for o in n.output if o != ""]
-
-        dispatch_node(_NodeWrap(node), ctx)
+        wrapped = _NodeWrap(node)
+        try:
+            dispatch_node(wrapped, ctx)
+        except NodeValidationError as ve:
+            raise NotImplementedError(
+                f"flatbuffer_direct validation failed: "
+                f"op={ve.node_op} node={ve.node_name} "
+                f"reason_code={ve.reason_code} message={ve.message}"
+            ) from ve
 
     # Outputs
     for graph_output in onnx_graph.graph.output:

--- a/onnx2tf/tflite_builder/op_registry.py
+++ b/onnx2tf/tflite_builder/op_registry.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+import numpy as np
+
+from onnx2tf.tflite_builder.op_builders import (
+    build_binary_op,
+    build_concat_op,
+    build_conv2d_or_depthwise_op,
+    build_fully_connected_from_gemm_or_matmul,
+    build_identity_op,
+    build_logistic_op,
+    build_pool2d_op,
+    build_reshape_op,
+    build_softmax_op,
+    build_transpose_op,
+)
+
+
+class NodeValidationError(ValueError):
+    def __init__(
+        self,
+        *,
+        reason_code: str,
+        message: str,
+        node_name: str,
+        node_op: str,
+    ) -> None:
+        super().__init__(message)
+        self.reason_code = str(reason_code)
+        self.node_name = str(node_name)
+        self.node_op = str(node_op)
+        self.message = str(message)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "node_name": self.node_name,
+            "onnx_op": self.node_op,
+            "reason_code": self.reason_code,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class ValidationSpec:
+    min_inputs: int = 0
+    max_inputs: Optional[int] = None
+    min_outputs: int = 1
+    max_outputs: Optional[int] = 1
+    required_attrs: List[str] = field(default_factory=list)
+    input_rank: Dict[int, List[int]] = field(default_factory=dict)
+    output_rank: Dict[int, List[int]] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DispatchEntry:
+    onnx_op: str
+    tflite_ops: List[str]
+    builder: Callable[[Any, Any], None]
+    validation: ValidationSpec = field(default_factory=ValidationSpec)
+    extra_validator: Optional[Callable[[Any, Any], None]] = None
+
+
+def _validate_counts(node: Any, spec: ValidationSpec) -> None:
+    input_count = len(node.inputs)
+    output_count = len(node.outputs)
+    if input_count < int(spec.min_inputs):
+        raise NodeValidationError(
+            reason_code="invalid_input_count",
+            message=f"input_count={input_count} is smaller than min_inputs={spec.min_inputs}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if spec.max_inputs is not None and input_count > int(spec.max_inputs):
+        raise NodeValidationError(
+            reason_code="invalid_input_count",
+            message=f"input_count={input_count} exceeds max_inputs={spec.max_inputs}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if output_count < int(spec.min_outputs):
+        raise NodeValidationError(
+            reason_code="invalid_output_count",
+            message=f"output_count={output_count} is smaller than min_outputs={spec.min_outputs}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if spec.max_outputs is not None and output_count > int(spec.max_outputs):
+        raise NodeValidationError(
+            reason_code="invalid_output_count",
+            message=f"output_count={output_count} exceeds max_outputs={spec.max_outputs}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
+def _validate_attrs(node: Any, spec: ValidationSpec) -> None:
+    for attr in spec.required_attrs:
+        if attr not in node.attrs:
+            raise NodeValidationError(
+                reason_code="missing_required_attribute",
+                message=f"required attribute '{attr}' is missing",
+                node_name=node.name,
+                node_op=node.op,
+            )
+
+
+def _validate_rank_constraints(node: Any, ctx: Any, spec: ValidationSpec) -> None:
+    for input_index, allowed_ranks in spec.input_rank.items():
+        if input_index >= len(node.inputs):
+            continue
+        tensor_name = node.inputs[input_index].name
+        rank = len(ctx.get_tensor_shape(tensor_name))
+        if rank not in allowed_ranks:
+            raise NodeValidationError(
+                reason_code="unsupported_input_rank",
+                message=(
+                    f"input[{input_index}] rank={rank} is not in supported ranks={allowed_ranks} "
+                    f"for tensor={tensor_name}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+    for output_index, allowed_ranks in spec.output_rank.items():
+        if output_index >= len(node.outputs):
+            continue
+        tensor_name = node.outputs[output_index].name
+        rank = len(ctx.get_tensor_shape(tensor_name))
+        if rank not in allowed_ranks:
+            raise NodeValidationError(
+                reason_code="unsupported_output_rank",
+                message=(
+                    f"output[{output_index}] rank={rank} is not in supported ranks={allowed_ranks} "
+                    f"for tensor={tensor_name}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+
+
+def _require_const_input(node: Any, ctx: Any, input_index: int, input_label: str) -> np.ndarray:
+    if input_index >= len(node.inputs):
+        raise NodeValidationError(
+            reason_code="missing_required_input",
+            message=f"{input_label} input index={input_index} is missing",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    tensor_name = node.inputs[input_index].name
+    const_value = ctx.get_constant_array(tensor_name)
+    if const_value is None:
+        raise NodeValidationError(
+            reason_code="requires_constant_input",
+            message=f"{input_label} must be constant. tensor={tensor_name}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    return np.asarray(const_value)
+
+
+def _validate_softmax(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    input_shape = ctx.get_tensor_shape(input_name)
+    axis = int(node.attrs.get("axis", 1))
+    if axis < 0:
+        axis += len(input_shape)
+    if axis != len(input_shape) - 1:
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=f"Softmax axis must be last dimension. axis={axis} shape={input_shape}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
+def _validate_reshape(node: Any, ctx: Any) -> None:
+    _require_const_input(node, ctx, 1, "reshape shape")
+
+
+def _validate_transpose(node: Any, ctx: Any) -> None:
+    _require_const_input(node, ctx, 1, "transpose permutation")
+
+
+def _validate_conv(node: Any, ctx: Any) -> None:
+    weights = _require_const_input(node, ctx, 1, "conv weights")
+    if weights.ndim != 4:
+        raise NodeValidationError(
+            reason_code="unsupported_weight_rank",
+            message=f"Conv weight rank must be 4. weight_shape={list(weights.shape)}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    input_shape = ctx.get_tensor_shape(node.inputs[0].name)
+    output_shape = ctx.get_tensor_shape(node.outputs[0].name)
+    if len(input_shape) != 4 or len(output_shape) != 4:
+        raise NodeValidationError(
+            reason_code="unsupported_tensor_rank",
+            message=f"Conv input/output rank must be 4. input_shape={input_shape} output_shape={output_shape}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    group = int(node.attrs.get("group", 1))
+    in_channels = int(input_shape[1])
+    is_depthwise = group == in_channels and int(weights.shape[1]) == 1 and group > 1
+    if group != 1 and not is_depthwise:
+        raise NodeValidationError(
+            reason_code="unsupported_grouped_convolution",
+            message=f"Only regular or depthwise group conv is supported. group={group} in_channels={in_channels}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
+def _validate_pool(node: Any, ctx: Any) -> None:
+    if int(node.attrs.get("ceil_mode", 0)) != 0:
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message="Pool ceil_mode must be 0.",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
+def _validate_fc(node: Any, ctx: Any) -> None:
+    input_rank = len(ctx.get_tensor_shape(node.inputs[0].name))
+    if input_rank != 2:
+        raise NodeValidationError(
+            reason_code="unsupported_input_rank",
+            message=f"FullyConnected input rank must be 2. rank={input_rank}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    weights = _require_const_input(node, ctx, 1, "fully_connected weights")
+    if weights.ndim != 2:
+        raise NodeValidationError(
+            reason_code="unsupported_weight_rank",
+            message=f"FullyConnected weight rank must be 2. weight_shape={list(weights.shape)}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if node.op == "Gemm":
+        if int(node.attrs.get("transA", 0)) != 0:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message="Gemm transA=1 is not supported.",
+                node_name=node.name,
+                node_op=node.op,
+            )
+
+
+def _make_binary_builder(tflite_op: str) -> Callable[[Any, Any], None]:
+    def _builder(node: Any, ctx: Any) -> None:
+        build_binary_op(node, ctx, tflite_op)
+
+    return _builder
+
+
+_DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
+    "Add": DispatchEntry(
+        onnx_op="Add",
+        tflite_ops=["ADD"],
+        builder=_make_binary_builder("ADD"),
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+    ),
+    "Sub": DispatchEntry(
+        onnx_op="Sub",
+        tflite_ops=["SUB"],
+        builder=_make_binary_builder("SUB"),
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+    ),
+    "Mul": DispatchEntry(
+        onnx_op="Mul",
+        tflite_ops=["MUL"],
+        builder=_make_binary_builder("MUL"),
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+    ),
+    "Div": DispatchEntry(
+        onnx_op="Div",
+        tflite_ops=["DIV"],
+        builder=_make_binary_builder("DIV"),
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+    ),
+    "Sigmoid": DispatchEntry(
+        onnx_op="Sigmoid",
+        tflite_ops=["LOGISTIC"],
+        builder=build_logistic_op,
+        validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
+    ),
+    "Softmax": DispatchEntry(
+        onnx_op="Softmax",
+        tflite_ops=["SOFTMAX"],
+        builder=build_softmax_op,
+        validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_softmax,
+    ),
+    "Reshape": DispatchEntry(
+        onnx_op="Reshape",
+        tflite_ops=["RESHAPE"],
+        builder=build_reshape_op,
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_reshape,
+    ),
+    "Transpose": DispatchEntry(
+        onnx_op="Transpose",
+        tflite_ops=["TRANSPOSE"],
+        builder=build_transpose_op,
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_transpose,
+    ),
+    "Concat": DispatchEntry(
+        onnx_op="Concat",
+        tflite_ops=["CONCATENATION"],
+        builder=build_concat_op,
+        validation=ValidationSpec(min_inputs=2, min_outputs=1, max_outputs=1),
+    ),
+    "Identity": DispatchEntry(
+        onnx_op="Identity",
+        tflite_ops=["RESHAPE"],
+        builder=build_identity_op,
+        validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
+    ),
+    "Conv": DispatchEntry(
+        onnx_op="Conv",
+        tflite_ops=["CONV_2D", "DEPTHWISE_CONV_2D"],
+        builder=build_conv2d_or_depthwise_op,
+        validation=ValidationSpec(
+            min_inputs=2,
+            max_inputs=3,
+            min_outputs=1,
+            max_outputs=1,
+            input_rank={0: [4]},
+            output_rank={0: [4]},
+        ),
+        extra_validator=_validate_conv,
+    ),
+    "AveragePool": DispatchEntry(
+        onnx_op="AveragePool",
+        tflite_ops=["AVERAGE_POOL_2D"],
+        builder=lambda node, ctx: build_pool2d_op(node, ctx, "AVERAGE_POOL_2D"),
+        validation=ValidationSpec(
+            min_inputs=1,
+            max_inputs=1,
+            min_outputs=1,
+            max_outputs=1,
+            required_attrs=["kernel_shape"],
+            input_rank={0: [4]},
+            output_rank={0: [4]},
+        ),
+        extra_validator=_validate_pool,
+    ),
+    "MaxPool": DispatchEntry(
+        onnx_op="MaxPool",
+        tflite_ops=["MAX_POOL_2D"],
+        builder=lambda node, ctx: build_pool2d_op(node, ctx, "MAX_POOL_2D"),
+        validation=ValidationSpec(
+            min_inputs=1,
+            max_inputs=1,
+            min_outputs=1,
+            max_outputs=1,
+            required_attrs=["kernel_shape"],
+            input_rank={0: [4]},
+            output_rank={0: [4]},
+        ),
+        extra_validator=_validate_pool,
+    ),
+    "Gemm": DispatchEntry(
+        onnx_op="Gemm",
+        tflite_ops=["FULLY_CONNECTED"],
+        builder=build_fully_connected_from_gemm_or_matmul,
+        validation=ValidationSpec(min_inputs=2, max_inputs=3, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_fc,
+    ),
+    "MatMul": DispatchEntry(
+        onnx_op="MatMul",
+        tflite_ops=["FULLY_CONNECTED"],
+        builder=build_fully_connected_from_gemm_or_matmul,
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_fc,
+    ),
+}
+
+
+def get_dispatch_registry() -> Dict[str, DispatchEntry]:
+    return dict(_DISPATCH_REGISTRY)
+
+
+def get_dispatch_entry(onnx_op: str) -> Optional[DispatchEntry]:
+    return _DISPATCH_REGISTRY.get(str(onnx_op))
+
+
+def get_supported_onnx_ops() -> List[str]:
+    return sorted(_DISPATCH_REGISTRY.keys())
+
+
+def validate_node_support(node: Any, ctx: Any) -> DispatchEntry:
+    entry = get_dispatch_entry(node.op)
+    if entry is None:
+        raise NodeValidationError(
+            reason_code="unsupported_onnx_op",
+            message=f"ONNX op is not supported by flatbuffer_direct: {node.op}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    _validate_counts(node, entry.validation)
+    _validate_attrs(node, entry.validation)
+    _validate_rank_constraints(node, ctx, entry.validation)
+    if entry.extra_validator is not None:
+        entry.extra_validator(node, ctx)
+    return entry

--- a/update-builder.md
+++ b/update-builder.md
@@ -60,6 +60,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 21 実装（IR/Tensor/Bufferベースのサイズ見積りと依存関係を壊さない分割候補探索、1GB近傍収束ロジックを追加）
 - Step 22 実装（`*_0001.tflite` 形式の分割出力、`*_split_manifest.json` 出力、各分割の `Interpreter.allocate_tensors()` 検証を追加）
 - Step 23 実装（manifestに従う分割モデル逐次実行評価器を追加し、`*_split_accuracy_report.json` を出力。`unsplit_tflite` / `onnx` 比較と閾値失敗制御を追加）
+- Step 24 実装（OPディスパッチを登録テーブル化し、共通検証フックと機械可読な未対応理由レポートを追加。ONNX schema 13-18 と対応状況の突合を自動化し、`--report_op_coverage` で `*_op_coverage_report.json` を出力）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`
@@ -86,9 +87,11 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - 分割出力された全 `*_nnnn.tflite` が `Interpreter.allocate_tensors()` を通過すること
 - `eval_split_models=True` 指定で `*_split_accuracy_report.json` が生成され、分割モデルと参照（`unsplit_tflite`/`onnx`）の差分が定量化されること
 - `eval_split_fail_on_threshold=True` または split評価器の `fail_on_threshold=True` 指定で閾値超過時に失敗終了できること
+- `--report_op_coverage` 指定で `*_op_coverage_report.json` が生成され、`graph_node_reports` / `unsupported_reason_counts` / `conversion_error` が出力されること
+- 未対応 OP を含むモデルでも失敗時に OP カバレッジレポートが出力されること（`unsupported_onnx_op` などの reason_code を確認）
 
 3. 未着手:
-- 追加要件 Step 24-28（全OP本格実装）
+- 追加要件 Step 25-28（全OP本格実装）
 
 ## 拡張ステージ（M5-Stage1: Dynamic Range Quant 最小対応）
 ### Step 10: 拡張仕様固定（限定解禁）
@@ -468,7 +471,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 22. `[x] Step 21 完了`
 23. `[x] Step 22 完了`
 24. `[x] Step 23 完了`
-25. `[ ] Step 24 完了`
+25. `[x] Step 24 完了`
 26. `[ ] Step 25 完了`
 27. `[ ] Step 26 完了`
 28. `[ ] Step 27 完了`


### PR DESCRIPTION
## Summary
- OPディスパッチを登録テーブル化し、共通検証フックを追加
- 未対応理由を機械可読で出力する OP カバレッジレポートを実装
- `--report_op_coverage` を CLI/API に追加し、direct builder 経路へ配線
- Step 24 の進捗を update-builder.md に反映

## Validation
- python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py onnx2tf/tflite_builder/lower_from_onnx2tf.py onnx2tf/tflite_builder/op_registry.py onnx2tf/tflite_builder/dispatcher.py tests/test_tflite_builder_direct.py
- pytest -q tests/test_tflite_builder_direct.py
- pytest -q tests/test_tflite_split_planner.py
