### PR TITLE
Support broken onnx/`Gelu`

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.7
+  ghcr.io/pinto0309/onnx2tf:2.0.8
 
   or
 
@@ -458,7 +458,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.7
+  docker.io/pinto0309/onnx2tf:2.0.8
 
   or
 
@@ -468,7 +468,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.0.7 \
+  docker.io/pinto0309/onnx2tf:2.0.8 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.7'
+__version__ = '2.0.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.7"
+version = "2.0.8"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
### 1. Content and background

- `Gelu`
  - Forced to avoid the problem of onnx normality check terminating abnormally due to the presence of `Gelu`, which should not exist in opset=17.
  - https://huggingface.co/qualcomm/ConvNext-Tiny/blob/5b8dbb4db0da2c36a4a05e1577cf5171a9395ec0/ConvNext-Tiny.onnx

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
