### PR TITLE
Step A2: direct 共通プリパス基盤の導入

### DIFF
--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -251,6 +251,7 @@ def build_op_coverage_report(
     conversion_error: Optional[str] = None,
     allow_custom_ops: bool = False,
     custom_op_allowlist: Optional[List[str]] = None,
+    preprocess_report: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     try:
         onnx_graph = onnx.shape_inference.infer_shapes(onnx_graph)
@@ -430,6 +431,25 @@ def build_op_coverage_report(
             ),
             "candidate_count": int(len(custom_candidate_ops)),
         },
+        "preprocess_report": (
+            dict(preprocess_report)
+            if isinstance(preprocess_report, dict)
+            else {
+                "schema_version": 1,
+                "pipeline_version": 1,
+                "registered_rule_ids": [],
+                "enabled_rule_ids": [],
+                "applied_rules": [],
+                "summary": {
+                    "registered_rule_count": 0,
+                    "enabled_rule_count": 0,
+                    "executed_rule_count": 0,
+                    "changed_rule_count": 0,
+                    "total_matched_nodes": 0,
+                    "total_rewritten_nodes": 0,
+                },
+            }
+        ),
         "conversion_error": conversion_error,
     }
     return report

--- a/onnx2tf/tflite_builder/preprocess/__init__.py
+++ b/onnx2tf/tflite_builder/preprocess/__init__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from onnx2tf.tflite_builder.preprocess.pipeline import (
+    clear_preprocess_rules,
+    get_registered_preprocess_rule_ids,
+    register_preprocess_rule,
+    run_preprocess_pipeline,
+)
+
+__all__ = [
+    "clear_preprocess_rules",
+    "get_registered_preprocess_rule_ids",
+    "register_preprocess_rule",
+    "run_preprocess_pipeline",
+]
+

--- a/onnx2tf/tflite_builder/preprocess/pipeline.py
+++ b/onnx2tf/tflite_builder/preprocess/pipeline.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+import onnx
+
+PreprocessRuleCallback = Callable[[onnx.ModelProto], Optional[Dict[str, Any]]]
+
+
+class _PreprocessRule:
+    def __init__(
+        self,
+        rule_id: str,
+        callback: PreprocessRuleCallback,
+    ) -> None:
+        self.rule_id = str(rule_id)
+        self.callback = callback
+
+
+_REGISTERED_PREPROCESS_RULES: "OrderedDict[str, _PreprocessRule]" = OrderedDict()
+
+
+def register_preprocess_rule(
+    *,
+    rule_id: str,
+    callback: PreprocessRuleCallback,
+    overwrite: bool = False,
+) -> None:
+    rid = str(rule_id).strip()
+    if rid == "":
+        raise ValueError("preprocess rule_id must not be empty.")
+    if not callable(callback):
+        raise TypeError("preprocess callback must be callable.")
+    if rid in _REGISTERED_PREPROCESS_RULES and not overwrite:
+        raise ValueError(f"preprocess rule already exists: {rid}")
+    _REGISTERED_PREPROCESS_RULES[rid] = _PreprocessRule(
+        rule_id=rid,
+        callback=callback,
+    )
+
+
+def clear_preprocess_rules() -> None:
+    _REGISTERED_PREPROCESS_RULES.clear()
+
+
+def get_registered_preprocess_rule_ids() -> List[str]:
+    return list(_REGISTERED_PREPROCESS_RULES.keys())
+
+
+def run_preprocess_pipeline(
+    *,
+    onnx_graph: onnx.ModelProto,
+    enabled_rule_ids: Optional[Sequence[str]] = None,
+) -> Tuple[onnx.ModelProto, Dict[str, Any]]:
+    working_graph = onnx.ModelProto()
+    working_graph.CopyFrom(onnx_graph)
+
+    registered_rule_ids = get_registered_preprocess_rule_ids()
+    if enabled_rule_ids is None:
+        target_rule_ids = list(registered_rule_ids)
+    else:
+        target_rule_ids = [str(v) for v in enabled_rule_ids]
+        unknown_rule_ids = sorted(
+            list(set(target_rule_ids) - set(registered_rule_ids))
+        )
+        if len(unknown_rule_ids) > 0:
+            raise ValueError(
+                f"Unknown preprocess rule id(s): {unknown_rule_ids}"
+            )
+
+    applied_rules: List[Dict[str, Any]] = []
+    total_matched_nodes = 0
+    total_rewritten_nodes = 0
+    for rule_id in target_rule_ids:
+        rule = _REGISTERED_PREPROCESS_RULES[rule_id]
+        raw_result = rule.callback(working_graph)
+        result = raw_result if isinstance(raw_result, dict) else {}
+        matched_nodes = int(result.get("matched_nodes", 0))
+        rewritten_nodes = int(result.get("rewritten_nodes", 0))
+        if matched_nodes < 0:
+            matched_nodes = 0
+        if rewritten_nodes < 0:
+            rewritten_nodes = 0
+        changed = bool(
+            result.get(
+                "changed",
+                rewritten_nodes > 0,
+            )
+        )
+        applied_rules.append(
+            {
+                "rule_id": rule_id,
+                "matched_nodes": matched_nodes,
+                "rewritten_nodes": rewritten_nodes,
+                "changed": changed,
+                "message": str(result.get("message", "")),
+            }
+        )
+        total_matched_nodes += matched_nodes
+        total_rewritten_nodes += rewritten_nodes
+
+    report = {
+        "schema_version": 1,
+        "pipeline_version": 1,
+        "registered_rule_ids": registered_rule_ids,
+        "enabled_rule_ids": target_rule_ids,
+        "applied_rules": applied_rules,
+        "summary": {
+            "registered_rule_count": int(len(registered_rule_ids)),
+            "enabled_rule_count": int(len(target_rule_ids)),
+            "executed_rule_count": int(len(applied_rules)),
+            "changed_rule_count": int(
+                len([r for r in applied_rules if bool(r.get("changed", False))])
+            ),
+            "total_matched_nodes": int(total_matched_nodes),
+            "total_rewritten_nodes": int(total_rewritten_nodes),
+        },
+    }
+    return working_graph, report
+

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -1156,6 +1156,9 @@ def test_flatbuffer_direct_op_coverage_report_generation() -> None:
         assert "Add" in report["graph_ops"]
         assert report["graph_summary"]["unsupported_nodes"] == 0
         assert report["graph_summary"]["coverage_ratio"] == 1.0
