### PR TITLE
Enhance flatbuffer_direct stability: shape propagation, quantized fusion, BN/preprocess folding

### DIFF
--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.14'
+__version__ = '2.0.15'

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -12,6 +12,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     replace_parameter,
     convert_axis,
+    _is_output_nhwc_assumed,
     get_constant_or_variable,
     print_node_info,
     inverted_operation_enable_disable,
@@ -100,8 +101,10 @@ def make_node(
         if isinstance(const_or_var, gs.Variable):
             values.append(tf_layers_dict[const_or_var.name]['tf_node'])
             nhwc_flags.append(
-                tf_layers_dict[const_or_var.name]['nhwc'] \
-                    if 'nhwc' in tf_layers_dict[const_or_var.name].keys() else False
+                _is_output_nhwc_assumed(
+                    graph_node_input=const_or_var,
+                    tf_layers_dict=tf_layers_dict,
+                )
             )
             same_input_shape_as_onnxs.append(
                 is_same_shape(
@@ -212,8 +215,10 @@ def make_node(
     nhwc_judge = True
     for graph_node_input in graph_node.inputs:
         if isinstance(graph_node_input, gs.Variable) \
-            and 'nhwc' in tf_layers_dict[graph_node_input.name].keys() \
-            and tf_layers_dict[graph_node_input.name]['nhwc'] == True:
+            and _is_output_nhwc_assumed(
+                graph_node_input=graph_node_input,
+                tf_layers_dict=tf_layers_dict,
+            ):
                 nhwc_judge = nhwc_judge and True
         elif isinstance(graph_node_input, gs.Constant) \
             and hasattr(graph_node_input, 'values') \

--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -26,6 +26,7 @@ from onnx2tf.utils.common_functions import (
     get_tf_model_inputs,
     onnx_tf_tensor_validation,
     post_process_transpose,
+    _is_output_nhwc_assumed,
 )
 from typing import Any, Dict
 from onnx2tf.utils.logging import *
@@ -91,6 +92,12 @@ def make_node(
 
     input_tensor = tf_layers_dict[graph_node_input.name]['tf_node'] \
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
+    input_nhwc_assumed = False
+    if isinstance(graph_node_input, gs.Variable):
+        input_nhwc_assumed = _is_output_nhwc_assumed(
+            graph_node_input=graph_node_input,
+            tf_layers_dict=tf_layers_dict,
+        )
     input_weights = tf_layers_dict[input_weights.name]['tf_node'] \
         if isinstance(input_weights, gs.Variable) else input_weights
     input_bias = tf_layers_dict[input_bias.name]['tf_node'] \
@@ -100,6 +107,16 @@ def make_node(
     input_tensor_rank = len(input_tensor_shape)
     spatial_size = input_tensor_rank - 2
     input_weights_shape = input_weights.shape
+
+    def _to_static_int_dim(dim):
+        if isinstance(dim, int):
+            return int(dim)
+        try:
+            if dim is not None:
+                return int(dim)
+        except Exception:
+            pass
+        return None
     auto_pad = graph_node.attrs.get('auto_pad', 'NOTSET')
     dilations = graph_node.attrs.get('dilations', [1] * spatial_size)
     group = graph_node.attrs.get('group', 1)
@@ -138,7 +155,8 @@ def make_node(
     all_axes_same = False
     if onnx_input_shape is not None \
         and len(onnx_input_shape) > 1 and len(tf_input_shape) > 1 \
-        and onnx_input_shape == tf_input_shape:
+        and onnx_input_shape == tf_input_shape \
+        and not input_nhwc_assumed:
 
         shape_for_judging_skip = [
             dim if dim is not None else INF_INDEX_VALUE for dim in onnx_input_shape[1:]
@@ -219,6 +237,47 @@ def make_node(
                         graph_node_output.name: onnx_tensor_infos_for_validation[graph_node_output.name]
                     }
                     del onnx_tensor_infos_for_validation
+
+    # Refresh input geometry after potential transpose workaround above.
+    input_tensor_shape = input_tensor.shape
+    input_tensor_rank = len(input_tensor_shape)
+    spatial_size = input_tensor_rank - 2
+
+    # Pre-padding layout guard:
+    # If the tensor is still effectively NCHW-like, convert to NHWC before any
+    # explicit padding is applied. Padding in the wrong layout corrupts channels.
+    if input_tensor_rank == 4:
+        group_for_layout = _to_static_int_dim(graph_node.attrs.get('group', 1))
+        if group_for_layout is None or group_for_layout <= 0:
+            group_for_layout = 1
+        tf_in_ch = _to_static_int_dim(input_tensor_shape[-1])
+        nchw_in_ch = _to_static_int_dim(input_tensor_shape[1])
+        expected_in_ch = None
+
+        # Prefer ONNX weight shape [O, I, KH, KW] when available.
+        onnx_weight_shape = graph_node.inputs[1].shape \
+            if hasattr(graph_node.inputs[1], 'shape') else None
+        if onnx_weight_shape is not None and len(onnx_weight_shape) == 4:
+            onnx_in_ch_per_group = _to_static_int_dim(onnx_weight_shape[1])
+            if onnx_in_ch_per_group is not None:
+                expected_in_ch = int(onnx_in_ch_per_group) * int(group_for_layout)
+
+        # Fallback to current TF weight layout guess.
+        if expected_in_ch is None:
+            current_weight_shape = [_to_static_int_dim(v) for v in list(input_weights.shape)]
+            if len(current_weight_shape) == 4 and current_weight_shape[-2] is not None:
+                expected_in_ch = int(current_weight_shape[-2]) * int(group_for_layout)
+
+        if tf_in_ch is not None and nchw_in_ch is not None and expected_in_ch is not None:
+            if tf_in_ch != expected_in_ch and nchw_in_ch == expected_in_ch:
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
+                    perm=[0, 2, 3, 1],
+                    **kwargs,
+                )
+                input_tensor_shape = input_tensor.shape
+                input_tensor_rank = len(input_tensor_shape)
+                spatial_size = input_tensor_rank - 2
     """
     Conv1D
     Conv2D
@@ -253,6 +312,9 @@ def make_node(
                 x=input_tensor,
                 pads=pads,
             )
+            input_tensor_shape = input_tensor.shape
+            input_tensor_rank = len(input_tensor_shape)
+            spatial_size = input_tensor_rank - 2
             pad_mode = 'VALID'
             padded = True
         else:
@@ -290,16 +352,116 @@ def make_node(
     if depthwise and input_tensor_shape[-1] != None:
         depthwise = bool(group == input_tensor_shape[-1])
 
-    if depthwise is True:
-        depthwise_filter_shape = list(input_weights_shape[0:2]) + [-1, input_weights_shape[3] // group]
-        input_weights = tf.reshape(input_weights, depthwise_filter_shape)
-
     input_weights = input_weights \
         if not isinstance(input_weights, np.ndarray) \
             else tf.convert_to_tensor(input_weights)
     input_bias = input_bias \
         if not isinstance(input_bias, np.ndarray) \
             else tf.convert_to_tensor(input_bias)
+
+    # Dynamic/variable Conv weights can arrive in ONNX layout (OI...).
+    # If spatial axes indicate OI... and not HW...IO, transpose once to TF layout.
+    def _to_int_or_none(dim: Any):
+        if dim is None:
+            return None
+        try:
+            return int(dim)
+        except Exception:
+            return None
+
+    def _spatial_match(shape_a: list, shape_b: list) -> bool:
+        if len(shape_a) != len(shape_b):
+            return False
+        for da, db in zip(shape_a, shape_b):
+            if da is None or db is None:
+                continue
+            if int(da) != int(db):
+                return False
+        return True
+
+    expected_spatial = []
+    if isinstance(kernel_shape, (list, tuple)) and len(kernel_shape) > 0:
+        expected_spatial = [_to_int_or_none(v) for v in kernel_shape]
+    elif hasattr(graph_node.inputs[1], 'shape') and graph_node.inputs[1].shape is not None:
+        weight_shape_onnx = [
+            _to_int_or_none(v) if not isinstance(v, str) else None
+            for v in list(graph_node.inputs[1].shape)
+        ]
+        if len(weight_shape_onnx) >= 3:
+            expected_spatial = list(weight_shape_onnx[2:])
+
+    input_weights_shape = [_to_int_or_none(v) for v in list(input_weights.shape)]
+    if len(input_weights_shape) >= 3 and len(expected_spatial) == len(input_weights_shape) - 2:
+        spatial_rank = len(expected_spatial)
+        hwio_spatial = list(input_weights_shape[:spatial_rank])
+        oix_spatial = list(input_weights_shape[2:])
+        oix_like = _spatial_match(oix_spatial, expected_spatial)
+        hwio_like = _spatial_match(hwio_spatial, expected_spatial)
+        if oix_like and not hwio_like:
+            weight_perm = [i for i in range(2, len(input_weights_shape))] + [1, 0]
+            input_weights = tf.transpose(input_weights, perm=weight_perm)
+            input_weights_shape = [_to_int_or_none(v) for v in list(input_weights.shape)]
+
+    if depthwise is True:
+        # Depthwise filter for TF must be [H, W, in_channels, channel_multiplier].
+        # Depending on the upstream path, weights may already be in this format.
+        # Reshape only when the current layout is clearly [H, W, 1, out_channels].
+        weight_in_ch = _to_static_int_dim(input_weights_shape[2]) \
+            if len(input_weights_shape) >= 3 else None
+        weight_out_ch = _to_static_int_dim(input_weights_shape[3]) \
+            if len(input_weights_shape) >= 4 else None
+        input_ch = _to_static_int_dim(input_tensor_shape[-1]) \
+            if len(input_tensor_shape) >= 1 else None
+        group_dim = _to_static_int_dim(group)
+        if group_dim is None or group_dim <= 0:
+            group_dim = 1
+
+        # Already depthwise-formatted.
+        if input_ch is not None and weight_in_ch == input_ch:
+            pass
+        else:
+            channel_multiplier = None
+            if input_ch is not None \
+                and weight_in_ch == 1 \
+                and weight_out_ch is not None \
+                and input_ch > 0 \
+                and weight_out_ch % input_ch == 0:
+                channel_multiplier = weight_out_ch // input_ch
+            elif weight_in_ch == 1 \
+                and weight_out_ch is not None \
+                and group_dim > 0 \
+                and weight_out_ch % group_dim == 0:
+                channel_multiplier = weight_out_ch // group_dim
+
+            if channel_multiplier is not None and channel_multiplier > 0:
+                depthwise_filter_shape = list(input_weights_shape[0:2]) + [-1, channel_multiplier]
+                input_weights = tf.reshape(input_weights, depthwise_filter_shape)
+                input_weights_shape = [_to_int_or_none(v) for v in list(input_weights.shape)]
+
+    # Additional layout guard:
+    # Some branches can reach Conv with NCHW-like tensors even when Conv runs
+    # in NHWC. Correct only when channel mismatch is unambiguous.
+    input_tensor_shape = input_tensor.shape
+    input_tensor_rank = len(input_tensor_shape)
+    if not padded and input_tensor_rank == 4 and len(input_weights_shape) == 4:
+        group = graph_node.attrs.get('group', 1)
+        group = _to_static_int_dim(group)
+        if group is None or group <= 0:
+            group = 1
+        tf_in_ch = _to_static_int_dim(input_tensor_shape[-1])
+        nchw_in_ch = _to_static_int_dim(input_tensor_shape[1])
+        filt_in_ch_per_group = _to_static_int_dim(input_weights_shape[-2])
+        expected_in_ch = None
+        if filt_in_ch_per_group is not None:
+            expected_in_ch = int(filt_in_ch_per_group) * int(group)
+        if tf_in_ch is not None and nchw_in_ch is not None and expected_in_ch is not None:
+            if tf_in_ch != expected_in_ch and nchw_in_ch == expected_in_ch:
+                input_tensor = transpose_with_flexing_deterrence(
+                    input_tensor=input_tensor,
+                    perm=[0, 2, 3, 1],
+                    **kwargs,
+                )
+                input_tensor_shape = input_tensor.shape
 
 
     def conv_bias(input_tensor, input_weights, strides, pad_mode, dilations, input_bias):

--- a/onnx2tf/ops/DequantizeLinear.py
+++ b/onnx2tf/ops/DequantizeLinear.py
@@ -13,6 +13,7 @@ from onnx2tf.utils.common_functions import (
     get_replacement_parameter,
     pre_process_transpose,
     post_process_transpose,
+    _is_output_nhwc_assumed,
 )
 
 def _expand_scale_or_zero_point(
@@ -104,7 +105,10 @@ def make_node(
     input_nhwc = False
     if isinstance(graph_node_input_1, gs.Variable):
         input_is_dequantized = tf_layers_dict.get(graph_node_input_1.name, {}).get('is_dequantized', False)
-        input_nhwc = tf_layers_dict.get(graph_node_input_1.name, {}).get('nhwc', False)
+        input_nhwc = _is_output_nhwc_assumed(
+            graph_node_input=graph_node_input_1,
+            tf_layers_dict=tf_layers_dict,
+        )
 
     # Pre-process transpose
     input_tensor = pre_process_transpose(

--- a/onnx2tf/ops/QLinearAdd.py
+++ b/onnx2tf/ops/QLinearAdd.py
@@ -9,6 +9,7 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    pre_explicit_broadcast,
     nhwc_determination_of_output_value_of_binary_input_op,
 )
 
@@ -118,6 +119,10 @@ def make_node(
     # dequantize a and b
     dequantized_a = tf.multiply(a_scale, tf.subtract(a, a_zero_point))
     dequantized_b = tf.multiply(b_scale, tf.subtract(b, b_zero_point))
+    dequantized_a, dequantized_b = pre_explicit_broadcast(
+        input_tensor_1=dequantized_a,
+        input_tensor_2=dequantized_b,
+    )
     dequantized_ab = tf.add(dequantized_a, dequantized_b)
     dequantized_abc = tf.add(tf.divide(dequantized_ab, c_scale), c_zero_point)
 

--- a/onnx2tf/ops/QLinearAveragePool.py
+++ b/onnx2tf/ops/QLinearAveragePool.py
@@ -135,9 +135,8 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': True,
     }
-    if x_nhwc:
-        tf_layers_dict[graph_node_output.name]['nhwc'] = True
 
     # Generation of TF OP
     x = tf.cast(x, tf.float32)

--- a/onnx2tf/ops/QLinearGlobalAveragePool.py
+++ b/onnx2tf/ops/QLinearGlobalAveragePool.py
@@ -98,9 +98,8 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': True,
     }
-    if x_nhwc:
-        tf_layers_dict[graph_node_output.name]['nhwc'] = True
 
     # Generation of TF OP
     x = tf.cast(x, tf.float32)

--- a/onnx2tf/ops/QLinearLeakyRelu.py
+++ b/onnx2tf/ops/QLinearLeakyRelu.py
@@ -64,6 +64,9 @@ def make_node(
 
     x = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    input_nhwc = False
+    if isinstance(graph_node_input_1, gs.Variable):
+        input_nhwc = tf_layers_dict.get(graph_node_input_1.name, {}).get('nhwc', False)
     x_scale = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
     x_zero_point = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
@@ -79,6 +82,7 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': input_nhwc,
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/QLinearMul.py
+++ b/onnx2tf/ops/QLinearMul.py
@@ -9,6 +9,7 @@ from onnx2tf.utils.common_functions import (
     print_node_info,
     inverted_operation_enable_disable,
     make_tf_node_info,
+    nhwc_determination_of_output_value_of_binary_input_op,
 )
 
 
@@ -97,6 +98,12 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': \
+            nhwc_determination_of_output_value_of_binary_input_op(
+                graph_node_input_1=graph_node_input_1,
+                graph_node_input_2=graph_node_input_4,
+                tf_layers_dict=tf_layers_dict,
+            ),
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/QLinearSigmoid.py
+++ b/onnx2tf/ops/QLinearSigmoid.py
@@ -61,6 +61,9 @@ def make_node(
 
     x = tf_layers_dict[graph_node_input_1.name]['tf_node'] \
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
+    input_nhwc = False
+    if isinstance(graph_node_input_1, gs.Variable):
+        input_nhwc = tf_layers_dict.get(graph_node_input_1.name, {}).get('nhwc', False)
     x_scale = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2
     x_zero_point = tf_layers_dict[graph_node_input_3.name]['tf_node'] \
@@ -76,6 +79,7 @@ def make_node(
         'optype': graph_node.op,
         'shape': shape,
         'dtype': dtype,
+        'nhwc': input_nhwc,
     }
 
     # Generation of TF OP

--- a/onnx2tf/ops/QuantizeLinear.py
+++ b/onnx2tf/ops/QuantizeLinear.py
@@ -10,6 +10,7 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
     convert_axis,
+    _is_output_nhwc_assumed,
 )
 from onnx2tf.utils.enums import ONNX_DTYPES_TO_TF_DTYPES
 
@@ -105,7 +106,10 @@ def make_node(
         if isinstance(graph_node_input_1, gs.Variable) else graph_node_input_1
     input_nhwc = False
     if isinstance(graph_node_input_1, gs.Variable):
-        input_nhwc = tf_layers_dict.get(graph_node_input_1.name, {}).get('nhwc', False)
+        input_nhwc = _is_output_nhwc_assumed(
+            graph_node_input=graph_node_input_1,
+            tf_layers_dict=tf_layers_dict,
+        )
     input_tensor_rank = len(input_tensor.shape)
     y_scale = tf_layers_dict[graph_node_input_2.name]['tf_node'] \
         if isinstance(graph_node_input_2, gs.Variable) else graph_node_input_2

--- a/onnx2tf/ops/Transpose.py
+++ b/onnx2tf/ops/Transpose.py
@@ -13,7 +13,47 @@ from onnx2tf.utils.common_functions import (
     inverted_operation_enable_disable,
     make_tf_node_info,
     transpose_with_flexing_deterrence,
+    _is_output_nhwc_assumed,
 )
+
+
+_LAYOUT_PRESERVING_CONSUMER_OPS = {
+    'Add',
+    'Sub',
+    'Mul',
+    'Div',
+    'Min',
+    'Max',
+    'Where',
+    'Relu',
+    'Clip',
+    'HardSwish',
+    'LeakyRelu',
+    'Sigmoid',
+    'Tanh',
+    'Exp',
+    'Sqrt',
+    'Neg',
+    'Abs',
+    'Sign',
+    'Floor',
+    'Ceil',
+    'Round',
+    'Identity',
+    'Cast',
+}
+
+
+def _channel_first_to_last_perm(rank: int):
+    if rank <= 2:
+        return [i for i in range(rank)]
+    return [0] + [i for i in range(2, rank)] + [1]
+
+
+def _channel_last_to_first_perm(rank: int):
+    if rank <= 2:
+        return [i for i in range(rank)]
+    return [0, rank - 1] + [i for i in range(1, rank - 1)]
 
 
 @print_node_info
@@ -52,6 +92,14 @@ def make_node(
         if isinstance(graph_node_input, gs.Variable) else graph_node_input
     input_tensor_shape = input_tensor.shape
     tensor_rank = len(input_tensor_shape)
+    identity_perm = [i for i in range(tensor_rank)]
+    cfirst_to_clast = _channel_first_to_last_perm(tensor_rank)
+    clast_to_cfirst = _channel_last_to_first_perm(tensor_rank)
+    input_nhwc_assumed = \
+        _is_output_nhwc_assumed(
+            graph_node_input=graph_node_input,
+            tf_layers_dict=tf_layers_dict,
+        ) if isinstance(graph_node_input, gs.Variable) else False
 
     perm = graph_node.attrs.get('perm', [idx for idx in reversed(range(tensor_rank))])
 
@@ -159,17 +207,35 @@ def make_node(
                                     break
                     perm = new_perm
 
+    perm = list(perm) if perm is not None else identity_perm
+
+    # Suppress redundant layout flips around layout-preserving ops.
+    # Case 1: input is already channel-last and perm asks C-first->C-last.
+    #         This transpose is redundant and can be identity.
+    if input_nhwc_assumed and perm == cfirst_to_clast:
+        perm = identity_perm
+    # Case 2: input is channel-last and perm asks C-last->C-first.
+    #         Keep identity only when all direct consumers are layout-preserving.
+    elif input_nhwc_assumed and perm == clast_to_cfirst:
+        try:
+            direct_consumers = list(graph_node_output.outputs)
+        except Exception:
+            direct_consumers = []
+        if len(direct_consumers) > 0 and all(
+            str(getattr(consumer, 'op', '')) in _LAYOUT_PRESERVING_CONSUMER_OPS
+            for consumer in direct_consumers
+        ):
+            perm = identity_perm
+
     # Preserving Graph Structure (Dict)
-    nwhc = False
     if nwc_nhwc_ndhwc_keep:
         nhwc = True
-    elif isinstance(graph_node_input, gs.Variable) \
-        and 'nhwc' in tf_layers_dict[graph_node_input.name].keys():
-        nhwc = tf_layers_dict[graph_node_input.name]['nhwc']
-        if nhwc and not before_op_output_shape_trans and perm == [i for i in range(len(input_tensor_shape))]:
-            nhwc = True
-        else:
-            nhwc = False
+    elif perm == identity_perm:
+        nhwc = bool(input_nhwc_assumed)
+    elif perm == cfirst_to_clast:
+        nhwc = True
+    elif perm == clast_to_cfirst:
+        nhwc = False
     else:
         nhwc = False
 
@@ -180,8 +246,6 @@ def make_node(
         'nhwc': nhwc,
         'nwc_nhwc_ndhwc_keep': nwc_nhwc_ndhwc_keep,
     }
-
-    perm = list(perm) if perm is not None else None
 
     if not enable_space_to_depth:
         # Transpose

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -1,6 +1,7 @@
 from onnx2tf.tflite_builder.op_builders.elementwise import (
     build_binary_op,
     build_clip_op,
+    build_hardsigmoid_op,
     build_logistic_op,
     build_prelu_op,
     build_softmax_op,
@@ -10,9 +11,11 @@ from onnx2tf.tflite_builder.op_builders.shape import (
     build_concat_op,
     build_flatten_op,
     build_identity_op,
+    build_pad_op,
     build_resize_op,
     build_reshape_op,
     build_slice_op,
+    build_split_op,
     build_space_to_depth_op,
     build_squeeze_op,
     build_transpose_op,
@@ -20,12 +23,14 @@ from onnx2tf.tflite_builder.op_builders.shape import (
 )
 from onnx2tf.tflite_builder.op_builders.conv import (
     build_conv2d_or_depthwise_op,
+    build_conv_transpose_op,
 )
 from onnx2tf.tflite_builder.op_builders.pool import (
     build_pool2d_op,
 )
 from onnx2tf.tflite_builder.op_builders.fc import (
     build_fully_connected_from_gemm_or_matmul,
+    build_matmul_op,
 )
 from onnx2tf.tflite_builder.op_builders.reduce import (
     build_reduce_op,
@@ -48,6 +53,7 @@ from onnx2tf.tflite_builder.op_builders.quantized import (
     build_qlinear_concat_op,
     build_qlinear_conv_op,
     build_qlinear_global_average_pool_op,
+    build_qlinear_leaky_relu_op,
     build_qlinear_matmul_op,
     build_qlinear_mul_op,
     build_qlinear_sigmoid_op,
@@ -58,6 +64,7 @@ from onnx2tf.tflite_builder.op_builders.quantized import (
 __all__ = [
     "build_binary_op",
     "build_clip_op",
+    "build_hardsigmoid_op",
     "build_logistic_op",
     "build_prelu_op",
     "build_softmax_op",
@@ -65,16 +72,20 @@ __all__ = [
     "build_concat_op",
     "build_flatten_op",
     "build_identity_op",
+    "build_pad_op",
     "build_resize_op",
     "build_reshape_op",
     "build_slice_op",
+    "build_split_op",
     "build_space_to_depth_op",
     "build_squeeze_op",
     "build_transpose_op",
     "build_unsqueeze_op",
     "build_conv2d_or_depthwise_op",
+    "build_conv_transpose_op",
     "build_pool2d_op",
     "build_fully_connected_from_gemm_or_matmul",
+    "build_matmul_op",
     "build_reduce_op",
     "build_gather_op",
     "build_batch_normalization_op",
@@ -87,6 +98,7 @@ __all__ = [
     "build_qlinear_concat_op",
     "build_qlinear_conv_op",
     "build_qlinear_global_average_pool_op",
+    "build_qlinear_leaky_relu_op",
     "build_qlinear_matmul_op",
     "build_qlinear_mul_op",
     "build_qlinear_sigmoid_op",

--- a/onnx2tf/tflite_builder/op_builders/conv.py
+++ b/onnx2tf/tflite_builder/op_builders/conv.py
@@ -8,6 +8,575 @@ from onnx2tf.tflite_builder.ir import OperatorIR
 from onnx2tf.tflite_builder.op_builders.shared import make_transpose, resolve_padding
 
 
+def _dummy_input_from_ort_meta(meta: Any) -> np.ndarray:
+    shape = []
+    for dim in list(getattr(meta, "shape", [])):
+        if isinstance(dim, int) and dim > 0:
+            shape.append(int(dim))
+        else:
+            shape.append(1)
+    type_str = str(getattr(meta, "type", "tensor(float)")).lower()
+    if "float16" in type_str:
+        dtype = np.float16
+    elif "float" in type_str:
+        dtype = np.float32
+    elif "int64" in type_str:
+        dtype = np.int64
+    elif "int32" in type_str:
+        dtype = np.int32
+    elif "int16" in type_str:
+        dtype = np.int16
+    elif "int8" in type_str:
+        dtype = np.int8
+    elif "uint8" in type_str:
+        dtype = np.uint8
+    elif "bool" in type_str:
+        dtype = np.bool_
+    else:
+        dtype = np.float32
+    return np.zeros(shape, dtype=dtype)
+
+
+def _infer_convtranspose_io_shapes_with_onnxruntime(
+    *,
+    ctx: Any,
+    input_name: str,
+    output_name: str,
+) -> tuple[list[int] | None, list[int] | None]:
+    onnx_model = getattr(ctx, "onnx_model", None)
+    if onnx_model is None:
+        return None, None
+    try:
+        import onnx
+        import onnxruntime as ort
+    except Exception:
+        return None, None
+    try:
+        work_model = onnx.ModelProto()
+        work_model.CopyFrom(onnx_model)
+        existing_outputs = {str(v.name) for v in list(work_model.graph.output)}
+        for tensor_name in [input_name, output_name]:
+            if str(tensor_name) in existing_outputs:
+                continue
+            work_model.graph.output.append(
+                onnx.helper.make_tensor_value_info(
+                    str(tensor_name),
+                    onnx.TensorProto.FLOAT,
+                    None,
+                )
+            )
+        sess = ort.InferenceSession(
+            work_model.SerializeToString(),
+            providers=["CPUExecutionProvider"],
+        )
+        feed = {
+            inp.name: _dummy_input_from_ort_meta(inp)
+            for inp in sess.get_inputs()
+        }
+        outputs = sess.run([str(input_name), str(output_name)], feed)
+        input_shape = [int(v) for v in list(np.asarray(outputs[0]).shape)]
+        output_shape = [int(v) for v in list(np.asarray(outputs[1]).shape)]
+        return input_shape, output_shape
+    except Exception:
+        return None, None
+
+
+def _infer_conv_transpose_output_shape_nchw(
+    *,
+    node: Any,
+    input_shape_nchw: list[int],
+    weights: np.ndarray,
+) -> list[int]:
+    group = int(node.attrs.get("group", 1))
+    kernel_shape_attr = node.attrs.get("kernel_shape", None)
+    if kernel_shape_attr is None:
+        kernel_h = int(weights.shape[2])
+        kernel_w = int(weights.shape[3])
+    else:
+        kernel_h, kernel_w = [int(v) for v in list(kernel_shape_attr)]
+    strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
+    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
+    pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+    output_padding = [int(v) for v in list(node.attrs.get("output_padding", [0, 0]))]
+
+    in_n = int(input_shape_nchw[0])
+    in_h = int(input_shape_nchw[2])
+    in_w = int(input_shape_nchw[3])
+    out_c = int(weights.shape[1]) * int(group)
+
+    eff_kh = (kernel_h - 1) * int(dilations[0]) + 1
+    eff_kw = (kernel_w - 1) * int(dilations[1]) + 1
+    out_h = int(strides[0]) * (in_h - 1) + eff_kh + int(output_padding[0]) - int(pads[0]) - int(pads[2])
+    out_w = int(strides[1]) * (in_w - 1) + eff_kw + int(output_padding[1]) - int(pads[1]) - int(pads[3])
+    return [in_n, out_c, out_h, out_w]
+
+
+def _infer_rank4_conv_output_signature(
+    *,
+    input_signature_nchw: list[int],
+    output_shape_nchw: list[int],
+    existing_output_signature_nchw: list[int] | None = None,
+) -> list[int]:
+    signature = [int(v) for v in list(output_shape_nchw)]
+    if len(signature) != 4:
+        return signature
+    if existing_output_signature_nchw is not None and len(existing_output_signature_nchw) == 4:
+        for axis in range(4):
+            if int(existing_output_signature_nchw[axis]) < 0:
+                signature[axis] = -1
+    if len(input_signature_nchw) == 4:
+        if int(input_signature_nchw[0]) < 0:
+            signature[0] = -1
+        if int(input_signature_nchw[2]) < 0:
+            signature[2] = -1
+        if int(input_signature_nchw[3]) < 0:
+            signature[3] = -1
+    return [int(v) for v in signature]
+
+
+def _resolve_conv_transpose_padding(node: Any) -> str:
+    auto_pad_raw = node.attrs.get("auto_pad", "NOTSET")
+    auto_pad = (
+        auto_pad_raw.decode("utf-8")
+        if isinstance(auto_pad_raw, (bytes, bytearray))
+        else str(auto_pad_raw)
+    )
+    auto_pad = str(auto_pad).upper()
+    if auto_pad in ["SAME_UPPER", "SAME_LOWER"]:
+        return "SAME"
+    if auto_pad in ["VALID", "NOTSET"]:
+        pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+        if len(pads) == 4 and sum(abs(int(v)) for v in pads) == 0:
+            return "VALID"
+    raise NotImplementedError(
+        "ConvTranspose currently supports auto_pad=SAME_* or zero pads with auto_pad in {NOTSET,VALID}. "
+        f"op={node.name} auto_pad={auto_pad_raw} pads={node.attrs.get('pads', [0,0,0,0])}"
+    )
+
+
+def build_conv_transpose_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    weight_name = node.inputs[1].name
+    output_name = node.outputs[0].name
+
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(weight_name)
+    ctx.ensure_tensor(output_name)
+
+    input_tensor = ctx.model_ir.tensors[input_name]
+    output_tensor = ctx.model_ir.tensors[output_name]
+
+    input_shape = [int(v) for v in list(ctx.get_tensor_shape(input_name))]
+    output_shape = [int(v) for v in list(ctx.get_tensor_shape(output_name))]
+    input_signature = (
+        [int(v) for v in list(input_tensor.shape_signature)]
+        if input_tensor.shape_signature is not None
+        else [int(v) for v in list(input_shape)]
+    )
+    output_signature = (
+        [int(v) for v in list(output_tensor.shape_signature)]
+        if output_tensor.shape_signature is not None
+        else [int(v) for v in list(output_shape)]
+    )
+    original_input_signature = [int(v) for v in list(input_signature)]
+    original_output_signature = [int(v) for v in list(output_signature)]
+
+    def _shape_from_rank4_signature(signature: list[int]) -> list[int] | None:
+        if len(signature) != 4:
+            return None
+        return [int(v) if int(v) > 0 else 1 for v in list(signature)]
+
+    rank4_input_from_signature = _shape_from_rank4_signature(input_signature)
+    if len(input_shape) != 4 and rank4_input_from_signature is not None:
+        input_shape = [int(v) for v in list(rank4_input_from_signature)]
+        input_tensor.shape = [int(v) for v in list(input_shape)]
+
+    rank4_output_from_signature = _shape_from_rank4_signature(output_signature)
+    if len(output_shape) != 4 and rank4_output_from_signature is not None:
+        output_shape = [int(v) for v in list(rank4_output_from_signature)]
+        output_tensor.shape = [int(v) for v in list(output_shape)]
+
+    if len(input_shape) != 4 or len(output_shape) != 4:
+        inferred_input_shape, inferred_output_shape = _infer_convtranspose_io_shapes_with_onnxruntime(
+            ctx=ctx,
+            input_name=input_name,
+            output_name=output_name,
+        )
+        if inferred_input_shape is not None and len(inferred_input_shape) == 4:
+            input_shape = [int(v) for v in list(inferred_input_shape)]
+            input_tensor.shape = [int(v) for v in list(input_shape)]
+            if len(input_signature) == 4:
+                input_tensor.shape_signature = [int(v) for v in list(input_signature)]
+            else:
+                input_tensor.shape_signature = [int(v) for v in list(inferred_input_shape)]
+        if inferred_output_shape is not None and len(inferred_output_shape) == 4:
+            output_shape = [int(v) for v in list(inferred_output_shape)]
+            output_tensor.shape = [int(v) for v in list(output_shape)]
+            if len(output_signature) == 4:
+                output_tensor.shape_signature = [int(v) for v in list(output_signature)]
+            else:
+                output_tensor.shape_signature = [int(v) for v in list(inferred_output_shape)]
+    if len(input_shape) != 4:
+        raise NotImplementedError(
+            f"ConvTranspose supports rank-4 input only in flatbuffer_direct. op={node.name} input_shape={input_shape}"
+        )
+
+    if len(original_input_signature) != 4:
+        input_signature = [int(input_shape[0]), int(input_shape[1]), -1, -1]
+        input_tensor.shape_signature = [int(v) for v in list(input_signature)]
+    else:
+        input_signature = (
+            [int(v) for v in list(input_tensor.shape_signature)]
+            if input_tensor.shape_signature is not None
+            else [int(v) for v in list(input_shape)]
+        )
+
+    weights = ctx.get_constant_array(weight_name)
+    if weights is None:
+        raise NotImplementedError(
+            f"ConvTranspose weights must be constant for flatbuffer_direct. op={node.name}"
+        )
+    weights = np.asarray(weights)
+    if weights.ndim != 4:
+        raise NotImplementedError(
+            f"ConvTranspose weight rank must be 4. op={node.name} weight_shape={list(weights.shape)}"
+        )
+
+    group = int(node.attrs.get("group", 1))
+    if group != 1:
+        raise NotImplementedError(
+            f"ConvTranspose currently supports group=1 only. op={node.name} group={group}"
+        )
+    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
+    if dilations != [1, 1]:
+        raise NotImplementedError(
+            f"ConvTranspose dilations must be [1,1] in flatbuffer_direct. op={node.name} dilations={dilations}"
+        )
+    output_padding = [int(v) for v in list(node.attrs.get("output_padding", [0, 0]))]
+    if any(v != 0 for v in output_padding):
+        raise NotImplementedError(
+            f"ConvTranspose output_padding must be [0,0] in flatbuffer_direct. op={node.name} output_padding={output_padding}"
+        )
+
+    output_shape = [int(v) for v in list(ctx.get_tensor_shape(output_name))]
+    if len(output_shape) != 4:
+        output_shape = _infer_conv_transpose_output_shape_nchw(
+            node=node,
+            input_shape_nchw=input_shape,
+            weights=weights,
+        )
+        output_tensor.shape = [int(v) for v in list(output_shape)]
+        if len(output_signature) == 4:
+            output_tensor.shape_signature = [int(v) for v in list(output_signature)]
+        else:
+            output_tensor.shape_signature = [int(v) for v in list(output_shape)]
+    output_shape = [int(v) for v in list(output_shape)]
+
+    if any(int(v) <= 0 for v in output_shape):
+        raise NotImplementedError(
+            f"ConvTranspose requires static positive output shape in flatbuffer_direct. op={node.name} output_shape={output_shape}"
+        )
+
+    if len(original_output_signature) != 4:
+        output_signature = [int(output_shape[0]), int(output_shape[1]), -1, -1]
+        output_tensor.shape_signature = [int(v) for v in list(output_signature)]
+    else:
+        output_signature = (
+            [int(v) for v in list(output_tensor.shape_signature)]
+            if output_tensor.shape_signature is not None
+            else [int(v) for v in list(output_shape)]
+        )
+
+    # ONNX ConvTranspose weights are [C_in, C_out/group, kH, kW].
+    # TFLite TRANSPOSE_CONV expects [C_out, kH, kW, C_in].
+    w_deconv = np.transpose(weights, (1, 2, 3, 0)).astype(np.float32)
+    w_name = ctx.add_const_tensor(
+        f"{node.name}_transpose_conv_filter",
+        w_deconv,
+    )
+
+    nhwc_input_shape = [int(input_shape[0]), int(input_shape[2]), int(input_shape[3]), int(input_shape[1])]
+    nhwc_output_shape = [int(output_shape[0]), int(output_shape[2]), int(output_shape[3]), int(output_shape[1])]
+
+    x_nhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_input_nhwc",
+        dtype=ctx.get_tensor_dtype(input_name),
+        shape=nhwc_input_shape,
+    )
+    x_nhwc = make_transpose(
+        ctx,
+        input_name,
+        x_nhwc,
+        [0, 2, 3, 1],
+        allow_elide_inverse_chain=True,
+    )
+
+    use_dynamic_output_shape = (
+        len(original_output_signature) != 4
+        or any(int(v) <= 0 for v in list(original_output_signature))
+    )
+    if use_dynamic_output_shape:
+        kernel_shape_attr = node.attrs.get("kernel_shape", None)
+        if kernel_shape_attr is None:
+            kernel_h = int(weights.shape[2])
+            kernel_w = int(weights.shape[3])
+        else:
+            kernel_h, kernel_w = [int(v) for v in list(kernel_shape_attr)]
+        pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
+        eff_kh = (int(kernel_h) - 1) * int(dilations[0]) + 1
+        eff_kw = (int(kernel_w) - 1) * int(dilations[1]) + 1
+        adjust_h = int(eff_kh + int(output_padding[0]) - int(pads[0]) - int(pads[2]))
+        adjust_w = int(eff_kw + int(output_padding[1]) - int(pads[1]) - int(pads[3]))
+
+        shape_vec = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_input_shape_vec",
+            dtype="INT32",
+            shape=[4],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SHAPE",
+                inputs=[x_nhwc],
+                outputs=[shape_vec],
+                options={"outType": "INT32"},
+            )
+        )
+
+        def _slice_dim(idx: int, suffix: str) -> str:
+            begin_name = ctx.add_const_tensor(
+                f"{node.name}_transpose_conv_shape_begin_{suffix}",
+                np.asarray([int(idx)], dtype=np.int32),
+            )
+            size_name = ctx.add_const_tensor(
+                f"{node.name}_transpose_conv_shape_size_{suffix}",
+                np.asarray([1], dtype=np.int32),
+            )
+            out_name = ctx.add_intermediate_tensor(
+                f"{node.name}_transpose_conv_dim_{suffix}",
+                dtype="INT32",
+                shape=[1],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[shape_vec, begin_name, size_name],
+                    outputs=[out_name],
+                )
+            )
+            return out_name
+
+        n_vec = _slice_dim(0, "n")
+        h_vec = _slice_dim(1, "h")
+        w_vec = _slice_dim(2, "w")
+        one_vec = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_one",
+            np.asarray([1], dtype=np.int32),
+        )
+        stride_h_vec = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_stride_h",
+            np.asarray([int(dilations[0] * 0 + node.attrs.get('strides', [1, 1])[0])], dtype=np.int32),
+        )
+        stride_w_vec = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_stride_w",
+            np.asarray([int(dilations[1] * 0 + node.attrs.get('strides', [1, 1])[1])], dtype=np.int32),
+        )
+        adjust_h_vec = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_adjust_h",
+            np.asarray([int(adjust_h)], dtype=np.int32),
+        )
+        adjust_w_vec = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_adjust_w",
+            np.asarray([int(adjust_w)], dtype=np.int32),
+        )
+        out_c_vec = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_out_c",
+            np.asarray([int(nhwc_output_shape[3])], dtype=np.int32),
+        )
+
+        h_minus_one = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_h_minus_one",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SUB",
+                inputs=[h_vec, one_vec],
+                outputs=[h_minus_one],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        h_scaled = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_h_scaled",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MUL",
+                inputs=[h_minus_one, stride_h_vec],
+                outputs=[h_scaled],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        out_h_vec = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_out_h",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="ADD",
+                inputs=[h_scaled, adjust_h_vec],
+                outputs=[out_h_vec],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+
+        w_minus_one = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_w_minus_one",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SUB",
+                inputs=[w_vec, one_vec],
+                outputs=[w_minus_one],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        w_scaled = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_w_scaled",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MUL",
+                inputs=[w_minus_one, stride_w_vec],
+                outputs=[w_scaled],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        out_w_vec = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_out_w",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="ADD",
+                inputs=[w_scaled, adjust_w_vec],
+                outputs=[out_w_vec],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+
+        out_shape_name = ctx.add_intermediate_tensor(
+            f"{node.name}_transpose_conv_output_shape",
+            dtype="INT32",
+            shape=[4],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CONCATENATION",
+                inputs=[n_vec, out_h_vec, out_w_vec, out_c_vec],
+                outputs=[out_shape_name],
+                options={
+                    "axis": 0,
+                    "fusedActivationFunction": "NONE",
+                },
+            )
+        )
+    else:
+        out_shape_name = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_output_shape",
+            np.asarray(nhwc_output_shape, dtype=np.int32),
+        )
+
+    y_nhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_output_nhwc",
+        dtype=ctx.get_tensor_dtype(output_name),
+        shape=nhwc_output_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="TRANSPOSE_CONV",
+            inputs=[out_shape_name, w_name, x_nhwc],
+            outputs=[y_nhwc],
+            options={
+                "padding": _resolve_conv_transpose_padding(node),
+                "strideH": int(node.attrs.get("strides", [1, 1])[0]),
+                "strideW": int(node.attrs.get("strides", [1, 1])[1]),
+            },
+        )
+    )
+
+    y_final_nhwc = y_nhwc
+    if len(node.inputs) >= 3:
+        bias_name = node.inputs[2].name
+        bias_values = ctx.get_constant_array(bias_name)
+        if bias_values is None:
+            raise NotImplementedError(
+                f"ConvTranspose bias must be constant when provided. op={node.name}"
+            )
+        bias_values = np.asarray(bias_values, dtype=np.float32).reshape(-1)
+        out_channels = int(nhwc_output_shape[3])
+        if int(bias_values.size) != out_channels:
+            raise NotImplementedError(
+                f"ConvTranspose bias size must match output channels. "
+                f"op={node.name} bias_size={int(bias_values.size)} out_channels={out_channels}"
+            )
+        bias_const = ctx.add_const_tensor(
+            f"{node.name}_transpose_conv_bias",
+            bias_values.reshape(1, 1, 1, out_channels).astype(np.float32),
+        )
+        y_bias_nhwc = ctx.add_intermediate_tensor(
+            f"{node.name}_output_nhwc_bias",
+            dtype=ctx.get_tensor_dtype(output_name),
+            shape=nhwc_output_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="ADD",
+                inputs=[y_nhwc, bias_const],
+                outputs=[y_bias_nhwc],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        y_final_nhwc = y_bias_nhwc
+
+    output_signature = (
+        list(output_tensor.shape_signature)
+        if output_tensor.shape_signature is not None
+        else list(output_shape)
+    )
+    nhwc_output_signature = list(nhwc_output_shape)
+    if len(output_signature) == 4:
+        nhwc_output_signature = [
+            int(output_signature[0]),
+            int(output_signature[2]),
+            int(output_signature[3]),
+            int(output_signature[1]),
+        ]
+    elif len(input_signature) == 4:
+        nhwc_output_signature = [
+            int(input_signature[0]),
+            -1,
+            -1,
+            int(nhwc_output_shape[3]),
+        ]
+    ctx.model_ir.tensors[y_final_nhwc].shape_signature = [int(v) for v in nhwc_output_signature]
+
+    make_transpose(
+        ctx,
+        y_final_nhwc,
+        output_name,
+        [0, 3, 1, 2],
+    )
+
+
 def build_conv2d_or_depthwise_op(node: Any, ctx: Any) -> None:
     input_name = node.inputs[0].name
     weight_name = node.inputs[1].name
@@ -42,11 +611,22 @@ def build_conv2d_or_depthwise_op(node: Any, ctx: Any) -> None:
     nchw_output = output_shape
     nhwc_input_shape = [nchw_input[0], nchw_input[2], nchw_input[3], nchw_input[1]]
     nhwc_output_shape = [nchw_output[0], nchw_output[2], nchw_output[3], nchw_output[1]]
+    input_tensor = ctx.model_ir.tensors[input_name]
     output_tensor = ctx.model_ir.tensors[output_name]
-    output_signature = (
+    input_signature = (
+        list(input_tensor.shape_signature)
+        if input_tensor.shape_signature is not None
+        else list(nchw_input)
+    )
+    existing_output_signature = (
         list(output_tensor.shape_signature)
-        if output_tensor.shape_signature is not None
-        else list(nchw_output)
+        if output_tensor.shape_signature is not None and len(list(output_tensor.shape_signature)) == 4
+        else None
+    )
+    output_signature = _infer_rank4_conv_output_signature(
+        input_signature_nchw=input_signature,
+        output_shape_nchw=nchw_output,
+        existing_output_signature_nchw=existing_output_signature,
     )
     nhwc_output_signature = list(nhwc_output_shape)
     if len(output_signature) == 4:

--- a/onnx2tf/tflite_builder/op_builders/nn.py
+++ b/onnx2tf/tflite_builder/op_builders/nn.py
@@ -1,9 +1,13 @@
 from onnx2tf.tflite_builder.op_builders.conv import build_conv2d_or_depthwise_op
 from onnx2tf.tflite_builder.op_builders.pool import build_pool2d_op
-from onnx2tf.tflite_builder.op_builders.fc import build_fully_connected_from_gemm_or_matmul
+from onnx2tf.tflite_builder.op_builders.fc import (
+    build_fully_connected_from_gemm_or_matmul,
+    build_matmul_op,
+)
 
 __all__ = [
     "build_conv2d_or_depthwise_op",
     "build_pool2d_op",
     "build_fully_connected_from_gemm_or_matmul",
+    "build_matmul_op",
 ]

--- a/onnx2tf/tflite_builder/preprocess/__init__.py
+++ b/onnx2tf/tflite_builder/preprocess/__init__.py
@@ -7,11 +7,15 @@ from onnx2tf.tflite_builder.preprocess.pipeline import (
     run_preprocess_pipeline,
 )
 from onnx2tf.tflite_builder.preprocess.rules import (
+    BN_FOLD_WAVE0_RULE_ID,
+    CLEANUP_UNUSED_INITIALIZERS_RULE_ID,
     CONSTANT_FOLD_RULE_ID,
     NORMALIZE_ATTRS_RULE_ID,
     PATTERN_FUSION_WAVE2_RULE_ID,
     QUANT_CHAIN_FUSION_WAVE3_RULE_ID,
     PSEUDO_OPS_WAVE1_RULE_ID,
+    register_bn_fold_wave0_rule,
+    register_cleanup_unused_initializers_rule,
     register_constant_fold_rule,
     register_default_preprocess_rules,
     register_normalize_attrs_rule,
@@ -22,6 +26,8 @@ from onnx2tf.tflite_builder.preprocess.rules import (
 
 __all__ = [
     "CONSTANT_FOLD_RULE_ID",
+    "BN_FOLD_WAVE0_RULE_ID",
+    "CLEANUP_UNUSED_INITIALIZERS_RULE_ID",
     "NORMALIZE_ATTRS_RULE_ID",
     "PATTERN_FUSION_WAVE2_RULE_ID",
     "QUANT_CHAIN_FUSION_WAVE3_RULE_ID",
@@ -29,6 +35,8 @@ __all__ = [
     "clear_preprocess_rules",
     "get_registered_preprocess_rule_ids",
     "register_constant_fold_rule",
+    "register_bn_fold_wave0_rule",
+    "register_cleanup_unused_initializers_rule",
     "register_default_preprocess_rules",
     "register_normalize_attrs_rule",
     "register_pattern_fusion_wave2_rule",

--- a/onnx2tf/tflite_builder/preprocess/rules/__init__.py
+++ b/onnx2tf/tflite_builder/preprocess/rules/__init__.py
@@ -4,6 +4,10 @@ from onnx2tf.tflite_builder.preprocess.rules.constant_fold import (
     CONSTANT_FOLD_RULE_ID,
     register_constant_fold_rule,
 )
+from onnx2tf.tflite_builder.preprocess.rules.bn_fold import (
+    BN_FOLD_WAVE0_RULE_ID,
+    register_bn_fold_wave0_rule,
+)
 from onnx2tf.tflite_builder.preprocess.rules.normalize_attrs import (
     NORMALIZE_ATTRS_RULE_ID,
     register_normalize_attrs_rule,
@@ -16,6 +20,10 @@ from onnx2tf.tflite_builder.preprocess.rules.quant_chain_fusion import (
     QUANT_CHAIN_FUSION_WAVE3_RULE_ID,
     register_quant_chain_fusion_wave3_rule,
 )
+from onnx2tf.tflite_builder.preprocess.rules.cleanup_unused_initializers import (
+    CLEANUP_UNUSED_INITIALIZERS_RULE_ID,
+    register_cleanup_unused_initializers_rule,
+)
 from onnx2tf.tflite_builder.preprocess.rules.pseudo_ops import (
     PSEUDO_OPS_WAVE1_RULE_ID,
     register_pseudo_ops_wave1_rule,
@@ -23,20 +31,26 @@ from onnx2tf.tflite_builder.preprocess.rules.pseudo_ops import (
 
 
 def register_default_preprocess_rules() -> None:
+    register_bn_fold_wave0_rule()
     register_pattern_fusion_wave2_rule()
     register_quant_chain_fusion_wave3_rule()
     register_pseudo_ops_wave1_rule()
     register_constant_fold_rule()
     register_normalize_attrs_rule()
+    register_cleanup_unused_initializers_rule()
 
 
 __all__ = [
     "CONSTANT_FOLD_RULE_ID",
+    "BN_FOLD_WAVE0_RULE_ID",
     "NORMALIZE_ATTRS_RULE_ID",
     "PATTERN_FUSION_WAVE2_RULE_ID",
     "QUANT_CHAIN_FUSION_WAVE3_RULE_ID",
     "PSEUDO_OPS_WAVE1_RULE_ID",
+    "CLEANUP_UNUSED_INITIALIZERS_RULE_ID",
     "register_default_preprocess_rules",
+    "register_bn_fold_wave0_rule",
+    "register_cleanup_unused_initializers_rule",
     "register_constant_fold_rule",
     "register_normalize_attrs_rule",
     "register_pattern_fusion_wave2_rule",

--- a/onnx2tf/tflite_builder/preprocess/rules/bn_fold.py
+++ b/onnx2tf/tflite_builder/preprocess/rules/bn_fold.py
@@ -1,0 +1,719 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+from onnx2tf.tflite_builder.preprocess.pipeline import register_preprocess_rule
+
+BN_FOLD_WAVE0_RULE_ID = "bn_fold_wave0"
+
+
+def _copy_node(node: onnx.NodeProto) -> onnx.NodeProto:
+    cloned = onnx.NodeProto()
+    cloned.CopyFrom(node)
+    return cloned
+
+
+def _collect_used_names(graph: onnx.GraphProto) -> set[str]:
+    used = set()
+    for vi in list(graph.input) + list(graph.output) + list(graph.value_info):
+        if vi.name != "":
+            used.add(str(vi.name))
+    for init in graph.initializer:
+        if init.name != "":
+            used.add(str(init.name))
+    for node in graph.node:
+        if node.name != "":
+            used.add(str(node.name))
+        for name in list(node.input) + list(node.output):
+            if name != "":
+                used.add(str(name))
+    return used
+
+
+def _next_name(used_names: set[str], base: str) -> str:
+    candidate = str(base) if str(base) != "" else "tmp"
+    if candidate not in used_names:
+        used_names.add(candidate)
+        return candidate
+    i = 1
+    while True:
+        c = f"{candidate}_{i}"
+        if c not in used_names:
+            used_names.add(c)
+            return c
+        i += 1
+
+
+def _build_const_map(graph: onnx.GraphProto) -> Dict[str, np.ndarray]:
+    const_map: Dict[str, np.ndarray] = {}
+    for init in graph.initializer:
+        const_map[str(init.name)] = np.asarray(numpy_helper.to_array(init))
+    for node in graph.node:
+        if str(node.op_type) != "Constant" or len(node.output) < 1:
+            continue
+        for attr in node.attribute:
+            if str(attr.name) == "value" and attr.type == onnx.AttributeProto.TENSOR:
+                const_map[str(node.output[0])] = np.asarray(numpy_helper.to_array(attr.t))
+                break
+    return const_map
+
+
+def _build_producer_index(nodes: List[onnx.NodeProto]) -> Dict[str, int]:
+    producers: Dict[str, int] = {}
+    for idx, node in enumerate(nodes):
+        for out_name in node.output:
+            if out_name == "":
+                continue
+            producers[str(out_name)] = int(idx)
+    return producers
+
+
+def _build_consumer_count(nodes: List[onnx.NodeProto]) -> Dict[str, int]:
+    counts: Dict[str, int] = {}
+    for node in nodes:
+        for in_name in node.input:
+            if in_name == "":
+                continue
+            key = str(in_name)
+            counts[key] = int(counts.get(key, 0) + 1)
+    return counts
+
+
+def _build_rank_map(graph: onnx.GraphProto) -> Dict[str, int]:
+    rank_map: Dict[str, int] = {}
+
+    def _record_value_info(vi: onnx.ValueInfoProto) -> None:
+        if str(vi.name) == "":
+            return
+        if not vi.type.HasField("tensor_type"):
+            return
+        tensor_type = vi.type.tensor_type
+        if not tensor_type.HasField("shape"):
+            return
+        rank_map[str(vi.name)] = int(len(list(tensor_type.shape.dim)))
+
+    for vi in list(graph.input) + list(graph.value_info) + list(graph.output):
+        _record_value_info(vi)
+    return rank_map
+
+
+def _bn_epsilon(node: onnx.NodeProto) -> float:
+    eps = 1e-5
+    for attr in node.attribute:
+        if str(attr.name) != "epsilon":
+            continue
+        if attr.type == onnx.AttributeProto.FLOAT:
+            eps = float(attr.f)
+        elif attr.type == onnx.AttributeProto.INT:
+            eps = float(attr.i)
+    return float(eps)
+
+
+def _reshape_bn_affine(
+    *,
+    bn_mul: np.ndarray,
+    bn_add: np.ndarray,
+    rank: int,
+) -> Tuple[np.ndarray, np.ndarray]:
+    channels = int(np.asarray(bn_mul).reshape(-1).size)
+    if rank == 4:
+        shape = (1, channels, 1, 1)
+    elif rank == 3:
+        shape = (1, channels, 1)
+    elif rank == 2:
+        shape = (1, channels)
+    else:
+        shape = (channels,)
+    return (
+        np.asarray(bn_mul, dtype=np.float32).reshape(shape),
+        np.asarray(bn_add, dtype=np.float32).reshape(shape),
+    )
+
+
+def _infer_rank_for_dq_bn_path(
+    *,
+    bn_input: str,
+    bn_output: str,
+    dq_node: onnx.NodeProto,
+    rank_map: Dict[str, int],
+    producer_idx: Dict[str, int],
+    nodes: List[onnx.NodeProto],
+) -> Optional[int]:
+    for candidate_name in [bn_input, bn_output]:
+        rank = rank_map.get(str(candidate_name), None)
+        if rank is not None and int(rank) > 0:
+            return int(rank)
+
+    if len(dq_node.input) >= 1:
+        dq_raw_input = str(dq_node.input[0])
+        rank = rank_map.get(dq_raw_input, None)
+        if rank is not None and int(rank) > 0:
+            return int(rank)
+        up_idx = producer_idx.get(dq_raw_input, None)
+        if up_idx is not None:
+            up_type = str(nodes[int(up_idx)].op_type)
+            if up_type in {"QLinearMatMul", "MatMul", "Gemm"}:
+                return 2
+            if up_type.startswith("QLinear"):
+                return 4
+            if up_type in {"Conv", "ConvTranspose", "MaxPool", "AveragePool"}:
+                return 4
+    return None
+
+
+def _fold_conv_bn(
+    *,
+    conv_w: np.ndarray,
+    conv_b: Optional[np.ndarray],
+    bn_scale: np.ndarray,
+    bn_bias: np.ndarray,
+    bn_mean: np.ndarray,
+    bn_var: np.ndarray,
+    epsilon: float,
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    w = np.asarray(conv_w, dtype=np.float32)
+    if w.ndim < 1:
+        return None
+
+    channels = int(w.shape[0])
+    scale = np.asarray(bn_scale, dtype=np.float32).reshape(-1)
+    bias = np.asarray(bn_bias, dtype=np.float32).reshape(-1)
+    mean = np.asarray(bn_mean, dtype=np.float32).reshape(-1)
+    var = np.asarray(bn_var, dtype=np.float32).reshape(-1)
+    if any(int(v.size) != channels for v in [scale, bias, mean, var]):
+        return None
+
+    bn_mul = scale / np.sqrt(var + float(epsilon))
+    reshape_dims = [channels] + [1] * (w.ndim - 1)
+    w_folded = w * bn_mul.reshape(reshape_dims)
+
+    if conv_b is None:
+        b_base = np.zeros((channels,), dtype=np.float32)
+    else:
+        b_base = np.asarray(conv_b, dtype=np.float32).reshape(-1)
+        if int(b_base.size) != channels:
+            return None
+    b_folded = (b_base - mean) * bn_mul + bias
+    return np.asarray(w_folded, dtype=np.float32), np.asarray(b_folded, dtype=np.float32)
+
+
+def _convtranspose_group(node: onnx.NodeProto) -> int:
+    group = 1
+    for attr in node.attribute:
+        if str(attr.name) == "group":
+            if attr.type == onnx.AttributeProto.INT:
+                group = int(attr.i)
+            break
+    return int(group)
+
+
+def _fold_convtranspose_bn(
+    *,
+    convt_w: np.ndarray,
+    convt_b: Optional[np.ndarray],
+    bn_scale: np.ndarray,
+    bn_bias: np.ndarray,
+    bn_mean: np.ndarray,
+    bn_var: np.ndarray,
+    epsilon: float,
+    group: int,
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    w = np.asarray(convt_w, dtype=np.float32)
+    if w.ndim < 2:
+        return None
+    if int(group) <= 0:
+        return None
+
+    in_channels = int(w.shape[0])
+    out_channels_per_group = int(w.shape[1])
+    if in_channels <= 0 or out_channels_per_group <= 0:
+        return None
+    if in_channels % int(group) != 0:
+        return None
+    out_channels = int(out_channels_per_group * int(group))
+
+    scale = np.asarray(bn_scale, dtype=np.float32).reshape(-1)
+    bias = np.asarray(bn_bias, dtype=np.float32).reshape(-1)
+    mean = np.asarray(bn_mean, dtype=np.float32).reshape(-1)
+    var = np.asarray(bn_var, dtype=np.float32).reshape(-1)
+    if any(int(v.size) != out_channels for v in [scale, bias, mean, var]):
+        return None
+
+    bn_mul = scale / np.sqrt(var + float(epsilon))
+    in_per_group = int(in_channels // int(group))
+    w_folded = np.asarray(w, dtype=np.float32).copy()
+    for c in range(in_channels):
+        g = int(c // in_per_group)
+        start = int(g * out_channels_per_group)
+        stop = int(start + out_channels_per_group)
+        local_mul = bn_mul[start:stop]
+        reshape_dims = [out_channels_per_group] + [1] * (w_folded.ndim - 2)
+        w_folded[c, ...] *= local_mul.reshape(reshape_dims)
+
+    if convt_b is None:
+        b_base = np.zeros((out_channels,), dtype=np.float32)
+    else:
+        b_base = np.asarray(convt_b, dtype=np.float32).reshape(-1)
+        if int(b_base.size) != out_channels:
+            return None
+    b_folded = (b_base - mean) * bn_mul + bias
+    return np.asarray(w_folded, dtype=np.float32), np.asarray(b_folded, dtype=np.float32)
+
+
+def _extract_channel_affine_vector(
+    *,
+    values: np.ndarray,
+    out_channels: int,
+    rank: int,
+) -> Optional[np.ndarray]:
+    arr = np.asarray(values, dtype=np.float32)
+    if int(arr.size) == 0 or int(out_channels) <= 0 or int(rank) < 2:
+        return None
+    if int(arr.size) == 1:
+        scalar = float(arr.reshape(-1)[0])
+        return np.full((int(out_channels),), scalar, dtype=np.float32)
+
+    dims = [int(v) for v in list(arr.shape)]
+    if len(dims) > int(rank):
+        extra = int(len(dims) - int(rank))
+        if any(int(v) != 1 for v in dims[:extra]):
+            return None
+        dims = dims[extra:]
+        arr = np.reshape(arr, dims)
+    if len(dims) < int(rank):
+        dims = [1] * int(int(rank) - len(dims)) + dims
+        arr = np.reshape(arr, dims)
+
+    for axis, dim in enumerate(dims):
+        if int(axis) == 1:
+            if int(dim) not in [1, int(out_channels)]:
+                return None
+        else:
+            if int(dim) != 1:
+                return None
+
+    if int(dims[1]) == 1:
+        scalar = float(np.asarray(arr).reshape(-1)[0])
+        return np.full((int(out_channels),), scalar, dtype=np.float32)
+
+    index = [0 for _ in range(int(rank))]
+    index[1] = slice(None)
+    vec = np.asarray(arr, dtype=np.float32)[tuple(index)].reshape(-1)
+    if int(vec.size) != int(out_channels):
+        return None
+    return np.asarray(vec, dtype=np.float32)
+
+
+def _fold_conv_mul_add_affine(
+    *,
+    nodes: List[onnx.NodeProto],
+    used_names: set[str],
+    const_map: Dict[str, np.ndarray],
+    graph_outputs: set[str],
+) -> Tuple[List[onnx.NodeProto], List[onnx.TensorProto], int, int]:
+    if len(nodes) < 3:
+        return list(nodes), [], 0, 0
+
+    consumer_count = _build_consumer_count(nodes)
+    rewritten_nodes: List[onnx.NodeProto] = []
+    new_initializers: List[onnx.TensorProto] = []
+    matched_patterns = 0
+    rewritten_patterns = 0
+
+    i = 0
+    while i < len(nodes):
+        if i + 2 >= len(nodes):
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        conv_node = nodes[i]
+        mul_node = nodes[i + 1]
+        add_node = nodes[i + 2]
+        conv_type = str(conv_node.op_type)
+        if (
+            conv_type not in {"Conv", "ConvTranspose"}
+            or str(mul_node.op_type) != "Mul"
+            or str(add_node.op_type) != "Add"
+            or len(conv_node.output) < 1
+            or len(mul_node.output) < 1
+            or len(add_node.output) < 1
+            or len(mul_node.input) < 2
+            or len(add_node.input) < 2
+        ):
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        conv_out = str(conv_node.output[0])
+        mul_out = str(mul_node.output[0])
+        add_out = str(add_node.output[0])
+        mul_inputs = [str(v) for v in mul_node.input]
+        add_inputs = [str(v) for v in add_node.input]
+        if conv_out not in mul_inputs:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+        if mul_out not in add_inputs:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        matched_patterns += 1
+
+        if (
+            int(consumer_count.get(conv_out, 0)) != 1
+            or int(consumer_count.get(mul_out, 0)) != 1
+            or conv_out in graph_outputs
+            or mul_out in graph_outputs
+        ):
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        mul_const_name = mul_inputs[0] if mul_inputs[1] == conv_out else mul_inputs[1]
+        add_const_name = add_inputs[0] if add_inputs[1] == mul_out else add_inputs[1]
+        mul_const = const_map.get(str(mul_const_name), None)
+        add_const = const_map.get(str(add_const_name), None)
+        if mul_const is None or add_const is None:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        if len(conv_node.input) < 2:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+        conv_w_name = str(conv_node.input[1])
+        conv_b_name = str(conv_node.input[2]) if len(conv_node.input) >= 3 else None
+        conv_w = const_map.get(conv_w_name, None)
+        conv_b = const_map.get(conv_b_name, None) if conv_b_name is not None else None
+        if conv_w is None:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        w_arr = np.asarray(conv_w, dtype=np.float32)
+        rank = int(w_arr.ndim)
+        if rank < 2:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        if conv_type == "Conv":
+            out_channels = int(w_arr.shape[0])
+        else:
+            out_channels_per_group = int(w_arr.shape[1])
+            out_channels = int(out_channels_per_group * int(_convtranspose_group(conv_node)))
+
+        mul_vec = _extract_channel_affine_vector(
+            values=np.asarray(mul_const),
+            out_channels=int(out_channels),
+            rank=int(rank),
+        )
+        add_vec = _extract_channel_affine_vector(
+            values=np.asarray(add_const),
+            out_channels=int(out_channels),
+            rank=int(rank),
+        )
+        if mul_vec is None or add_vec is None:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+
+        neutral_mean = np.zeros((int(out_channels),), dtype=np.float32)
+        neutral_var = np.ones((int(out_channels),), dtype=np.float32)
+        if conv_type == "Conv":
+            folded = _fold_conv_bn(
+                conv_w=w_arr,
+                conv_b=conv_b,
+                bn_scale=mul_vec,
+                bn_bias=add_vec,
+                bn_mean=neutral_mean,
+                bn_var=neutral_var,
+                epsilon=0.0,
+            )
+        else:
+            folded = _fold_convtranspose_bn(
+                convt_w=w_arr,
+                convt_b=conv_b,
+                bn_scale=mul_vec,
+                bn_bias=add_vec,
+                bn_mean=neutral_mean,
+                bn_var=neutral_var,
+                epsilon=0.0,
+                group=_convtranspose_group(conv_node),
+            )
+        if folded is None:
+            rewritten_nodes.append(_copy_node(nodes[i]))
+            i += 1
+            continue
+        w_folded, b_folded = folded
+
+        op_name = conv_node.name or conv_type.lower()
+        new_w_name = _next_name(used_names, f"{op_name}_affine_fold_w")
+        new_b_name = _next_name(used_names, f"{op_name}_affine_fold_b")
+        new_initializers.extend(
+            [
+                numpy_helper.from_array(np.asarray(w_folded, dtype=np.float32), name=new_w_name),
+                numpy_helper.from_array(np.asarray(b_folded, dtype=np.float32), name=new_b_name),
+            ]
+        )
+        const_map[new_w_name] = np.asarray(w_folded, dtype=np.float32)
+        const_map[new_b_name] = np.asarray(b_folded, dtype=np.float32)
+
+        folded_conv = _copy_node(conv_node)
+        del folded_conv.input[:]
+        folded_conv.input.extend([str(conv_node.input[0]), new_w_name, new_b_name])
+        del folded_conv.output[:]
+        folded_conv.output.extend([add_out])
+        rewritten_nodes.append(folded_conv)
+
+        rewritten_patterns += 1
+        i += 3
+
+    return rewritten_nodes, new_initializers, int(matched_patterns), int(rewritten_patterns)
+
+
+def apply_bn_fold_wave0(onnx_graph: onnx.ModelProto) -> Dict[str, Any]:
+    graph = onnx_graph.graph
+    nodes = list(graph.node)
+    bn_node_count = int(
+        sum(1 for n in nodes if str(n.op_type) == "BatchNormalization")
+    )
+    if len(nodes) == 0:
+        return {
+            "matched_nodes": 0,
+            "rewritten_nodes": 0,
+            "changed": False,
+            "message": (
+                f"bn_nodes_in_graph={bn_node_count} "
+                "matched_patterns=0 rewritten_patterns=0"
+            ),
+        }
+
+    used_names = _collect_used_names(graph)
+    const_map = _build_const_map(graph)
+    producer_idx = _build_producer_index(nodes)
+    consumer_count = _build_consumer_count(nodes)
+    rank_map = _build_rank_map(graph)
+    graph_outputs = {str(v.name) for v in graph.output if str(v.name) != ""}
+
+    rewritten_nodes_bn: List[onnx.NodeProto] = []
+    new_initializers: List[onnx.TensorProto] = []
+    skip_indices: set[int] = set()
+    replacement_nodes: Dict[int, List[onnx.NodeProto]] = {}
+
+    matched_patterns = 0
+    rewritten_patterns = 0
+
+    for bn_idx, bn_node in enumerate(nodes):
+        if str(bn_node.op_type) != "BatchNormalization" or bn_idx in skip_indices:
+            continue
+        if len(bn_node.input) < 5 or len(bn_node.output) < 1:
+            continue
+
+        bn_input = str(bn_node.input[0])
+        bn_output = str(bn_node.output[0])
+        conv_idx = producer_idx.get(bn_input, None)
+        if conv_idx is None:
+            continue
+        producer_node = nodes[int(conv_idx)]
+        producer_type = str(producer_node.op_type)
+        if producer_type not in {"Conv", "ConvTranspose", "DequantizeLinear"}:
+            continue
+        if len(producer_node.output) < 1:
+            continue
+        producer_output = str(producer_node.output[0])
+        if producer_output != bn_input:
+            continue
+        if int(consumer_count.get(producer_output, 0)) != 1:
+            continue
+        if producer_output in graph_outputs:
+            continue
+
+        bn_scale_name = str(bn_node.input[1])
+        bn_bias_name = str(bn_node.input[2])
+        bn_mean_name = str(bn_node.input[3])
+        bn_var_name = str(bn_node.input[4])
+
+        bn_scale = const_map.get(bn_scale_name, None)
+        bn_bias = const_map.get(bn_bias_name, None)
+        bn_mean = const_map.get(bn_mean_name, None)
+        bn_var = const_map.get(bn_var_name, None)
+        if (
+            bn_scale is None
+            or bn_bias is None
+            or bn_mean is None
+            or bn_var is None
+        ):
+            continue
+
+        matched_patterns += 1
+
+        if producer_type in {"Conv", "ConvTranspose"}:
+            if len(producer_node.input) < 2:
+                continue
+            w_name = str(producer_node.input[1])
+            b_name = str(producer_node.input[2]) if len(producer_node.input) >= 3 else None
+            conv_w = const_map.get(w_name, None)
+            conv_b = const_map.get(b_name, None) if b_name is not None else None
+            if conv_w is None:
+                continue
+
+            if producer_type == "Conv":
+                folded = _fold_conv_bn(
+                    conv_w=conv_w,
+                    conv_b=conv_b,
+                    bn_scale=bn_scale,
+                    bn_bias=bn_bias,
+                    bn_mean=bn_mean,
+                    bn_var=bn_var,
+                    epsilon=_bn_epsilon(bn_node),
+                )
+            else:
+                folded = _fold_convtranspose_bn(
+                    convt_w=conv_w,
+                    convt_b=conv_b,
+                    bn_scale=bn_scale,
+                    bn_bias=bn_bias,
+                    bn_mean=bn_mean,
+                    bn_var=bn_var,
+                    epsilon=_bn_epsilon(bn_node),
+                    group=_convtranspose_group(producer_node),
+                )
+            if folded is None:
+                continue
+            w_folded, b_folded = folded
+
+            op_name = producer_node.name or producer_type.lower()
+            new_w_name = _next_name(used_names, f"{op_name}_bn_fold_w")
+            new_b_name = _next_name(used_names, f"{op_name}_bn_fold_b")
+            new_initializers.extend(
+                [
+                    numpy_helper.from_array(np.asarray(w_folded, dtype=np.float32), name=new_w_name),
+                    numpy_helper.from_array(np.asarray(b_folded, dtype=np.float32), name=new_b_name),
+                ]
+            )
+            const_map[new_w_name] = np.asarray(w_folded, dtype=np.float32)
+            const_map[new_b_name] = np.asarray(b_folded, dtype=np.float32)
+
+            folded_op = _copy_node(producer_node)
+            del folded_op.input[:]
+            folded_op.input.extend([str(producer_node.input[0]), new_w_name, new_b_name])
+            del folded_op.output[:]
+            folded_op.output.extend([bn_output])
+
+            nodes[int(conv_idx)] = folded_op
+            skip_indices.add(int(bn_idx))
+            rewritten_patterns += 1
+            continue
+
+        if producer_type == "DequantizeLinear":
+            rank = _infer_rank_for_dq_bn_path(
+                bn_input=bn_input,
+                bn_output=bn_output,
+                dq_node=producer_node,
+                rank_map=rank_map,
+                producer_idx=producer_idx,
+                nodes=nodes,
+            )
+            if rank is None:
+                continue
+
+            scale = np.asarray(bn_scale, dtype=np.float32).reshape(-1)
+            bias = np.asarray(bn_bias, dtype=np.float32).reshape(-1)
+            mean = np.asarray(bn_mean, dtype=np.float32).reshape(-1)
+            var = np.asarray(bn_var, dtype=np.float32).reshape(-1)
+            if not (int(scale.size) == int(bias.size) == int(mean.size) == int(var.size)):
+                continue
+            bn_mul = scale / np.sqrt(var + float(_bn_epsilon(bn_node)))
+            bn_add = bias - mean * bn_mul
+            bn_mul_shaped, bn_add_shaped = _reshape_bn_affine(
+                bn_mul=np.asarray(bn_mul, dtype=np.float32),
+                bn_add=np.asarray(bn_add, dtype=np.float32),
+                rank=int(rank),
+            )
+
+            bn_name = bn_node.name or "bn"
+            mul_const_name = _next_name(used_names, f"{bn_name}_fold_mul")
+            add_const_name = _next_name(used_names, f"{bn_name}_fold_add")
+            mul_out_name = _next_name(used_names, f"{bn_name}_fold_mul_out")
+            new_initializers.extend(
+                [
+                    numpy_helper.from_array(np.asarray(bn_mul_shaped, dtype=np.float32), name=mul_const_name),
+                    numpy_helper.from_array(np.asarray(bn_add_shaped, dtype=np.float32), name=add_const_name),
+                ]
+            )
+            const_map[mul_const_name] = np.asarray(bn_mul_shaped, dtype=np.float32)
+            const_map[add_const_name] = np.asarray(bn_add_shaped, dtype=np.float32)
+
+            mul_node = helper.make_node(
+                "Mul",
+                [bn_input, mul_const_name],
+                [mul_out_name],
+                name=_next_name(used_names, f"{bn_name}_fold_mul"),
+            )
+            add_node = helper.make_node(
+                "Add",
+                [mul_out_name, add_const_name],
+                [bn_output],
+                name=_next_name(used_names, f"{bn_name}_fold_add"),
+            )
+            replacement_nodes[int(bn_idx)] = [mul_node, add_node]
+            skip_indices.add(int(bn_idx))
+            rewritten_patterns += 1
+            continue
+
+    for idx, node in enumerate(nodes):
+        replacement = replacement_nodes.get(int(idx), None)
+        if replacement is not None:
+            for rep_node in replacement:
+                rewritten_nodes_bn.append(_copy_node(rep_node))
+            continue
+        if idx in skip_indices:
+            continue
+        rewritten_nodes_bn.append(_copy_node(node))
+
+    (
+        rewritten_nodes,
+        affine_initializers,
+        affine_matched_patterns,
+        affine_rewritten_patterns,
+    ) = _fold_conv_mul_add_affine(
+        nodes=rewritten_nodes_bn,
+        used_names=used_names,
+        const_map=const_map,
+        graph_outputs=graph_outputs,
+    )
+    new_initializers.extend(affine_initializers)
+
+    total_rewritten_patterns = int(rewritten_patterns + affine_rewritten_patterns)
+    if total_rewritten_patterns > 0:
+        del graph.node[:]
+        graph.node.extend(rewritten_nodes)
+        graph.initializer.extend(new_initializers)
+
+    return {
+        "matched_nodes": int(matched_patterns * 2 + affine_matched_patterns * 3),
+        "rewritten_nodes": int(rewritten_patterns * 2 + affine_rewritten_patterns * 3),
+        "changed": bool(total_rewritten_patterns > 0),
+        "message": (
+            f"bn_nodes_in_graph={bn_node_count} "
+            f"matched_patterns={matched_patterns} rewritten_patterns={rewritten_patterns} "
+            f"matched_affine_patterns={affine_matched_patterns} "
+            f"rewritten_affine_patterns={affine_rewritten_patterns}"
+        ),
+    }
+
+
+def register_bn_fold_wave0_rule() -> None:
+    register_preprocess_rule(
+        rule_id=BN_FOLD_WAVE0_RULE_ID,
+        callback=apply_bn_fold_wave0,
+        overwrite=True,
+    )

--- a/onnx2tf/tflite_builder/preprocess/rules/cleanup_unused_initializers.py
+++ b/onnx2tf/tflite_builder/preprocess/rules/cleanup_unused_initializers.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Set
+
+import onnx
+
+from onnx2tf.tflite_builder.preprocess.pipeline import register_preprocess_rule
+
+CLEANUP_UNUSED_INITIALIZERS_RULE_ID = "cleanup_unused_initializers_z9"
+
+
+def prune_unused_initializers_inplace(
+    onnx_graph: onnx.ModelProto,
+    *,
+    prune_orphan_value_info: bool = True,
+) -> Dict[str, Any]:
+    graph = onnx_graph.graph
+
+    used_input_names: Set[str] = set()
+    for node in graph.node:
+        for name in node.input:
+            if name != "":
+                used_input_names.add(str(name))
+
+    graph_output_names = {str(v.name) for v in graph.output if str(v.name) != ""}
+
+    original_initializer_count = int(len(graph.initializer))
+    kept_initializers: List[onnx.TensorProto] = []
+    removed_initializer_names: Set[str] = set()
+    for initializer in graph.initializer:
+        name = str(initializer.name)
+        if name == "":
+            kept_initializers.append(initializer)
+            continue
+        if name in used_input_names or name in graph_output_names:
+            kept_initializers.append(initializer)
+            continue
+        removed_initializer_names.add(name)
+
+    removed_count = int(len(removed_initializer_names))
+    if removed_count > 0:
+        del graph.initializer[:]
+        graph.initializer.extend(kept_initializers)
+
+    removed_value_info_count = 0
+    if prune_orphan_value_info and removed_count > 0:
+        active_tensor_names: Set[str] = set()
+        for node in graph.node:
+            for name in list(node.input) + list(node.output):
+                if name != "":
+                    active_tensor_names.add(str(name))
+        for value in list(graph.input) + list(graph.output):
+            if value.name != "":
+                active_tensor_names.add(str(value.name))
+        for initializer in graph.initializer:
+            if initializer.name != "":
+                active_tensor_names.add(str(initializer.name))
+
+        kept_value_infos: List[onnx.ValueInfoProto] = []
+        for value_info in graph.value_info:
+            value_name = str(value_info.name)
+            if value_name in active_tensor_names:
+                kept_value_infos.append(value_info)
+                continue
+            removed_value_info_count += 1
+        if removed_value_info_count > 0:
+            del graph.value_info[:]
+            graph.value_info.extend(kept_value_infos)
+
+    return {
+        "removed_initializer_count": removed_count,
+        "removed_value_info_count": int(removed_value_info_count),
+        "original_initializer_count": int(original_initializer_count),
+        "changed": bool(removed_count > 0 or removed_value_info_count > 0),
+    }
+
+
+def apply_cleanup_unused_initializers(onnx_graph: onnx.ModelProto) -> Dict[str, Any]:
+    stats = prune_unused_initializers_inplace(
+        onnx_graph,
+        prune_orphan_value_info=True,
+    )
+    removed_initializer_count = int(stats.get("removed_initializer_count", 0))
+    removed_value_info_count = int(stats.get("removed_value_info_count", 0))
+    return {
+        "matched_nodes": int(removed_initializer_count),
+        "rewritten_nodes": int(removed_initializer_count),
+        "changed": bool(stats.get("changed", False)),
+        "message": (
+            f"removed_initializers={removed_initializer_count} "
+            f"removed_value_info={removed_value_info_count}"
+        ),
+    }
+
+
+def register_cleanup_unused_initializers_rule() -> None:
+    register_preprocess_rule(
+        rule_id=CLEANUP_UNUSED_INITIALIZERS_RULE_ID,
+        callback=apply_cleanup_unused_initializers,
+        overwrite=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.14"
+version = "2.0.15"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
This PR significantly improves the `flatbuffer_direct` path, focusing on conversion stability, quantization-chain optimizations, shape/NHWC propagation, and redundant transpose reduction.

- Changed files: 37
- Diffstat: +7283 / -493
- Base commit (`main`): `9281976`
- Head commit (`fix-var`): `2d9ca0a`

## Main Changes
1. FlatBuffer direct lowering and shape propagation
- Strengthened `shape` / `shape_signature` propagation, mainly in `lower_from_onnx2tf.py`.
- Reduced shape-freezing issues in dynamic-shape cases.
  <img width="716" height="492" alt="image" src="https://github.com/user-attachments/assets/d6f22ad5-7564-485f-937e-67ca48173054" />
- Expanded redundant `Transpose`-chain elimination around NCHW/NHWC bridges.
- Improved shape consistency around `Resize*`, `Conv`, `DepthwiseConv`, `ConvTranspose`, `Mean`, `Squeeze`, and `Concat`.

2. Quantized chain optimizations
- Added/extended folds for:
  - `Dequantize -> HardSigmoid -> Quantize`
  - `Dequantize -> TransposeConv -> Quantize`
  - `Dequantize -> Reshape -> Quantize`
  - `Dequantize -> MaxPool -> Quantize`
  - `Dequantize -> Softmax -> Quantize`
- Improved robustness for QLinear-family ops, including `QLinearConv`, `QLinearConcat`, `QLinearAdd`, `QLinearMul`, and `QLinearSigmoid`.

3. Preprocess pipeline improvements
- Added new rule: `bn_fold_wave0` (`preprocess/rules/bn_fold.py`)
  - `Conv/ConvTranspose + BatchNormalization` fold
  - affine expansion for `Dequantize + BatchNormalization`
  - new fold for `Conv -> Mul -> Add` affine chains
- Added new rule: `cleanup_unused_initializers_z9` (`preprocess/rules/cleanup_unused_initializers.py`)
  - removes unused initializers/value_info
- Improved preprocess report visibility so BN target/fold counts are easier to diagnose.

4. Runtime/logging and developer experience
- Filtered verbose `Captures:` lines during SavedModel export.
- Suppressed TensorFlow startup STDERR noise with:
  - `ONNX2TF_SUPPRESS_TF_STARTUP_STDERR` (default: enabled)
- Enhanced `flatbuffer_direct` OP error and tensor-correspondence reporting.

5. Docs/metadata updates
- Updated README OP summary.
- Updated package metadata/version files (`__init__.py`, `pyproject.toml`).

## Validation
Validated mainly with real conversion runs (examples):
- `text_detection_en_ppocrv3_2023may_int8.onnx`
- `human_segmentation_pphumanseg_2023mar_int8.onnx`
- `pose_estimation_mediapipe_2023mar_int8bq.onnx`
- `face_recognition_sface_2021dec_int8.onnx`

Also confirmed:
- `python -m compileall` on key modified modules
- preprocess-only checks for `bn_fold_wave0` and `cleanup_unused_initializers_z9` statistics

