### PR TITLE
Step A5: 属性・shape 正規化の強化

### DIFF
--- a/onnx2tf/tflite_builder/preprocess/__init__.py
+++ b/onnx2tf/tflite_builder/preprocess/__init__.py
@@ -7,19 +7,27 @@ from onnx2tf.tflite_builder.preprocess.pipeline import (
     run_preprocess_pipeline,
 )
 from onnx2tf.tflite_builder.preprocess.rules import (
+    CONSTANT_FOLD_RULE_ID,
+    NORMALIZE_ATTRS_RULE_ID,
     PATTERN_FUSION_WAVE2_RULE_ID,
     PSEUDO_OPS_WAVE1_RULE_ID,
+    register_constant_fold_rule,
     register_default_preprocess_rules,
+    register_normalize_attrs_rule,
     register_pattern_fusion_wave2_rule,
     register_pseudo_ops_wave1_rule,
 )
 
 __all__ = [
+    "CONSTANT_FOLD_RULE_ID",
+    "NORMALIZE_ATTRS_RULE_ID",
     "PATTERN_FUSION_WAVE2_RULE_ID",
     "PSEUDO_OPS_WAVE1_RULE_ID",
     "clear_preprocess_rules",
     "get_registered_preprocess_rule_ids",
+    "register_constant_fold_rule",
     "register_default_preprocess_rules",
+    "register_normalize_attrs_rule",
     "register_pattern_fusion_wave2_rule",
     "register_preprocess_rule",
     "register_pseudo_ops_wave1_rule",

--- a/onnx2tf/tflite_builder/preprocess/rules/__init__.py
+++ b/onnx2tf/tflite_builder/preprocess/rules/__init__.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+from onnx2tf.tflite_builder.preprocess.rules.constant_fold import (
+    CONSTANT_FOLD_RULE_ID,
+    register_constant_fold_rule,
+)
+from onnx2tf.tflite_builder.preprocess.rules.normalize_attrs import (
+    NORMALIZE_ATTRS_RULE_ID,
+    register_normalize_attrs_rule,
+)
 from onnx2tf.tflite_builder.preprocess.rules.pattern_fusion import (
     PATTERN_FUSION_WAVE2_RULE_ID,
     register_pattern_fusion_wave2_rule,
@@ -13,12 +21,18 @@ from onnx2tf.tflite_builder.preprocess.rules.pseudo_ops import (
 def register_default_preprocess_rules() -> None:
     register_pattern_fusion_wave2_rule()
     register_pseudo_ops_wave1_rule()
+    register_constant_fold_rule()
+    register_normalize_attrs_rule()
 
 
 __all__ = [
+    "CONSTANT_FOLD_RULE_ID",
+    "NORMALIZE_ATTRS_RULE_ID",
     "PATTERN_FUSION_WAVE2_RULE_ID",
     "PSEUDO_OPS_WAVE1_RULE_ID",
     "register_default_preprocess_rules",
+    "register_constant_fold_rule",
+    "register_normalize_attrs_rule",
     "register_pattern_fusion_wave2_rule",
     "register_pseudo_ops_wave1_rule",
 ]

--- a/onnx2tf/tflite_builder/preprocess/rules/constant_fold.py
+++ b/onnx2tf/tflite_builder/preprocess/rules/constant_fold.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+from onnx2tf.tflite_builder.preprocess.pipeline import register_preprocess_rule
+
+CONSTANT_FOLD_RULE_ID = "constant_fold_a5"
+_FOLDABLE_OPS = {
+    "Identity",
+    "Cast",
+    "Unsqueeze",
+    "Squeeze",
+    "Concat",
+    "Reshape",
+    "Transpose",
+    "Gather",
+    "Shape",
+    "Add",
+    "Sub",
+    "Mul",
+    "Div",
+    "Neg",
+}
+
+
+def _copy_node(node: onnx.NodeProto) -> onnx.NodeProto:
+    cloned = onnx.NodeProto()
+    cloned.CopyFrom(node)
+    return cloned
+
+
+def _find_attr(node: onnx.NodeProto, name: str) -> Optional[onnx.AttributeProto]:
+    for attr in node.attribute:
+        if str(attr.name) == str(name):
+            return attr
+    return None
+
+
+def _get_attr_int(node: onnx.NodeProto, name: str, default: int) -> int:
+    attr = _find_attr(node, name)
+    if attr is None:
+        return int(default)
+    if attr.type == onnx.AttributeProto.INT:
+        return int(attr.i)
+    if attr.type == onnx.AttributeProto.FLOAT:
+        return int(attr.f)
+    return int(default)
+
+
+def _get_attr_ints(node: onnx.NodeProto, name: str) -> Optional[List[int]]:
+    attr = _find_attr(node, name)
+    if attr is None:
+        return None
+    if attr.type == onnx.AttributeProto.INTS:
+        return [int(v) for v in attr.ints]
+    if attr.type == onnx.AttributeProto.INT:
+        return [int(attr.i)]
+    return None
+
+
+def _find_const_tensor_attribute(node: onnx.NodeProto, name: str) -> Optional[onnx.TensorProto]:
+    for attr in node.attribute:
+        if str(attr.name) != str(name):
+            continue
+        if attr.type == onnx.AttributeProto.TENSOR:
+            return attr.t
+    return None
+
+
+def _build_constant_map(graph: onnx.GraphProto) -> Dict[str, np.ndarray]:
+    consts: Dict[str, np.ndarray] = {}
+    for init in graph.initializer:
+        consts[str(init.name)] = np.asarray(numpy_helper.to_array(init))
+    for node in graph.node:
+        if str(node.op_type) != "Constant" or len(node.output) < 1:
+            continue
+        value = _find_const_tensor_attribute(node, "value")
+        if value is None:
+            continue
+        consts[str(node.output[0])] = np.asarray(numpy_helper.to_array(value))
+    return consts
+
+
+def _normalize_axes(axes: Sequence[int], rank: int) -> List[int]:
+    normalized = []
+    for axis in axes:
+        a = int(axis)
+        if a < 0:
+            a += int(rank)
+        normalized.append(a)
+    return [int(v) for v in normalized]
+
+
+def _fold_cast(values: List[np.ndarray], node: onnx.NodeProto) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    to = int(_get_attr_int(node, "to", 1))
+    np_dtype = {
+        onnx.TensorProto.FLOAT: np.float32,
+        onnx.TensorProto.FLOAT16: np.float16,
+        onnx.TensorProto.DOUBLE: np.float64,
+        onnx.TensorProto.INT8: np.int8,
+        onnx.TensorProto.INT16: np.int16,
+        onnx.TensorProto.INT32: np.int32,
+        onnx.TensorProto.INT64: np.int64,
+        onnx.TensorProto.UINT8: np.uint8,
+        onnx.TensorProto.UINT16: np.uint16,
+        onnx.TensorProto.UINT32: np.uint32,
+        onnx.TensorProto.UINT64: np.uint64,
+        onnx.TensorProto.BOOL: np.bool_,
+    }.get(to, None)
+    if np_dtype is None:
+        return None
+    return np.asarray(values[0]).astype(np_dtype)
+
+
+def _fold_unsqueeze(values: List[np.ndarray], node: onnx.NodeProto) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    data = np.asarray(values[0])
+    axes = None
+    if len(values) >= 2:
+        axes = [int(v) for v in np.asarray(values[1]).reshape(-1).tolist()]
+    if axes is None:
+        axes = _get_attr_ints(node, "axes")
+    if axes is None:
+        return None
+    rank = data.ndim
+    normalized = _normalize_axes(axes, rank + 1)
+    out = data
+    for axis in sorted(normalized):
+        out = np.expand_dims(out, axis=axis)
+    return np.asarray(out)
+
+
+def _fold_squeeze(values: List[np.ndarray], node: onnx.NodeProto) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    data = np.asarray(values[0])
+    axes = None
+    if len(values) >= 2:
+        axes = [int(v) for v in np.asarray(values[1]).reshape(-1).tolist()]
+    if axes is None:
+        axes = _get_attr_ints(node, "axes")
+    if axes is None or len(axes) == 0:
+        return np.squeeze(data)
+    normalized = _normalize_axes(axes, data.ndim)
+    return np.squeeze(data, axis=tuple(normalized))
+
+
+def _fold_concat(values: List[np.ndarray], node: onnx.NodeProto) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    axis = int(_get_attr_int(node, "axis", 0))
+    rank = max(v.ndim for v in values)
+    if axis < 0:
+        axis += rank
+    return np.concatenate([np.asarray(v) for v in values], axis=axis)
+
+
+def _fold_reshape(values: List[np.ndarray]) -> Optional[np.ndarray]:
+    if len(values) < 2:
+        return None
+    data = np.asarray(values[0])
+    shape = [int(v) for v in np.asarray(values[1]).reshape(-1).tolist()]
+    return np.reshape(data, shape)
+
+
+def _fold_transpose(values: List[np.ndarray], node: onnx.NodeProto) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    data = np.asarray(values[0])
+    perm = None
+    if len(values) >= 2:
+        perm = [int(v) for v in np.asarray(values[1]).reshape(-1).tolist()]
+    if perm is None:
+        perm = _get_attr_ints(node, "perm")
+    if perm is None:
+        perm = [int(v) for v in reversed(range(data.ndim))]
+    return np.transpose(data, axes=perm)
+
+
+def _fold_gather(values: List[np.ndarray], node: onnx.NodeProto) -> Optional[np.ndarray]:
+    if len(values) < 2:
+        return None
+    data = np.asarray(values[0])
+    indices = np.asarray(values[1])
+    axis = int(_get_attr_int(node, "axis", 0))
+    if axis < 0:
+        axis += data.ndim
+    return np.take(data, indices, axis=axis)
+
+
+def _fold_shape(values: List[np.ndarray]) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    return np.asarray(np.asarray(values[0]).shape, dtype=np.int64)
+
+
+def _fold_binary(values: List[np.ndarray], op_type: str) -> Optional[np.ndarray]:
+    if len(values) < 2:
+        return None
+    x = np.asarray(values[0])
+    y = np.asarray(values[1])
+    if op_type == "Add":
+        return x + y
+    if op_type == "Sub":
+        return x - y
+    if op_type == "Mul":
+        return x * y
+    if op_type == "Div":
+        return x / y
+    return None
+
+
+def _fold_unary(values: List[np.ndarray], op_type: str) -> Optional[np.ndarray]:
+    if len(values) < 1:
+        return None
+    x = np.asarray(values[0])
+    if op_type == "Identity":
+        return np.asarray(x)
+    if op_type == "Neg":
+        return -x
+    return None
+
+
+def _fold_node(
+    *,
+    node: onnx.NodeProto,
+    const_map: Dict[str, np.ndarray],
+) -> Optional[np.ndarray]:
+    if len(node.output) != 1:
+        return None
+    op_type = str(node.op_type)
+    if op_type not in _FOLDABLE_OPS:
+        return None
+    input_names = [str(v) for v in node.input if str(v) != ""]
+    values: List[np.ndarray] = []
+    for name in input_names:
+        if name not in const_map:
+            return None
+        values.append(np.asarray(const_map[name]))
+    try:
+        if op_type == "Cast":
+            return _fold_cast(values, node)
+        if op_type == "Unsqueeze":
+            return _fold_unsqueeze(values, node)
+        if op_type == "Squeeze":
+            return _fold_squeeze(values, node)
+        if op_type == "Concat":
+            return _fold_concat(values, node)
+        if op_type == "Reshape":
+            return _fold_reshape(values)
+        if op_type == "Transpose":
+            return _fold_transpose(values, node)
+        if op_type == "Gather":
+            return _fold_gather(values, node)
+        if op_type == "Shape":
+            return _fold_shape(values)
+        if op_type in {"Add", "Sub", "Mul", "Div"}:
+            return _fold_binary(values, op_type)
+        if op_type in {"Identity", "Neg"}:
+            return _fold_unary(values, op_type)
+    except Exception:
+        return None
+    return None
+
+
+def apply_constant_fold_rule(onnx_graph: onnx.ModelProto) -> Dict[str, Any]:
+    graph = onnx_graph.graph
+    const_map = _build_constant_map(graph)
+    rewritten_nodes: List[onnx.NodeProto] = []
+    matched_nodes = 0
+    rewritten_count = 0
+    matched_by_op: Dict[str, int] = {}
+    rewritten_by_op: Dict[str, int] = {}
+
+    for node in graph.node:
+        op_type = str(node.op_type)
+        if op_type in _FOLDABLE_OPS:
+            matched_nodes += 1
+            matched_by_op[op_type] = int(matched_by_op.get(op_type, 0) + 1)
+        folded = _fold_node(node=node, const_map=const_map)
+        if folded is None:
+            rewritten_nodes.append(_copy_node(node))
+            continue
+        output_name = str(node.output[0])
+        const_tensor = numpy_helper.from_array(np.asarray(folded), name=output_name)
+        const_node = helper.make_node(
+            "Constant",
+            [],
+            [output_name],
+            name=str(node.name) if str(node.name) != "" else f"{output_name}_constant_folded",
+            value=const_tensor,
+        )
+        rewritten_nodes.append(const_node)
+        const_map[output_name] = np.asarray(folded)
+        rewritten_count += 1
+        rewritten_by_op[op_type] = int(rewritten_by_op.get(op_type, 0) + 1)
+
+    if rewritten_count > 0:
+        del graph.node[:]
+        graph.node.extend(rewritten_nodes)
+    return {
+        "matched_nodes": int(matched_nodes),
+        "rewritten_nodes": int(rewritten_count),
+        "changed": bool(rewritten_count > 0),
+        "message": (
+            f"matched_by_op={matched_by_op}, "
+            f"rewritten_by_op={rewritten_by_op}"
+        ),
+    }
+
+
+def register_constant_fold_rule() -> None:
+    register_preprocess_rule(
+        rule_id=CONSTANT_FOLD_RULE_ID,
+        callback=apply_constant_fold_rule,
+        overwrite=True,
+    )
+

--- a/onnx2tf/tflite_builder/preprocess/rules/normalize_attrs.py
+++ b/onnx2tf/tflite_builder/preprocess/rules/normalize_attrs.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+from onnx2tf.tflite_builder.preprocess.pipeline import register_preprocess_rule
+
+NORMALIZE_ATTRS_RULE_ID = "normalize_attrs_a5"
+
+
+def _copy_node(node: onnx.NodeProto) -> onnx.NodeProto:
+    cloned = onnx.NodeProto()
+    cloned.CopyFrom(node)
+    return cloned
+
+
+def _collect_used_names(graph: onnx.GraphProto) -> set[str]:
+    used = set()
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        if vi.name != "":
+            used.add(str(vi.name))
+    for init in graph.initializer:
+        if init.name != "":
+            used.add(str(init.name))
+    for node in graph.node:
+        if node.name != "":
+            used.add(str(node.name))
+        for name in list(node.input) + list(node.output):
+            if name != "":
+                used.add(str(name))
+    return used
+
+
+def _next_name(used_names: set[str], base: str) -> str:
+    candidate = str(base) if str(base) != "" else "tmp"
+    if candidate not in used_names:
+        used_names.add(candidate)
+        return candidate
+    i = 1
+    while True:
+        c = f"{candidate}_{i}"
+        if c not in used_names:
+            used_names.add(c)
+            return c
+        i += 1
+
+
+def _make_const_initializer(
+    *,
+    used_names: set[str],
+    name_base: str,
+    value: np.ndarray,
+) -> onnx.TensorProto:
+    name = _next_name(used_names, name_base)
+    return numpy_helper.from_array(np.asarray(value), name=name)
+
+
+def _find_attr(node: onnx.NodeProto, name: str) -> Optional[onnx.AttributeProto]:
+    for attr in node.attribute:
+        if str(attr.name) == str(name):
+            return attr
+    return None
+
+
+def _get_attr_int(node: onnx.NodeProto, name: str, default: int) -> int:
+    attr = _find_attr(node, name)
+    if attr is None:
+        return int(default)
+    if attr.type == onnx.AttributeProto.INT:
+        return int(attr.i)
+    if attr.type == onnx.AttributeProto.FLOAT:
+        return int(attr.f)
+    return int(default)
+
+
+def _get_attr_ints(node: onnx.NodeProto, name: str) -> Optional[List[int]]:
+    attr = _find_attr(node, name)
+    if attr is None:
+        return None
+    if attr.type == onnx.AttributeProto.INTS:
+        return [int(v) for v in attr.ints]
+    if attr.type == onnx.AttributeProto.INT:
+        return [int(attr.i)]
+    return None
+
+
+def _get_attr_str(node: onnx.NodeProto, name: str, default: str) -> str:
+    attr = _find_attr(node, name)
+    if attr is None:
+        return str(default)
+    if attr.type == onnx.AttributeProto.STRING:
+        try:
+            return str(attr.s.decode("utf-8"))
+        except Exception:
+            return str(default)
+    return str(default)
+
+
+def _set_int_attr(node: onnx.NodeProto, name: str, value: int) -> None:
+    existing = _find_attr(node, name)
+    if existing is not None:
+        existing.type = onnx.AttributeProto.INT
+        existing.i = int(value)
+        return
+    node.attribute.append(helper.make_attribute(name, int(value)))
+
+
+def _set_ints_attr(node: onnx.NodeProto, name: str, values: Sequence[int]) -> None:
+    existing = _find_attr(node, name)
+    vals = [int(v) for v in values]
+    if existing is not None:
+        existing.type = onnx.AttributeProto.INTS
+        del existing.ints[:]
+        existing.ints.extend(vals)
+        return
+    node.attribute.append(helper.make_attribute(name, vals))
+
+
+def _set_str_attr(node: onnx.NodeProto, name: str, value: str) -> None:
+    existing = _find_attr(node, name)
+    v = str(value)
+    if existing is not None:
+        existing.type = onnx.AttributeProto.STRING
+        existing.s = v.encode("utf-8")
+        return
+    node.attribute.append(helper.make_attribute(name, v))
+
+
+def _build_rank_map(onnx_graph: onnx.ModelProto) -> Dict[str, int]:
+    shape_map: Dict[str, int] = {}
+
+    def _set_from_vi(value_info: onnx.ValueInfoProto) -> None:
+        if value_info.name == "":
+            return
+        if not value_info.type.HasField("tensor_type"):
+            return
+        tt = value_info.type.tensor_type
+        if not tt.HasField("shape"):
+            return
+        shape_map[str(value_info.name)] = int(len(tt.shape.dim))
+
+    for vi in onnx_graph.graph.input:
+        _set_from_vi(vi)
+    for vi in onnx_graph.graph.value_info:
+        _set_from_vi(vi)
+    for vi in onnx_graph.graph.output:
+        _set_from_vi(vi)
+    for init in onnx_graph.graph.initializer:
+        arr = np.asarray(numpy_helper.to_array(init))
+        shape_map[str(init.name)] = int(arr.ndim)
+    return shape_map
+
+
+def _normalize_axis(axis: int, rank: int) -> int:
+    a = int(axis)
+    if a < 0:
+        a += int(rank)
+    return int(a)
+
+
+def _inverse_perm(perm: Sequence[int]) -> List[int]:
+    inv = [-1] * len(perm)
+    for i, p in enumerate(perm):
+        inv[int(p)] = int(i)
+    return [int(v) for v in inv]
+
+
+def apply_normalize_attrs_rule(onnx_graph: onnx.ModelProto) -> Dict[str, Any]:
+    graph = onnx_graph.graph
+    used_names = _collect_used_names(graph)
+    rank_map = _build_rank_map(onnx_graph)
+    added_initializers: List[onnx.TensorProto] = []
+
+    rewritten_nodes: List[onnx.NodeProto] = []
+    matched_nodes = 0
+    rewritten_count = 0
+    inserted_nodes = 0
+    details: Dict[str, int] = {
+        "transpose_perm_input_added": 0,
+        "axes_input_added": 0,
+        "axis_normalized": 0,
+        "pads_normalized": 0,
+        "softmax_transpose_inserted": 0,
+    }
+
+    for node in graph.node:
+        n = _copy_node(node)
+        op = str(n.op_type)
+        changed = False
+
+        if op in {"Transpose", "ReduceMean", "ReduceSum", "Squeeze", "Unsqueeze", "Gather", "Softmax", "LpNormalization", "Conv", "AveragePool", "MaxPool", "SpaceToDepth"}:
+            matched_nodes += 1
+
+        if op in {"Conv", "AveragePool", "MaxPool"}:
+            pads = _get_attr_ints(n, "pads")
+            if pads is not None and len(pads) == 2:
+                _set_ints_attr(n, "pads", [pads[0], pads[1], pads[0], pads[1]])
+                changed = True
+                details["pads_normalized"] += 1
+
+        if op == "SpaceToDepth":
+            _set_str_attr(n, "mode", _get_attr_str(n, "mode", "DCR").upper())
+            block_size = _get_attr_int(n, "blocksize", _get_attr_int(n, "block_size", 0))
+            if block_size > 0:
+                _set_int_attr(n, "blocksize", int(block_size))
+                changed = True
+
+        if op in {"Gather", "Softmax", "LpNormalization"}:
+            rank = int(rank_map.get(str(n.input[0]), -1)) if len(n.input) >= 1 else -1
+            if rank > 0:
+                axis = _get_attr_int(n, "axis", -1 if op != "Gather" else 0)
+                norm_axis = _normalize_axis(axis, rank)
+                if norm_axis != axis:
+                    _set_int_attr(n, "axis", norm_axis)
+                    changed = True
+                    details["axis_normalized"] += 1
+
+        if op in {"ReduceMean", "ReduceSum", "Squeeze", "Unsqueeze"} and len(n.input) == 1:
+            axes = _get_attr_ints(n, "axes")
+            if axes is not None:
+                rank = int(rank_map.get(str(n.input[0]), -1))
+                if rank > 0:
+                    axes = [_normalize_axis(v, rank + (1 if op == "Unsqueeze" else 0)) for v in axes]
+                axes_init = _make_const_initializer(
+                    used_names=used_names,
+                    name_base=f"{n.name or op}_axes",
+                    value=np.asarray(axes, dtype=np.int64),
+                )
+                added_initializers.append(axes_init)
+                n.input.append(axes_init.name)
+                changed = True
+                details["axes_input_added"] += 1
+
+        if op == "Transpose" and len(n.input) == 1:
+            perm = _get_attr_ints(n, "perm")
+            rank = int(rank_map.get(str(n.input[0]), -1))
+            if perm is None and rank > 0:
+                perm = [int(v) for v in reversed(range(rank))]
+            if perm is not None:
+                if rank > 0:
+                    perm = [_normalize_axis(v, rank) for v in perm]
+                perm_init = _make_const_initializer(
+                    used_names=used_names,
+                    name_base=f"{n.name or 'Transpose'}_perm",
+                    value=np.asarray(perm, dtype=np.int64),
+                )
+                added_initializers.append(perm_init)
+                n.input.append(perm_init.name)
+                changed = True
+                details["transpose_perm_input_added"] += 1
+
+        if op == "Softmax":
+            rank = int(rank_map.get(str(n.input[0]), -1)) if len(n.input) >= 1 else -1
+            axis = _get_attr_int(n, "axis", 1)
+            if rank > 1:
+                axis = _normalize_axis(axis, rank)
+                if axis != rank - 1:
+                    perm_to_last = [int(v) for v in range(rank) if v != axis] + [int(axis)]
+                    perm_from_last = _inverse_perm(perm_to_last)
+                    pre_name = _next_name(used_names, f"{n.name or 'Softmax'}_pre")
+                    post_name = str(n.output[0])
+
+                    perm_to_last_init = _make_const_initializer(
+                        used_names=used_names,
+                        name_base=f"{n.name or 'Softmax'}_perm_to_last",
+                        value=np.asarray(perm_to_last, dtype=np.int64),
+                    )
+                    perm_from_last_init = _make_const_initializer(
+                        used_names=used_names,
+                        name_base=f"{n.name or 'Softmax'}_perm_from_last",
+                        value=np.asarray(perm_from_last, dtype=np.int64),
+                    )
+                    added_initializers.extend([perm_to_last_init, perm_from_last_init])
+
+                    pre_node = helper.make_node(
+                        "Transpose",
+                        [str(n.input[0]), perm_to_last_init.name],
+                        [pre_name],
+                        name=_next_name(used_names, f"{n.name or 'Softmax'}_pre_transpose"),
+                    )
+                    soft_out = _next_name(used_names, f"{n.name or 'Softmax'}_softmax_out")
+                    soft_node = helper.make_node(
+                        "Softmax",
+                        [pre_name],
+                        [soft_out],
+                        name=_next_name(used_names, f"{n.name or 'Softmax'}_normalized"),
+                        axis=rank - 1,
+                    )
+                    post_node = helper.make_node(
+                        "Transpose",
+                        [soft_out, perm_from_last_init.name],
+                        [post_name],
+                        name=_next_name(used_names, f"{n.name or 'Softmax'}_post_transpose"),
+                    )
+                    rewritten_nodes.extend([pre_node, soft_node, post_node])
+                    rewritten_count += 1
+                    inserted_nodes += 2
+                    details["softmax_transpose_inserted"] += 1
+                    continue
+
+        rewritten_nodes.append(n)
+        if changed:
+            rewritten_count += 1
+
+    if len(added_initializers) > 0:
+        graph.initializer.extend(added_initializers)
+    if rewritten_count > 0:
+        del graph.node[:]
+        graph.node.extend(rewritten_nodes)
+
+    return {
+        "matched_nodes": int(matched_nodes),
+        "rewritten_nodes": int(rewritten_count),
+        "changed": bool(rewritten_count > 0),
+        "message": f"details={details}, inserted_nodes={inserted_nodes}",
+    }
+
+
+def register_normalize_attrs_rule() -> None:
+    register_preprocess_rule(
+        rule_id=NORMALIZE_ATTRS_RULE_ID,
+        callback=apply_normalize_attrs_rule,
+        overwrite=True,
+    )
+


### PR DESCRIPTION
## Summary
- `normalize_attrs_a5` ルールを追加し、axis/perm/pads の事前正規化を実装
- `constant_fold_a5` ルールを追加し、限定的な constant-folding を実装
- `Softmax(axis != last)` を `Transpose -> Softmax(last) -> Transpose` へ事前変換
- `Transpose` を attr-perm / implicit-perm でも受理できるよう direct 側を拡張
- preprocess rule registry を更新し、A5ルールを default pipeline に組み込み
- `update-builder2.md` に Step A5 実施結果と進捗を反映

## Testing
- `pytest -q tests/test_tflite_builder_preprocess.py`
- `pytest -q tests/test_tflite_builder_direct.py -k "flatbuffer_direct_operator_smoke and (transpose_attr_only or softmax_axis_non_last or reduce_axes_concat_const or space_to_depth_chain or gelu or pow_square)"`
- `pytest -q tests/test_tflite_builder_direct.py -k op_coverage_report_generation`
- `python -m compileall onnx2tf/tflite_builder/preprocess onnx2tf/tflite_builder/op_registry.py onnx2tf/tflite_builder/op_builders/shape.py`
