### PR TITLE
Step 26: Wave2 reduce/index/norm support

### DIFF
--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -71,6 +71,32 @@ def _build_transpose_options(schema_tflite: Dict[str, Any], _op: OperatorIR) -> 
     return _enum(schema_tflite, "BuiltinOptions", "TransposeOptions"), options
 
 
+def _build_reducer_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["ReducerOptionsT"]()
+    options.keepDims = bool(op.options.get("keepDims", True))
+    return _enum(schema_tflite, "BuiltinOptions", "ReducerOptions"), options
+
+
+def _build_squeeze_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["SqueezeOptionsT"]()
+    options.squeezeDims = [int(v) for v in op.options.get("squeezeDims", [])]
+    return _enum(schema_tflite, "BuiltinOptions", "SqueezeOptions"), options
+
+
+def _build_gather_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["GatherOptionsT"]()
+    options.axis = int(op.options.get("axis", 0))
+    options.batchDims = int(op.options.get("batchDims", 0))
+    return _enum(schema_tflite, "BuiltinOptions", "GatherOptions"), options
+
+
+def _build_l2_norm_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["L2NormOptionsT"]()
+    fused = str(op.options.get("fusedActivationFunction", "NONE"))
+    options.fusedActivationFunction = _enum(schema_tflite, "ActivationFunctionType", fused)
+    return _enum(schema_tflite, "BuiltinOptions", "L2NormOptions"), options
+
+
 def _build_conv_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
     options = schema_tflite["Conv2DOptionsT"]()
     options.padding = _enum(schema_tflite, "Padding", str(op.options["padding"]))
