### PR TITLE
Fix major regression set in TF/flatbuffer_direct conversion paths

### DIFF
--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.15'
+__version__ = '2.0.16'

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -143,6 +143,42 @@ def _build_gather_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tupl
     return _enum(schema_tflite, "BuiltinOptions", "GatherOptions"), options
 
 
+def _build_argmax_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["ArgMaxOptionsT"]()
+    output_type = str(op.options.get("outputType", "INT64")).upper()
+    options.outputType = _enum(schema_tflite, "TensorType", output_type)
+    return _enum(schema_tflite, "BuiltinOptions", "ArgMaxOptions"), options
+
+
+def _build_cast_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["CastOptionsT"]()
+    in_dtype = str(op.options.get("inDataType", "FLOAT32")).upper()
+    out_dtype = str(op.options.get("outDataType", "FLOAT32")).upper()
+    options.inDataType = _enum(schema_tflite, "TensorType", in_dtype)
+    options.outDataType = _enum(schema_tflite, "TensorType", out_dtype)
+    return _enum(schema_tflite, "BuiltinOptions", "CastOptions"), options
+
+
+def _build_gather_nd_options(schema_tflite: Dict[str, Any], _op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["GatherNdOptionsT"]()
+    return _enum(schema_tflite, "BuiltinOptions", "GatherNdOptions"), options
+
+
+def _build_broadcast_to_options(schema_tflite: Dict[str, Any], _op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["BroadcastToOptionsT"]()
+    return _enum(schema_tflite, "BuiltinOptions", "BroadcastToOptions"), options
+
+
+def _build_floor_mod_options(schema_tflite: Dict[str, Any], _op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["FloorModOptionsT"]()
+    return _enum(schema_tflite, "BuiltinOptions", "FloorModOptions"), options
+
+
+def _build_tile_options(schema_tflite: Dict[str, Any], _op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["TileOptionsT"]()
+    return _enum(schema_tflite, "BuiltinOptions", "TileOptions"), options
+
+
 def _build_l2_norm_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
     options = schema_tflite["L2NormOptionsT"]()
     fused = str(op.options.get("fusedActivationFunction", "NONE"))
@@ -283,12 +319,24 @@ def _build_builtin_options(
         return _build_softmax_options(schema_tflite, op)
     if op.op_type == "TRANSPOSE":
         return _build_transpose_options(schema_tflite, op)
-    if op.op_type in ["MEAN", "SUM"]:
+    if op.op_type in ["MEAN", "SUM", "REDUCE_MAX"]:
         return _build_reducer_options(schema_tflite, op)
     if op.op_type == "SQUEEZE":
         return _build_squeeze_options(schema_tflite, op)
     if op.op_type == "GATHER":
         return _build_gather_options(schema_tflite, op)
+    if op.op_type == "ARG_MAX":
+        return _build_argmax_options(schema_tflite, op)
+    if op.op_type == "CAST":
+        return _build_cast_options(schema_tflite, op)
+    if op.op_type == "GATHER_ND":
+        return _build_gather_nd_options(schema_tflite, op)
+    if op.op_type == "BROADCAST_TO":
+        return _build_broadcast_to_options(schema_tflite, op)
+    if op.op_type == "FLOOR_MOD":
+        return _build_floor_mod_options(schema_tflite, op)
+    if op.op_type == "TILE":
+        return _build_tile_options(schema_tflite, op)
     if op.op_type == "L2_NORMALIZATION":
         return _build_l2_norm_options(schema_tflite, op)
     if op.op_type == "SPACE_TO_DEPTH":

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -1,14 +1,18 @@
 from onnx2tf.tflite_builder.op_builders.elementwise import (
     build_binary_op,
     build_clip_op,
+    build_div_op,
     build_hardsigmoid_op,
     build_logistic_op,
+    build_mod_op,
     build_prelu_op,
     build_softmax_op,
     build_unary_op,
 )
 from onnx2tf.tflite_builder.op_builders.shape import (
+    build_cast_op,
     build_concat_op,
+    build_expand_op,
     build_flatten_op,
     build_identity_op,
     build_pad_op,
@@ -36,7 +40,9 @@ from onnx2tf.tflite_builder.op_builders.reduce import (
     build_reduce_op,
 )
 from onnx2tf.tflite_builder.op_builders.index import (
+    build_argmax_op,
     build_gather_op,
+    build_gather_elements_op,
 )
 from onnx2tf.tflite_builder.op_builders.norm import (
     build_batch_normalization_op,
@@ -64,12 +70,16 @@ from onnx2tf.tflite_builder.op_builders.quantized import (
 __all__ = [
     "build_binary_op",
     "build_clip_op",
+    "build_div_op",
     "build_hardsigmoid_op",
     "build_logistic_op",
+    "build_mod_op",
     "build_prelu_op",
     "build_softmax_op",
     "build_unary_op",
+    "build_cast_op",
     "build_concat_op",
+    "build_expand_op",
     "build_flatten_op",
     "build_identity_op",
     "build_pad_op",
@@ -87,7 +97,9 @@ __all__ = [
     "build_fully_connected_from_gemm_or_matmul",
     "build_matmul_op",
     "build_reduce_op",
+    "build_argmax_op",
     "build_gather_op",
+    "build_gather_elements_op",
     "build_batch_normalization_op",
     "build_l2_normalization_op",
     "build_custom_passthrough_op",

--- a/onnx2tf/tflite_builder/op_builders/index.py
+++ b/onnx2tf/tflite_builder/op_builders/index.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from onnx2tf.tflite_builder.ir import OperatorIR
 
 
@@ -33,5 +35,194 @@ def build_gather_op(node: Any, ctx: Any) -> None:
                 "axis": int(axis),
                 "batchDims": int(batch_dims),
             },
+        )
+    )
+
+
+def build_argmax_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(input_name)]
+    input_rank = len(input_shape)
+    axis = int(node.attrs.get("axis", 0))
+    if axis < 0:
+        axis += input_rank
+    if axis < 0 or axis >= input_rank:
+        raise NotImplementedError(
+            f"ArgMax axis out of range in flatbuffer_direct. op={node.name} axis={axis} rank={input_rank}"
+        )
+
+    select_last_index = int(node.attrs.get("select_last_index", 0))
+    if select_last_index != 0:
+        raise NotImplementedError(
+            f"ArgMax select_last_index != 0 is not supported in flatbuffer_direct. "
+            f"op={node.name} select_last_index={select_last_index}"
+        )
+
+    keepdims = bool(int(node.attrs.get("keepdims", 1)))
+    output_dtype = str(ctx.get_tensor_dtype(output_name)).upper()
+    if output_dtype not in {"INT32", "INT64"}:
+        output_dtype = "INT64"
+
+    argmax_output_name = output_name
+    if keepdims:
+        reduced_shape = [
+            int(dim) for idx, dim in enumerate(input_shape) if idx != axis
+        ]
+        if len(reduced_shape) == 0:
+            reduced_shape = [1]
+        argmax_output_name = ctx.add_intermediate_tensor(
+            f"{output_name}_argmax",
+            dtype=output_dtype,
+            shape=reduced_shape,
+        )
+
+    axis_name = ctx.add_const_tensor(
+        f"{output_name}_argmax_axis",
+        np.asarray([axis], dtype=np.int32),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="ARG_MAX",
+            inputs=[input_name, axis_name],
+            outputs=[argmax_output_name],
+            options={
+                "outputType": output_dtype,
+            },
+        )
+    )
+
+    if keepdims:
+        output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+        shape_name = ctx.add_const_tensor(
+            f"{output_name}_argmax_keepdims_shape",
+            np.asarray(output_shape, dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[argmax_output_name, shape_name],
+                outputs=[output_name],
+                options={
+                    "newShape": output_shape,
+                },
+            )
+        )
+
+
+def build_gather_elements_op(node: Any, ctx: Any) -> None:
+    data_name = node.inputs[0].name
+    indices_name = node.inputs[1].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(data_name)
+    ctx.ensure_tensor(indices_name)
+    ctx.ensure_tensor(output_name)
+
+    data_shape = [int(v) for v in ctx.get_tensor_shape(data_name)]
+    indices_shape = [int(v) for v in ctx.get_tensor_shape(indices_name)]
+    output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+    if len(data_shape) != len(indices_shape):
+        raise NotImplementedError(
+            "GatherElements requires data and indices with the same rank in flatbuffer_direct. "
+            f"op={node.name} data_shape={data_shape} indices_shape={indices_shape}"
+        )
+    if indices_shape != output_shape:
+        raise NotImplementedError(
+            "GatherElements requires output shape equal to indices shape in flatbuffer_direct. "
+            f"op={node.name} indices_shape={indices_shape} output_shape={output_shape}"
+        )
+    if any(int(v) <= 0 for v in output_shape):
+        raise NotImplementedError(
+            "GatherElements requires fully static positive output shape in flatbuffer_direct. "
+            f"op={node.name} output_shape={output_shape}"
+        )
+
+    rank = len(data_shape)
+    axis = int(node.attrs.get("axis", 0))
+    if axis < 0:
+        axis += rank
+    if axis < 0 or axis >= rank:
+        raise NotImplementedError(
+            f"GatherElements axis out of range in flatbuffer_direct. op={node.name} axis={axis} rank={rank}"
+        )
+
+    indices_i32_name = indices_name
+    indices_dtype = str(ctx.get_tensor_dtype(indices_name)).upper()
+    if indices_dtype != "INT32":
+        indices_i32_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gather_elements_indices_i32",
+            dtype="INT32",
+            shape=indices_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[indices_name],
+                outputs=[indices_i32_name],
+                options={
+                    "inDataType": indices_dtype,
+                    "outDataType": "INT32",
+                },
+            )
+        )
+
+    axis_coord_shape = [int(v) for v in output_shape] + [1]
+    axis_coord_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_elements_axis_coord",
+        dtype="INT32",
+        shape=axis_coord_shape,
+    )
+    axis_coord_shape_const = ctx.add_const_tensor(
+        f"{output_name}_gather_elements_axis_coord_shape",
+        np.asarray(axis_coord_shape, dtype=np.int32),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=[indices_i32_name, axis_coord_shape_const],
+            outputs=[axis_coord_name],
+            options={"newShape": [int(v) for v in axis_coord_shape]},
+        )
+    )
+
+    grid = np.indices(output_shape, dtype=np.int32)
+    coord_tensors: list[str] = []
+    for dim in range(rank):
+        if dim == axis:
+            coord_tensors.append(axis_coord_name)
+            continue
+        coord_const = ctx.add_const_tensor(
+            f"{output_name}_gather_elements_coord_{dim}",
+            np.expand_dims(grid[dim], axis=-1),
+        )
+        coord_tensors.append(coord_const)
+
+    coords_name = coord_tensors[0]
+    if len(coord_tensors) > 1:
+        coords_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gather_elements_coords",
+            dtype="INT32",
+            shape=[int(v) for v in output_shape] + [int(rank)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CONCATENATION",
+                inputs=coord_tensors,
+                outputs=[coords_name],
+                options={
+                    "axis": int(rank),
+                    "fusedActivationFunction": "NONE",
+                },
+            )
+        )
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="GATHER_ND",
+            inputs=[data_name, coords_name],
+            outputs=[output_name],
         )
     )

