### PR TITLE
Step A8: 文書化・運用導線整備と experimental 明示

### DIFF
--- a/update-builder.md
+++ b/update-builder.md
@@ -69,6 +69,7 @@ ONNX -> TensorFlow -> TFLiteConverter の最終段を段階的に置き換え、
 - Step 27 実装（難所対応の方針化: `If/Loop/Scan/Sequence*/GridSample/RoiAlign/DeformConv/Einsum/...` を custom-op candidate として定義し、`--flatbuffer_direct_allow_custom_ops` + allowlist による `CUSTOM` 降格経路を追加。失敗時 reason_code（`custom_op_candidate_disabled` / `custom_op_not_in_allowlist`）と OP coverage 診断を拡張）
 - Step 28 実装（収束・安定化: schema-op 単位の policy matrix（`builtin_supported/custom_candidate/explicit_error`）を coverage report に追加し、統合回帰テスト（量子化+評価+coverage、分割+split評価+coverage）を導入。`--flatbuffer_direct_fallback_to_tf_converter` を追加し、README と `FLATBUFFER_DIRECT_MIGRATION_GUIDE.md` を最終更新）
 - Step 29 実装（`--auto_split_max_size_mb` を `--auto_split_max_size` へ移行し、`KB/MB/GB` 指定を解禁。`auto_split_tflite_by_size=True` かつ `auto_split_max_size` 指定時は同値を TFLite 分割 target に同期するよう変更）
+- Step 30 実装（Step A8 文書化: README に `tf_converter` vs `flatbuffer_direct` 差分、direct前処理の吸収範囲、reason_code別回避策を追記。`FLATBUFFER_DIRECT_MIGRATION_GUIDE.md` を段階移行/既知制約/運用チェックリスト構成へ更新）
 
 2. 検証済み:
 - `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py`

--- a/update-builder2.md
+++ b/update-builder2.md
@@ -311,6 +311,22 @@ reason_code 付き明示失敗:
 1. 利用者が「なぜ失敗したか」「何を有効化すべきか」を自己解決できる。
 2. 追加された最適化ルールの適用範囲が追跡可能。
 
+#### Step A8 実施結果（2026-02-11）
+実装内容:
+1. `README.md` に `tf_converter` と `flatbuffer_direct` の運用差分を追記（失敗モデル、診断、custom-op方針、fallback差分）。
+2. `README.md` に direct 前処理の吸収範囲（`pattern_fusion_wave2` / `pseudo_ops_wave1` / `constant_fold_a5` / `normalize_attrs_a5`）を追記。
+3. `README.md` に `reason_code` ごとの回避オプション表を追記し、利用者が失敗理由から対処を逆引きできるように整理。
+4. `FLATBUFFER_DIRECT_MIGRATION_GUIDE.md` を段階移行手順中心に再構成し、以下を追加:
+5. backend差分の早見表
+6. Stage 0-3 の実運用コマンド（baseline/quant/split/fallback）
+7. 既知制約と mitigation 表
+8. 運用チェックリスト
+9. `update-builder.md` に Step A8 の進捗を反映。
+
+カバレッジ差分:
+1. 前回値 `16.56%` -> 今回値 `16.56%`（差分 `+0.00%`）
+2. 変化なし理由: Step A8 は文書化・運用導線整備のみで、Builtin 対応 OP の追加はなし。
+
 ## 測定指標（KPI）
 1. `unsupported_onnx_op` 件数
 2. `custom_op_candidate_disabled` 件数
@@ -352,4 +368,4 @@ reason_code 付き明示失敗:
 5. `[x] Step A5 完了`
 6. `[x] Step A6 完了`
 7. `[x] Step A7 完了`
-8. `[ ] Step A8 完了`
+8. `[x] Step A8 完了`


### PR DESCRIPTION
## Summary
- Complete Step A8 documentation and operational guidance updates
- Clarify `tf_converter` vs `flatbuffer_direct` differences in README
- Add visible experimental-status warning for `flatbuffer_direct`
- Rework migration guide with staged rollout, known limitations, mitigation, and checklist
- Update progress trackers (`update-builder.md`, `update-builder2.md`)

## Changed files
- `README.md`
- `FLATBUFFER_DIRECT_MIGRATION_GUIDE.md`
- `update-builder.md`
- `update-builder2.md`

## Notes
- Documentation-only update
- No auto-merge configured
