### PR TITLE
Step 25: Wave1 high-frequency unary op support

### DIFF
--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -147,7 +147,17 @@ def _build_builtin_options(
         return _build_pool2d_options(schema_tflite, op)
     if op.op_type == "FULLY_CONNECTED":
         return _build_fully_connected_options(schema_tflite, op)
-    if op.op_type in ["LOGISTIC", "DEQUANTIZE", "QUANTIZE"]:
+    if op.op_type in [
+        "LOGISTIC",
+        "RELU",
+        "RELU6",
+        "TANH",
+        "EXP",
+        "SQRT",
+        "NEG",
+        "DEQUANTIZE",
+        "QUANTIZE",
+    ]:
         return _enum(schema_tflite, "BuiltinOptions", "NONE"), None
     raise NotImplementedError(
         f"BuiltinOptions mapping is not implemented for op_type={op.op_type}"

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -1,7 +1,9 @@
 from onnx2tf.tflite_builder.op_builders.elementwise import (
     build_binary_op,
+    build_clip_op,
     build_logistic_op,
     build_softmax_op,
+    build_unary_op,
 )
 from onnx2tf.tflite_builder.op_builders.shape import (
     build_concat_op,
@@ -21,8 +23,10 @@ from onnx2tf.tflite_builder.op_builders.fc import (
 
 __all__ = [
     "build_binary_op",
+    "build_clip_op",
     "build_logistic_op",
     "build_softmax_op",
+    "build_unary_op",
     "build_concat_op",
     "build_identity_op",
     "build_reshape_op",

--- a/onnx2tf/tflite_builder/op_builders/elementwise.py
+++ b/onnx2tf/tflite_builder/op_builders/elementwise.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+import math
 
 from onnx2tf.tflite_builder.ir import OperatorIR
 
@@ -31,6 +32,69 @@ def build_logistic_op(node: Any, ctx: Any) -> None:
     ctx.add_operator(
         OperatorIR(
             op_type="LOGISTIC",
+            inputs=[input_name],
+            outputs=[output_name],
+        )
+    )
+
+
+def build_unary_op(node: Any, ctx: Any, op_type: str) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+    ctx.add_operator(
+        OperatorIR(
+            op_type=op_type,
+            inputs=[input_name],
+            outputs=[output_name],
+        )
+    )
+
+
+def _get_clip_bound_value(value: Any, default_value: float) -> float:
+    if value is None:
+        return float(default_value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        import numpy as np
+        arr = np.asarray(value)
+        if arr.size == 0:
+            return float(default_value)
+        return float(arr.reshape(-1)[0])
+    except Exception:
+        return float(default_value)
+
+
+def build_clip_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+
+    clip_min = _get_clip_bound_value(node.attrs.get("min", None), float("-inf"))
+    clip_max = _get_clip_bound_value(node.attrs.get("max", None), float("inf"))
+    if len(node.inputs) >= 2:
+        min_const = ctx.get_constant_array(node.inputs[1].name)
+        clip_min = _get_clip_bound_value(min_const, clip_min)
+    if len(node.inputs) >= 3:
+        max_const = ctx.get_constant_array(node.inputs[2].name)
+        clip_max = _get_clip_bound_value(max_const, clip_max)
+
+    if abs(clip_min - 0.0) <= 1e-6 and abs(clip_max - 6.0) <= 1e-6:
+        op_type = "RELU6"
+    elif abs(clip_min - 0.0) <= 1e-6 and math.isinf(clip_max) and clip_max > 0.0:
+        op_type = "RELU"
+    else:
+        raise NotImplementedError(
+            "Clip is supported only for relu-style ranges: "
+            f"min=0,max=6 or min=0,max=+inf. op={node.name} min={clip_min} max={clip_max}"
+        )
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type=op_type,
             inputs=[input_name],
             outputs=[output_name],
         )

--- a/update-builder.md
+++ b/update-builder.md
@@ -61,6 +61,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 22 実装（`*_0001.tflite` 形式の分割出力、`*_split_manifest.json` 出力、各分割の `Interpreter.allocate_tensors()` 検証を追加）
 - Step 23 実装（manifestに従う分割モデル逐次実行評価器を追加し、`*_split_accuracy_report.json` を出力。`unsplit_tflite` / `onnx` 比較と閾値失敗制御を追加）
 - Step 24 実装（OPディスパッチを登録テーブル化し、共通検証フックと機械可読な未対応理由レポートを追加。ONNX schema 13-18 と対応状況の突合を自動化し、`--report_op_coverage` で `*_op_coverage_report.json` を出力）
+- Step 25 実装（全OP Wave1 第1弾: `Relu`, `Tanh`, `Exp`, `Sqrt`, `Neg`, `Clip(min=0,max=6 / +inf)` を追加し、高頻度活性化・単項演算の変換成功率を向上）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`
@@ -89,9 +90,10 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - `eval_split_fail_on_threshold=True` または split評価器の `fail_on_threshold=True` 指定で閾値超過時に失敗終了できること
 - `--report_op_coverage` 指定で `*_op_coverage_report.json` が生成され、`graph_node_reports` / `unsupported_reason_counts` / `conversion_error` が出力されること
 - 未対応 OP を含むモデルでも失敗時に OP カバレッジレポートが出力されること（`unsupported_onnx_op` などの reason_code を確認）
+- 追加対応 OP（`Relu`, `Tanh`, `Exp`, `Sqrt`, `Neg`, `Clip` relu系限定）を含む小規模モデルで `flatbuffer_direct` 変換・`Interpreter.invoke()` が通ること
 
 3. 未着手:
-- 追加要件 Step 25-28（全OP本格実装）
+- 追加要件 Step 26-28（全OP本格実装）
 
 ## 拡張ステージ（M5-Stage1: Dynamic Range Quant 最小対応）
 ### Step 10: 拡張仕様固定（限定解禁）
@@ -472,7 +474,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 23. `[x] Step 22 完了`
 24. `[x] Step 23 完了`
 25. `[x] Step 24 完了`
-26. `[ ] Step 25 完了`
+26. `[x] Step 25 完了`
 27. `[ ] Step 26 完了`
 28. `[ ] Step 27 完了`
 29. `[ ] Step 28 完了`


### PR DESCRIPTION
## Summary
- `flatbuffer_direct` の Wave1 拡張として高頻度の単項OPを追加
- 追加対応: `Relu`, `Tanh`, `Exp`, `Sqrt`, `Neg`, `Clip`（`min=0,max=6` / `min=0,max=+inf`）
- OP registry と model writer のマッピングを拡張
- direct builder テストを拡張し、`update-builder.md` の Step 25 を完了更新

## Validation
- `python -m py_compile onnx2tf/tflite_builder/op_builders/elementwise.py onnx2tf/tflite_builder/op_builders/__init__.py onnx2tf/tflite_builder/op_registry.py onnx2tf/tflite_builder/model_writer.py tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_split_planner.py`
