### PR TITLE
Enhance flatbuffer_direct INT8 op support and stability

### DIFF
--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.12'
+__version__ = '2.0.13'

--- a/onnx2tf/ops/QGemm.py
+++ b/onnx2tf/ops/QGemm.py
@@ -1,0 +1,235 @@
+import random
+random.seed(0)
+import numpy as np
+np.random.seed(0)
+import tensorflow as tf
+import onnx2tf.gs as gs
+from onnx2tf.utils.common_functions import (
+    get_constant_or_variable,
+    print_node_info,
+    inverted_operation_enable_disable,
+    make_tf_node_info,
+)
+
+
+def _get_qmin_qmax(dtype: tf.dtypes.DType):
+    if dtype == tf.uint8:
+        return 0.0, 255.0
+    if dtype == tf.int8:
+        return -128.0, 127.0
+    if dtype == tf.uint16:
+        return 0.0, 65535.0
+    if dtype == tf.int16:
+        return -32768.0, 32767.0
+    return None, None
+
+
+def _reshape_for_axis(
+    *,
+    value,
+    input_tensor,
+    axis: int,
+):
+    value_rank = len(value.shape)
+    input_rank = len(input_tensor.shape)
+    if value_rank == 1 and input_rank is not None:
+        shape = [1] * input_rank
+        shape[axis] = -1
+        return tf.reshape(value, shape)
+    return value
+
+
+def _reshape_for_output(
+    *,
+    value,
+    output_tensor,
+):
+    value_rank = len(value.shape)
+    output_rank = len(output_tensor.shape)
+    if value_rank == 1 and output_rank is not None and output_rank >= 2:
+        if output_tensor.shape[-1] == value.shape[0]:
+            shape = [1] * output_rank
+            shape[-1] = -1
+            return tf.reshape(value, shape)
+    return value
+
+
+@print_node_info
+@inverted_operation_enable_disable
+def make_node(
+    *,
+    graph_node: gs.Node,
+    tf_layers_dict: dict,
+    **kwargs: dict,
+):
+    """QGemm
+
+    Parameters
+    ----------
+    graph_node: gs.Node
+        graph_surgeon Node
+
+    tf_layers_dict: dict
+        optype, shape, dtype, tensorflow graph
+    """
+    before_op_output_shape_trans_1 = \
+        tf_layers_dict.get(graph_node.inputs[0].name, {}).get('before_op_output_shape_trans', True)
+    before_op_output_shape_trans_2 = \
+        tf_layers_dict.get(graph_node.inputs[1].name, {}).get('before_op_output_shape_trans', True)
+    before_op_output_shape_trans = \
+        before_op_output_shape_trans_1 \
+        and before_op_output_shape_trans_2
+
+    graph_node_input_1 = get_constant_or_variable(
+        graph_node.inputs[0],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_2 = get_constant_or_variable(
+        graph_node.inputs[1],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_3 = get_constant_or_variable(
+        graph_node.inputs[2],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_4 = get_constant_or_variable(
+        graph_node.inputs[3],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_5 = get_constant_or_variable(
+        graph_node.inputs[4],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_6 = get_constant_or_variable(
+        graph_node.inputs[5],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_7 = get_constant_or_variable(
+        graph_node.inputs[6],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_8 = get_constant_or_variable(
+        graph_node.inputs[7],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_9 = get_constant_or_variable(
+        graph_node.inputs[8],
+        before_op_output_shape_trans,
+    )
+    graph_node_output: gs.Variable = graph_node.outputs[0]
+    shape = graph_node_output.shape
+    dtype = graph_node_output.dtype
+
+    trans_a = bool(graph_node.attrs.get('transA', 0))
+    trans_b = bool(graph_node.attrs.get('transB', 0))
+
+    a = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    a_is_dequantized = False
+    if isinstance(graph_node_input_1, gs.Variable):
+        a_is_dequantized = tf_layers_dict.get(graph_node_input_1.name, {}).get('is_dequantized', False)
+    a_scale_raw = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    a_zero_point_raw = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
+        if isinstance(graph_node_input_3, gs.Variable) else graph_node_input_3
+    b = tf_layers_dict[graph_node_input_4.name]['tf_node'] \
+        if isinstance(graph_node_input_4, gs.Variable) else graph_node_input_4
+    b_is_dequantized = False
+    if isinstance(graph_node_input_4, gs.Variable):
+        b_is_dequantized = tf_layers_dict.get(graph_node_input_4.name, {}).get('is_dequantized', False)
+    b_scale_raw = tf_layers_dict[graph_node_input_5.name]['tf_node'] \
+        if isinstance(graph_node_input_5, gs.Variable) else graph_node_input_5
+    b_zero_point_raw = tf_layers_dict[graph_node_input_6.name]['tf_node'] \
+        if isinstance(graph_node_input_6, gs.Variable) else graph_node_input_6
+    bias = tf_layers_dict[graph_node_input_7.name]['tf_node'] \
+        if isinstance(graph_node_input_7, gs.Variable) else graph_node_input_7
+    y_scale = tf_layers_dict[graph_node_input_8.name]['tf_node'] \
+        if isinstance(graph_node_input_8, gs.Variable) else graph_node_input_8
+    y_zero_point = tf_layers_dict[graph_node_input_9.name]['tf_node'] \
+        if isinstance(graph_node_input_9, gs.Variable) else graph_node_input_9
+    y_dtype = y_zero_point.dtype
+
+    # Preserving Graph Structure (Dict)
+    tf_layers_dict[graph_node_output.name] = {
+        'optype': graph_node.op,
+        'shape': shape,
+        'dtype': dtype,
+        'is_dequantized': True,
+    }
+
+    # reshape scale/zero_point for dequantization broadcast
+    a_scale = _reshape_for_axis(value=a_scale_raw, input_tensor=a, axis=-2)
+    a_zero_point = _reshape_for_axis(value=a_zero_point_raw, input_tensor=a, axis=-2)
+    b_scale = _reshape_for_axis(value=b_scale_raw, input_tensor=b, axis=-1)
+    b_zero_point = _reshape_for_axis(value=b_zero_point_raw, input_tensor=b, axis=-1)
+
+    # cast all inputs to float32
+    a = tf.cast(a, tf.float32)
+    a_scale = tf.cast(a_scale, tf.float32)
+    a_zero_point = tf.cast(a_zero_point, tf.float32)
+    b = tf.cast(b, tf.float32)
+    b_scale = tf.cast(b_scale, tf.float32)
+    b_zero_point = tf.cast(b_zero_point, tf.float32)
+    bias = tf.cast(bias, tf.float32)
+    y_scale = tf.cast(y_scale, tf.float32)
+    y_zero_point = tf.cast(y_zero_point, tf.float32)
+
+    # dequantize a and b
+    if a_is_dequantized:
+        dequantized_a = tf.cast(a, tf.float32)
+    else:
+        dequantized_a = tf.multiply(tf.subtract(a, a_zero_point), a_scale)
+
+    if b_is_dequantized:
+        dequantized_b = tf.cast(b, tf.float32)
+    else:
+        dequantized_b = tf.multiply(tf.subtract(b, b_zero_point), b_scale)
+
+    if trans_a:
+        dequantized_a = tf.linalg.matrix_transpose(dequantized_a)
+    if trans_b:
+        dequantized_b = tf.linalg.matrix_transpose(dequantized_b)
+
+    x = tf.matmul(dequantized_a, dequantized_b)
+
+    # bias is int32 quantized by (a_scale * b_scale)
+    bias_scale = tf.cast(a_scale_raw, tf.float32) * tf.cast(b_scale_raw, tf.float32)
+    bias_scale = _reshape_for_output(value=bias_scale, output_tensor=x)
+    bias = _reshape_for_output(value=bias, output_tensor=x)
+    x = tf.add(x, tf.multiply(bias, bias_scale))
+
+    # quantize then dequantize to float32
+    y_scale = _reshape_for_output(value=y_scale, output_tensor=x)
+    y_zero_point = _reshape_for_output(value=y_zero_point, output_tensor=x)
+    y = tf.round(tf.divide(x, y_scale))
+    y = tf.add(y, y_zero_point)
+    qmin, qmax = _get_qmin_qmax(y_dtype)
+    if qmin is not None and qmax is not None:
+        y = tf.clip_by_value(y, qmin, qmax)
+    y = tf.multiply(tf.subtract(y, y_zero_point), y_scale)
+
+    tf_layers_dict[graph_node_output.name]['tf_node'] = y
+
+    # Generation of Debug Info
+    tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
+        make_tf_node_info(
+            node_info={
+                'tf_op_type': 'QGemm',
+                'tf_inputs': {
+                    'a': a,
+                    'a_scale': a_scale,
+                    'a_zero_point': a_zero_point,
+                    'b': b,
+                    'b_scale': b_scale,
+                    'b_zero_point': b_zero_point,
+                    'bias': bias,
+                    'y_scale': y_scale,
+                    'y_zero_point': y_zero_point,
+                    'transA': trans_a,
+                    'transB': trans_b,
+                },
+                'tf_outputs': {
+                    'output': tf_layers_dict[graph_node_output.name]['tf_node'],
+                },
+            }
+        )

--- a/onnx2tf/ops/QLinearAveragePool.py
+++ b/onnx2tf/ops/QLinearAveragePool.py
@@ -1,0 +1,268 @@
+import random
+random.seed(0)
+import numpy as np
+np.random.seed(0)
+import tensorflow as tf
+import onnx2tf.gs as gs
+from tensorflow.python.keras.layers import (
+    AveragePooling1D,
+    AveragePooling2D,
+    AveragePooling3D,
+)
+from onnx2tf.utils.common_functions import (
+    get_constant_or_variable,
+    print_node_info,
+    inverted_operation_enable_disable,
+    make_tf_node_info,
+    calc_tf_pooling_pads,
+    calc_extra_padding_with_ceil,
+)
+
+
+def _apply_avg_pool(
+    *,
+    input_tensor: tf.Tensor,
+    kernel_shape: list,
+    strides: list,
+    padding: str,
+):
+    spatial_size = len(kernel_shape)
+    if spatial_size == 1:
+        if input_tensor.shape[1] is not None and kernel_shape[0] > input_tensor.shape[1]:
+            return AveragePooling1D(
+                pool_size=[input_tensor.shape[1]],
+                strides=[input_tensor.shape[1]],
+                padding=padding.upper(),
+            )(input_tensor), AveragePooling1D
+        return AveragePooling1D(
+            pool_size=kernel_shape,
+            strides=strides,
+            padding=padding.upper(),
+        )(input_tensor), AveragePooling1D
+    if spatial_size == 2:
+        return AveragePooling2D(
+            pool_size=kernel_shape,
+            strides=strides,
+            padding=padding.upper(),
+        )(input_tensor), AveragePooling2D
+    if spatial_size == 3:
+        return AveragePooling3D(
+            pool_size=kernel_shape,
+            strides=strides,
+            padding=padding.upper(),
+        )(input_tensor), AveragePooling3D
+    raise ValueError(
+        f'QLinearAveragePool supports only 1D, 2D, and 3D. Type: AveragePool{spatial_size}D'
+    )
+
+
+@print_node_info
+@inverted_operation_enable_disable
+def make_node(
+    *,
+    graph_node: gs.Node,
+    tf_layers_dict: dict,
+    **kwargs: dict,
+):
+    """QLinearAveragePool
+
+    Parameters
+    ----------
+    graph_node: gs.Node
+        graph_surgeon Node
+
+    tf_layers_dict: dict
+        optype, shape, dtype, tensorflow graph
+    """
+    before_op_output_shape_trans_1 = \
+        tf_layers_dict.get(graph_node.inputs[0].name, {}).get('before_op_output_shape_trans', True)
+    before_op_output_shape_trans = \
+        before_op_output_shape_trans_1
+
+    graph_node_input_1 = get_constant_or_variable(
+        graph_node.inputs[0],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_2 = get_constant_or_variable(
+        graph_node.inputs[1],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_3 = get_constant_or_variable(
+        graph_node.inputs[2],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_4 = get_constant_or_variable(
+        graph_node.inputs[3],
+        before_op_output_shape_trans,
+    )
+    graph_node_input_5 = get_constant_or_variable(
+        graph_node.inputs[4],
+        before_op_output_shape_trans,
+    )
+    graph_node_output: gs.Variable = graph_node.outputs[0]
+    shape = graph_node_output.shape
+    dtype = graph_node_output.dtype
+
+    x = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
+        if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    x_is_dequantized = False
+    x_nhwc = False
+    if isinstance(graph_node_input_1, gs.Variable):
+        x_is_dequantized = tf_layers_dict.get(graph_node_input_1.name, {}).get('is_dequantized', False)
+        x_nhwc = tf_layers_dict.get(graph_node_input_1.name, {}).get('nhwc', False)
+
+    x_scale = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
+        if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
+    x_zero_point = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
+        if isinstance(graph_node_input_3, gs.Variable) else graph_node_input_3
+    y_scale = tf_layers_dict[graph_node_input_4.name]['tf_node'] \
+        if isinstance(graph_node_input_4, gs.Variable) else graph_node_input_4
+    y_zero_point = tf_layers_dict[graph_node_input_5.name]['tf_node'] \
+        if isinstance(graph_node_input_5, gs.Variable) else graph_node_input_5
+    output_dtype = y_zero_point.dtype if y_zero_point.dtype not in [tf.int8, tf.uint8] else tf.float32
+
+    auto_pad = graph_node.attrs.get('auto_pad', 'NOTSET')
+    ceil_mode = bool(graph_node.attrs.get('ceil_mode', 0))
+    count_include_pad = bool(graph_node.attrs.get('count_include_pad', 0))
+    kernel_shape = graph_node.attrs['kernel_shape']
+    spatial_size = len(kernel_shape)
+    dilations = graph_node.attrs.get('dilations', [1] * spatial_size)
+    pads = graph_node.attrs.get('pads', [0] * spatial_size * 2)
+    strides = graph_node.attrs.get('strides', [1] * spatial_size)
+
+    # Preserving Graph Structure (Dict)
+    tf_layers_dict[graph_node_output.name] = {
+        'optype': graph_node.op,
+        'shape': shape,
+        'dtype': dtype,
+    }
+    if x_nhwc:
+        tf_layers_dict[graph_node_output.name]['nhwc'] = True
+
+    # Generation of TF OP
+    x = tf.cast(x, tf.float32)
+    x_scale = tf.cast(x_scale, tf.float32)
+    x_zero_point = tf.cast(x_zero_point, tf.float32)
+    y_scale = tf.cast(y_scale, tf.float32)
+    y_zero_point = tf.cast(y_zero_point, tf.float32)
+
+    if x_is_dequantized:
+        dequantized_x = x
+    else:
+        dequantized_x = tf.multiply(
+            x=x_scale,
+            y=tf.subtract(x, x_zero_point),
+        )
+
+    input_tensor_shape = dequantized_x.shape.as_list()
+    is_known_shape = None not in input_tensor_shape[1:]
+    tf_pad_mode = 'VALID'
+    is_explicit_padding = False
+    tf_pads = calc_tf_pooling_pads(
+        input_shape=input_tensor_shape,
+        kernel=kernel_shape,
+        strides=strides,
+        input_tensor=dequantized_x,
+    )
+
+    if auto_pad == 'NOTSET':
+        if is_known_shape and pads != [0] * spatial_size * 2 and tf_pads == pads:
+            tf_pad_mode = 'SAME'
+        else:
+            is_explicit_padding = True
+            if ceil_mode and is_known_shape:
+                extra_pads = calc_extra_padding_with_ceil(
+                    input_shape=input_tensor_shape[1:-1],
+                    kernel=kernel_shape,
+                    pads=pads,
+                    dilations=dilations,
+                    strides=strides,
+                )
+                pads = pads[:len(pads) // 2] + [p + e for p, e in zip(pads[len(pads) // 2:], extra_pads)]
+            tf_pads = pads
+    elif auto_pad == 'SAME_UPPER':
+        tf_pad_mode = 'SAME'
+    elif auto_pad == 'SAME_LOWER':
+        is_explicit_padding = True
+    elif auto_pad == 'VALID':
+        tf_pads = [0] * spatial_size * 2
+    else:
+        raise ValueError(f'Wrong auto_pad parameter in QLinearAveragePool: {auto_pad}.')
+
+    tf_pads_as_tf = None
+    pooled_input = dequantized_x
+    if is_explicit_padding and tf_pads != [0] * spatial_size * 2:
+        if auto_pad == 'SAME_LOWER':
+            # switch the order of pads
+            tf_pads = [i for tup in zip(tf_pads[len(tf_pads) // 2:], tf_pads[:len(tf_pads) // 2]) for i in tup]
+
+        tf_pads_as_tf = \
+            [[0, 0]] + \
+            [list(i) for i in zip(tf_pads[:len(tf_pads) // 2], tf_pads[len(tf_pads) // 2:])] + \
+            [[0, 0]]
+        pooled_input = tf.pad(
+            tensor=dequantized_x,
+            paddings=tf_pads_as_tf,
+            mode='CONSTANT',
+        )
+
+    pooled, tf_op_type = _apply_avg_pool(
+        input_tensor=pooled_input,
+        kernel_shape=kernel_shape,
+        strides=strides,
+        padding=tf_pad_mode,
+    )
+
+    # Match ONNX count_include_pad=False for explicit paddings.
+    if is_explicit_padding and not count_include_pad and tf_pads_as_tf is not None:
+        mask = tf.ones_like(dequantized_x, dtype=pooled.dtype)
+        mask = tf.pad(
+            tensor=mask,
+            paddings=tf_pads_as_tf,
+            mode='CONSTANT',
+        )
+        mask_pooled, _ = _apply_avg_pool(
+            input_tensor=mask,
+            kernel_shape=kernel_shape,
+            strides=strides,
+            padding=tf_pad_mode,
+        )
+        kernel_volume = float(np.prod(kernel_shape))
+        count_valid = mask_pooled * tf.cast(kernel_volume, dtype=mask_pooled.dtype)
+        multiplier = tf.math.divide_no_nan(
+            tf.cast(kernel_volume, dtype=mask_pooled.dtype),
+            count_valid,
+        )
+        pooled = pooled * multiplier
+
+    requantized = tf.add(
+        x=tf.divide(
+            x=pooled,
+            y=y_scale,
+        ),
+        y=y_zero_point,
+    )
+
+    tf_layers_dict[graph_node_output.name]['tf_node'] = tf.cast(requantized, output_dtype)
+
+    # Generation of Debug Info
+    tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
+        make_tf_node_info(
+            node_info={
+                'tf_op_type': tf_op_type,
+                'tf_inputs': {
+                    'x': x,
+                    'x_scale': x_scale,
+                    'x_zero_point': x_zero_point,
+                    'y_scale': y_scale,
+                    'y_zero_point': y_zero_point,
+                    'kernel_shape': kernel_shape,
+                    'strides': strides,
+                    'pads': tf_pads if tf_pad_mode != 'SAME' else tf_pad_mode,
+                    'count_include_pad': count_include_pad,
+                },
+                'tf_outputs': {
+                    'output': tf_layers_dict[graph_node_output.name]['tf_node'],
+                },
+            }
+        )

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -266,6 +266,8 @@ def _build_builtin_options(
         "PRELU",
         "DEQUANTIZE",
         "QUANTIZE",
+        "PAD",
+        "PADV2",
     ]:
         return _enum(schema_tflite, "BuiltinOptions", "NONE"), None
     raise NotImplementedError(

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -41,13 +41,16 @@ from onnx2tf.tflite_builder.op_builders.custom import (
 )
 from onnx2tf.tflite_builder.op_builders.quantized import (
     build_dequantize_linear_op,
+    build_qgemm_op,
     build_qlinear_add_op,
+    build_qlinear_average_pool_op,
     build_qlinear_concat_op,
     build_qlinear_conv_op,
     build_qlinear_global_average_pool_op,
     build_qlinear_matmul_op,
     build_qlinear_mul_op,
     build_qlinear_sigmoid_op,
+    build_qlinear_softmax_op,
     build_quantize_linear_op,
 )
 
@@ -76,12 +79,15 @@ __all__ = [
     "build_l2_normalization_op",
     "build_custom_passthrough_op",
     "build_dequantize_linear_op",
+    "build_qgemm_op",
     "build_qlinear_add_op",
+    "build_qlinear_average_pool_op",
     "build_qlinear_concat_op",
     "build_qlinear_conv_op",
     "build_qlinear_global_average_pool_op",
     "build_qlinear_matmul_op",
     "build_qlinear_mul_op",
     "build_qlinear_sigmoid_op",
+    "build_qlinear_softmax_op",
     "build_quantize_linear_op",
 ]

--- a/onnx2tf/tflite_builder/op_builders/pool.py
+++ b/onnx2tf/tflite_builder/op_builders/pool.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import copy
 import math
-from typing import Any
+from typing import Any, List, Optional, Tuple
 
-from onnx2tf.tflite_builder.ir import OperatorIR
+import numpy as np
+
+from onnx2tf.tflite_builder.ir import OperatorIR, QuantParamIR
 from onnx2tf.tflite_builder.op_builders.shared import make_transpose, resolve_padding
 
 
@@ -16,6 +19,8 @@ def _infer_pool_output_hw(
     kernel_w: int,
     stride_h: int,
     stride_w: int,
+    ceil_mode: int = 0,
+    effective_pads: Optional[List[int]] = None,
 ) -> tuple[int, int]:
     auto_pad = str(node.attrs.get("auto_pad", "NOTSET")).upper()
     if auto_pad in ["SAME", "SAME_UPPER", "SAME_LOWER"]:
@@ -27,21 +32,220 @@ def _infer_pool_output_hw(
         out_w = int(math.floor((float(input_w) - float(kernel_w)) / float(stride_w) + 1.0))
         return max(out_h, 1), max(out_w, 1)
 
-    pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    pads = (
+        [int(v) for v in list(effective_pads)]
+        if effective_pads is not None
+        else [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    )
     if len(pads) < 4:
         pads = [0, 0, 0, 0]
     pad_top, pad_left, pad_bottom, pad_right = pads[0], pads[1], pads[2], pads[3]
+    if int(ceil_mode) == 1:
+        out_h = int(
+            math.ceil(
+                (float(input_h + pad_top + pad_bottom - kernel_h) / float(stride_h)) + 1.0
+            )
+        )
+        out_w = int(
+            math.ceil(
+                (float(input_w + pad_left + pad_right - kernel_w) / float(stride_w)) + 1.0
+            )
+        )
+    else:
+        out_h = int(
+            math.floor(
+                (float(input_h + pad_top + pad_bottom - kernel_h) / float(stride_h)) + 1.0
+            )
+        )
+        out_w = int(
+            math.floor(
+                (float(input_w + pad_left + pad_right - kernel_w) / float(stride_w)) + 1.0
+            )
+        )
+    return max(out_h, 1), max(out_w, 1)
+
+
+def _calc_same_pads_2d(
+    *,
+    input_h: int,
+    input_w: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_h: int,
+    stride_w: int,
+) -> List[int]:
+    out_h = int(math.floor((float(input_h) - 1.0) / float(stride_h)) + 1.0)
+    out_w = int(math.floor((float(input_w) - 1.0) / float(stride_w)) + 1.0)
+    pad_h = max(int((out_h - 1) * stride_h + kernel_h - input_h), 0)
+    pad_w = max(int((out_w - 1) * stride_w + kernel_w - input_w), 0)
+    pad_top = int(pad_h // 2)
+    pad_bottom = int(pad_h - pad_top)
+    pad_left = int(pad_w // 2)
+    pad_right = int(pad_w - pad_left)
+    return [pad_top, pad_left, pad_bottom, pad_right]
+
+
+def _calc_extra_padding_with_ceil_2d(
+    *,
+    input_h: int,
+    input_w: int,
+    kernel_h: int,
+    kernel_w: int,
+    pads: List[int],
+    dilations: List[int],
+    strides: List[int],
+) -> List[int]:
+    pad_top, pad_left, pad_bottom, pad_right = [int(v) for v in pads]
+    dilation_h, dilation_w = int(dilations[0]), int(dilations[1])
+    stride_h, stride_w = int(strides[0]), int(strides[1])
+    pads_h = int(pad_top + pad_bottom)
+    pads_w = int(pad_left + pad_right)
+
     out_h = int(
-        math.floor(
-            (float(input_h + pad_top + pad_bottom - kernel_h) / float(stride_h)) + 1.0
+        math.ceil(
+            (float(input_h + pads_h - dilation_h * (kernel_h - 1) - 1) / float(stride_h)) + 1.0
         )
     )
     out_w = int(
-        math.floor(
-            (float(input_w + pad_left + pad_right - kernel_w) / float(stride_w)) + 1.0
+        math.ceil(
+            (float(input_w + pads_w - dilation_w * (kernel_w - 1) - 1) / float(stride_w)) + 1.0
         )
     )
-    return max(out_h, 1), max(out_w, 1)
+    last_stride_h = int((out_h - 1) * stride_h)
+    last_stride_w = int((out_w - 1) * stride_w)
+
+    valid_h = bool(last_stride_h < (int(input_h) + int(pad_top)))
+    valid_w = bool(last_stride_w < (int(input_w) + int(pad_left)))
+    extra_h = (
+        int(last_stride_h + (kernel_h - 1) * dilation_h + 1 - (input_h + pads_h))
+        if valid_h
+        else 0
+    )
+    extra_w = (
+        int(last_stride_w + (kernel_w - 1) * dilation_w + 1 - (input_w + pads_w))
+        if valid_w
+        else 0
+    )
+    return [int(max(extra_h, 0)), int(max(extra_w, 0))]
+
+
+def _resolve_max_pool_padding_and_explicit_pads(
+    *,
+    node: Any,
+    input_shape_nchw: List[int],
+    kernel: List[int],
+    strides: List[int],
+    dilations: List[int],
+    ceil_mode: int,
+) -> Tuple[str, Optional[List[int]], List[int]]:
+    auto_pad = str(node.attrs.get("auto_pad", "NOTSET")).upper()
+    raw_pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    if len(raw_pads) < 4:
+        raw_pads = [0, 0, 0, 0]
+    pads = [int(raw_pads[0]), int(raw_pads[1]), int(raw_pads[2]), int(raw_pads[3])]
+
+    input_h = int(input_shape_nchw[2])
+    input_w = int(input_shape_nchw[3])
+    kernel_h = int(kernel[0])
+    kernel_w = int(kernel[1])
+    stride_h = int(strides[0])
+    stride_w = int(strides[1])
+
+    if auto_pad in ["SAME", "SAME_UPPER"]:
+        return "SAME", None, [0, 0, 0, 0]
+    if auto_pad == "VALID":
+        return "VALID", None, [0, 0, 0, 0]
+    if auto_pad == "SAME_LOWER":
+        same_upper_pads = _calc_same_pads_2d(
+            input_h=input_h,
+            input_w=input_w,
+            kernel_h=kernel_h,
+            kernel_w=kernel_w,
+            stride_h=stride_h,
+            stride_w=stride_w,
+        )
+        top, left, bottom, right = [int(v) for v in same_upper_pads]
+        same_lower_pads = [bottom, right, top, left]
+        if any(int(v) != 0 for v in same_lower_pads):
+            return "VALID", same_lower_pads, list(same_lower_pads)
+        return "VALID", None, list(same_lower_pads)
+    if auto_pad != "NOTSET":
+        raise NotImplementedError(
+            f"MaxPool auto_pad attribute is invalid for flatbuffer_direct. op={node.name} auto_pad={auto_pad}"
+        )
+
+    same_upper_pads = _calc_same_pads_2d(
+        input_h=input_h,
+        input_w=input_w,
+        kernel_h=kernel_h,
+        kernel_w=kernel_w,
+        stride_h=stride_h,
+        stride_w=stride_w,
+    )
+    if int(ceil_mode) == 0 and any(int(v) != 0 for v in pads) and same_upper_pads == pads:
+        return "SAME", None, list(pads)
+
+    explicit_pads = list(pads)
+    if int(ceil_mode) == 1:
+        extra_h, extra_w = _calc_extra_padding_with_ceil_2d(
+            input_h=input_h,
+            input_w=input_w,
+            kernel_h=kernel_h,
+            kernel_w=kernel_w,
+            pads=explicit_pads,
+            dilations=dilations,
+            strides=strides,
+        )
+        explicit_pads[2] = int(explicit_pads[2]) + int(extra_h)
+        explicit_pads[3] = int(explicit_pads[3]) + int(extra_w)
+
+    if any(int(v) != 0 for v in explicit_pads):
+        return "VALID", explicit_pads, list(explicit_pads)
+    return "VALID", None, list(explicit_pads)
+
+
+def _numpy_dtype_from_tflite_dtype(tflite_dtype: str) -> np.dtype:
+    dt = str(tflite_dtype).upper()
+    if dt == "INT8":
+        return np.dtype(np.int8)
+    if dt == "UINT8":
+        return np.dtype(np.uint8)
+    if dt == "INT16":
+        return np.dtype(np.int16)
+    if dt == "UINT16":
+        return np.dtype(np.uint16)
+    if dt == "INT32":
+        return np.dtype(np.int32)
+    if dt == "UINT32":
+        return np.dtype(np.uint32)
+    if dt == "FLOAT16":
+        return np.dtype(np.float16)
+    if dt == "FLOAT32":
+        return np.dtype(np.float32)
+    raise NotImplementedError(f"Unsupported TFLite dtype in pool builder: {tflite_dtype}")
+
+
+def _max_pool_pad_value_for_tensor(tensor_dtype: str, tensor_quant: Optional[Any]) -> Any:
+    if isinstance(tensor_quant, QuantParamIR) or isinstance(tensor_quant, dict):
+        return 0
+    np_dtype = _numpy_dtype_from_tflite_dtype(tensor_dtype)
+    if np.issubdtype(np_dtype, np.floating):
+        return np.finfo(np_dtype).min
+    return np.iinfo(np_dtype).min
+
+
+def _clone_quantization(quantization: Any) -> Any:
+    if quantization is None:
+        return None
+    if isinstance(quantization, QuantParamIR):
+        return QuantParamIR(
+            scale=list(quantization.scale),
+            zero_point=list(quantization.zero_point),
+            quantized_dimension=int(quantization.quantized_dimension),
+            min=list(quantization.min) if quantization.min is not None else None,
+            max=list(quantization.max) if quantization.max is not None else None,
+        )
+    return copy.deepcopy(quantization)
 
 
 def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
@@ -55,13 +259,40 @@ def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
     if len(input_shape) != 4:
         raise NotImplementedError(f"Only 2D pooling (rank=4) is supported. op={node.name}")
 
-    kernel = list(node.attrs.get("kernel_shape", [1, 1]))
-    strides = list(node.attrs.get("strides", [1, 1]))
-    padding = resolve_padding(node)
-    if int(node.attrs.get("ceil_mode", 0)) != 0:
+    kernel = [int(v) for v in list(node.attrs.get("kernel_shape", [1, 1]))]
+    strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
+    if len(kernel) != 2 or len(strides) != 2:
         raise NotImplementedError(
-            f"ceil_mode is not supported in flatbuffer_direct. op={node.name}"
+            f"Only 2D pooling is supported in flatbuffer_direct. op={node.name} kernel={kernel} strides={strides}"
         )
+    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
+    if dilations != [1, 1]:
+        raise NotImplementedError(
+            f"{node.op} dilations must be [1,1] for flatbuffer_direct. op={node.name} dilations={dilations}"
+        )
+    ceil_mode = int(node.attrs.get("ceil_mode", 0))
+    explicit_pads: Optional[List[int]] = None
+    effective_pads: List[int] = [0, 0, 0, 0]
+    if op_type == "MAX_POOL_2D":
+        if ceil_mode not in [0, 1]:
+            raise NotImplementedError(
+                f"MaxPool ceil_mode must be 0 or 1 for flatbuffer_direct. op={node.name} ceil_mode={ceil_mode}"
+            )
+        padding, explicit_pads, effective_pads = _resolve_max_pool_padding_and_explicit_pads(
+            node=node,
+            input_shape_nchw=[int(v) for v in input_shape],
+            kernel=kernel,
+            strides=strides,
+            dilations=dilations,
+            ceil_mode=ceil_mode,
+        )
+    else:
+        if ceil_mode != 0:
+            raise NotImplementedError(
+                f"ceil_mode is not supported for {node.op} in flatbuffer_direct. op={node.name}"
+            )
+        padding = resolve_padding(node)
+
     if len(output_shape) != 4:
         out_h, out_w = _infer_pool_output_hw(
             node=node,
@@ -71,6 +302,8 @@ def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
             kernel_w=int(kernel[1]),
             stride_h=int(strides[0]),
             stride_w=int(strides[1]),
+            ceil_mode=ceil_mode,
+            effective_pads=effective_pads,
         )
         output_shape = [int(input_shape[0]), int(input_shape[1]), int(out_h), int(out_w)]
         output_tensor = ctx.model_ir.tensors[output_name]
@@ -86,9 +319,13 @@ def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
             output_signature[1] = int(input_signature[1])
         output_tensor.shape_signature = list(output_signature)
 
+    input_tensor = ctx.model_ir.tensors[input_name]
+    output_tensor = ctx.model_ir.tensors[output_name]
+    if output_tensor.quantization is None and input_tensor.quantization is not None:
+        output_tensor.quantization = _clone_quantization(input_tensor.quantization)
+
     nhwc_input_shape = [input_shape[0], input_shape[2], input_shape[3], input_shape[1]]
     nhwc_output_shape = [output_shape[0], output_shape[2], output_shape[3], output_shape[1]]
-    output_tensor = ctx.model_ir.tensors[output_name]
     output_signature = (
         list(output_tensor.shape_signature)
         if output_tensor.shape_signature is not None
@@ -108,6 +345,9 @@ def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
         dtype=ctx.get_tensor_dtype(input_name),
         shape=nhwc_input_shape,
     )
+    x_quant = input_tensor.quantization
+    if x_quant is not None:
+        ctx.model_ir.tensors[x_nhwc].quantization = _clone_quantization(x_quant)
     x_nhwc = make_transpose(
         ctx,
         input_name,
@@ -115,6 +355,66 @@ def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
         [0, 2, 3, 1],
         allow_elide_inverse_chain=True,
     )
+    x_nhwc_pool = x_nhwc
+    if op_type == "MAX_POOL_2D" and explicit_pads is not None:
+        pad_top, pad_left, pad_bottom, pad_right = [int(v) for v in explicit_pads]
+        if any(int(v) != 0 for v in [pad_top, pad_left, pad_bottom, pad_right]):
+            x_tensor = ctx.model_ir.tensors[x_nhwc_pool]
+            padded_shape = list(x_tensor.shape)
+            padded_shape[1] = int(padded_shape[1]) + int(pad_top) + int(pad_bottom)
+            padded_shape[2] = int(padded_shape[2]) + int(pad_left) + int(pad_right)
+            x_nhwc_padded = ctx.add_intermediate_tensor(
+                f"{node.name}_input_nhwc_padded",
+                dtype=ctx.get_tensor_dtype(x_nhwc_pool),
+                shape=padded_shape,
+            )
+            x_nhwc_padded_tensor = ctx.model_ir.tensors[x_nhwc_padded]
+            x_nhwc_padded_tensor.quantization = _clone_quantization(x_tensor.quantization)
+
+            x_sig = (
+                list(x_tensor.shape_signature)
+                if x_tensor.shape_signature is not None
+                else list(x_tensor.shape)
+            )
+            if len(x_sig) == 4:
+                padded_sig = list(x_sig)
+                if int(padded_sig[1]) >= 0:
+                    padded_sig[1] = int(padded_sig[1]) + int(pad_top) + int(pad_bottom)
+                if int(padded_sig[2]) >= 0:
+                    padded_sig[2] = int(padded_sig[2]) + int(pad_left) + int(pad_right)
+                x_nhwc_padded_tensor.shape_signature = [int(v) for v in padded_sig]
+
+            pads_name = ctx.add_const_tensor(
+                f"{node.name}_pads_nhwc",
+                np.asarray(
+                    [
+                        [0, 0],
+                        [pad_top, pad_bottom],
+                        [pad_left, pad_right],
+                        [0, 0],
+                    ],
+                    dtype=np.int32,
+                ),
+            )
+            pad_value = _max_pool_pad_value_for_tensor(
+                tensor_dtype=ctx.get_tensor_dtype(x_nhwc_pool),
+                tensor_quant=x_tensor.quantization,
+            )
+            pad_value_name = ctx.add_const_tensor(
+                f"{node.name}_pad_value",
+                np.asarray(
+                    [pad_value],
+                    dtype=_numpy_dtype_from_tflite_dtype(ctx.get_tensor_dtype(x_nhwc_pool)),
+                ),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="PADV2",
+                    inputs=[x_nhwc_pool, pads_name, pad_value_name],
+                    outputs=[x_nhwc_padded],
+                )
+            )
+            x_nhwc_pool = x_nhwc_padded
 
     y_nhwc = ctx.add_intermediate_tensor(
         f"{node.name}_output_nhwc",
@@ -122,10 +422,13 @@ def build_pool2d_op(node: Any, ctx: Any, op_type: str) -> None:
         shape=nhwc_output_shape,
     )
     ctx.model_ir.tensors[y_nhwc].shape_signature = [int(v) for v in nhwc_output_signature]
+    y_quant = output_tensor.quantization
+    if y_quant is not None:
+        ctx.model_ir.tensors[y_nhwc].quantization = _clone_quantization(y_quant)
     ctx.add_operator(
         OperatorIR(
             op_type=op_type,
-            inputs=[x_nhwc],
+            inputs=[x_nhwc_pool],
             outputs=[y_nhwc],
             options={
                 "padding": padding,

--- a/onnx2tf/tflite_builder/op_builders/quantized.py
+++ b/onnx2tf/tflite_builder/op_builders/quantized.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any, List, Tuple
 
 import numpy as np
@@ -71,6 +72,27 @@ def _tflite_dtype_from_numpy_dtype(np_dtype: np.dtype) -> str:
     raise NotImplementedError(f"Unsupported dtype for flatbuffer_direct quantized builder: {dt}")
 
 
+def _numpy_dtype_from_tflite_dtype(tflite_dtype: str) -> np.dtype:
+    dt = str(tflite_dtype).upper()
+    if dt == "INT8":
+        return np.dtype(np.int8)
+    if dt == "UINT8":
+        return np.dtype(np.uint8)
+    if dt == "INT16":
+        return np.dtype(np.int16)
+    if dt == "UINT16":
+        return np.dtype(np.uint16)
+    if dt == "INT32":
+        return np.dtype(np.int32)
+    if dt == "UINT32":
+        return np.dtype(np.uint32)
+    if dt == "FLOAT16":
+        return np.dtype(np.float16)
+    if dt == "FLOAT32":
+        return np.dtype(np.float32)
+    raise NotImplementedError(f"Unsupported TFLite dtype in quantized builder: {tflite_dtype}")
+
+
 def _set_tensor_dtype_from_array(ctx: Any, tensor_name: str, array: np.ndarray) -> None:
     ctx.ensure_tensor(tensor_name)
     tensor = ctx.model_ir.tensors[tensor_name]
@@ -89,11 +111,36 @@ def _set_tensor_quantization(
 ) -> None:
     ctx.ensure_tensor(tensor_name)
     scales, zps = _normalize_quant_params(scale=scale, zero_point=zero_point)
+    tensor_dtype = str(ctx.get_tensor_dtype(tensor_name))
+    zero_point_dtype = np.asarray(zero_point).dtype
+    if tensor_dtype == "INT8" and zero_point_dtype == np.dtype(np.uint8):
+        zps = [int(v) - 128 for v in zps]
+    elif tensor_dtype == "UINT8" and zero_point_dtype == np.dtype(np.int8):
+        zps = [int(v) + 128 for v in zps]
     ctx.model_ir.tensors[tensor_name].quantization = QuantParamIR(
         scale=[float(v) for v in scales],
         zero_point=[int(v) for v in zps],
         quantized_dimension=int(quantized_dimension),
     )
+
+
+def _promote_internal_uint8_tensor_to_int8(ctx: Any, tensor_name: str) -> None:
+    if str(tensor_name) in set(ctx.graph_output_names):
+        return
+    ctx.ensure_tensor(tensor_name)
+    tensor = ctx.model_ir.tensors.get(tensor_name, None)
+    if tensor is None or str(tensor.dtype) != "UINT8":
+        return
+    tensor.dtype = "INT8"
+    if isinstance(tensor.data, np.ndarray):
+        shifted = np.asarray(tensor.data, dtype=np.int16) - 128
+        tensor.data = np.clip(shifted, -128, 127).astype(np.int8)
+        if tensor_name in ctx.constants:
+            ctx.constants[tensor_name] = tensor.data
+    if isinstance(tensor.quantization, QuantParamIR):
+        tensor.quantization.zero_point = [
+            int(v) - 128 for v in list(tensor.quantization.zero_point)
+        ]
 
 
 def _propagate_shape(ctx: Any, src_tensor_name: str, dst_tensor_name: str) -> None:
@@ -119,6 +166,99 @@ def _require_const(ctx: Any, tensor_name: str, label: str) -> np.ndarray:
     return np.asarray(value)
 
 
+def _infer_pool_output_hw_for_qlinear(
+    *,
+    node: Any,
+    input_h: int,
+    input_w: int,
+    kernel_h: int,
+    kernel_w: int,
+    stride_h: int,
+    stride_w: int,
+    ceil_mode: int = 0,
+) -> tuple[int, int]:
+    auto_pad = str(node.attrs.get("auto_pad", "NOTSET")).upper()
+    if auto_pad in ["SAME", "SAME_UPPER", "SAME_LOWER"]:
+        out_h = int(math.ceil(float(input_h) / float(stride_h)))
+        out_w = int(math.ceil(float(input_w) / float(stride_w)))
+        return max(out_h, 1), max(out_w, 1)
+    if auto_pad == "VALID":
+        if int(ceil_mode) == 1:
+            out_h = int(math.ceil((float(input_h) - float(kernel_h)) / float(stride_h) + 1.0))
+            out_w = int(math.ceil((float(input_w) - float(kernel_w)) / float(stride_w) + 1.0))
+        else:
+            out_h = int(math.floor((float(input_h) - float(kernel_h)) / float(stride_h) + 1.0))
+            out_w = int(math.floor((float(input_w) - float(kernel_w)) / float(stride_w) + 1.0))
+        return max(out_h, 1), max(out_w, 1)
+
+    pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    if len(pads) < 4:
+        pads = [0, 0, 0, 0]
+    pad_top, pad_left, pad_bottom, pad_right = pads[0], pads[1], pads[2], pads[3]
+    if int(ceil_mode) == 1:
+        out_h = int(
+            math.ceil(
+                (float(input_h + pad_top + pad_bottom - kernel_h) / float(stride_h)) + 1.0
+            )
+        )
+        out_w = int(
+            math.ceil(
+                (float(input_w + pad_left + pad_right - kernel_w) / float(stride_w)) + 1.0
+            )
+        )
+    else:
+        out_h = int(
+            math.floor(
+                (float(input_h + pad_top + pad_bottom - kernel_h) / float(stride_h)) + 1.0
+            )
+        )
+        out_w = int(
+            math.floor(
+                (float(input_w + pad_left + pad_right - kernel_w) / float(stride_w)) + 1.0
+            )
+        )
+    return max(out_h, 1), max(out_w, 1)
+
+
+def _resolve_qlinear_conv_padding_and_explicit_pads(
+    *,
+    node: Any,
+    input_shape_nchw: List[int],
+    output_shape_nchw: List[int],
+) -> Tuple[str, List[int] | None]:
+    auto_pad = str(node.attrs.get("auto_pad", "NOTSET")).upper()
+    raw_pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    if len(raw_pads) < 4:
+        raw_pads = [0, 0, 0, 0]
+    pads = [int(raw_pads[0]), int(raw_pads[1]), int(raw_pads[2]), int(raw_pads[3])]
+    pad_top, pad_left, pad_bottom, pad_right = pads
+    pads_axes_opposite_same = bool((pad_top == pad_bottom) and (pad_left == pad_right))
+
+    if auto_pad == "NOTSET":
+        if (
+            pads_axes_opposite_same
+            and len(input_shape_nchw) == 4
+            and len(output_shape_nchw) == 4
+            and list(input_shape_nchw[2:]) == list(output_shape_nchw[2:])
+        ):
+            return "SAME", None
+        if any(int(v) != 0 for v in pads):
+            return "VALID", pads
+        return "VALID", None
+
+    if auto_pad == "SAME_UPPER":
+        return "SAME", None
+    if auto_pad == "VALID":
+        return "VALID", None
+    if auto_pad == "SAME_LOWER":
+        raise NotImplementedError(
+            f"QLinearConv auto_pad=SAME_LOWER is not supported in flatbuffer_direct. op={node.name}"
+        )
+    raise NotImplementedError(
+        f"QLinearConv auto_pad attribute is invalid for flatbuffer_direct. op={node.name} auto_pad={auto_pad}"
+    )
+
+
 def build_quantize_linear_op(node: Any, ctx: Any) -> None:
     input_name = node.inputs[0].name
     y_scale_name = node.inputs[1].name
@@ -135,6 +275,7 @@ def build_quantize_linear_op(node: Any, ctx: Any) -> None:
     else:
         y_zero_point = np.zeros_like(y_scale, dtype=np.int32)
     _set_tensor_dtype_from_array(ctx, output_name, y_zero_point)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
 
     output_rank = len(ctx.get_tensor_shape(output_name))
     axis = int(node.attrs.get("axis", 1))
@@ -223,6 +364,9 @@ def _build_qlinear_binary_op(node: Any, ctx: Any, op_type: str) -> None:
     _set_tensor_dtype_from_array(ctx, a_name, a_zero)
     _set_tensor_dtype_from_array(ctx, b_name, b_zero)
     _set_tensor_dtype_from_array(ctx, output_name, c_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, a_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, b_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
 
     a_rank = len(ctx.get_tensor_shape(a_name))
     b_rank = len(ctx.get_tensor_shape(b_name))
@@ -292,6 +436,8 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
     y_zero = _require_const(ctx, y_zero_name, "QLinearConv output zero_point")
     _set_tensor_dtype_from_array(ctx, x_name, x_zero)
     _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, x_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
 
     _set_tensor_quantization(
         ctx=ctx,
@@ -340,13 +486,17 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
             f"input_shape={input_shape} output_shape={output_shape} op={node.name}"
         )
 
+    nchw_input = input_shape
+    nchw_output = output_shape
     strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
     dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
     group = int(node.attrs.get("group", 1))
-    padding = resolve_padding(node)
+    padding, explicit_pads = _resolve_qlinear_conv_padding_and_explicit_pads(
+        node=node,
+        input_shape_nchw=nchw_input,
+        output_shape_nchw=nchw_output,
+    )
 
-    nchw_input = input_shape
-    nchw_output = output_shape
     nhwc_input_shape = [nchw_input[0], nchw_input[2], nchw_input[3], nchw_input[1]]
     nhwc_output_shape = [nchw_output[0], nchw_output[2], nchw_output[3], nchw_output[1]]
     output_tensor = ctx.model_ir.tensors[output_name]
@@ -377,6 +527,65 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
         [0, 2, 3, 1],
         allow_elide_inverse_chain=True,
     )
+    x_nhwc_conv = x_nhwc
+    if explicit_pads is not None:
+        pad_top, pad_left, pad_bottom, pad_right = [int(v) for v in explicit_pads]
+        if any(int(v) != 0 for v in [pad_top, pad_left, pad_bottom, pad_right]):
+            x_tensor = ctx.model_ir.tensors[x_nhwc_conv]
+            padded_shape = list(x_tensor.shape)
+            padded_shape[1] = int(padded_shape[1]) + int(pad_top) + int(pad_bottom)
+            padded_shape[2] = int(padded_shape[2]) + int(pad_left) + int(pad_right)
+            x_nhwc_padded = ctx.add_intermediate_tensor(
+                f"{node.name}_input_nhwc_padded",
+                dtype=ctx.get_tensor_dtype(x_nhwc_conv),
+                shape=padded_shape,
+            )
+            x_nhwc_padded_tensor = ctx.model_ir.tensors[x_nhwc_padded]
+            x_nhwc_padded_tensor.quantization = x_tensor.quantization
+
+            x_sig = (
+                list(x_tensor.shape_signature)
+                if x_tensor.shape_signature is not None
+                else list(x_tensor.shape)
+            )
+            if len(x_sig) == 4:
+                padded_sig = list(x_sig)
+                if int(padded_sig[1]) >= 0:
+                    padded_sig[1] = int(padded_sig[1]) + int(pad_top) + int(pad_bottom)
+                if int(padded_sig[2]) >= 0:
+                    padded_sig[2] = int(padded_sig[2]) + int(pad_left) + int(pad_right)
+                x_nhwc_padded_tensor.shape_signature = [int(v) for v in padded_sig]
+
+            pads_name = ctx.add_const_tensor(
+                f"{node.name}_pads_nhwc",
+                np.asarray(
+                    [
+                        [0, 0],
+                        [pad_top, pad_bottom],
+                        [pad_left, pad_right],
+                        [0, 0],
+                    ],
+                    dtype=np.int32,
+                ),
+            )
+            pad_value = 0
+            if isinstance(x_tensor.quantization, QuantParamIR) and len(x_tensor.quantization.zero_point) > 0:
+                pad_value = int(x_tensor.quantization.zero_point[0])
+            pad_value_name = ctx.add_const_tensor(
+                f"{node.name}_pad_value",
+                np.asarray(
+                    [pad_value],
+                    dtype=_numpy_dtype_from_tflite_dtype(ctx.get_tensor_dtype(x_nhwc_conv)),
+                ),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="PADV2",
+                    inputs=[x_nhwc_conv, pads_name, pad_value_name],
+                    outputs=[x_nhwc_padded],
+                )
+            )
+            x_nhwc_conv = x_nhwc_padded
 
     in_channels = int(nchw_input[1])
     out_channels = int(weights.shape[0])
@@ -396,6 +605,8 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
             tensor_name=w_q_name,
             scale=w_scale,
             zero_point=w_zero,
+            # DEPTHWISE_CONV_2D weights are [1, H, W, I*depth_multiplier].
+            # Per-channel quantization axis is channel-last (axis=3).
             quantized_dimension=(len(ctx.model_ir.tensors[w_q_name].shape) - 1) if np.asarray(w_scale).size > 1 else 0,
         )
     else:
@@ -415,7 +626,8 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
             tensor_name=w_q_name,
             scale=w_scale,
             zero_point=w_zero,
-            quantized_dimension=(len(ctx.model_ir.tensors[w_q_name].shape) - 1) if np.asarray(w_scale).size > 1 else 0,
+            # CONV_2D weights are OHWI. Per-channel quantization axis is O (axis=0).
+            quantized_dimension=0 if np.asarray(w_scale).size > 1 else 0,
         )
 
     if bias_name != "":
@@ -446,13 +658,14 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
     )
     ctx.model_ir.tensors[y_nhwc].quantization = ctx.model_ir.tensors[output_name].quantization
     ctx.model_ir.tensors[y_nhwc].shape_signature = [int(v) for v in nhwc_output_signature]
+    y_nhwc_conv = y_nhwc
 
     if is_depthwise:
         ctx.add_operator(
             OperatorIR(
                 op_type="DEPTHWISE_CONV_2D",
-                inputs=[x_nhwc, w_q_name, bias_q_name],
-                outputs=[y_nhwc],
+                inputs=[x_nhwc_conv, w_q_name, bias_q_name],
+                outputs=[y_nhwc_conv],
                 options={
                     "padding": padding,
                     "strideH": int(strides[0]),
@@ -462,14 +675,15 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
                     "depthMultiplier": int(depth_multiplier),
                     "fusedActivationFunction": "NONE",
                 },
+                version=3,
             )
         )
     else:
         ctx.add_operator(
             OperatorIR(
                 op_type="CONV_2D",
-                inputs=[x_nhwc, w_q_name, bias_q_name],
-                outputs=[y_nhwc],
+                inputs=[x_nhwc_conv, w_q_name, bias_q_name],
+                outputs=[y_nhwc_conv],
                 options={
                     "padding": padding,
                     "strideH": int(strides[0]),
@@ -478,9 +692,9 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
                     "dilationWFactor": int(dilations[1]),
                     "fusedActivationFunction": "NONE",
                 },
+                version=3,
             )
         )
-
     make_transpose(
         ctx,
         y_nhwc,
@@ -489,15 +703,21 @@ def build_qlinear_conv_op(node: Any, ctx: Any) -> None:
     )
 
 
-def build_qlinear_matmul_op(node: Any, ctx: Any) -> None:
+def _build_qlinear_fc_like_op(
+    node: Any,
+    ctx: Any,
+    *,
+    has_bias_input: bool,
+) -> None:
     a_name = node.inputs[0].name
     a_scale_name = node.inputs[1].name
     a_zero_name = node.inputs[2].name
     b_name = node.inputs[3].name
     b_scale_name = node.inputs[4].name
     b_zero_name = node.inputs[5].name
-    y_scale_name = node.inputs[6].name
-    y_zero_name = node.inputs[7].name
+    bias_name = node.inputs[6].name if has_bias_input else ""
+    y_scale_name = node.inputs[7].name if has_bias_input else node.inputs[6].name
+    y_zero_name = node.inputs[8].name if has_bias_input else node.inputs[7].name
     output_name = node.outputs[0].name
 
     ctx.ensure_tensor(a_name)
@@ -512,14 +732,40 @@ def build_qlinear_matmul_op(node: Any, ctx: Any) -> None:
     y_zero = _require_const(ctx, y_zero_name, "QLinearMatMul output zero_point")
     _set_tensor_dtype_from_array(ctx, a_name, a_zero)
     _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, a_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
+
+    trans_a = int(node.attrs.get("transA", 0))
+    trans_b = int(node.attrs.get("transB", 0))
+    if trans_a != 0:
+        raise NotImplementedError(
+            f"{node.op} transA=1 is not supported in flatbuffer_direct. op={node.name}"
+        )
+    if trans_b not in [0, 1]:
+        raise NotImplementedError(
+            f"{node.op} transB must be 0 or 1 in flatbuffer_direct. op={node.name} transB={trans_b}"
+        )
+
+    weights = _require_const(ctx, b_name, "QLinearMatMul weights")
+    if weights.ndim != 2:
+        raise NotImplementedError(
+            f"QLinearMatMul weight rank must be 2. op={node.name} weight_shape={list(weights.shape)}"
+        )
+    if trans_b == 0:
+        # ONNX B is [K, N] when transB=0. TFLite FC expects [N, K].
+        fc_weights = np.asarray(weights.T, dtype=weights.dtype)
+    else:
+        # ONNX B is [N, K] when transB=1. It already matches TFLite FC layout.
+        fc_weights = np.asarray(weights, dtype=weights.dtype)
+    out_features = int(fc_weights.shape[0])
 
     input_shape = ctx.get_tensor_shape(a_name)
     if len(input_shape) != 2:
         output_shape = ctx.get_tensor_shape(output_name)
         if len(output_shape) == 2:
-            inferred_shape = [int(output_shape[0]), int(_require_const(ctx, b_name, "QLinearMatMul weights").shape[0])]
+            inferred_shape = [int(output_shape[0]), int(fc_weights.shape[1])]
         else:
-            inferred_shape = [1, int(_require_const(ctx, b_name, "QLinearMatMul weights").shape[0])]
+            inferred_shape = [1, int(fc_weights.shape[1])]
         ctx.model_ir.tensors[a_name].shape = inferred_shape
         ctx.model_ir.tensors[a_name].shape_signature = list(inferred_shape)
         input_shape = inferred_shape
@@ -538,16 +784,10 @@ def build_qlinear_matmul_op(node: Any, ctx: Any) -> None:
         zero_point=y_zero,
         quantized_dimension=0 if np.asarray(y_scale).size <= 1 else 1,
     )
-
-    weights = _require_const(ctx, b_name, "QLinearMatMul weights")
-    if weights.ndim != 2:
-        raise NotImplementedError(
-            f"QLinearMatMul weight rank must be 2. op={node.name} weight_shape={list(weights.shape)}"
-        )
-    fc_weights = np.asarray(weights.T, dtype=weights.dtype)
     if ctx.model_ir.tensors[output_name].shape == [1]:
-        ctx.model_ir.tensors[output_name].shape = [int(input_shape[0]), int(fc_weights.shape[0])]
-        ctx.model_ir.tensors[output_name].shape_signature = [int(input_shape[0]), int(fc_weights.shape[0])]
+        ctx.model_ir.tensors[output_name].shape = [int(input_shape[0]), int(out_features)]
+        ctx.model_ir.tensors[output_name].shape_signature = [int(input_shape[0]), int(out_features)]
+    a_fc_name = a_name
     w_q_name = ctx.add_const_tensor(
         f"{node.name}_fc_weights_q",
         fc_weights,
@@ -559,37 +799,340 @@ def build_qlinear_matmul_op(node: Any, ctx: Any) -> None:
         zero_point=b_zero,
         quantized_dimension=0 if np.asarray(b_scale).size <= 1 else 0,
     )
+    if has_bias_input:
+        bias_values = _require_const(ctx, bias_name, f"{node.op} bias")
+        bias_values = np.asarray(bias_values, dtype=np.int32).reshape(-1)
+        if bias_values.size == 1 and out_features > 1:
+            bias_values = np.repeat(bias_values, repeats=out_features, axis=0)
+        if int(bias_values.size) != int(out_features):
+            raise NotImplementedError(
+                f"{node.op} bias size must match output features. "
+                f"op={node.name} bias_size={int(bias_values.size)} out_features={out_features}"
+            )
+    else:
+        bias_values = np.zeros((out_features,), dtype=np.int32)
 
-    out_features = int(fc_weights.shape[0])
-    bias_values = np.zeros((out_features,), dtype=np.int32)
-    bias_q_name = ctx.add_const_tensor(
-        f"{node.name}_fc_bias_q",
-        bias_values,
-    )
     a_scales, _ = _normalize_quant_params(scale=a_scale, zero_point=a_zero)
     b_scales, _ = _normalize_quant_params(scale=b_scale, zero_point=b_zero)
     if len(b_scales) == 1:
         bias_scales = [float(a_scales[0] * b_scales[0])]
     else:
         bias_scales = [float(a_scales[0] * bs) for bs in b_scales]
+    bias_q_name = ctx.add_const_tensor(
+        f"{node.name}_fc_bias_q",
+        bias_values,
+    )
     ctx.model_ir.tensors[bias_q_name].quantization = QuantParamIR(
         scale=bias_scales,
         zero_point=[0 for _ in range(len(bias_scales))],
         quantized_dimension=0,
     )
-
+    y_fc_name = output_name
     ctx.add_operator(
         OperatorIR(
             op_type="FULLY_CONNECTED",
-            inputs=[a_name, w_q_name, bias_q_name],
-            outputs=[output_name],
+            inputs=[a_fc_name, w_q_name, bias_q_name],
+            outputs=[y_fc_name],
             options={
                 "fusedActivationFunction": "NONE",
                 "weightsFormat": "DEFAULT",
                 "keepNumDims": False,
                 "asymmetricQuantizeInputs": False,
             },
+            version=4,
         )
+    )
+
+def build_qlinear_matmul_op(node: Any, ctx: Any) -> None:
+    _build_qlinear_fc_like_op(
+        node=node,
+        ctx=ctx,
+        has_bias_input=False,
+    )
+
+
+def build_qgemm_op(node: Any, ctx: Any) -> None:
+    _build_qlinear_fc_like_op(
+        node=node,
+        ctx=ctx,
+        has_bias_input=True,
+    )
+
+
+def build_qlinear_average_pool_op(node: Any, ctx: Any) -> None:
+    x_name = node.inputs[0].name
+    x_scale_name = node.inputs[1].name
+    x_zero_name = node.inputs[2].name
+    y_scale_name = node.inputs[3].name
+    y_zero_name = node.inputs[4].name
+    output_name = node.outputs[0].name
+
+    ctx.ensure_tensor(x_name)
+    ctx.ensure_tensor(output_name)
+
+    x_scale = _require_const(ctx, x_scale_name, "QLinearAveragePool input scale")
+    x_zero = _require_const(ctx, x_zero_name, "QLinearAveragePool input zero_point")
+    y_scale = _require_const(ctx, y_scale_name, "QLinearAveragePool output scale")
+    y_zero = _require_const(ctx, y_zero_name, "QLinearAveragePool output zero_point")
+
+    _set_tensor_dtype_from_array(ctx, x_name, x_zero)
+    _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, x_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
+    output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+    if len(input_shape) != 4:
+        raise NotImplementedError(
+            f"QLinearAveragePool supports only rank-4 input for flatbuffer_direct. "
+            f"op={node.name} input_shape={input_shape}"
+        )
+
+    kernel = [int(v) for v in list(node.attrs.get("kernel_shape", [1, 1]))]
+    strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
+    if len(kernel) != 2 or len(strides) != 2:
+        raise NotImplementedError(
+            f"QLinearAveragePool supports only 2D pooling in flatbuffer_direct. "
+            f"op={node.name} kernel_shape={kernel} strides={strides}"
+        )
+    ceil_mode = int(node.attrs.get("ceil_mode", 0))
+    if ceil_mode not in [0, 1]:
+        raise NotImplementedError(
+            f"QLinearAveragePool ceil_mode must be 0 or 1 for flatbuffer_direct. op={node.name} ceil_mode={ceil_mode}"
+        )
+    auto_pad = str(node.attrs.get("auto_pad", "NOTSET")).upper()
+    pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    if len(pads) < 4:
+        pads = [0, 0, 0, 0]
+    if ceil_mode == 1:
+        if auto_pad not in ["NOTSET", "SAME", "SAME_UPPER", "SAME_LOWER"]:
+            raise NotImplementedError(
+                f"QLinearAveragePool ceil_mode=1 supports auto_pad NOTSET/SAME only. op={node.name} auto_pad={auto_pad}"
+            )
+        if auto_pad == "NOTSET" and any(int(v) != 0 for v in pads):
+            raise NotImplementedError(
+                f"QLinearAveragePool ceil_mode=1 with auto_pad=NOTSET requires pads=[0,0,0,0]. op={node.name} pads={pads}"
+            )
+    if int(node.attrs.get("count_include_pad", 0)) != 0:
+        raise NotImplementedError(
+            f"QLinearAveragePool count_include_pad must be 0 for flatbuffer_direct. op={node.name}"
+        )
+    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
+    if dilations != [1, 1]:
+        raise NotImplementedError(
+            f"QLinearAveragePool dilations must be [1,1] for flatbuffer_direct. "
+            f"op={node.name} dilations={dilations}"
+        )
+
+    if ceil_mode == 1:
+        # TFLite has no explicit ceil_mode flag; use SAME-style output sizing for this supported subset.
+        padding = "SAME"
+    else:
+        padding = resolve_padding(node)
+
+    input_tensor = ctx.model_ir.tensors[x_name]
+    input_signature = (
+        list(input_tensor.shape_signature)
+        if input_tensor.shape_signature is not None
+        else list(input_shape)
+    )
+    if len(output_shape) != 4:
+        out_h, out_w = _infer_pool_output_hw_for_qlinear(
+            node=node,
+            input_h=int(input_shape[2]),
+            input_w=int(input_shape[3]),
+            kernel_h=int(kernel[0]),
+            kernel_w=int(kernel[1]),
+            stride_h=int(strides[0]),
+            stride_w=int(strides[1]),
+            ceil_mode=ceil_mode,
+        )
+        output_shape = [int(input_shape[0]), int(input_shape[1]), int(out_h), int(out_w)]
+        output_tensor = ctx.model_ir.tensors[output_name]
+        output_tensor.shape = list(output_shape)
+        output_signature = list(output_shape)
+        if len(input_signature) == 4:
+            output_signature[0] = int(input_signature[0])
+            output_signature[1] = int(input_signature[1])
+        output_tensor.shape_signature = list(output_signature)
+
+    _set_tensor_quantization(
+        ctx=ctx,
+        tensor_name=x_name,
+        scale=x_scale,
+        zero_point=x_zero,
+        quantized_dimension=0 if np.asarray(x_scale).size <= 1 else _normalize_axis(1, 4),
+    )
+    _set_tensor_quantization(
+        ctx=ctx,
+        tensor_name=output_name,
+        scale=y_scale,
+        zero_point=y_zero,
+        quantized_dimension=0 if np.asarray(y_scale).size <= 1 else _normalize_axis(1, 4),
+    )
+
+    nhwc_input_shape = [int(input_shape[0]), int(input_shape[2]), int(input_shape[3]), int(input_shape[1])]
+    nhwc_output_shape = [int(output_shape[0]), int(output_shape[2]), int(output_shape[3]), int(output_shape[1])]
+    output_tensor = ctx.model_ir.tensors[output_name]
+    output_signature = (
+        list(output_tensor.shape_signature)
+        if output_tensor.shape_signature is not None
+        else list(output_shape)
+    )
+    nhwc_output_signature = [int(v) for v in nhwc_output_shape]
+    if len(output_signature) == 4:
+        nhwc_output_signature = [
+            int(output_signature[0]),
+            int(output_signature[2]),
+            int(output_signature[3]),
+            int(output_signature[1]),
+        ]
+    nhwc_input_signature = [
+        int(input_signature[0]),
+        int(input_signature[2]),
+        int(input_signature[3]),
+        int(input_signature[1]),
+    ]
+
+    def _lower_via_dequantize_avgpool_quantize() -> None:
+        dq_out = ctx.add_intermediate_tensor(
+            f"{node.name}_dq_out",
+            dtype="FLOAT32",
+            shape=list(input_shape),
+        )
+        ctx.model_ir.tensors[dq_out].shape_signature = list(input_signature)
+        ctx.add_operator(
+            OperatorIR(
+                op_type="DEQUANTIZE",
+                inputs=[x_name],
+                outputs=[dq_out],
+            )
+        )
+
+        x_nhwc = ctx.add_intermediate_tensor(
+            f"{node.name}_input_nhwc",
+            dtype="FLOAT32",
+            shape=nhwc_input_shape,
+        )
+        ctx.model_ir.tensors[x_nhwc].shape_signature = list(nhwc_input_signature)
+        x_nhwc = make_transpose(
+            ctx,
+            dq_out,
+            x_nhwc,
+            [0, 2, 3, 1],
+            allow_elide_inverse_chain=True,
+        )
+
+        y_nhwc = ctx.add_intermediate_tensor(
+            f"{node.name}_output_nhwc",
+            dtype="FLOAT32",
+            shape=nhwc_output_shape,
+        )
+        ctx.model_ir.tensors[y_nhwc].shape_signature = [int(v) for v in nhwc_output_signature]
+        ctx.add_operator(
+            OperatorIR(
+                op_type="AVERAGE_POOL_2D",
+                inputs=[x_nhwc],
+                outputs=[y_nhwc],
+                options={
+                    "padding": padding,
+                    "strideH": int(strides[0]),
+                    "strideW": int(strides[1]),
+                    "filterHeight": int(kernel[0]),
+                    "filterWidth": int(kernel[1]),
+                    "fusedActivationFunction": "NONE",
+                },
+            )
+        )
+
+        pool_out_nchw = ctx.add_intermediate_tensor(
+            f"{node.name}_pool_out_nchw",
+            dtype="FLOAT32",
+            shape=list(output_shape),
+        )
+        ctx.model_ir.tensors[pool_out_nchw].shape_signature = list(output_signature)
+        make_transpose(
+            ctx,
+            y_nhwc,
+            pool_out_nchw,
+            [0, 3, 1, 2],
+        )
+
+        ctx.add_operator(
+            OperatorIR(
+                op_type="QUANTIZE",
+                inputs=[pool_out_nchw],
+                outputs=[output_name],
+            )
+        )
+
+    # Prefer quantized AVERAGE_POOL_2D and avoid DEQUANTIZE/QUANTIZE bridges.
+    # Keep this conservative: only per-tensor activation quantization.
+    can_use_quantized_pool = (
+        len(input_shape) == 4
+        and len(output_shape) == 4
+        and np.asarray(x_scale).size <= 1
+        and np.asarray(y_scale).size <= 1
+    )
+    if not can_use_quantized_pool:
+        _lower_via_dequantize_avgpool_quantize()
+        return
+
+    x_nhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_input_nhwc",
+        dtype=ctx.get_tensor_dtype(x_name),
+        shape=nhwc_input_shape,
+    )
+    ctx.model_ir.tensors[x_nhwc].shape_signature = list(nhwc_input_signature)
+    _set_tensor_quantization(
+        ctx=ctx,
+        tensor_name=x_nhwc,
+        scale=x_scale,
+        zero_point=x_zero,
+        quantized_dimension=0,
+    )
+    x_nhwc = make_transpose(
+        ctx,
+        x_name,
+        x_nhwc,
+        [0, 2, 3, 1],
+        allow_elide_inverse_chain=True,
+    )
+
+    y_nhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_output_nhwc",
+        dtype=ctx.get_tensor_dtype(output_name),
+        shape=nhwc_output_shape,
+    )
+    ctx.model_ir.tensors[y_nhwc].shape_signature = [int(v) for v in nhwc_output_signature]
+    _set_tensor_quantization(
+        ctx=ctx,
+        tensor_name=y_nhwc,
+        scale=y_scale,
+        zero_point=y_zero,
+        quantized_dimension=0,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="AVERAGE_POOL_2D",
+            inputs=[x_nhwc],
+            outputs=[y_nhwc],
+            options={
+                "padding": padding,
+                "strideH": int(strides[0]),
+                "strideW": int(strides[1]),
+                "filterHeight": int(kernel[0]),
+                "filterWidth": int(kernel[1]),
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    )
+
+    make_transpose(
+        ctx,
+        y_nhwc,
+        output_name,
+        [0, 3, 1, 2],
     )
 
 
@@ -611,6 +1154,8 @@ def build_qlinear_global_average_pool_op(node: Any, ctx: Any) -> None:
 
     _set_tensor_dtype_from_array(ctx, x_name, x_zero)
     _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, x_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
 
     input_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
     input_tensor = ctx.model_ir.tensors[x_name]
@@ -705,123 +1250,8 @@ def build_qlinear_global_average_pool_op(node: Any, ctx: Any) -> None:
             )
         )
 
-    # Prefer quantized global average pool path when representable by TFLite AVERAGE_POOL_2D.
-    # Keep quantized lowering conservative: rank-4 + static spatial dims + per-tensor params.
-    can_use_quantized_pool = (
-        len(input_shape) == 4
-        and len(output_shape) == 4
-        and np.asarray(x_scale).size <= 1
-        and np.asarray(y_scale).size <= 1
-    )
-    if can_use_quantized_pool:
-        spatial_sizes = [int(input_shape[axis]) for axis in spatial_axes]
-        if any(int(v) <= 0 for v in spatial_sizes):
-            can_use_quantized_pool = False
-
-    if not can_use_quantized_pool:
-        _lower_via_dequantize_mean_quantize()
-        return
-
-    # Build quantized AVERAGE_POOL_2D path.
-    if channels_last:
-        x_nhwc_name = x_name
-        y_nhwc_name = output_name
-        nhwc_input_shape = list(input_shape)
-        nhwc_output_shape = list(output_shape)
-        nhwc_input_signature = list(input_signature)
-        nhwc_output_signature = list(output_signature)
-    else:
-        nhwc_input_shape = [int(input_shape[0]), int(input_shape[2]), int(input_shape[3]), int(input_shape[1])]
-        nhwc_output_shape = [int(output_shape[0]), int(output_shape[2]), int(output_shape[3]), int(output_shape[1])]
-        nhwc_input_signature = [
-            int(input_signature[0]),
-            int(input_signature[2]),
-            int(input_signature[3]),
-            int(input_signature[1]),
-        ]
-        nhwc_output_signature = [
-            int(output_signature[0]),
-            int(output_signature[2]),
-            int(output_signature[3]),
-            int(output_signature[1]),
-        ]
-
-        x_nhwc_name = ctx.add_intermediate_tensor(
-            f"{node.name}_input_nhwc",
-            dtype=ctx.get_tensor_dtype(x_name),
-            shape=nhwc_input_shape,
-        )
-        ctx.model_ir.tensors[x_nhwc_name].shape_signature = list(nhwc_input_signature)
-        _set_tensor_quantization(
-            ctx=ctx,
-            tensor_name=x_nhwc_name,
-            scale=x_scale,
-            zero_point=x_zero,
-            quantized_dimension=0 if np.asarray(x_scale).size <= 1 else _normalize_axis(3, 4),
-        )
-        x_nhwc_name = make_transpose(
-            ctx,
-            x_name,
-            x_nhwc_name,
-            [0, 2, 3, 1],
-            allow_elide_inverse_chain=True,
-        )
-
-        y_nhwc_name = ctx.add_intermediate_tensor(
-            f"{node.name}_output_nhwc",
-            dtype=ctx.get_tensor_dtype(output_name),
-            shape=nhwc_output_shape,
-        )
-        ctx.model_ir.tensors[y_nhwc_name].shape_signature = list(nhwc_output_signature)
-        _set_tensor_quantization(
-            ctx=ctx,
-            tensor_name=y_nhwc_name,
-            scale=y_scale,
-            zero_point=y_zero,
-            quantized_dimension=0 if np.asarray(y_scale).size <= 1 else _normalize_axis(3, 4),
-        )
-
-    if channels_last:
-        _set_tensor_quantization(
-            ctx=ctx,
-            tensor_name=x_nhwc_name,
-            scale=x_scale,
-            zero_point=x_zero,
-            quantized_dimension=0 if np.asarray(x_scale).size <= 1 else _normalize_axis(3, 4),
-        )
-        _set_tensor_quantization(
-            ctx=ctx,
-            tensor_name=y_nhwc_name,
-            scale=y_scale,
-            zero_point=y_zero,
-            quantized_dimension=0 if np.asarray(y_scale).size <= 1 else _normalize_axis(3, 4),
-        )
-
-    kernel_h = int(spatial_sizes[0])
-    kernel_w = int(spatial_sizes[1]) if len(spatial_sizes) > 1 else 1
-    ctx.add_operator(
-        OperatorIR(
-            op_type="AVERAGE_POOL_2D",
-            inputs=[x_nhwc_name],
-            outputs=[y_nhwc_name],
-            options={
-                "padding": "VALID",
-                "strideH": 1,
-                "strideW": 1,
-                "filterHeight": int(kernel_h),
-                "filterWidth": int(kernel_w),
-                "fusedActivationFunction": "NONE",
-            },
-        )
-    )
-
-    if not channels_last:
-        make_transpose(
-            ctx,
-            y_nhwc_name,
-            output_name,
-            [0, 3, 1, 2],
-        )
+    # Use MEAN-based lowering unconditionally for stability across delegates/runtimes.
+    _lower_via_dequantize_mean_quantize()
 
 
 def build_qlinear_concat_op(node: Any, ctx: Any) -> None:
@@ -852,6 +1282,7 @@ def build_qlinear_concat_op(node: Any, ctx: Any) -> None:
     y_scale = _require_const(ctx, y_scale_name, "QLinearConcat output scale")
     y_zero = _require_const(ctx, y_zero_name, "QLinearConcat output zero_point")
     _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
 
     first_shape = [int(v) for v in ctx.get_tensor_shape(input_names[0])]
     rank = len(first_shape)
@@ -863,6 +1294,7 @@ def build_qlinear_concat_op(node: Any, ctx: Any) -> None:
         input_scale = _require_const(ctx, input_scale_names[idx], f"QLinearConcat input[{idx}] scale")
         input_zero = _require_const(ctx, input_zero_names[idx], f"QLinearConcat input[{idx}] zero_point")
         _set_tensor_dtype_from_array(ctx, input_name, input_zero)
+        _promote_internal_uint8_tensor_to_int8(ctx, input_name)
         _set_tensor_quantization(
             ctx=ctx,
             tensor_name=input_name,
@@ -964,6 +1396,8 @@ def build_qlinear_sigmoid_op(node: Any, ctx: Any) -> None:
 
     _set_tensor_dtype_from_array(ctx, x_name, x_zero)
     _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, x_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
 
     input_rank = len(ctx.get_tensor_shape(x_name))
     output_rank = len(ctx.get_tensor_shape(output_name))
@@ -1012,6 +1446,89 @@ def build_qlinear_sigmoid_op(node: Any, ctx: Any) -> None:
         OperatorIR(
             op_type="QUANTIZE",
             inputs=[sig_out],
+            outputs=[output_name],
+        )
+    )
+
+
+def build_qlinear_softmax_op(node: Any, ctx: Any) -> None:
+    x_name = node.inputs[0].name
+    x_scale_name = node.inputs[1].name
+    x_zero_name = node.inputs[2].name
+    y_scale_name = node.inputs[3].name
+    y_zero_name = node.inputs[4].name
+    output_name = node.outputs[0].name
+
+    ctx.ensure_tensor(x_name)
+    ctx.ensure_tensor(output_name)
+    _propagate_shape(ctx, x_name, output_name)
+
+    x_scale = _require_const(ctx, x_scale_name, "QLinearSoftmax input scale")
+    x_zero = _require_const(ctx, x_zero_name, "QLinearSoftmax input zero_point")
+    y_scale = _require_const(ctx, y_scale_name, "QLinearSoftmax output scale")
+    y_zero = _require_const(ctx, y_zero_name, "QLinearSoftmax output zero_point")
+
+    _set_tensor_dtype_from_array(ctx, x_name, x_zero)
+    _set_tensor_dtype_from_array(ctx, output_name, y_zero)
+    _promote_internal_uint8_tensor_to_int8(ctx, x_name)
+    _promote_internal_uint8_tensor_to_int8(ctx, output_name)
+
+    input_rank = len(ctx.get_tensor_shape(x_name))
+    output_rank = len(ctx.get_tensor_shape(output_name))
+    axis = int(node.attrs.get("axis", 1))
+    axis = _normalize_axis(axis, input_rank)
+    if axis != input_rank - 1:
+        raise NotImplementedError(
+            "QLinearSoftmax supports axis=last only in flatbuffer_direct. "
+            f"op={node.name} axis={axis} input_rank={input_rank}"
+        )
+
+    _set_tensor_quantization(
+        ctx=ctx,
+        tensor_name=x_name,
+        scale=x_scale,
+        zero_point=x_zero,
+        quantized_dimension=0 if np.asarray(x_scale).size <= 1 else _normalize_axis(1, input_rank),
+    )
+    _set_tensor_quantization(
+        ctx=ctx,
+        tensor_name=output_name,
+        scale=y_scale,
+        zero_point=y_zero,
+        quantized_dimension=0 if np.asarray(y_scale).size <= 1 else _normalize_axis(1, output_rank),
+    )
+
+    dq_out = ctx.add_intermediate_tensor(
+        f"{node.name}_dq_out",
+        dtype="FLOAT32",
+        shape=ctx.get_tensor_shape(x_name),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="DEQUANTIZE",
+            inputs=[x_name],
+            outputs=[dq_out],
+        )
+    )
+
+    softmax_out = ctx.add_intermediate_tensor(
+        f"{node.name}_softmax_out",
+        dtype="FLOAT32",
+        shape=ctx.get_tensor_shape(x_name),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SOFTMAX",
+            inputs=[dq_out],
+            outputs=[softmax_out],
+            options={"beta": float(node.attrs.get("beta", 1.0))},
+        )
+    )
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="QUANTIZE",
+            inputs=[softmax_out],
             outputs=[output_name],
         )
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.12"
+version = "2.0.13"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
This PR consolidates `fix-fe` updates focused on INT8 conversion stability and op coverage in the `flatbuffer_direct` path.

## Main changes
- Added temporary `com.microsoft` domain supplementation for selected quantized ops during conversion/evaluation.
  - Targeted ops include `QLinearAdd`, `QLinearMul`, `QLinearConcat`, `QLinearAveragePool`, `QLinearGlobalAveragePool`, `QLinearSigmoid`, `QGemm`.
- Expanded quantized op support:
  - Added `QLinearAveragePool` implementation (`onnx2tf/ops/QLinearAveragePool.py`) and flatbuffer_direct lowering/validation.
  - Added `QGemm` implementation (`onnx2tf/ops/QGemm.py`) and flatbuffer_direct lowering/validation.
  - Added `QLinearSoftmax` support in flatbuffer_direct registry/validators.
- Improved `QLinearConv` behavior to align more closely with ONNX semantics:
  - Explicit padding handling via `PADV2` when needed.
  - Quantization axis handling cleanup for conv/depthwise weights.
- Improved pooling handling in flatbuffer_direct:
  - `MaxPool` padding/ceil_mode handling enhancements.
  - Quantization propagation fixes for pool intermediates/outputs.
- Switched `QLinearGlobalAveragePool` lowering to a stable path:
  - Use `DEQUANTIZE -> MEAN -> QUANTIZE` unconditionally (avoid `AVERAGE_POOL_2D` instability).
- Improved evaluation flow:
  - Unified ONNX/TFLite output check runner.
  - `-cotof` auto-triggers ONNX/TFLite check for flatbuffer_direct outputs.
- Added/updated layout and shape reconciliation optimizations in the lowerer.

## Validation
Executed:
- `python onnx2tf/onnx2tf.py -i handpose_estimation_mediapipe_2023feb_int8.onnx -cotof -tb flatbuffer_direct --report_op_coverage`

Observed:
- Conversion completed without native crash.
- Float32/Float16 tflite outputs generated.
- OP coverage report generated.
- ONNX/TFLite output check completed and report generated.

## Notes
- Accuracy check completion does not imply `pass=True`; this PR primarily targets conversion/runtime stability and op support/coverage.