@@ -139,6 +165,14 @@ def _build_builtin_options(
         return _build_softmax_options(schema_tflite, op)
     if op.op_type == "TRANSPOSE":
         return _build_transpose_options(schema_tflite, op)
+    if op.op_type in ["MEAN", "SUM"]:
+        return _build_reducer_options(schema_tflite, op)
+    if op.op_type == "SQUEEZE":
+        return _build_squeeze_options(schema_tflite, op)
+    if op.op_type == "GATHER":
+        return _build_gather_options(schema_tflite, op)
+    if op.op_type == "L2_NORMALIZATION":
+        return _build_l2_norm_options(schema_tflite, op)
     if op.op_type == "CONV_2D":
         return _build_conv_options(schema_tflite, op)
     if op.op_type == "DEPTHWISE_CONV_2D":

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -9,7 +9,9 @@ from onnx2tf.tflite_builder.op_builders.shape import (
     build_concat_op,
     build_identity_op,
     build_reshape_op,
+    build_squeeze_op,
     build_transpose_op,
+    build_unsqueeze_op,
 )
 from onnx2tf.tflite_builder.op_builders.conv import (
     build_conv2d_or_depthwise_op,
@@ -19,6 +21,15 @@ from onnx2tf.tflite_builder.op_builders.pool import (
 )
 from onnx2tf.tflite_builder.op_builders.fc import (
     build_fully_connected_from_gemm_or_matmul,
+)
+from onnx2tf.tflite_builder.op_builders.reduce import (
+    build_reduce_op,
+)
+from onnx2tf.tflite_builder.op_builders.index import (
+    build_gather_op,
+)
+from onnx2tf.tflite_builder.op_builders.norm import (
+    build_l2_normalization_op,
 )
 
 __all__ = [
@@ -30,8 +41,13 @@ __all__ = [
     "build_concat_op",
     "build_identity_op",
     "build_reshape_op",
+    "build_squeeze_op",
     "build_transpose_op",
+    "build_unsqueeze_op",
     "build_conv2d_or_depthwise_op",
     "build_pool2d_op",
     "build_fully_connected_from_gemm_or_matmul",
+    "build_reduce_op",
+    "build_gather_op",
+    "build_l2_normalization_op",
 ]

--- a/onnx2tf/tflite_builder/op_builders/index.py
+++ b/onnx2tf/tflite_builder/op_builders/index.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+from onnx2tf.tflite_builder.ir import OperatorIR
+
+
+def build_gather_op(node: Any, ctx: Any) -> None:
+    params_name = node.inputs[0].name
+    indices_name = node.inputs[1].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(params_name)
+    ctx.ensure_tensor(indices_name)
+    ctx.ensure_tensor(output_name)
+
+    input_rank = len(ctx.get_tensor_shape(params_name))
+    axis = int(node.attrs.get("axis", 0))
+    if axis < 0:
+        axis += input_rank
+    batch_dims = int(node.attrs.get("batch_dims", 0))
+    if batch_dims != 0:
+        raise NotImplementedError(
+            f"Gather batch_dims != 0 is not supported in flatbuffer_direct. "
+            f"op={node.name} batch_dims={batch_dims}"
+        )
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="GATHER",
+            inputs=[params_name, indices_name],
+            outputs=[output_name],
+            options={
+                "axis": int(axis),
+                "batchDims": int(batch_dims),
+            },
+        )
+    )

--- a/onnx2tf/tflite_builder/op_builders/norm.py
+++ b/onnx2tf/tflite_builder/op_builders/norm.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Any
+
+from onnx2tf.tflite_builder.ir import OperatorIR
+
+
+def build_l2_normalization_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+    ctx.add_operator(
+        OperatorIR(
+            op_type="L2_NORMALIZATION",
+            inputs=[input_name],
+            outputs=[output_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )

--- a/onnx2tf/tflite_builder/op_builders/reduce.py
+++ b/onnx2tf/tflite_builder/op_builders/reduce.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import numpy as np
+
+from onnx2tf.tflite_builder.ir import OperatorIR
+
+
+def _normalize_axes(axes: List[int], rank: int, node_name: str) -> List[int]:
+    normalized: List[int] = []
+    for axis in axes:
+        a = int(axis)
+        if a < 0:
+            a += rank
+        if a < 0 or a >= rank:
+            raise NotImplementedError(
+                f"Reduce axis is out of range. op={node_name} axis={axis} rank={rank}"
+            )
+        if a not in normalized:
+            normalized.append(a)
+    return normalized
+
+
+def _resolve_reduce_axes(node: Any, ctx: Any, input_rank: int) -> List[int]:
+    axes: List[int]
+    if len(node.inputs) >= 2:
+        axes_arr = ctx.get_constant_array(node.inputs[1].name)
+        if axes_arr is None:
+            raise NotImplementedError(
+                f"Reduce axes must be constant for flatbuffer_direct. op={node.name}"
+            )
+        axes = [int(v) for v in np.asarray(axes_arr).reshape(-1).tolist()]
+    else:
+        attr_axes = node.attrs.get("axes", None)
+        if attr_axes is None:
+            axes = [int(v) for v in range(input_rank)]
+        elif isinstance(attr_axes, (list, tuple)):
+            axes = [int(v) for v in attr_axes]
+        else:
+            axes = [int(attr_axes)]
+
+    if len(axes) == 0:
+        if int(node.attrs.get("noop_with_empty_axes", 0)) == 1:
+            return []
+        axes = [int(v) for v in range(input_rank)]
+    return _normalize_axes(axes, input_rank, node.name)
+
+
+def build_reduce_op(node: Any, ctx: Any, op_type: str) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+
+    input_shape = ctx.get_tensor_shape(input_name)
+    output_shape = ctx.get_tensor_shape(output_name)
+    axes = _resolve_reduce_axes(node, ctx, len(input_shape))
+    if len(axes) == 0 and int(node.attrs.get("noop_with_empty_axes", 0)) == 1:
+        shape_const = ctx.add_const_tensor(
+            f"{output_name}_reduce_noop_shape",
+            np.asarray(output_shape, dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[input_name, shape_const],
+                outputs=[output_name],
+                options={"newShape": [int(v) for v in output_shape]},
+            )
+        )
+        return
+
+    axes_const = ctx.add_const_tensor(
+        f"{output_name}_{op_type.lower()}_axes",
+        np.asarray(axes, dtype=np.int32),
+    )
+    keepdims = bool(int(node.attrs.get("keepdims", 1)))
+    ctx.add_operator(
+        OperatorIR(
+            op_type=op_type,
+            inputs=[input_name, axes_const],
+            outputs=[output_name],
+            options={"keepDims": keepdims},
+        )
+    )

--- a/update-builder.md
+++ b/update-builder.md
@@ -62,6 +62,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 23 実装（manifestに従う分割モデル逐次実行評価器を追加し、`*_split_accuracy_report.json` を出力。`unsplit_tflite` / `onnx` 比較と閾値失敗制御を追加）
 - Step 24 実装（OPディスパッチを登録テーブル化し、共通検証フックと機械可読な未対応理由レポートを追加。ONNX schema 13-18 と対応状況の突合を自動化し、`--report_op_coverage` で `*_op_coverage_report.json` を出力）
 - Step 25 実装（全OP Wave1 第1弾: `Relu`, `Tanh`, `Exp`, `Sqrt`, `Neg`, `Clip(min=0,max=6 / +inf)` を追加し、高頻度活性化・単項演算の変換成功率を向上）
+- Step 26 実装（Wave2 第1弾: `ReduceMean`, `ReduceSum`, `Squeeze`, `Unsqueeze`, `Gather`, `LpNormalization(p=2, axis=last)` を追加し、Reduce/Norm/Index 系を拡張。`Gather(int32)` と integer quantized 経路で互換性を検証）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`
@@ -91,9 +92,11 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - `--report_op_coverage` 指定で `*_op_coverage_report.json` が生成され、`graph_node_reports` / `unsupported_reason_counts` / `conversion_error` が出力されること
 - 未対応 OP を含むモデルでも失敗時に OP カバレッジレポートが出力されること（`unsupported_onnx_op` などの reason_code を確認）
 - 追加対応 OP（`Relu`, `Tanh`, `Exp`, `Sqrt`, `Neg`, `Clip` relu系限定）を含む小規模モデルで `flatbuffer_direct` 変換・`Interpreter.invoke()` が通ること
+- 追加対応 OP（`ReduceMean`, `ReduceSum`, `Squeeze`, `Unsqueeze`, `Gather`, `LpNormalization`）を含む小規模モデルで `flatbuffer_direct` 変換・`Interpreter.invoke()` が通ること
+- `Gather(int32)` で dtype 境界ケースが通ること、および `Gemm -> Relu -> ReduceMean` 構成で `*_integer_quant.tflite` 推論が可能なこと
 
 3. 未着手:
-- 追加要件 Step 26-28（全OP本格実装）
+- 追加要件 Step 27-28（全OP本格実装）
 
 ## 拡張ステージ（M5-Stage1: Dynamic Range Quant 最小対応）
 ### Step 10: 拡張仕様固定（限定解禁）
@@ -475,6 +478,6 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 24. `[x] Step 23 完了`
 25. `[x] Step 24 完了`
 26. `[x] Step 25 完了`
-27. `[ ] Step 26 完了`
+27. `[x] Step 26 完了`
 28. `[ ] Step 27 完了`
 29. `[ ] Step 28 完了`


### PR DESCRIPTION
## Summary
- Wave2 第1弾として Reduce/Index/Norm 系の高頻度OPを direct builder に追加
- 追加対応: `ReduceMean`, `ReduceSum`, `Squeeze`, `Unsqueeze`, `Gather`, `LpNormalization(p=2, axis=last)`
- OP registry の検証フックを拡張し、制約違反は reason_code 付きで明示失敗
- model writer の BuiltinOptions マッピングを拡張（Reducer/Gather/Squeeze/L2Norm）
- `tests/test_tflite_builder_direct.py` を拡張し、dtype境界（Gather int32）と integer quantized 経路互換を確認
- `update-builder.md` の Step 26 を完了更新

## Validation
- `python -m py_compile onnx2tf/tflite_builder/op_builders/reduce.py onnx2tf/tflite_builder/op_builders/index.py onnx2tf/tflite_builder/op_builders/norm.py onnx2tf/tflite_builder/op_builders/shape.py onnx2tf/tflite_builder/op_builders/__init__.py onnx2tf/tflite_builder/op_registry.py onnx2tf/tflite_builder/model_writer.py tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_split_planner.py`
