### PR TITLE
Fix -coion input/output mapping ambiguity for same-shape tensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.9
+  ghcr.io/pinto0309/onnx2tf:2.0.10
 
   or
 
@@ -465,7 +465,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.9
+  docker.io/pinto0309/onnx2tf:2.0.10
 
   or
 
@@ -475,7 +475,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.0.9 \
+  docker.io/pinto0309/onnx2tf:2.0.10 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.9'
+__version__ = '2.0.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.9"
+version = "2.0.10"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- improve `rewrite_tflite_inout_opname` I/O tensor index resolution for `-coion`
- add name-based matching with normalization (`serving_default_`, `:0`, `/`, `__` -> `:`)
- add staged fallback order: existing SignatureDef -> existing tensor names -> unambiguous shape-product -> raw tflite order
- validate SignatureDef candidate indices and avoid duplicate tensor index assignments
- fix SignatureDef `tensorIndex` assignment to use real tensor indices (instead of `buffer - 1`)
- bump package version to `2.0.10` (`pyproject.toml`, `onnx2tf/__init__.py`) and sync Docker tag examples in README

## Why
When multiple inputs/outputs have identical shapes, shape-only matching cannot reliably preserve ONNX I/O name/order. This change reduces reliance on shape heuristics and uses stable metadata first.

## Validation
- `python -m py_compile onnx2tf/utils/common_functions.py onnx2tf/__init__.py`
