### PR TITLE
Step 27: establish custom-op policy and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1674,11 +1674,23 @@ flatbuffer_direct notes:
 3. Integer quantization (`-oiqt`) is supported in a limited form:
    `*_integer_quant.tflite`, `*_full_integer_quant.tflite`,
    `*_integer_quant_with_int16_act.tflite`, `*_full_integer_quant_with_int16_act.tflite` are generated.
-4. Supported builtin OP set: `ADD`, `SUB`, `MUL`, `DIV`, `RESHAPE`, `TRANSPOSE`, `CONCATENATION`, `LOGISTIC`, `SOFTMAX`, `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`, `DEQUANTIZE`, `QUANTIZE`.
+4. Supported builtin OP set includes:
+   `ADD`, `SUB`, `MUL`, `DIV`,
+   `MEAN`, `SUM`, `RESHAPE`, `TRANSPOSE`, `SQUEEZE`,
+   `CONCATENATION`, `GATHER`,
+   `LOGISTIC`, `RELU`, `RELU6`, `TANH`, `EXP`, `SQRT`, `NEG`,
+   `SOFTMAX`, `L2_NORMALIZATION`,
+   `CONV_2D`, `DEPTHWISE_CONV_2D`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`,
+   `DEQUANTIZE`, `QUANTIZE`.
 5. Unsupported OPs fail explicitly with `NotImplementedError`.
-6. `schema.fbs` is fetched from LiteRT by pinned tag by default (`v2.1.2`), and can be overridden by:
+6. Custom OP policy (opt-in):
+   `--flatbuffer_direct_allow_custom_ops` enables lowering selected hard ops as TFLite `CUSTOM`.
+   `--flatbuffer_direct_custom_op_allowlist` (comma-separated ONNX OP names) restricts allowed custom lowering targets.
+   If a custom-op candidate appears while disabled, conversion fails with `reason_code=custom_op_candidate_disabled`.
+   If enabled but not in allowlist, conversion fails with `reason_code=custom_op_not_in_allowlist`.
+7. `schema.fbs` is fetched from LiteRT by pinned tag by default (`v2.1.2`), and can be overridden by:
    `ONNX2TF_TFLITE_SCHEMA_REPOSITORY`, `ONNX2TF_TFLITE_SCHEMA_TAG`, `ONNX2TF_TFLITE_SCHEMA_RELATIVE_PATH`.
-7. flatbuffer_direct quantization precision controls are configurable via environment variables:
+8. flatbuffer_direct quantization precision controls are configurable via environment variables:
    `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_METHOD` (`max` or `percentile`),
    `ONNX2TF_FLATBUFFER_DIRECT_CALIBRATION_PERCENTILE` (e.g. `99.99`),
    `ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_NUMEL`,

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -31,6 +31,9 @@ from onnx2tf.tflite_builder.op_builders.index import (
 from onnx2tf.tflite_builder.op_builders.norm import (
     build_l2_normalization_op,
 )
+from onnx2tf.tflite_builder.op_builders.custom import (
+    build_custom_passthrough_op,
+)
 
 __all__ = [
     "build_binary_op",
@@ -50,4 +53,5 @@ __all__ = [
     "build_reduce_op",
     "build_gather_op",
     "build_l2_normalization_op",
+    "build_custom_passthrough_op",
 ]

--- a/onnx2tf/tflite_builder/op_builders/custom.py
+++ b/onnx2tf/tflite_builder/op_builders/custom.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+from onnx2tf.tflite_builder.ir import OperatorIR
+
+
+def build_custom_passthrough_op(node: Any, ctx: Any) -> None:
+    input_names = [i.name for i in node.inputs if i.name != ""]
+    output_names = [o.name for o in node.outputs if o.name != ""]
+    for name in input_names:
+        ctx.ensure_tensor(name)
+    for name in output_names:
+        ctx.ensure_tensor(name)
+
+    custom_code = f"ONNX_{str(node.op).upper()}"
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CUSTOM",
+            inputs=input_names,
+            outputs=output_names,
+            options={
+                "customCode": custom_code,
+                "customOptionsFormat": "FLEXBUFFERS",
+                "customOptions": b"",
+                "onnxOp": str(node.op),
+                "onnxNodeName": str(node.name),
+            },
+        )
+    )

--- a/onnx2tf/tflite_builder/opcodes.py
+++ b/onnx2tf/tflite_builder/opcodes.py
@@ -5,21 +5,30 @@ from typing import Dict, List, Tuple
 from onnx2tf.tflite_builder.ir import OperatorIR
 
 
+def operator_code_key(op: OperatorIR) -> Tuple[str, int, str]:
+    custom_code = ""
+    if op.op_type == "CUSTOM":
+        custom_code = str(op.options.get("customCode", "CUSTOM"))
+    return (str(op.op_type), int(op.version), custom_code)
+
+
 def build_operator_codes(
     schema_tflite: Dict,
     operators: List[OperatorIR],
-) -> Tuple[List[object], Dict[Tuple[str, int], int]]:
+) -> Tuple[List[object], Dict[Tuple[str, int, str], int]]:
     operator_codes = []
-    op_index_map: Dict[Tuple[str, int], int] = {}
+    op_index_map: Dict[Tuple[str, int, str], int] = {}
     for op in operators:
-        key = (op.op_type, op.version)
+        key = operator_code_key(op)
         if key in op_index_map:
             continue
         oc = schema_tflite["OperatorCodeT"]()
         builtin_code = getattr(schema_tflite["BuiltinOperator"], op.op_type)
         oc.builtinCode = builtin_code
         oc.deprecatedBuiltinCode = builtin_code
-        oc.version = op.version
+        oc.version = int(op.version)
+        if op.op_type == "CUSTOM":
+            oc.customCode = str(op.options.get("customCode", "CUSTOM"))
         op_index_map[key] = len(operator_codes)
         operator_codes.append(oc)
     return operator_codes, op_index_map


### PR DESCRIPTION
## Summary
- Step 27 (Wave3) として、Builtin で表現困難な演算向けの Custom OP 方針を実装
- custom-op candidate 群を定義し、既定は明示失敗（reason_code 付き）
- `--flatbuffer_direct_allow_custom_ops` + allowlist 指定時のみ `CUSTOM` へ降格
- `CUSTOM` の OperatorCode/Operator 書き込み（customCode/customOptions）を実装
- OP coverage report に `dispatch_mode`, `graph_custom_ops`, `custom_lowered_nodes`, `custom_op_policy` を追加
- README と update-builder.md を更新（Step 27 完了）

## Validation
- `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py onnx2tf/tflite_builder/lower_from_onnx2tf.py onnx2tf/tflite_builder/opcodes.py onnx2tf/tflite_builder/model_writer.py onnx2tf/tflite_builder/op_registry.py onnx2tf/tflite_builder/op_builders/custom.py tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_builder_direct.py`
- `pytest -q tests/test_tflite_split_planner.py`
- `python -m onnx2tf.onnx2tf -h` で custom-op オプション表示確認
