### PR TITLE
Step A6: custom-op candidate 縮小フェーズ（Einsum builtin優先）

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ https://github.com/PINTO0309/onnx2tf/wiki/model_status
 - Source of truth: `onnx2tf/tflite_builder/op_registry.py` and `--report_op_coverage` output.
 - Current summary:
   - Listed ONNX ops in this README section: `205`
-  - `builtin_supported`: `27`
-  - `custom_candidate` (opt-in): `17`
-  - `explicit_error` (default): `161`
+  - `builtin_supported`: `29`
+  - `custom_candidate` (opt-in): `16`
+  - `explicit_error` (default): `160`
 
 Notes:
 - `flatbuffer_direct` supports only a subset of ONNX ops as TFLite builtins.
@@ -292,6 +292,7 @@ Notes:
 |Concat|CONCATENATION|-|
 |Conv|CONV_2D / DEPTHWISE_CONV_2D|2D only (rank=4), weights must be constant, grouped conv only regular/depthwise, zero pads or `auto_pad=SAME_*`|
 |Div|DIV|-|
+|Einsum|FULLY_CONNECTED|Rank-2 matmul-style equation only (`ij,jk->ik`), rhs input must be constant weights|
 |Exp|EXP|-|
 |Gather|GATHER|`batch_dims=0` only|
 |Gemm|FULLY_CONNECTED|Input rank=2, weight rank=2 + constant, `transA=0` only|
@@ -307,6 +308,7 @@ Notes:
 |Reshape|RESHAPE|Shape input must be constant|
 |Sigmoid|LOGISTIC|-|
 |Softmax|SOFTMAX|`axis=last` only|
+|SpaceToDepth|SPACE_TO_DEPTH|`blocksize > 1`, rank=4 (NCHW)|
 |Sqrt|SQRT|-|
 |Squeeze|SQUEEZE|Axes must be constant when provided via input tensor|
 |Sub|SUB|-|
@@ -322,7 +324,6 @@ Notes:
 |:-|:-|:-|
 |DeformConv|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |DynamicQuantizeLinear|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
-|Einsum|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |GridSample|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |If|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |Loop|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
@@ -339,6 +340,9 @@ Notes:
 |Unique|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 
 </div></details>
+
+Notes:
+- `Einsum` is now treated as `builtin_supported` when it matches builtin constraints; unsupported `Einsum` patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 
 ## Demo
 Video speed is adjusted approximately 50 times slower than actual speed.


### PR DESCRIPTION
## Summary
- Add builtin dispatch for matmul-style rank-2 `Einsum` to `FULLY_CONNECTED` in direct builder path
- Keep custom-op fallback for unsupported `Einsum` patterns via existing candidate flow
- Extend op coverage diagnostics (`custom_op_policy`) with allowlist/builtin overlap details
- Update direct-builder tests and docs, and mark Step A6 done in `update-builder2.md`

## Changes
- `onnx2tf/tflite_builder/op_registry.py`
- `onnx2tf/tflite_builder/lower_from_onnx2tf.py`
- `tests/test_tflite_builder_direct.py`
- `README.md`
- `update-builder2.md`

## Verification
- `pytest -q tests/test_tflite_builder_direct.py -k "einsum or custom_op_coverage_report"`
- `pytest -q tests/test_tflite_builder_direct.py -k "operator_smoke and einsum_fc_const"`
- `pytest -q tests/test_tflite_builder_direct.py -k "custom_op"`
