### PR TITLE
Fix QLinearConv/PRelu edge cases and add NMS argmax option

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.8
+  ghcr.io/pinto0309/onnx2tf:2.0.9
 
   or
 
@@ -465,7 +465,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.8
+  docker.io/pinto0309/onnx2tf:2.0.9
 
   or
 
@@ -475,7 +475,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.0.8 \
+  docker.io/pinto0309/onnx2tf:2.0.9 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or
@@ -1141,7 +1141,7 @@ PyTorch's `NonMaxSuppression (torchvision.ops.nms)` and ONNX's `NonMaxSuppressio
 
     https://github.com/PINTO0309/PINTO_model_zoo/tree/main/307_YOLOv7/post_process_gen_tools
 
-3. Finally, simply convert ONNX to TFLite or saved_model or TFJS using onnx2tf. onnx2tf performs an internal operation to automatically optimize the NMS output to a fixed shape if `max_output_boxes_per_class` is set to a value other than `-Infinity` and `9223372036854775807 (Maximum value of INT64)`. Specify `--output_nms_with_dynamic_tensor` or `-onwdt` if you do not want to optimize for a fixed shape.
+3. Finally, simply convert ONNX to TFLite or saved_model or TFJS using onnx2tf. onnx2tf performs an internal operation to automatically optimize the NMS output to a fixed shape if `max_output_boxes_per_class` is set to a value other than `-Infinity` and `9223372036854775807 (Maximum value of INT64)`. Specify `--output_nms_with_dynamic_tensor` or `-onwdt` if you do not want to optimize for a fixed shape. If you want to shrink class scores in NMS from `[B, C, N]` to `[B, 1, N]`, enable `--output_nms_with_argmax` or `-onwa`.
     ```
     onnx2tf -i nms_yolov7_update.onnx -osd -cotof
     ```
@@ -1999,6 +1999,10 @@ optional arguments:
     enable --output_nms_with_dynamic_tensor:
         output_tensor_shape: [N, 7]
 
+  -onwa, --output_nms_with_argmax
+    Apply argmax to class scores dimension in NonMaxSuppression and shrink
+    scores tensor from [B, C, N] to [B, 1, N].
+
   -snms {v4,v5}, --switch_nms_version {v4,v5}
     Switch the NMS version to V4 or V5 to convert.
     e.g.
@@ -2333,6 +2337,7 @@ convert(
   value_hints: Union[List[str], NoneType] = None,
   no_large_tensor: Optional[bool] = False,
   output_nms_with_dynamic_tensor: Optional[bool] = False,
+  output_nms_with_argmax: Optional[bool] = False,
   switch_nms_version: Optional[str] = 'v4',
   keep_ncw_or_nchw_or_ncdhw_input_names: Union[List[str], NoneType] = None,
   keep_nwc_or_nhwc_or_ndhwc_input_names: Union[List[str], NoneType] = None,
@@ -2583,6 +2588,10 @@ convert(
           output_tensor_shape: [100, 7]
       enable --output_nms_with_dynamic_tensor:
           output_tensor_shape: [N, 7]
+
+    output_nms_with_argmax: Optional[bool]
+      Apply argmax over scores class dimension in NonMaxSuppression to
+      shrink scores from [B, C, N] to [B, 1, N].
 
     switch_nms_version {v4,v5}
       Switch the NMS version to V4 or V5 to convert.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.8'
+__version__ = '2.0.9'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -764,6 +764,7 @@ def convert(
     value_hints: Optional[List[str]] = None,
     no_large_tensor: Optional[bool] = False,
     output_nms_with_dynamic_tensor: Optional[bool] = False,
+    output_nms_with_argmax: Optional[bool] = False,
     switch_nms_version: Optional[str] = 'v4',
     keep_ncw_or_nchw_or_ncdhw_input_names: Optional[List[str]] = None,
     keep_nwc_or_nhwc_or_ndhwc_input_names: Optional[List[str]] = None,
@@ -1085,6 +1086,10 @@ def convert(
             output_tensor_shape: [100, 7]\n
         enable --output_nms_with_dynamic_tensor:\n
             output_tensor_shape: [N, 7]
+
+    output_nms_with_argmax: Optional[bool]
+        Apply argmax over scores class dimension in NonMaxSuppression to\n
+        shrink scores from [B, C, N] to [B, 1, N].\n
 
     switch_nms_version: Optional[str]
         Switch the NMS version to V4 or V5 to convert.\n\n
@@ -2103,6 +2108,7 @@ def convert(
                     'value_hints': value_hints,
                     'no_large_tensor': no_large_tensor,
                     'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
+                    'output_nms_with_argmax': output_nms_with_argmax,
                     'switch_nms_version': switch_nms_version,
                     'keep_ncw_or_nchw_or_ncdhw_input_names': keep_ncw_or_nchw_or_ncdhw_input_names,
                     'keep_nwc_or_nhwc_or_ndhwc_input_names': keep_nwc_or_nhwc_or_ndhwc_input_names,
@@ -2538,6 +2544,7 @@ def convert(
         'mvn_epsilon': mvn_epsilon,
         'output_signaturedefs': output_signaturedefs,
         'output_nms_with_dynamic_tensor': output_nms_with_dynamic_tensor,
+        'output_nms_with_argmax': output_nms_with_argmax,
         'switch_nms_version': switch_nms_version,
         'output_integer_quantized_tflite': output_integer_quantized_tflite,
         'gelu_replace_op_names': {},
@@ -4776,6 +4783,14 @@ def main():
             '    output_tensor_shape: [N, 7]'
     )
     parser.add_argument(
+        '-onwa',
+        '--output_nms_with_argmax',
+        action='store_true',
+        help=\
+            'Apply argmax to class scores dimension in NonMaxSuppression and shrink \n' +
+            'scores tensor from [B, C, N] to [B, 1, N].'
+    )
+    parser.add_argument(
         '-snms',
         '--switch_nms_version',
         type=str,
@@ -5292,6 +5307,7 @@ def main():
         value_hints=args.value_hints,
         no_large_tensor=args.no_large_tensor,
         output_nms_with_dynamic_tensor=args.output_nms_with_dynamic_tensor,
+        output_nms_with_argmax=args.output_nms_with_argmax,
         switch_nms_version=args.switch_nms_version,
         keep_ncw_or_nchw_or_ncdhw_input_names=args.keep_ncw_or_nchw_or_ncdhw_input_names,
         keep_nwc_or_nhwc_or_ndhwc_input_names=args.keep_nwc_or_nhwc_or_ndhwc_input_names,

--- a/onnx2tf/ops/QLinearConv.py
+++ b/onnx2tf/ops/QLinearConv.py
@@ -226,7 +226,9 @@ def make_node(
     pad_mode = 'VALID'
     if auto_pad == 'NOTSET':
         if input_tensor_rank >=2 \
-            and graph_node.i().inputs[0].shape[2:] == output_tensor_shape[2:]:
+            and graph_node.inputs[0].shape is not None \
+            and output_tensor_shape is not None \
+            and graph_node.inputs[0].shape[2:] == output_tensor_shape[2:]:
             pad_mode = "SAME"
         elif pads != [0, 0] * spatial_size:
             input_tensor = get_padding_as_op(
@@ -260,7 +262,7 @@ def make_node(
         depthwise = bool(group == input_tensor_shape[-1])
 
     if depthwise is True:
-        depthwise_filter_shape = list(input_weights_shape[0:2]) + [input_weights_shape[2], input_weights_shape[3] // group]
+        depthwise_filter_shape = list(input_weights_shape[0:2]) + [-1, input_weights_shape[3] // group]
         input_weights = tf.reshape(input_weights, depthwise_filter_shape)
 
     # Conv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.8"
+version = "2.0.9"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
This PR improves robustness in quantized conversion paths and adds a new NonMaxSuppression option for class-score shrinking.

It addresses three concrete conversion failures seen during real model conversion, and adds a user-facing CLI/API switch for NMS behavior.

## Background / Motivation
While converting quantized and post-process-heavy models, the following failure patterns were observed:

1. `QLinearConv` aborted when output shape metadata was `None` in the `auto_pad == 'NOTSET'` path.
2. `QLinearConv` depthwise weight reshape failed with mismatched element counts (invalid reshape target).
3. `PRelu` failed broadcasting when slope was channel-first style (e.g. `[C,1,1]`) but runtime tensor layout was channel-last.

In addition, for some NMS post-processing models (e.g. DAMO-YOLO style layouts), users requested a mode to shrink `scores` class dimension by argmax before NMS.

## Changes
### 1) QLinearConv robustness fixes
File: `onnx2tf/ops/QLinearConv.py`

- Guarded SAME-padding shape comparison against missing metadata:
  - Before: accessed `output_tensor_shape[2:]` directly
  - After: checks both input/output shapes are not `None` before comparison
- Fixed depthwise filter reshape target:
  - Before: `[..., input_weights_shape[2], input_weights_shape[3] // group]`
  - After:  `[..., -1, input_weights_shape[3] // group]`
  - This aligns behavior with `Conv.py` and avoids invalid reshape size errors.

### 2) PRelu slope layout alignment
File: `onnx2tf/ops/PRelu.py`

- Reworked slope handling to align slope layout with **runtime** input tensor layout.
- Added reshape logic for patterns like:
  - input: `[N,H,W,C]`
  - slope: `[C,1,1]`
  - transformed slope: `[1,1,C]`
- Implemented in a layout-agnostic way based on runtime tensor shape inspection.

### 3) New NMS option: `--output_nms_with_argmax` (`-onwa`)
Files:
- `onnx2tf/onnx2tf.py`
- `onnx2tf/ops/NonMaxSuppression.py`
- `README.md`

Added new CLI/API option to shrink class dimension of NMS `scores`:
- Input scores: `[B, C, N]`
- With option: argmax/reduce_max over class axis -> `[B, 1, N]`

Implementation details in `NonMaxSuppression.py`:
- Compute per-box class ids with `argmax(scores, axis=1)`
- Use reduced scores for NMS (`reduce_max(..., keepdims=True)`)
- Reconstruct output `[batch_index, class_index, box_index]` by gathering class ids for selected boxes
- If scores rank is not 3, warn and fallback to existing behavior

<img width="826" height="600" alt="image" src="https://github.com/user-attachments/assets/5c7b05fc-db25-4f75-af51-9b6bd86e546c" />
<img width="1396" height="268" alt="image" src="https://github.com/user-attachments/assets/918af08a-bd8b-47f7-a364-b78634bcd39b" />

### 4) Documentation and version update
Files:
- `README.md`
- `onnx2tf/__init__.py`
- `pyproject.toml`

- Documented the new NMS argmax option in README (CLI and Python API sections).
- Updated version from `2.0.8` to `2.0.9`.

## Validation
- `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/ops/QLinearConv.py onnx2tf/ops/PRelu.py onnx2tf/ops/NonMaxSuppression.py onnx2tf/__init__.py`
- Sanity-checked NMS output tuple construction for argmax mode and verified output format `[batch, class, box]`.

## Compatibility / Risk
- Default behavior is unchanged unless `--output_nms_with_argmax` is explicitly enabled.
- `QLinearConv` and `PRelu` changes are defensive and targeted at previously failing shape/layout edge cases.

## Issue
- https://github.com/PINTO0309/onnx2tf/issues/420