--- a/onnx2tf/tflite_builder/opcodes.py
+++ b/onnx2tf/tflite_builder/opcodes.py
@@ -23,9 +23,17 @@ def build_operator_codes(
         if key in op_index_map:
             continue
         oc = schema_tflite["OperatorCodeT"]()
-        builtin_code = getattr(schema_tflite["BuiltinOperator"], op.op_type)
-        oc.builtinCode = builtin_code
-        oc.deprecatedBuiltinCode = builtin_code
+        builtin_code = int(getattr(schema_tflite["BuiltinOperator"], op.op_type))
+        oc.builtinCode = int(builtin_code)
+        deprecated_builtin_code = int(builtin_code)
+        placeholder_code = getattr(
+            schema_tflite["BuiltinOperator"],
+            "PLACEHOLDER_FOR_GREATER_OP_CODES",
+            None,
+        )
+        if deprecated_builtin_code > 127 and placeholder_code is not None:
+            deprecated_builtin_code = int(placeholder_code)
+        oc.deprecatedBuiltinCode = int(deprecated_builtin_code)
         oc.version = int(op.version)
         if op.op_type == "CUSTOM":
             oc.customCode = str(op.options.get("customCode", "CUSTOM"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.15"
+version = "2.0.16"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
This PR is focused on **regression recovery** after the 2.0.15 series, while keeping the TF backend stable and improving flatbuffer_direct robustness.

## Regression-focused fixes
- Reverted high-risk TF backend layout heuristics in `onnx2tf/ops/Conv.py` and `onnx2tf/ops/Transpose.py` that caused channel/layout mismatch regressions.
- Added NMS layout canonicalization in `onnx2tf/ops/NonMaxSuppression.py` to normalize:
  - `boxes`: `[batch, num_boxes, 4]`
  - `scores`: `[batch, num_classes, num_boxes]`
  This addresses reported shape mismatch failures.

## flatbuffer_direct stability and coverage improvements
- Added safer conversion fallback in `onnx2tf/onnx2tf.py`:
  - if TF conversion path fails, try flatbuffer_direct-only conversion directly
  - retry once with custom-op lowering enabled (when not explicitly requested)
- In flatbuffer_direct mode, continue processing when saved_model export path errors are irrelevant.
- Expanded builtin lowering/validation:
  - `ArgMax`, `Cast`, `Expand`, `GatherElements`, `Mod`, `ReduceMax`
- Added Div constant-denominator lowering:
  - `Div(x, const)` -> reciprocal precompute + `Mul`
  - non-float outputs are handled via `CAST -> MUL -> CAST`
- Added `Conv/DepthwiseConv + (RELU/RELU6/TANH)` fusion into `fusedActivationFunction` in flatbuffer_direct IR.
- Improved QLinearConv grouped/depthwise handling and custom fallback behavior for unsupported grouped cases.
- Updated opcode emission for builtin codes >127 compatibility (`deprecatedBuiltinCode` handling).

## Documentation / version
- Updated README flatbuffer_direct capability matrix and notes.
- Bumped version to `2.0.16`.

## Validation performed
- `onnx2tf -i convnext-det.onnx -cotof -tb flatbuffer_direct --report_op_coverage`
  - conversion completed successfully
  - OP error report generation completed