+        assert "preprocess_report" in report
+        assert report["preprocess_report"]["schema_version"] == 1
+        assert report["preprocess_report"]["summary"]["executed_rule_count"] >= 0
 
 
 @pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires flatc and curl")

--- a/tests/test_tflite_builder_preprocess.py
+++ b/tests/test_tflite_builder_preprocess.py
@@ -1,0 +1,39 @@
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+from onnx2tf.tflite_builder.preprocess import (
+    clear_preprocess_rules,
+    run_preprocess_pipeline,
+)
+
+
+def _make_add_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
+    z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])
+    node = helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")
+    graph = helper.make_graph([node], "add_graph", [x, y], [z])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def test_preprocess_pipeline_no_rules_is_noop() -> None:
+    clear_preprocess_rules()
+    model = _make_add_model()
+    preprocessed, report = run_preprocess_pipeline(onnx_graph=model)
+    assert len(preprocessed.graph.node) == len(model.graph.node)
+    assert report["schema_version"] == 1
+    assert report["summary"]["registered_rule_count"] == 0
+    assert report["summary"]["executed_rule_count"] == 0
+    assert report["applied_rules"] == []
+
+
+def test_preprocess_pipeline_unknown_rule_id_fails() -> None:
+    clear_preprocess_rules()
+    model = _make_add_model()
+    with pytest.raises(ValueError):
+        run_preprocess_pipeline(
+            onnx_graph=model,
+            enabled_rule_ids=["missing_rule"],
+        )
+

--- a/update-builder2.md
+++ b/update-builder2.md
@@ -98,6 +98,18 @@ Step A2 以降の優先着手対象（確定）:
 1. ルール未登録でも no-op で従来通り動作する。
 2. レポートにプリパス適用履歴を出力できる。
 
+#### Step A2 実施結果（2026-02-11）
+実装内容:
+1. `onnx2tf/tflite_builder/preprocess/` を新設し、direct 前処理パイプラインの共通基盤を追加。
+2. `export_tflite_model_flatbuffer_direct` で `lower_onnx_to_ir` 前に `run_preprocess_pipeline` を実行。
+3. `report_op_coverage` 出力に `preprocess_report` を追加し、`rule_id` 単位の適用履歴を出力可能化。
+4. ルール未登録時は `registered_rule_count=0` / `executed_rule_count=0` の no-op 動作を確認。
+5. テスト: `tests/test_tflite_builder_preprocess.py`（新規）と `tests/test_tflite_builder_direct.py` の coverage report 検証を更新。
+
+カバレッジ差分:
+1. 前回値 `15.34%` -> 今回値 `15.34%`（差分 `+0.00%`）
+2. 変化なし理由: Step A2 は前処理基盤と計測導線の追加のみで、Builtin 化ルール自体は未追加。
+
 ### Step A3: 擬似OP置換ルール（Wave1）移植
 1. TF 経路で頻用の `replace_to_pseudo_operators` 相当を direct 前処理へ移植する。
 2. 対象候補: `Erf`, `GeLU`, `HardSwish`, `LeakyRelu`, `PReLU`, `Power/Pow`, `MatMulInteger`。
@@ -217,7 +229,7 @@ Step A2 以降の優先着手対象（確定）:
 
 ## 進捗トラッキング（テンプレ）
 1. `[x] Step A1 完了`
-2. `[ ] Step A2 完了`
+2. `[x] Step A2 完了`
 3. `[ ] Step A3 完了`
 4. `[ ] Step A4 完了`
 5. `[ ] Step A5 完了`


### PR DESCRIPTION
## Summary
- `flatbuffer_direct` の前段に共通プリパス実行ポイントを追加
- `onnx2tf/tflite_builder/preprocess` を新設し、ルール登録/実行と適用履歴レポートの土台を追加
- OPカバレッジレポートに `preprocess_report` を追加
- Step A2 進捗を `update-builder2.md` に反映
- プリパス no-op 挙動と coverage report をテストで検証

## Testing
- `pytest -q tests/test_tflite_builder_preprocess.py`
- `pytest -q tests/test_tflite_builder_direct.py -k op_coverage_report_generation`
