### PR TITLE
feat(flatbuffer_direct): add builtin coverage and reduce transpose chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Notes:
 |DequantizeLinear|DEQUANTIZE|`scale` must be constant, `zero_point` (if provided) must be constant, per-axis `axis` must be in range|
 |DepthToSpace|DEPTH_TO_SPACE (DCR) / RESHAPE + TRANSPOSE + RESHAPE (CRD)|Rank-4 only, `blocksize > 1`, `mode` in `{DCR,CRD}`|
 |Div|DIV or MUL (when divisor is constant reciprocal)|For non-floating outputs, lowered as `CAST -> MUL(reciprocal) -> CAST` to preserve output dtype without using unsupported integer DIV paths|
+|Dropout|RESHAPE (+ optional SHAPE + FILL for mask output)|Inference-time no-op in flatbuffer_direct; inputs `ratio`/`training_mode` are ignored|
 |DynamicQuantizeLinear|NEG + REDUCE_MAX + MINIMUM + MAXIMUM + SUB + DIV + ADD + CAST|Input dtype must be `FLOAT16/FLOAT32`, output dtypes must be `Y=UINT8`, `Y_Scale=FLOAT16/FLOAT32`, `Y_ZeroPoint=UINT8`; scale/zero-point outputs must be scalar|
 |Einsum|FULLY_CONNECTED|Rank-2 matmul-style equation only (`ij,jk->ik`), rhs input must be constant weights|
 |Elu|ELU|-|
@@ -365,6 +366,7 @@ Notes:
 |HardSigmoid|MUL + ADD + MAXIMUM + MINIMUM|Input/output dtype must be FLOAT16 or FLOAT32|
 |HardSwish|HARD_SWISH|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |Identity|RESHAPE|-|
+|InstanceNormalization|MEAN + SUB + MUL + MEAN + ADD + SQRT + DIV + MUL + ADD|Input/output dtype must be `FLOAT16` or `FLOAT32`; input rank must be `>=3`; `scale` and `bias` inputs must be constant|
 |Less|LESS|-|
 |LessOrEqual|LESS_EQUAL|-|
 |LogSoftmax|SOFTMAX + LOG (+ transpose in/out for non-last axis)|`axis` must be in range (negative axis normalized)|
@@ -556,8 +558,8 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - onnxruntime==1.24.1
 - onnxsim-prebuilt==0.4.39.post2
 - onnxoptimizer==0.4.2
-- sne4onnx>=2.0.0
-- sng4onnx>=2.0.0
+- sne4onnx>=2.0.1
+- sng4onnx>=2.0.1
 - tensorflow==2.19.0
 - tf-keras==2.19.0
 - ai-edge-litert==2.1.2
@@ -610,7 +612,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.21
+  ghcr.io/pinto0309/onnx2tf:2.0.22
 
   or
 
@@ -619,7 +621,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.21
+  docker.io/pinto0309/onnx2tf:2.0.22
 
   or
 
@@ -629,7 +631,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.0.21 \
+  docker.io/pinto0309/onnx2tf:2.0.22 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.21'
+__version__ = '2.0.22'

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -1798,6 +1798,12 @@ def _reconcile_static_tensor_shapes(model_ir: ModelIR) -> Dict[str, int]:
                 size_tensor = model_ir.tensors.get(inputs[2], None)
                 if input_tensor is None:
                     continue
+                input_signature = (
+                    list(input_tensor.shape_signature)
+                    if input_tensor.shape_signature is not None
+                    else list(input_tensor.shape)
+                )
+                has_dynamic_input_dim = any(int(v) < 0 for v in input_signature)
                 begin_vals = _read_const_ints_from_tensor(begin_tensor)
                 size_vals = _read_const_ints_from_tensor(size_tensor)
                 out_shape, resolved_begin, resolved_size = _infer_slice_output_shape_and_resolved_params(
@@ -1808,8 +1814,12 @@ def _reconcile_static_tensor_shapes(model_ir: ModelIR) -> Dict[str, int]:
                 if out_shape is None or resolved_begin is None or resolved_size is None:
                     continue
                 changed |= _update_tensor_shape(outputs[0], out_shape)
-                changed |= _write_const_ints_to_tensor(begin_tensor, resolved_begin)
-                changed |= _write_const_ints_to_tensor(size_tensor, resolved_size)
+                # Keep runtime-driven SLICE semantics when input dimensions are dynamic.
+                # Rewriting `size=-1` with placeholder static dims (e.g. 1) can collapse
+                # dynamic axes and change model outputs.
+                if not has_dynamic_input_dim:
+                    changed |= _write_const_ints_to_tensor(begin_tensor, resolved_begin)
+                    changed |= _write_const_ints_to_tensor(size_tensor, resolved_size)
                 continue
 
             if op_type in {"CONV_2D", "DEPTHWISE_CONV_2D"} and len(inputs) >= 2 and len(outputs) == 1:
@@ -9226,6 +9236,482 @@ def _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir:
     return {"optimized_transpose_input_chains_pre_concat_to_single_post_adapter": int(optimized)}
 
 
+def _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Collapse repeated NCHW adapters in detection heads into a single 3D post-CONCAT transpose.
+
+    Target (per branch):
+      x_nhwc --TRANSPOSE(0,3,1,2)--> x_nchw
+      x_nchw --SLICE--> a_nchw --(optional LOGISTIC)--> a'_nchw
+      x_nchw --SLICE--> b_nchw
+      CONCAT(axis=1, [a'_nchw, b_nchw]) -> c_nchw
+      RESHAPE([N,C,S]) -> r_nchw
+
+    Tail:
+      CONCAT(axis=2, [r0_nchw, r1_nchw, ...]) -> y_nchw
+
+    Rewrite:
+      - Per branch: keep everything in NHWC
+          x_nhwc --SLICE--> a_nhwc --(optional LOGISTIC)--> a'_nhwc
+          x_nhwc --SLICE--> b_nhwc
+          CONCAT(axis=3) -> c_nhwc
+          RESHAPE([N,S,C]) -> r_nhwc
+      - Tail:
+          CONCAT(axis=1, [r0_nhwc, r1_nhwc, ...]) -> y_nhwc
+          y_nhwc --TRANSPOSE(0,2,1)--> y_nchw
+    """
+    optimized = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    perm_3d_nchw_to_nhwc = [0, 2, 1]
+    unary_ops = {"LOGISTIC"}
+
+    def _unique_tensor_name(base: str) -> str:
+        name = str(base)
+        suffix = 1
+        while name in model_ir.tensors:
+            name = f"{base}_{suffix}"
+            suffix += 1
+        return name
+
+    def _op_index(op_ref: OperatorIR) -> Optional[int]:
+        for idx, op in enumerate(model_ir.operators):
+            if int(id(op)) == int(id(op_ref)):
+                return int(idx)
+        return None
+
+    def _find_or_create_perm_3d_nhwc_to_nchw() -> str:
+        target = np.asarray(perm_3d_nchw_to_nhwc, dtype=np.int32)
+        for tensor_name, tensor in model_ir.tensors.items():
+            if tensor is None or tensor.data is None:
+                continue
+            data = np.asarray(tensor.data)
+            if data.dtype != np.int32 or int(data.size) != 3:
+                continue
+            if np.array_equal(data.reshape(-1), target):
+                return str(tensor_name)
+        perm_name = _unique_tensor_name("transpose_tail_3d_nhwc_to_nchw_perm")
+        model_ir.tensors[perm_name] = TensorIR(
+            name=perm_name,
+            dtype="INT32",
+            shape=[3],
+            shape_signature=[3],
+            data=np.asarray(target, dtype=np.int32),
+            is_variable=False,
+        )
+        return perm_name
+
+    def _swap_reshape_shape_tensor(
+        *,
+        reshape_op: OperatorIR,
+        reshape_idx: int,
+        consumers: Dict[str, List[int]],
+    ) -> bool:
+        if len(reshape_op.inputs) < 2:
+            return False
+        shape_name = str(reshape_op.inputs[1])
+        shape_tensor = model_ir.tensors.get(shape_name, None)
+        shape_vals = _read_const_ints_from_tensor(shape_tensor)
+        if shape_vals is None or len(shape_vals) != 3:
+            return False
+        swapped = [int(shape_vals[0]), int(shape_vals[2]), int(shape_vals[1])]
+        shape_consumers = [int(v) for v in consumers.get(shape_name, [])]
+        if any(int(v) != int(reshape_idx) for v in shape_consumers):
+            if shape_tensor is None:
+                return False
+            cloned_name = _unique_tensor_name(f"{shape_name}_nhwc")
+            data_dtype = np.int32
+            if shape_tensor.data is not None:
+                try:
+                    data_dtype = np.asarray(shape_tensor.data).dtype
+                except Exception:
+                    data_dtype = np.int32
+            swapped_arr = np.asarray(swapped, dtype=data_dtype)
+            model_ir.tensors[cloned_name] = TensorIR(
+                name=cloned_name,
+                dtype=str(shape_tensor.dtype),
+                shape=[int(v) for v in list(swapped_arr.shape)],
+                shape_signature=[int(v) for v in list(swapped_arr.shape)],
+                data=np.asarray(swapped_arr),
+                is_variable=False,
+                quantization=_clone_quantization(shape_tensor.quantization),
+            )
+            reshape_inputs = [str(v) for v in list(reshape_op.inputs)]
+            reshape_inputs[1] = str(cloned_name)
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=reshape_op,
+                new_inputs=reshape_inputs,
+            )
+            return True
+        _write_const_ints_to_tensor(shape_tensor, swapped)
+        return True
+
+    def _swap_reshape_option_shape(reshape_op: OperatorIR) -> None:
+        if not isinstance(reshape_op.options, dict):
+            return
+        opts = dict(reshape_op.options)
+        changed = False
+        for key in ["newShape", "onnxRawNewShape"]:
+            value = opts.get(key, None)
+            if not isinstance(value, list) or len(value) != 3:
+                continue
+            swapped = [int(value[0]), int(value[2]), int(value[1])]
+            if swapped != [int(v) for v in value]:
+                opts[key] = swapped
+                changed = True
+        if changed:
+            reshape_op.options = opts
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for tail_concat_idx, tail_concat_op in enumerate(model_ir.operators):
+            if str(tail_concat_op.op_type) != "CONCATENATION" or len(tail_concat_op.outputs) != 1:
+                continue
+            tail_axis = int(tail_concat_op.options.get("axis", 2))
+            if tail_axis < 0:
+                tail_axis += 3
+            if tail_axis != 2:
+                continue
+
+            tail_out_name = str(tail_concat_op.outputs[0])
+            tail_out_tensor = model_ir.tensors.get(tail_out_name, None)
+            if tail_out_tensor is None or len(list(tail_out_tensor.shape)) != 3:
+                continue
+
+            tail_inputs = [str(v) for v in list(tail_concat_op.inputs)]
+            if len(tail_inputs) < 2:
+                continue
+
+            branch_plans: List[Dict[str, Any]] = []
+            removable_pre_transpose_ids: set[int] = set()
+            rewritable = True
+
+            for reshape_out_name in tail_inputs:
+                reshape_idx = producers.get(str(reshape_out_name), None)
+                if reshape_idx is None:
+                    rewritable = False
+                    break
+                reshape_op = model_ir.operators[int(reshape_idx)]
+                if (
+                    str(reshape_op.op_type) != "RESHAPE"
+                    or len(reshape_op.inputs) < 2
+                    or len(reshape_op.outputs) != 1
+                    or str(reshape_op.outputs[0]) != str(reshape_out_name)
+                ):
+                    rewritable = False
+                    break
+                if set(int(v) for v in consumers.get(str(reshape_out_name), [])) != {int(tail_concat_idx)}:
+                    rewritable = False
+                    break
+
+                branch_concat_out_name = str(reshape_op.inputs[0])
+                branch_concat_idx = producers.get(branch_concat_out_name, None)
+                if branch_concat_idx is None:
+                    rewritable = False
+                    break
+                branch_concat_op = model_ir.operators[int(branch_concat_idx)]
+                if str(branch_concat_op.op_type) != "CONCATENATION" or len(branch_concat_op.outputs) != 1:
+                    rewritable = False
+                    break
+                branch_axis = int(branch_concat_op.options.get("axis", 1))
+                if branch_axis < 0:
+                    branch_axis += 4
+                if branch_axis != 1:
+                    rewritable = False
+                    break
+                if set(int(v) for v in consumers.get(branch_concat_out_name, [])) != {int(reshape_idx)}:
+                    rewritable = False
+                    break
+
+                branch_concat_inputs = [str(v) for v in list(branch_concat_op.inputs)]
+                if len(branch_concat_inputs) != 2:
+                    rewritable = False
+                    break
+
+                pre_transpose_idx: Optional[int] = None
+                unary_indices: List[int] = []
+                slice_plans: List[Dict[str, Any]] = []
+                expected_pre_users: set[int] = set()
+
+                for branch_input_name in branch_concat_inputs:
+                    slice_out_name = str(branch_input_name)
+                    unary_idx: Optional[int] = None
+
+                    maybe_unary_idx = producers.get(slice_out_name, None)
+                    if maybe_unary_idx is not None:
+                        maybe_unary_op = model_ir.operators[int(maybe_unary_idx)]
+                        if (
+                            str(maybe_unary_op.op_type) in unary_ops
+                            and len(maybe_unary_op.inputs) == 1
+                            and len(maybe_unary_op.outputs) == 1
+                            and str(maybe_unary_op.outputs[0]) == slice_out_name
+                            and set(int(v) for v in consumers.get(slice_out_name, [])) == {int(branch_concat_idx)}
+                            and slice_out_name not in model_outputs
+                        ):
+                            unary_idx = int(maybe_unary_idx)
+                            unary_indices.append(int(maybe_unary_idx))
+                            slice_out_name = str(maybe_unary_op.inputs[0])
+
+                    slice_idx = producers.get(slice_out_name, None)
+                    if slice_idx is None:
+                        rewritable = False
+                        break
+                    slice_op = model_ir.operators[int(slice_idx)]
+                    if (
+                        str(slice_op.op_type) != "SLICE"
+                        or len(slice_op.inputs) < 3
+                        or len(slice_op.outputs) != 1
+                        or str(slice_op.outputs[0]) != slice_out_name
+                    ):
+                        rewritable = False
+                        break
+                    expected_slice_users = {int(unary_idx)} if unary_idx is not None else {int(branch_concat_idx)}
+                    if set(int(v) for v in consumers.get(slice_out_name, [])) != expected_slice_users:
+                        rewritable = False
+                        break
+
+                    begin_name = str(slice_op.inputs[1])
+                    size_name = str(slice_op.inputs[2])
+                    begin_vals = _read_const_ints_from_tensor(model_ir.tensors.get(begin_name, None))
+                    size_vals = _read_const_ints_from_tensor(model_ir.tensors.get(size_name, None))
+                    if begin_vals is None or size_vals is None or len(begin_vals) != 4 or len(size_vals) != 4:
+                        rewritable = False
+                        break
+                    if int(begin_vals[0]) != 0 or int(begin_vals[2]) != 0 or int(begin_vals[3]) != 0:
+                        rewritable = False
+                        break
+                    if int(begin_vals[1]) < 0 or int(size_vals[1]) <= 0:
+                        rewritable = False
+                        break
+
+                    pre_idx = producers.get(str(slice_op.inputs[0]), None)
+                    if pre_idx is None:
+                        rewritable = False
+                        break
+                    pre_op = model_ir.operators[int(pre_idx)]
+                    if (
+                        str(pre_op.op_type) != "TRANSPOSE"
+                        or len(pre_op.inputs) < 2
+                        or len(pre_op.outputs) != 1
+                        or str(pre_op.outputs[0]) != str(slice_op.inputs[0])
+                        or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+                        or str(pre_op.outputs[0]) in model_outputs
+                    ):
+                        rewritable = False
+                        break
+                    if pre_transpose_idx is None:
+                        pre_transpose_idx = int(pre_idx)
+                    elif int(pre_transpose_idx) != int(pre_idx):
+                        rewritable = False
+                        break
+
+                    expected_pre_users.add(int(slice_idx))
+                    slice_plans.append(
+                        {
+                            "slice_idx": int(slice_idx),
+                            "slice_out_name": str(slice_out_name),
+                            "begin_name": str(begin_name),
+                            "size_name": str(size_name),
+                        }
+                    )
+
+                if not rewritable or pre_transpose_idx is None:
+                    rewritable = False
+                    break
+
+                pre_op = model_ir.operators[int(pre_transpose_idx)]
+                pre_out_name = str(pre_op.outputs[0])
+                if set(int(v) for v in consumers.get(pre_out_name, [])) != set(expected_pre_users):
+                    rewritable = False
+                    break
+
+                pre_input_name = str(pre_op.inputs[0])
+                pre_input_tensor = model_ir.tensors.get(pre_input_name, None)
+                pre_out_tensor = model_ir.tensors.get(pre_out_name, None)
+                if (
+                    pre_input_tensor is None
+                    or pre_out_tensor is None
+                    or len(list(pre_input_tensor.shape)) != 4
+                    or len(list(pre_out_tensor.shape)) != 4
+                ):
+                    rewritable = False
+                    break
+
+                branch_plans.append(
+                    {
+                        "reshape_idx": int(reshape_idx),
+                        "reshape_out_name": str(reshape_out_name),
+                        "branch_concat_idx": int(branch_concat_idx),
+                        "branch_concat_out_name": str(branch_concat_out_name),
+                        "pre_transpose_idx": int(pre_transpose_idx),
+                        "pre_input_name": str(pre_input_name),
+                        "unary_indices": [int(v) for v in unary_indices],
+                        "slice_plans": list(slice_plans),
+                    }
+                )
+                removable_pre_transpose_ids.add(int(id(pre_op)))
+
+            if not rewritable or len(branch_plans) < 2:
+                continue
+
+            # Keep this rewrite strict: all branch reshapes must share the same channel dimension.
+            channel_dim: Optional[int] = None
+            for plan in branch_plans:
+                reshape_tensor = model_ir.tensors.get(str(plan["reshape_out_name"]), None)
+                if reshape_tensor is None or len(list(reshape_tensor.shape)) != 3:
+                    rewritable = False
+                    break
+                cdim = int(reshape_tensor.shape[1]) if len(list(reshape_tensor.shape)) > 1 else -1
+                if cdim <= 0:
+                    rewritable = False
+                    break
+                if channel_dim is None:
+                    channel_dim = int(cdim)
+                elif int(channel_dim) != int(cdim):
+                    rewritable = False
+                    break
+            if not rewritable:
+                continue
+
+            apply_ok = True
+            for plan in branch_plans:
+                pre_input_name = str(plan["pre_input_name"])
+
+                for slice_plan in list(plan["slice_plans"]):
+                    slice_idx = int(slice_plan["slice_idx"])
+                    begin_name = str(slice_plan["begin_name"])
+                    size_name = str(slice_plan["size_name"])
+                    if set(int(v) for v in consumers.get(begin_name, [])) != {int(slice_idx)}:
+                        apply_ok = False
+                        break
+                    if set(int(v) for v in consumers.get(size_name, [])) != {int(slice_idx)}:
+                        apply_ok = False
+                        break
+
+                    slice_op = model_ir.operators[int(slice_idx)]
+                    begin_tensor = model_ir.tensors.get(begin_name, None)
+                    size_tensor = model_ir.tensors.get(size_name, None)
+                    begin_vals = _read_const_ints_from_tensor(begin_tensor)
+                    size_vals = _read_const_ints_from_tensor(size_tensor)
+                    if begin_vals is None or size_vals is None or len(begin_vals) != 4 or len(size_vals) != 4:
+                        apply_ok = False
+                        break
+
+                    new_begin = [int(begin_vals[0]), int(begin_vals[2]), int(begin_vals[3]), int(begin_vals[1])]
+                    new_size = [int(size_vals[0]), int(size_vals[2]), int(size_vals[3]), int(size_vals[1])]
+                    _write_const_ints_to_tensor(begin_tensor, new_begin)
+                    _write_const_ints_to_tensor(size_tensor, new_size)
+                    _replace_operator_input_at(
+                        model_ir=model_ir,
+                        op=slice_op,
+                        input_index=0,
+                        new_input_name=pre_input_name,
+                    )
+                    _permute_tensor_metadata_if_rank_matches(
+                        model_ir.tensors.get(str(slice_plan["slice_out_name"]), None),
+                        perm_nchw_to_nhwc,
+                    )
+
+                if not apply_ok:
+                    break
+
+                for unary_idx in list(plan["unary_indices"]):
+                    unary_out_name = str(model_ir.operators[int(unary_idx)].outputs[0])
+                    _permute_tensor_metadata_if_rank_matches(
+                        model_ir.tensors.get(unary_out_name, None),
+                        perm_nchw_to_nhwc,
+                    )
+
+                branch_concat_op = model_ir.operators[int(plan["branch_concat_idx"])]
+                branch_concat_op.options["axis"] = 3
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(plan["branch_concat_out_name"]), None),
+                    perm_nchw_to_nhwc,
+                )
+
+                reshape_op = model_ir.operators[int(plan["reshape_idx"])]
+                if not _swap_reshape_shape_tensor(
+                    reshape_op=reshape_op,
+                    reshape_idx=int(plan["reshape_idx"]),
+                    consumers=consumers,
+                ):
+                    apply_ok = False
+                    break
+                _swap_reshape_option_shape(reshape_op)
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(plan["reshape_out_name"]), None),
+                    perm_3d_nchw_to_nhwc,
+                )
+
+            if not apply_ok:
+                continue
+
+            tail_shape = [int(v) for v in list(tail_out_tensor.shape)]
+            tail_signature = (
+                [int(v) for v in list(tail_out_tensor.shape_signature)]
+                if tail_out_tensor.shape_signature is not None
+                else [int(v) for v in list(tail_out_tensor.shape)]
+            )
+            tail_nhwc_shape = _permute_shape(tail_shape, perm_3d_nchw_to_nhwc)
+            tail_nhwc_signature = _permute_shape(tail_signature, perm_3d_nchw_to_nhwc)
+            if tail_nhwc_shape is None or tail_nhwc_signature is None:
+                continue
+
+            tail_concat_nhwc_name = _unique_tensor_name(f"{tail_out_name}_nhwc")
+            model_ir.tensors[tail_concat_nhwc_name] = TensorIR(
+                name=tail_concat_nhwc_name,
+                dtype=str(tail_out_tensor.dtype),
+                shape=[int(v) for v in list(tail_nhwc_shape)],
+                shape_signature=[int(v) for v in list(tail_nhwc_signature)],
+                data=None,
+                is_variable=False,
+                quantization=_clone_quantization(tail_out_tensor.quantization),
+            )
+            tail_concat_op.options["axis"] = 1
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=tail_concat_op,
+                new_outputs=[tail_concat_nhwc_name],
+            )
+
+            perm_3d_name = _find_or_create_perm_3d_nhwc_to_nchw()
+            tail_concat_current_idx = _op_index(tail_concat_op)
+            if tail_concat_current_idx is None:
+                continue
+            model_ir.operators.insert(
+                int(tail_concat_current_idx) + 1,
+                OperatorIR(
+                    op_type="TRANSPOSE",
+                    inputs=[tail_concat_nhwc_name, perm_3d_name],
+                    outputs=[tail_out_name],
+                    options={},
+                ),
+            )
+
+            remove_indices = [
+                int(op_idx)
+                for op_idx, op in enumerate(model_ir.operators)
+                if int(id(op)) in removable_pre_transpose_ids
+            ]
+            for remove_idx in sorted(list(set(remove_indices)), reverse=True):
+                del model_ir.operators[int(remove_idx)]
+
+            optimized += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_slice_logistic_concat_reshape_tail_nhwc_chains": int(optimized)}
+
+
 def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str, int]:
     """
     Optimize ShuffleNet-style channel-shuffle blocks that rely on NCHW transpose chains.
@@ -9315,6 +9801,76 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
             and int(out_shape[1]) == 1
         )
 
+    def _parse_shuffle_split_candidate(
+        *,
+        op: OperatorIR,
+        split_base_name: str,
+        half_channels: int,
+    ) -> Optional[Tuple[int, str]]:
+        """
+        Parse one shuffle split branch selector and return:
+          (selector_idx_value, output_name), where selector_idx_value in {0, 1}.
+
+        Supported forms:
+        - GATHER(axis=0, indices scalar in {0,1}) on rank-5 split base
+        - SLICE(begin/size const) selecting channel-halves on NCHW rank-4 split base
+        """
+        if len(op.outputs) != 1:
+            return None
+        output_name = str(op.outputs[0])
+
+        if str(op.op_type) == "GATHER":
+            if len(op.inputs) < 2:
+                return None
+            if int(op.options.get("axis", 0)) != 0:
+                return None
+            idx_vals = _read_const_ints_from_tensor(model_ir.tensors.get(str(op.inputs[1]), None))
+            if idx_vals is None or len(idx_vals) != 1:
+                return None
+            idx_value = int(idx_vals[0])
+            if idx_value not in [0, 1]:
+                return None
+            return int(idx_value), output_name
+
+        if str(op.op_type) == "SLICE":
+            if len(op.inputs) < 3:
+                return None
+            if str(op.inputs[0]) != str(split_base_name):
+                return None
+            begin_vals = _read_const_ints_from_tensor(model_ir.tensors.get(str(op.inputs[1]), None))
+            size_vals = _read_const_ints_from_tensor(model_ir.tensors.get(str(op.inputs[2]), None))
+            if begin_vals is None or size_vals is None:
+                return None
+            if len(begin_vals) != len(size_vals) or len(begin_vals) != 4:
+                return None
+
+            axis = 1
+            begin = [int(v) for v in begin_vals]
+            size = [int(v) for v in size_vals]
+            start = int(begin[axis])
+            if start not in [0, int(half_channels)]:
+                return None
+            idx_value = 0 if int(start) == 0 else 1
+            if int(size[axis]) != int(half_channels):
+                return None
+            for dim_idx in range(4):
+                if dim_idx == axis:
+                    continue
+                if int(begin[dim_idx]) != 0:
+                    return None
+                # Non-channel dims can be full extent (-1) or explicit full size.
+                # Anything else means this is not a simple channel-halving split.
+                if int(size[dim_idx]) not in [-1]:
+                    split_base_tensor = model_ir.tensors.get(str(split_base_name), None)
+                    if split_base_tensor is None or len(list(split_base_tensor.shape)) != 4:
+                        return None
+                    split_dim = int(split_base_tensor.shape[dim_idx])
+                    if int(split_dim) <= 0 or int(size[dim_idx]) != int(split_dim):
+                        return None
+            return int(idx_value), output_name
+
+        return None
+
     while True:
         changed = False
         consumers = _build_tensor_consumer_map(model_ir)
@@ -9365,8 +9921,10 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
             t1_op = model_ir.operators[int(t1_users[0])]
             if str(t1_op.op_type) != "TRANSPOSE" or len(t1_op.inputs) < 2 or len(t1_op.outputs) != 1:
                 continue
-            if _read_transpose_perm(model_ir, t1_op) != [1, 0, 2]:
+            t1_perm = _read_transpose_perm(model_ir, t1_op)
+            if t1_perm not in ([1, 0, 2], [0, 2, 1, 3, 4]):
                 continue
+            is_rank5_shuffle_swap = bool(t1_perm == [0, 2, 1, 3, 4])
             t1_out = str(t1_op.outputs[0])
             if t1_out in model_outputs:
                 continue
@@ -9381,43 +9939,43 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
             if split_base in model_outputs:
                 continue
 
-            gather_user_indices = [int(v) for v in consumers.get(split_base, [])]
-            if len(gather_user_indices) != 2:
+            split_user_indices = [int(v) for v in consumers.get(split_base, [])]
+            if len(split_user_indices) != 2:
                 continue
-            gather_candidates: Dict[int, Tuple[int, OperatorIR, str]] = {}
-            gather_ops: List[OperatorIR] = []
-            gather_ids: set[int] = set()
-            valid_gathers = True
-            for g_idx in gather_user_indices:
-                g_op = model_ir.operators[int(g_idx)]
-                if str(g_op.op_type) != "GATHER" or len(g_op.inputs) < 2 or len(g_op.outputs) != 1:
-                    valid_gathers = False
+            split_candidates: Dict[int, Tuple[int, OperatorIR, str]] = {}
+            split_ids: set[int] = set()
+            valid_split_candidates = True
+            for split_idx in split_user_indices:
+                split_op = model_ir.operators[int(split_idx)]
+                parsed = _parse_shuffle_split_candidate(
+                    op=split_op,
+                    split_base_name=split_base,
+                    half_channels=int(half_channels),
+                )
+                if parsed is None:
+                    valid_split_candidates = False
                     break
-                if int(g_op.options.get("axis", 0)) != 0:
-                    valid_gathers = False
+                idx_value, out_name = parsed
+                if int(idx_value) in split_ids:
+                    valid_split_candidates = False
                     break
-                idx_vals = _read_const_ints_from_tensor(model_ir.tensors.get(str(g_op.inputs[1]), None))
-                if idx_vals is None or len(idx_vals) != 1:
-                    valid_gathers = False
-                    break
-                idx_value = int(idx_vals[0])
-                if idx_value not in [0, 1] or idx_value in gather_ids:
-                    valid_gathers = False
-                    break
-                gather_ids.add(int(idx_value))
-                gather_candidates[int(idx_value)] = (int(g_idx), g_op, str(g_op.outputs[0]))
-                gather_ops.append(g_op)
-            if not valid_gathers or set(gather_candidates.keys()) != {0, 1}:
+                split_ids.add(int(idx_value))
+                split_candidates[int(idx_value)] = (
+                    int(split_idx),
+                    split_op,
+                    str(out_name),
+                )
+            if not valid_split_candidates or set(split_candidates.keys()) != {0, 1}:
                 continue
 
-            # Determine which gather feeds NHWC conv-branch through NCHW->NHWC transpose.
-            conv_gather_idx_value: Optional[int] = None
+            # Determine which split candidate feeds NHWC conv-branch through NCHW->NHWC transpose.
+            conv_split_idx_value: Optional[int] = None
             pre_conv_t_idx: Optional[int] = None
             pre_conv_t_op: Optional[OperatorIR] = None
             pre_conv_out_name: Optional[str] = None
             for idx_value in [0, 1]:
-                _, _, gather_out = gather_candidates[idx_value]
-                users = [int(v) for v in consumers.get(gather_out, [])]
+                _, _, split_out = split_candidates[idx_value]
+                users = [int(v) for v in consumers.get(split_out, [])]
                 if len(users) != 1:
                     continue
                 maybe_t_idx = int(users[0])
@@ -9429,21 +9987,21 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
                     and _read_transpose_perm(model_ir, maybe_t_op) == perm_nchw_to_nhwc
                     and str(maybe_t_op.outputs[0]) not in model_outputs
                 ):
-                    conv_gather_idx_value = int(idx_value)
+                    conv_split_idx_value = int(idx_value)
                     pre_conv_t_idx = int(maybe_t_idx)
                     pre_conv_t_op = maybe_t_op
                     pre_conv_out_name = str(maybe_t_op.outputs[0])
                     break
             if (
-                conv_gather_idx_value is None
+                conv_split_idx_value is None
                 or pre_conv_t_idx is None
                 or pre_conv_t_op is None
                 or pre_conv_out_name is None
             ):
                 continue
-            skip_gather_idx_value = 1 - int(conv_gather_idx_value)
-            _, _, skip_gather_out_name = gather_candidates[int(skip_gather_idx_value)]
-            if skip_gather_out_name in model_outputs:
+            skip_split_idx_value = 1 - int(conv_split_idx_value)
+            _, _, skip_split_out_name = split_candidates[int(skip_split_idx_value)]
+            if skip_split_out_name in model_outputs:
                 continue
 
             pre_conv_out_users = [int(v) for v in consumers.get(pre_conv_out_name, [])]
@@ -9493,7 +10051,7 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
             if branch_nchw_start_name in model_outputs:
                 continue
 
-            skip_users = [int(v) for v in consumers.get(skip_gather_out_name, [])]
+            skip_users = [int(v) for v in consumers.get(skip_split_out_name, [])]
             if len(skip_users) != 1:
                 continue
             concat1_idx = int(skip_users[0])
@@ -9503,7 +10061,7 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
             if int(concat1_op.options.get("axis", -1)) != 1:
                 continue
             concat1_inputs = [str(v) for v in list(concat1_op.inputs)]
-            if len(concat1_inputs) != 2 or skip_gather_out_name not in concat1_inputs:
+            if len(concat1_inputs) != 2 or skip_split_out_name not in concat1_inputs:
                 continue
 
             branch_nchw_cursor = branch_nchw_start_name
@@ -9536,7 +10094,7 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
             if branch_concat_input_nchw not in concat1_inputs:
                 continue
 
-            # Build NHWC even/odd gather tensors from concat0 output.
+            # Build NHWC branch gather tensors from concat0 output.
             x_signature = (
                 list(x_nhwc_tensor.shape_signature)
                 if x_nhwc_tensor.shape_signature is not None
@@ -9563,6 +10121,43 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
                 quantization=_clone_quantization(x_nhwc_tensor.quantization),
             )
 
+            if is_rank5_shuffle_swap:
+                r1_tensor = model_ir.tensors.get(str(r1_out), None)
+                if r1_tensor is None:
+                    continue
+                r1_shape = [int(v) for v in list(r1_tensor.shape)]
+                if len(r1_shape) != 5 or not _is_fully_known_positive_shape(r1_shape):
+                    continue
+                groups = int(r1_shape[1])
+                cpg = int(r1_shape[2])
+                if (
+                    int(groups) <= 1
+                    or int(cpg) <= 0
+                    or int(groups) != 2
+                    or int(groups * cpg) != int(channels)
+                ):
+                    continue
+                shuffle_indices = np.asarray(
+                    [int((k % groups) * cpg + (k // groups)) for k in range(int(channels))],
+                    dtype=np.int32,
+                )
+                first_split_indices = np.asarray(shuffle_indices[:int(half_channels)], dtype=np.int32)
+                second_split_indices = np.asarray(shuffle_indices[int(half_channels):], dtype=np.int32)
+            else:
+                first_split_indices = np.asarray(
+                    [int(v) for v in range(0, int(channels), 2)],
+                    dtype=np.int32,
+                )
+                second_split_indices = np.asarray(
+                    [int(v) for v in range(1, int(channels), 2)],
+                    dtype=np.int32,
+                )
+            if (
+                len(first_split_indices) != int(half_channels)
+                or len(second_split_indices) != int(half_channels)
+            ):
+                continue
+
             even_indices_name = _unique_tensor_name(f"{x_nhwc_name}_shuffle_even_indices")
             odd_indices_name = _unique_tensor_name(f"{x_nhwc_name}_shuffle_odd_indices")
             model_ir.tensors[even_indices_name] = TensorIR(
@@ -9570,7 +10165,7 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
                 dtype="INT32",
                 shape=[int(half_channels)],
                 shape_signature=[int(half_channels)],
-                data=np.asarray([int(v) for v in range(0, int(channels), 2)], dtype=np.int32),
+                data=np.asarray(first_split_indices, dtype=np.int32),
                 is_variable=False,
             )
             model_ir.tensors[odd_indices_name] = TensorIR(
@@ -9578,7 +10173,7 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
                 dtype="INT32",
                 shape=[int(half_channels)],
                 shape_signature=[int(half_channels)],
-                data=np.asarray([int(v) for v in range(1, int(channels), 2)], dtype=np.int32),
+                data=np.asarray(second_split_indices, dtype=np.int32),
                 is_variable=False,
             )
 
@@ -9595,8 +10190,8 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
                 options={"axis": 3, "batchDims": 0},
             )
 
-            conv_branch_input_nhwc = even_name if int(conv_gather_idx_value) == 0 else odd_name
-            skip_branch_input_nhwc = odd_name if int(conv_gather_idx_value) == 0 else even_name
+            conv_branch_input_nhwc = even_name if int(conv_split_idx_value) == 0 else odd_name
+            skip_branch_input_nhwc = odd_name if int(conv_split_idx_value) == 0 else even_name
 
             # Rewrite branch start input.
             _replace_tensor_inputs(model_ir, pre_conv_out_name, conv_branch_input_nhwc)
@@ -9644,7 +10239,7 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
 
             new_concat1_inputs: List[str] = []
             for input_name in concat1_inputs:
-                if str(input_name) == str(skip_gather_out_name):
+                if str(input_name) == str(skip_split_out_name):
                     new_concat1_inputs.append(str(skip_branch_input_nhwc))
                 elif str(input_name) == str(branch_concat_input_nchw):
                     new_concat1_inputs.append(str(branch_concat_input_nhwc))
@@ -9704,8 +10299,8 @@ def _optimize_shufflenet_transpose_shuffle_chains(model_ir: ModelIR) -> Dict[str
                 int(id(r1_op)),
                 int(id(t1_op)),
                 int(id(r2_op)),
-                int(id(gather_candidates[0][1])),
-                int(id(gather_candidates[1][1])),
+                int(id(split_candidates[0][1])),
+                int(id(split_candidates[1][1])),
                 int(id(pre_conv_t_op)),
                 int(id(transpose_post_op)),
             }
@@ -9959,7 +10554,7 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
     optimized = 0
     perm_nhwc_to_nchw = [0, 3, 1, 2]
     perm_nchw_to_nhwc = [0, 2, 3, 1]
-    unary_passthrough_ops = {"RELU", "RELU6", "LOGISTIC", "TANH", "GELU", "HARD_SWISH"}
+    unary_passthrough_ops = {"RELU", "RELU6", "LOGISTIC", "TANH", "GELU", "HARD_SWISH", "LEAKY_RELU"}
     skip_add_activation_fuse_marker = "__skip_add_activation_fuse__"
 
     def _unique_tensor_name(base: str) -> str:
@@ -10217,7 +10812,7 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                 continue
 
             side_data = np.asarray(side_tensor.data)
-            if int(side_data.size) != 1 and side_data.ndim != 4:
+            if int(side_data.size) != 1 and side_data.ndim not in {3, 4}:
                 continue
             if int(side_data.size) != 1:
                 if _broadcast_static_shapes(list(data_tensor.shape), [int(v) for v in list(side_data.shape)]) is None:
@@ -10256,8 +10851,14 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
             else:
                 rotated = np.asarray(side_data)
                 found = False
-                for _ in range(3):
-                    rotated = np.transpose(rotated, perm_nchw_to_nhwc).astype(side_data.dtype, copy=False)
+                transpose_perm = (
+                    perm_nchw_to_nhwc
+                    if int(rotated.ndim) == 4
+                    else [1, 2, 0]
+                )
+                max_rotate = 3 if int(rotated.ndim) == 3 else 1
+                for _ in range(int(max_rotate)):
+                    rotated = np.transpose(rotated, transpose_perm).astype(side_data.dtype, copy=False)
                     rotated_shape = [int(v) for v in list(rotated.shape)]
                     if _broadcast_static_shapes(target_nhwc_shape, rotated_shape) is not None:
                         nhwc_side_data = np.asarray(rotated)
@@ -10335,6 +10936,252 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
         )
         return [int(pre_idx)]
 
+    def _analyze_mul_sub_const_input_to_nhwc(
+        *,
+        input_name: str,
+        consumer_idx: int,
+        producers: Dict[str, int],
+        consumers: Dict[str, List[int]],
+        model_outputs: set[str],
+    ) -> Optional[Dict[str, Any]]:
+        mul_idx = producers.get(str(input_name), None)
+        if mul_idx is None:
+            return None
+        mul_op = model_ir.operators[int(mul_idx)]
+        if str(mul_op.op_type) != "MUL" or len(mul_op.inputs) != 2 or len(mul_op.outputs) != 1:
+            return None
+        if str(mul_op.outputs[0]) != str(input_name):
+            return None
+        if str(input_name) in model_outputs:
+            return None
+        if set(int(v) for v in consumers.get(str(input_name), [])) != {int(consumer_idx)}:
+            return None
+
+        mul_data_input_index: Optional[int] = None
+        mul_side_input_index: Optional[int] = None
+        mul_side_input_name: Optional[str] = None
+        sub_idx: Optional[int] = None
+        sub_out_name: Optional[str] = None
+        sub_input_rewrites: List[Dict[str, Any]] = []
+        removable_pre_indices: List[int] = []
+        target_nhwc_shape: Optional[List[int]] = None
+
+        for candidate_data_index, candidate_side_index in [(0, 1), (1, 0)]:
+            data_name = str(mul_op.inputs[int(candidate_data_index)])
+            side_name = str(mul_op.inputs[int(candidate_side_index)])
+            side_tensor = model_ir.tensors.get(side_name, None)
+            if side_tensor is None or side_tensor.data is None:
+                continue
+
+            candidate_sub_idx = producers.get(data_name, None)
+            if candidate_sub_idx is None:
+                continue
+            candidate_sub_op = model_ir.operators[int(candidate_sub_idx)]
+            if (
+                str(candidate_sub_op.op_type) != "SUB"
+                or len(candidate_sub_op.inputs) != 2
+                or len(candidate_sub_op.outputs) != 1
+                or str(candidate_sub_op.outputs[0]) != data_name
+                or str(data_name) in model_outputs
+            ):
+                continue
+            if set(int(v) for v in consumers.get(data_name, [])) != {int(mul_idx)}:
+                continue
+
+            candidate_rewrites: List[Dict[str, Any]] = []
+            candidate_removable: List[int] = []
+            candidate_target_shape: Optional[List[int]] = None
+            valid_sub_inputs = True
+            for sub_input_index, sub_input_name in enumerate([str(v) for v in list(candidate_sub_op.inputs)]):
+                sub_pre_idx = producers.get(str(sub_input_name), None)
+                if sub_pre_idx is None:
+                    valid_sub_inputs = False
+                    break
+                sub_pre_op = model_ir.operators[int(sub_pre_idx)]
+                if (
+                    str(sub_pre_op.op_type) != "TRANSPOSE"
+                    or len(sub_pre_op.inputs) < 2
+                    or len(sub_pre_op.outputs) != 1
+                    or str(sub_pre_op.outputs[0]) != str(sub_input_name)
+                    or _read_transpose_perm(model_ir, sub_pre_op) != perm_nhwc_to_nchw
+                    or str(sub_input_name) in model_outputs
+                ):
+                    valid_sub_inputs = False
+                    break
+                sub_input_users = set(int(v) for v in consumers.get(str(sub_input_name), []))
+                if not sub_input_users.issubset({int(candidate_sub_idx), int(consumer_idx)}):
+                    valid_sub_inputs = False
+                    break
+                nhwc_name = str(sub_pre_op.inputs[0])
+                candidate_rewrites.append(
+                    {
+                        "sub_input_index": int(sub_input_index),
+                        "nhwc_name": nhwc_name,
+                        "pre_idx": int(sub_pre_idx),
+                    }
+                )
+                candidate_removable.append(int(sub_pre_idx))
+                nhwc_tensor = model_ir.tensors.get(nhwc_name, None)
+                if (
+                    candidate_target_shape is None
+                    and nhwc_tensor is not None
+                    and _is_fully_known_positive_shape(list(nhwc_tensor.shape))
+                ):
+                    candidate_target_shape = [int(v) for v in list(nhwc_tensor.shape)]
+
+            if not valid_sub_inputs or len(candidate_rewrites) != 2:
+                continue
+
+            mul_data_input_index = int(candidate_data_index)
+            mul_side_input_index = int(candidate_side_index)
+            mul_side_input_name = str(side_name)
+            sub_idx = int(candidate_sub_idx)
+            sub_out_name = str(data_name)
+            sub_input_rewrites = [dict(v) for v in candidate_rewrites]
+            removable_pre_indices = [int(v) for v in candidate_removable]
+            target_nhwc_shape = (
+                [int(v) for v in list(candidate_target_shape)]
+                if candidate_target_shape is not None
+                else None
+            )
+            break
+
+        if (
+            mul_data_input_index is None
+            or mul_side_input_index is None
+            or mul_side_input_name is None
+            or sub_idx is None
+            or sub_out_name is None
+            or len(sub_input_rewrites) != 2
+        ):
+            return None
+
+        side_tensor = model_ir.tensors.get(str(mul_side_input_name), None)
+        if side_tensor is None or side_tensor.data is None:
+            return None
+
+        side_data = np.asarray(side_tensor.data)
+        if int(side_data.size) != 1 and side_data.ndim not in {1, 3, 4}:
+            return None
+
+        nhwc_side_data: Optional[np.ndarray] = None
+        side_needs_update = False
+        if int(side_data.size) != 1 and side_data.ndim in {3, 4}:
+            side_shape = [int(v) for v in list(side_data.shape)]
+            if (
+                target_nhwc_shape is not None
+                and _broadcast_static_shapes(target_nhwc_shape, side_shape) is not None
+            ):
+                nhwc_side_data = np.asarray(side_data)
+            else:
+                rotated = np.asarray(side_data)
+                transpose_perm = perm_nchw_to_nhwc if int(rotated.ndim) == 4 else [1, 2, 0]
+                max_rotate = 1 if int(rotated.ndim) == 4 else 3
+                found = False
+                for _ in range(int(max_rotate)):
+                    rotated = np.transpose(rotated, transpose_perm).astype(side_data.dtype, copy=False)
+                    rotated_shape = [int(v) for v in list(rotated.shape)]
+                    if (
+                        target_nhwc_shape is None
+                        or _broadcast_static_shapes(target_nhwc_shape, rotated_shape) is not None
+                    ):
+                        nhwc_side_data = np.asarray(rotated)
+                        side_needs_update = True
+                        found = True
+                        break
+                if not found:
+                    return None
+
+        side_shared_outside_mul = any(
+            int(v) != int(mul_idx)
+            for v in consumers.get(str(mul_side_input_name), [])
+        )
+
+        return {
+            "sub_idx": int(sub_idx),
+            "sub_input_rewrites": [dict(v) for v in sub_input_rewrites],
+            "sub_out_name": str(sub_out_name),
+            "mul_idx": int(mul_idx),
+            "mul_data_input_index": int(mul_data_input_index),
+            "mul_side_input_index": int(mul_side_input_index),
+            "mul_side_input_name": str(mul_side_input_name),
+            "mul_out_name": str(input_name),
+            "removable_pre_indices": sorted(list({int(v) for v in removable_pre_indices})),
+            "side_needs_update": bool(side_needs_update),
+            "side_shared_outside_mul": bool(side_shared_outside_mul),
+            "side_nhwc_data": (None if nhwc_side_data is None else np.asarray(nhwc_side_data)),
+        }
+
+    def _apply_mul_sub_const_nhwc_plan(*, plan: Dict[str, Any]) -> List[int]:
+        sub_idx = int(plan["sub_idx"])
+        sub_input_rewrites = [dict(v) for v in list(plan["sub_input_rewrites"])]
+        sub_out_name = str(plan["sub_out_name"])
+        mul_idx = int(plan["mul_idx"])
+        mul_data_input_index = int(plan["mul_data_input_index"])
+        mul_side_input_index = int(plan["mul_side_input_index"])
+        mul_side_input_name = str(plan["mul_side_input_name"])
+        mul_out_name = str(plan["mul_out_name"])
+        removable_pre_indices = [int(v) for v in list(plan.get("removable_pre_indices", []))]
+
+        side_input_name_for_mul = str(mul_side_input_name)
+        if bool(plan.get("side_needs_update", False)):
+            nhwc_data = np.asarray(plan.get("side_nhwc_data"))
+            side_tensor = model_ir.tensors.get(str(mul_side_input_name), None)
+            if side_tensor is None:
+                return []
+            if bool(plan.get("side_shared_outside_mul", False)):
+                side_input_name_for_mul = _unique_tensor_name(f"{mul_side_input_name}_nhwc")
+                model_ir.tensors[side_input_name_for_mul] = TensorIR(
+                    name=side_input_name_for_mul,
+                    dtype=str(side_tensor.dtype),
+                    shape=[int(v) for v in list(nhwc_data.shape)],
+                    shape_signature=[int(v) for v in list(nhwc_data.shape)],
+                    data=np.asarray(nhwc_data),
+                    is_variable=False,
+                    quantization=_clone_quantization(side_tensor.quantization),
+                )
+            else:
+                side_tensor.data = np.asarray(nhwc_data)
+                side_tensor.shape = [int(v) for v in list(nhwc_data.shape)]
+                side_tensor.shape_signature = [int(v) for v in list(nhwc_data.shape)]
+
+        sub_op = model_ir.operators[int(sub_idx)]
+        sub_inputs = [str(v) for v in list(sub_op.inputs)]
+        for rewrite in sub_input_rewrites:
+            input_index = int(rewrite["sub_input_index"])
+            if int(input_index) < 0 or int(input_index) >= len(sub_inputs):
+                return []
+            sub_inputs[int(input_index)] = str(rewrite["nhwc_name"])
+        _set_operator_inputs(
+            model_ir=model_ir,
+            op=sub_op,
+            new_inputs=sub_inputs,
+        )
+        _permute_tensor_metadata_if_rank_matches(
+            model_ir.tensors.get(sub_out_name, None),
+            perm_nchw_to_nhwc,
+        )
+
+        mul_op = model_ir.operators[int(mul_idx)]
+        mul_inputs = [str(v) for v in list(mul_op.inputs)]
+        if int(mul_data_input_index) < 0 or int(mul_data_input_index) >= len(mul_inputs):
+            return []
+        if int(mul_side_input_index) < 0 or int(mul_side_input_index) >= len(mul_inputs):
+            return []
+        mul_inputs[int(mul_data_input_index)] = str(sub_out_name)
+        mul_inputs[int(mul_side_input_index)] = str(side_input_name_for_mul)
+        _set_operator_inputs(
+            model_ir=model_ir,
+            op=mul_op,
+            new_inputs=mul_inputs,
+        )
+        _permute_tensor_metadata_if_rank_matches(
+            model_ir.tensors.get(mul_out_name, None),
+            perm_nchw_to_nhwc,
+        )
+
+        return [int(v) for v in list(removable_pre_indices)]
+
     def _resolve_add_input_to_nhwc(
         *,
         input_name: str,
@@ -10384,6 +11231,7 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                 "swish_plan": swish_plan,
                 "unary_plan": None,
                 "mul_const_plan": None,
+                "mul_sub_const_plan": None,
                 "nested_add_plan": None,
             }
 
@@ -10401,6 +11249,7 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                 "swish_plan": None,
                 "unary_plan": unary_plan,
                 "mul_const_plan": None,
+                "mul_sub_const_plan": None,
                 "nested_add_plan": None,
             }
 
@@ -10418,6 +11267,25 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                 "swish_plan": None,
                 "unary_plan": None,
                 "mul_const_plan": mul_const_plan,
+                "mul_sub_const_plan": None,
+                "nested_add_plan": None,
+            }
+
+        mul_sub_const_plan = _analyze_mul_sub_const_input_to_nhwc(
+            input_name=input_name,
+            consumer_idx=int(add_idx),
+            producers=producers,
+            consumers=consumers,
+            model_outputs=model_outputs,
+        )
+        if mul_sub_const_plan is not None:
+            return {
+                "nhwc_input_name": str(input_name),
+                "pre_remove_indices": [],
+                "swish_plan": None,
+                "unary_plan": None,
+                "mul_const_plan": None,
+                "mul_sub_const_plan": mul_sub_const_plan,
                 "nested_add_plan": None,
             }
 
@@ -10454,6 +11322,7 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                             "swish_plan": None,
                             "unary_plan": None,
                             "mul_const_plan": None,
+                            "mul_sub_const_plan": None,
                             "nested_add_plan": {
                                 "input_name": str(input_name),
                                 "add_idx": int(input_producer_idx),
@@ -10488,6 +11357,7 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                         "swish_plan": None,
                         "unary_plan": None,
                         "mul_const_plan": None,
+                        "mul_sub_const_plan": None,
                         "nested_add_plan": None,
                     }
 
@@ -10588,6 +11458,11 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                     nested_mul_const_plan = nested_input_plan.get("mul_const_plan", None)
                     if nested_mul_const_plan is not None:
                         nested_remove_indices.extend(_apply_mul_const_nhwc_plan(plan=dict(nested_mul_const_plan)))
+                    nested_mul_sub_const_plan = nested_input_plan.get("mul_sub_const_plan", None)
+                    if nested_mul_sub_const_plan is not None:
+                        nested_remove_indices.extend(
+                            _apply_mul_sub_const_nhwc_plan(plan=dict(nested_mul_sub_const_plan))
+                        )
                     nested_nested_add_plan = nested_input_plan.get("nested_add_plan", None)
                     if nested_nested_add_plan is not None:
                         nested_remove_indices.extend(
@@ -10628,6 +11503,9 @@ def _optimize_transpose_pre_add_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]
                 mul_const_plan = plan.get("mul_const_plan", None)
                 if mul_const_plan is not None:
                     pre_remove_indices.extend(_apply_mul_const_nhwc_plan(plan=dict(mul_const_plan)))
+                mul_sub_const_plan = plan.get("mul_sub_const_plan", None)
+                if mul_sub_const_plan is not None:
+                    pre_remove_indices.extend(_apply_mul_sub_const_nhwc_plan(plan=dict(mul_sub_const_plan)))
                 nested_add_plan = plan.get("nested_add_plan", None)
                 if nested_add_plan is not None:
                     pre_remove_indices.extend(_apply_nested_add_nhwc_plan(plan=dict(nested_add_plan)))
@@ -11559,7 +12437,7 @@ def _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(mo
             if side_tensor is None or side_tensor.data is None:
                 continue
             side_data = np.asarray(side_tensor.data)
-            if int(side_data.size) != 1 and side_data.ndim != 4:
+            if int(side_data.size) != 1 and side_data.ndim not in {3, 4}:
                 continue
 
             data_prod_idx = producers.get(data_name, None)
@@ -11625,8 +12503,10 @@ def _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(mo
             else:
                 rotated = np.asarray(side_data)
                 found = False
-                for _ in range(3):
-                    rotated = np.transpose(rotated, perm_nchw_to_nhwc).astype(side_data.dtype, copy=False)
+                transpose_perm = perm_nchw_to_nhwc if int(rotated.ndim) == 4 else [1, 2, 0]
+                max_rotate = 1 if int(rotated.ndim) == 4 else 3
+                for _ in range(int(max_rotate)):
+                    rotated = np.transpose(rotated, transpose_perm).astype(side_data.dtype, copy=False)
                     rotated_shape = [int(v) for v in list(rotated.shape)]
                     if _broadcast_static_shapes(target_shape, rotated_shape) is not None:
                         nhwc_side_data = np.asarray(rotated)
@@ -11895,6 +12775,191 @@ def _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(mo
     return {
         "optimized_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains": int(rewritten)
     }
+
+
+def _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate NHWC->NCHW unary wrappers that immediately feed
+    [N,C,HW] reshape + [0,2,1] transpose suffixes.
+
+    Target:
+      x_nhwc --TRANSPOSE(0,3,1,2)--> x_nchw
+      x_nchw --UNARY(1-input)-> u_nchw
+      u_nchw --RESHAPE([N,C,HW])--> r
+      r --TRANSPOSE([0,2,1])--> z
+
+    Rewrite:
+      x_nhwc --UNARY(1-input)-> u_nhwc
+      u_nhwc --RESHAPE([N,HW,C])--> z
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    perm_3d_nchw_to_nhwc = [0, 2, 1]
+    unary_ops = {
+        "RELU",
+        "RELU6",
+        "LEAKY_RELU",
+        "LOGISTIC",
+        "TANH",
+        "ABS",
+        "NEG",
+        "SQRT",
+        "EXP",
+        "CAST",
+        "FLOOR",
+        "CEIL",
+        "ROUND",
+    }
+
+    def _swap_reshape_shape_tensor(reshape_op: OperatorIR) -> bool:
+        if len(reshape_op.inputs) < 2:
+            return False
+        shape_name = str(reshape_op.inputs[1])
+        shape_tensor = model_ir.tensors.get(shape_name, None)
+        shape_vals = _read_const_ints_from_tensor(shape_tensor)
+        if shape_vals is None or len(shape_vals) != 3:
+            return False
+        swapped = [int(shape_vals[0]), int(shape_vals[2]), int(shape_vals[1])]
+        return _write_const_ints_to_tensor(shape_tensor, swapped)
+
+    def _swap_reshape_option_shape(reshape_op: OperatorIR) -> bool:
+        if not isinstance(reshape_op.options, dict):
+            return False
+        opts = dict(reshape_op.options)
+        changed = False
+        for key in ["newShape", "onnxRawNewShape"]:
+            value = opts.get(key, None)
+            if not isinstance(value, list) or len(value) != 3:
+                continue
+            swapped = [int(value[0]), int(value[2]), int(value[1])]
+            if swapped != [int(v) for v in value]:
+                opts[key] = swapped
+                changed = True
+        if changed:
+            reshape_op.options = opts
+        return changed
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for reshape_idx, reshape_op in enumerate(model_ir.operators):
+            if str(reshape_op.op_type) != "RESHAPE" or len(reshape_op.inputs) < 1 or len(reshape_op.outputs) != 1:
+                continue
+
+            reshape_in_name = str(reshape_op.inputs[0])
+            reshape_out_name = str(reshape_op.outputs[0])
+            if reshape_in_name in model_outputs:
+                continue
+
+            reshape_users = [int(v) for v in consumers.get(reshape_out_name, [])]
+            if len(reshape_users) != 1:
+                continue
+            post_idx = int(reshape_users[0])
+            post_op = model_ir.operators[int(post_idx)]
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or str(post_op.inputs[0]) != reshape_out_name
+                or _read_transpose_perm(model_ir, post_op) != perm_3d_nchw_to_nhwc
+            ):
+                continue
+            post_out_name = str(post_op.outputs[0])
+            if reshape_out_name in model_outputs:
+                continue
+
+            unary_idx = producers.get(reshape_in_name, None)
+            if unary_idx is None:
+                continue
+            unary_op = model_ir.operators[int(unary_idx)]
+            if (
+                str(unary_op.op_type) not in unary_ops
+                or len(unary_op.inputs) != 1
+                or len(unary_op.outputs) != 1
+                or str(unary_op.outputs[0]) != reshape_in_name
+            ):
+                continue
+
+            pre_out_name = str(unary_op.inputs[0])
+            pre_idx = producers.get(pre_out_name, None)
+            if pre_idx is None:
+                continue
+            pre_op = model_ir.operators[int(pre_idx)]
+            if (
+                str(pre_op.op_type) != "TRANSPOSE"
+                or len(pre_op.inputs) < 2
+                or len(pre_op.outputs) != 1
+                or str(pre_op.outputs[0]) != pre_out_name
+                or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            pre_in_name = str(pre_op.inputs[0])
+
+            if (
+                pre_in_name in model_outputs
+                or pre_out_name in model_outputs
+                or reshape_in_name in model_outputs
+            ):
+                continue
+
+            if set(int(v) for v in consumers.get(pre_out_name, [])) != {int(unary_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(reshape_in_name, [])) != {int(reshape_idx)}:
+                continue
+
+            shape_changed = _swap_reshape_shape_tensor(reshape_op)
+            opts_changed = _swap_reshape_option_shape(reshape_op)
+            if not shape_changed and not opts_changed:
+                continue
+
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=unary_op,
+                new_inputs=[pre_in_name],
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(reshape_in_name, None),
+                perm_nchw_to_nhwc,
+            )
+
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=reshape_op,
+                new_outputs=[post_out_name],
+            )
+
+            old_reshape_out_tensor = model_ir.tensors.get(reshape_out_name, None)
+            canonical_tensor = model_ir.tensors.get(post_out_name, None)
+            if old_reshape_out_tensor is not None and canonical_tensor is not None:
+                canonical_tensor.dtype = str(old_reshape_out_tensor.dtype)
+                canonical_tensor.quantization = _clone_quantization(old_reshape_out_tensor.quantization)
+                canonical_tensor.shape = [int(v) for v in list(old_reshape_out_tensor.shape)]
+                canonical_tensor.shape_signature = (
+                    [int(v) for v in list(old_reshape_out_tensor.shape_signature)]
+                    if old_reshape_out_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_reshape_out_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    canonical_tensor,
+                    perm_3d_nchw_to_nhwc,
+                )
+
+            for remove_idx in sorted([int(pre_idx), int(post_idx)], reverse=True):
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains": int(rewritten)}
 
 
 def _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -16498,6 +17563,295 @@ def _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir: ModelI
     return {"optimized_transpose_sum_logistic_muladd_prepost_nhwc_chains": int(rewritten)}
 
 
+def _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate NCHW round-trips around LOGISTIC + MUL + ADD merge blocks.
+
+    Target:
+      skip_nhwc --T(0,3,1,2)--> skip_nchw
+      data_nhwc --T(0,3,1,2)--> data_nchw
+      gate_nhwc --T(0,3,1,2)--> gate_nchw --LOGISTIC--> sig_nchw
+      MUL(data_nchw, sig_nchw) -> mul_nchw
+      ADD(mul_nchw, skip_nchw) -> y_nchw
+      y_nchw --T(0,2,3,1)--> y_nhwc
+
+    Rewrite:
+      - Bypass three pre-transposes (skip/data/gate) to NHWC.
+      - Keep LOGISTIC/MUL/ADD in NHWC.
+      - Remove inverse post-transpose by making ADD emit NHWC directly.
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for post_idx, post_op in enumerate(model_ir.operators):
+            if str(post_op.op_type) != "TRANSPOSE" or len(post_op.inputs) < 2 or len(post_op.outputs) != 1:
+                continue
+            if _read_transpose_perm(model_ir, post_op) != perm_nchw_to_nhwc:
+                continue
+
+            add_output_name = str(post_op.inputs[0])
+            post_output_name = str(post_op.outputs[0])
+            if add_output_name in model_outputs or post_output_name in model_outputs:
+                continue
+
+            add_idx = producers.get(add_output_name, None)
+            if add_idx is None:
+                continue
+            add_op = model_ir.operators[int(add_idx)]
+            if str(add_op.op_type) != "ADD" or len(add_op.inputs) != 2 or len(add_op.outputs) != 1:
+                continue
+            if str(add_op.outputs[0]) != add_output_name:
+                continue
+
+            add_inputs = [str(v) for v in list(add_op.inputs)]
+            mul_input_side: Optional[int] = None
+            mul_idx: Optional[int] = None
+            for i, input_name in enumerate(add_inputs):
+                producer_idx = producers.get(str(input_name), None)
+                if producer_idx is None:
+                    continue
+                producer_op = model_ir.operators[int(producer_idx)]
+                if (
+                    str(producer_op.op_type) == "MUL"
+                    and len(producer_op.outputs) == 1
+                    and str(producer_op.outputs[0]) == str(input_name)
+                ):
+                    if mul_idx is not None:
+                        mul_idx = None
+                        break
+                    mul_input_side = int(i)
+                    mul_idx = int(producer_idx)
+            if mul_idx is None or mul_input_side is None:
+                continue
+
+            skip_input_name = str(add_inputs[1 - int(mul_input_side)])
+            skip_pre_idx = producers.get(skip_input_name, None)
+            if skip_pre_idx is None:
+                continue
+            skip_pre_op = model_ir.operators[int(skip_pre_idx)]
+            if (
+                str(skip_pre_op.op_type) != "TRANSPOSE"
+                or len(skip_pre_op.inputs) < 2
+                or len(skip_pre_op.outputs) != 1
+                or str(skip_pre_op.outputs[0]) != skip_input_name
+                or _read_transpose_perm(model_ir, skip_pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            skip_nhwc_name = str(skip_pre_op.inputs[0])
+            if skip_nhwc_name in model_outputs or skip_input_name in model_outputs:
+                continue
+
+            mul_op = model_ir.operators[int(mul_idx)]
+            if str(mul_op.op_type) != "MUL" or len(mul_op.inputs) != 2 or len(mul_op.outputs) != 1:
+                continue
+            mul_output_name = str(mul_op.outputs[0])
+            if mul_output_name in model_outputs:
+                continue
+
+            pre_data_idx: Optional[int] = None
+            pre_data_in_name: Optional[str] = None
+            pre_data_out_name: Optional[str] = None
+            logistic_idx: Optional[int] = None
+            logistic_out_name: Optional[str] = None
+            for input_name in [str(v) for v in list(mul_op.inputs)]:
+                input_producer_idx = producers.get(str(input_name), None)
+                if input_producer_idx is None:
+                    continue
+                input_producer_op = model_ir.operators[int(input_producer_idx)]
+                if (
+                    str(input_producer_op.op_type) == "TRANSPOSE"
+                    and len(input_producer_op.inputs) >= 2
+                    and len(input_producer_op.outputs) == 1
+                    and str(input_producer_op.outputs[0]) == str(input_name)
+                    and _read_transpose_perm(model_ir, input_producer_op) == perm_nhwc_to_nchw
+                ):
+                    if pre_data_idx is not None:
+                        pre_data_idx = None
+                        break
+                    pre_data_idx = int(input_producer_idx)
+                    pre_data_in_name = str(input_producer_op.inputs[0])
+                    pre_data_out_name = str(input_producer_op.outputs[0])
+                    continue
+                if (
+                    str(input_producer_op.op_type) == "LOGISTIC"
+                    and len(input_producer_op.outputs) == 1
+                    and str(input_producer_op.outputs[0]) == str(input_name)
+                ):
+                    if logistic_idx is not None:
+                        logistic_idx = None
+                        break
+                    logistic_idx = int(input_producer_idx)
+                    logistic_out_name = str(input_name)
+            if (
+                pre_data_idx is None
+                or pre_data_in_name is None
+                or pre_data_out_name is None
+                or logistic_idx is None
+                or logistic_out_name is None
+            ):
+                continue
+
+            if pre_data_in_name in model_outputs or pre_data_out_name in model_outputs:
+                continue
+
+            logistic_op = model_ir.operators[int(logistic_idx)]
+            if str(logistic_op.op_type) != "LOGISTIC" or len(logistic_op.inputs) != 1 or len(logistic_op.outputs) != 1:
+                continue
+            if str(logistic_op.outputs[0]) != logistic_out_name:
+                continue
+            gate_pre_out_name = str(logistic_op.inputs[0])
+            if gate_pre_out_name in model_outputs:
+                continue
+
+            gate_pre_idx = producers.get(gate_pre_out_name, None)
+            if gate_pre_idx is None:
+                continue
+            gate_pre_op = model_ir.operators[int(gate_pre_idx)]
+            if (
+                str(gate_pre_op.op_type) != "TRANSPOSE"
+                or len(gate_pre_op.inputs) < 2
+                or len(gate_pre_op.outputs) != 1
+                or str(gate_pre_op.outputs[0]) != gate_pre_out_name
+                or _read_transpose_perm(model_ir, gate_pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            gate_nhwc_name = str(gate_pre_op.inputs[0])
+            if gate_nhwc_name in model_outputs or gate_pre_out_name in model_outputs:
+                continue
+
+            # Three pre-transpose outputs must be local to this chain.
+            if set(int(v) for v in consumers.get(skip_input_name, [])) != {int(add_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(pre_data_out_name, [])) != {int(mul_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(gate_pre_out_name, [])) != {int(logistic_idx)}:
+                continue
+
+            # ADD output must fan out only to inverse post-transposes.
+            add_out_users = [int(v) for v in consumers.get(add_output_name, [])]
+            if len(add_out_users) == 0:
+                continue
+            post_indices: List[int] = []
+            post_output_names: List[str] = []
+            valid_posts = True
+            for user_idx in add_out_users:
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) == "TRANSPOSE"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == add_output_name
+                    and _read_transpose_perm(model_ir, user_op) == perm_nchw_to_nhwc
+                    and str(user_op.outputs[0]) not in model_outputs
+                ):
+                    post_indices.append(int(user_idx))
+                    post_output_names.append(str(user_op.outputs[0]))
+                else:
+                    valid_posts = False
+                    break
+            if not valid_posts or len(post_indices) == 0:
+                continue
+
+            # Rewire LOGISTIC/MUL/ADD to NHWC sources.
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=logistic_op,
+                new_inputs=[str(gate_nhwc_name)],
+            )
+
+            mul_inputs = [str(v) for v in list(mul_op.inputs)]
+            mul_replaced = False
+            for i, input_name in enumerate(list(mul_inputs)):
+                if str(input_name) == str(pre_data_out_name):
+                    mul_inputs[i] = str(pre_data_in_name)
+                    mul_replaced = True
+            if not mul_replaced:
+                continue
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=mul_op,
+                new_inputs=mul_inputs,
+            )
+
+            add_inputs_rewritten = [str(v) for v in list(add_op.inputs)]
+            add_replaced = False
+            for i, input_name in enumerate(list(add_inputs_rewritten)):
+                if str(input_name) == str(skip_input_name):
+                    add_inputs_rewritten[i] = str(skip_nhwc_name)
+                    add_replaced = True
+            if not add_replaced:
+                continue
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=add_op,
+                new_inputs=add_inputs_rewritten,
+            )
+
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(logistic_out_name), None),
+                perm_nchw_to_nhwc,
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(mul_output_name), None),
+                perm_nchw_to_nhwc,
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(add_output_name), None),
+                perm_nchw_to_nhwc,
+            )
+
+            canonical_post_output_name = str(post_output_names[0])
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=add_op,
+                new_outputs=[canonical_post_output_name],
+            )
+            for alias_name in post_output_names[1:]:
+                _replace_tensor_inputs(model_ir, str(alias_name), canonical_post_output_name)
+
+            old_add_out_tensor = model_ir.tensors.get(add_output_name, None)
+            canonical_tensor = model_ir.tensors.get(canonical_post_output_name, None)
+            if old_add_out_tensor is not None and canonical_tensor is not None:
+                canonical_tensor.dtype = str(old_add_out_tensor.dtype)
+                canonical_tensor.quantization = _clone_quantization(old_add_out_tensor.quantization)
+                canonical_tensor.shape = [int(v) for v in list(old_add_out_tensor.shape)]
+                canonical_tensor.shape_signature = (
+                    [int(v) for v in list(old_add_out_tensor.shape_signature)]
+                    if old_add_out_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_add_out_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    canonical_tensor,
+                    perm_nchw_to_nhwc,
+                )
+
+            remove_indices = {
+                int(skip_pre_idx),
+                int(pre_data_idx),
+                int(gate_pre_idx),
+                *[int(v) for v in post_indices],
+            }
+            for remove_idx in sorted(remove_indices, reverse=True):
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_logistic_muladd_prepost_nhwc_chains": int(rewritten)}
+
+
 def _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
     """
     Eliminate NCHW round-trips around a logistic/sub-gated dual-MUL/ADD block feeding two convs.
@@ -18553,7 +19907,27 @@ def _optimize_singleton_channel_layout_transpose_to_reshape(model_ir: ModelIR) -
 
         input_shape = [int(v) for v in list(input_tensor.shape)]
         output_shape = [int(v) for v in list(output_tensor.shape)]
+        input_signature = (
+            [int(v) for v in list(input_tensor.shape_signature)]
+            if input_tensor.shape_signature is not None
+            else [int(v) for v in list(input_shape)]
+        )
+        output_signature = (
+            [int(v) for v in list(output_tensor.shape_signature)]
+            if output_tensor.shape_signature is not None
+            else [int(v) for v in list(output_shape)]
+        )
         if len(input_shape) != 4 or len(output_shape) != 4:
+            continue
+        # Dynamic dimensions can be represented as placeholder static 1s in `shape`.
+        # Replacing transpose with reshape is only safe when the rank-4 layout is
+        # fully static in signatures as well.
+        if (
+            len(input_signature) != 4
+            or len(output_signature) != 4
+            or any(int(v) < 0 for v in input_signature)
+            or any(int(v) < 0 for v in output_signature)
+        ):
             continue
 
         if perm == perm_nhwc_to_nchw:
@@ -18596,6 +19970,11 @@ def _optimize_singleton_spatial_nhwc_transpose_reshape_flatten(model_ir: ModelIR
       x_nhwc [N,1,1,C] -> TRANSPOSE(0,3,1,2) -> x_nchw [N,C,1,1]
       x_nchw -> RESHAPE -> y [N,C]
 
+    Extended pattern:
+      x_nhwc [N,1,1,C] -> TRANSPOSE(0,3,1,2) -> x_nchw [N,C,1,1]
+      x_nchw -> RESHAPE(identity) -> x_keep [N,C,1,1]
+      x_keep -> RESHAPE -> y [N,C]
+
     For singleton spatial dims, flatten result is identical without transpose:
       RESHAPE(x_nhwc) -> y
     """
@@ -18605,6 +19984,7 @@ def _optimize_singleton_spatial_nhwc_transpose_reshape_flatten(model_ir: ModelIR
     while True:
         changed = False
         consumers = _build_tensor_consumer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
 
         for transpose_idx, transpose_op in enumerate(model_ir.operators):
             if (
@@ -18621,19 +20001,54 @@ def _optimize_singleton_spatial_nhwc_transpose_reshape_flatten(model_ir: ModelIR
             if len(users) != 1:
                 continue
 
-            reshape_idx = int(users[0])
-            reshape_op = model_ir.operators[int(reshape_idx)]
+            first_reshape_idx = int(users[0])
+            first_reshape_op = model_ir.operators[int(first_reshape_idx)]
             if (
-                str(reshape_op.op_type) != "RESHAPE"
-                or len(reshape_op.inputs) < 1
-                or str(reshape_op.inputs[0]) != transpose_output_name
-                or len(reshape_op.outputs) != 1
+                str(first_reshape_op.op_type) != "RESHAPE"
+                or len(first_reshape_op.inputs) < 1
+                or str(first_reshape_op.inputs[0]) != transpose_output_name
+                or len(first_reshape_op.outputs) != 1
             ):
                 continue
 
+            target_reshape_idx = int(first_reshape_idx)
+            target_reshape_op = first_reshape_op
+            target_reshape_output_name = str(target_reshape_op.outputs[0])
+            intermediate_reshape_idx: Optional[int] = None
+            intermediate_reshape_output_name = ""
+
+            first_reshape_output_name = str(first_reshape_op.outputs[0])
+            first_reshape_output_tensor = model_ir.tensors.get(first_reshape_output_name, None)
+            if (
+                first_reshape_output_tensor is not None
+                and len(list(first_reshape_output_tensor.shape)) == 4
+                and first_reshape_output_name not in model_outputs
+            ):
+                second_users = [int(v) for v in consumers.get(first_reshape_output_name, [])]
+                if len(second_users) == 1:
+                    second_reshape_idx = int(second_users[0])
+                    second_reshape_op = model_ir.operators[int(second_reshape_idx)]
+                    if (
+                        str(second_reshape_op.op_type) == "RESHAPE"
+                        and len(second_reshape_op.inputs) >= 1
+                        and str(second_reshape_op.inputs[0]) == first_reshape_output_name
+                        and len(second_reshape_op.outputs) == 1
+                    ):
+                        second_reshape_output_name = str(second_reshape_op.outputs[0])
+                        second_reshape_output_tensor = model_ir.tensors.get(second_reshape_output_name, None)
+                        if (
+                            second_reshape_output_tensor is not None
+                            and len(list(second_reshape_output_tensor.shape)) == 2
+                        ):
+                            target_reshape_idx = int(second_reshape_idx)
+                            target_reshape_op = second_reshape_op
+                            target_reshape_output_name = second_reshape_output_name
+                            intermediate_reshape_idx = int(first_reshape_idx)
+                            intermediate_reshape_output_name = first_reshape_output_name
+
             input_tensor = model_ir.tensors.get(transpose_input_name, None)
             output_tensor = model_ir.tensors.get(transpose_output_name, None)
-            reshape_output_tensor = model_ir.tensors.get(str(reshape_op.outputs[0]), None)
+            reshape_output_tensor = model_ir.tensors.get(target_reshape_output_name, None)
             if (
                 input_tensor is None
                 or output_tensor is None
@@ -18654,17 +20069,32 @@ def _optimize_singleton_spatial_nhwc_transpose_reshape_flatten(model_ir: ModelIR
             expected_output_shape = _permute_shape(input_shape, perm_nhwc_to_nchw)
             if expected_output_shape is None or [int(v) for v in list(expected_output_shape)] != output_shape:
                 continue
+            if intermediate_reshape_idx is not None:
+                intermediate_tensor = model_ir.tensors.get(intermediate_reshape_output_name, None)
+                if intermediate_tensor is None:
+                    continue
+                intermediate_shape = [int(v) for v in list(intermediate_tensor.shape)]
+                if intermediate_shape != output_shape:
+                    continue
             if int(reshape_output_shape[1]) != int(input_shape[3]):
                 continue
 
-            reshape_inputs = [str(v) for v in list(reshape_op.inputs)]
+            reshape_inputs = [str(v) for v in list(target_reshape_op.inputs)]
             reshape_inputs[0] = str(transpose_input_name)
             _set_operator_inputs(
                 model_ir=model_ir,
-                op=reshape_op,
+                op=target_reshape_op,
                 new_inputs=reshape_inputs,
             )
-            del model_ir.operators[int(transpose_idx)]
+            remove_indices = [int(transpose_idx)]
+            if (
+                intermediate_reshape_idx is not None
+                and intermediate_reshape_output_name not in model_outputs
+                and set(int(v) for v in consumers.get(intermediate_reshape_output_name, [])) == {int(target_reshape_idx)}
+            ):
+                remove_indices.append(int(intermediate_reshape_idx))
+            for remove_idx in sorted(set(remove_indices), reverse=True):
+                del model_ir.operators[int(remove_idx)]
             rewritten += 1
             changed = True
             break
@@ -21236,14 +22666,18 @@ def _optimize_fuse_conv_activation_chains(model_ir: ModelIR) -> Dict[str, int]:
 
 def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, int]:
     """
-    Fold single-path CONV_2D -> MUL(const) -> ADD(const) affine chains into CONV_2D.
+    Fold single-path CONV_2D -> MUL(const) [-> ADD(const)] affine chains into CONV_2D.
 
-    Target:
+    Targets:
       x --CONV_2D(w,b)--> y
       y --MUL(m)--> z
-      z --ADD(a)--> o
+      (optional) z --ADD(a)--> o
 
-    Rewrite:
+    Rewrite 1:
+      x --CONV_2D(w',b')--> z
+
+    Rewrite 2:
+      z --ADD(a)--> o
       x --CONV_2D(w',b')--> o
       where:
         w'[oc,kh,kw,ic] = w[oc,kh,kw,ic] * m[oc]
@@ -21251,7 +22685,8 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
 
     Safety:
     - Conv output must have exactly one consumer (single path).
-    - MUL and ADD side inputs must be constants representable as scalar or NHWC-channelwise.
+    - MUL side input must be constant representable as scalar or NHWC-channelwise.
+    - When ADD is present, ADD side input must also be constant representable as scalar or NHWC-channelwise.
     - Conv filter/bias must be constant and not shared by other operators.
     - Chains with Conv output fan-out (>=2) are excluded.
     """
@@ -21274,6 +22709,9 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
         shape = [int(v) for v in list(coeff.shape)]
         if len(shape) == 1 and int(shape[0]) == int(out_channels):
             return coeff.reshape(int(out_channels)).astype(np.float32, copy=False)
+        if len(shape) >= 2 and int(shape[0]) == int(out_channels):
+            if int(np.prod(shape[1:])) == 1:
+                return coeff.reshape(int(out_channels)).astype(np.float32, copy=False)
         if len(shape) >= 2 and int(shape[-1]) == int(out_channels):
             if int(np.prod(shape[:-1])) == 1:
                 return coeff.reshape(int(out_channels)).astype(np.float32, copy=False)
@@ -21288,6 +22726,8 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
         return name
 
     folded = 0
+    folded_conv_mul_only = 0
+    folded_conv_mul_add = 0
 
     while True:
         changed = False
@@ -21296,6 +22736,9 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
 
         for conv_idx, conv_op in enumerate(model_ir.operators):
             if str(conv_op.op_type) != "CONV_2D" or len(conv_op.inputs) < 2 or len(conv_op.outputs) != 1:
+                continue
+            conv_opts = dict(conv_op.options) if isinstance(conv_op.options, dict) else {}
+            if str(conv_opts.get("fusedActivationFunction", "NONE")) != "NONE":
                 continue
             conv_out_name = str(conv_op.outputs[0])
             conv_users = [int(v) for v in consumers.get(conv_out_name, [])]
@@ -21318,25 +22761,30 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
                 continue
 
             mul_out_name = str(mul_op.outputs[0])
-            if mul_out_name in model_outputs:
-                continue
             mul_users = [int(v) for v in consumers.get(mul_out_name, [])]
-            if len(mul_users) != 1:
-                continue
-            add_idx = int(mul_users[0])
-            add_op = model_ir.operators[int(add_idx)]
-            if str(add_op.op_type) != "ADD" or len(add_op.inputs) != 2 or len(add_op.outputs) != 1:
-                continue
-            add_inputs = [str(v) for v in list(add_op.inputs)]
-            if add_inputs[0] == mul_out_name:
-                add_side_name = str(add_inputs[1])
-            elif add_inputs[1] == mul_out_name:
-                add_side_name = str(add_inputs[0])
-            else:
-                continue
-            add_side_tensor = model_ir.tensors.get(add_side_name, None)
-            if add_side_tensor is None or add_side_tensor.data is None:
-                continue
+            has_add = False
+            add_idx: Optional[int] = None
+            add_op: Optional[OperatorIR] = None
+            add_side_name: Optional[str] = None
+            add_side_tensor: Optional[TensorIR] = None
+            if len(mul_users) == 1:
+                candidate_add_idx = int(mul_users[0])
+                candidate_add_op = model_ir.operators[int(candidate_add_idx)]
+                if str(candidate_add_op.op_type) == "ADD" and len(candidate_add_op.inputs) == 2 and len(candidate_add_op.outputs) == 1:
+                    add_inputs = [str(v) for v in list(candidate_add_op.inputs)]
+                    candidate_add_side_name: Optional[str] = None
+                    if add_inputs[0] == mul_out_name:
+                        candidate_add_side_name = str(add_inputs[1])
+                    elif add_inputs[1] == mul_out_name:
+                        candidate_add_side_name = str(add_inputs[0])
+                    if candidate_add_side_name is not None:
+                        candidate_add_side_tensor = model_ir.tensors.get(candidate_add_side_name, None)
+                        if candidate_add_side_tensor is not None and candidate_add_side_tensor.data is not None:
+                            has_add = True
+                            add_idx = int(candidate_add_idx)
+                            add_op = candidate_add_op
+                            add_side_name = str(candidate_add_side_name)
+                            add_side_tensor = candidate_add_side_tensor
 
             filter_name = str(conv_op.inputs[1])
             filter_tensor = model_ir.tensors.get(filter_name, None)
@@ -21397,12 +22845,16 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
                 tensor=mul_side_tensor,
                 out_channels=int(out_channels),
             )
-            add_coeff = _extract_nhwc_channelwise_coeff(
-                tensor=add_side_tensor,
-                out_channels=int(out_channels),
-            )
-            if mul_coeff is None or add_coeff is None:
+            if mul_coeff is None:
                 continue
+            add_coeff = np.zeros((int(out_channels),), dtype=np.float32)
+            if has_add:
+                add_coeff = _extract_nhwc_channelwise_coeff(
+                    tensor=add_side_tensor,
+                    out_channels=int(out_channels),
+                )
+                if add_coeff is None:
+                    continue
             if not np.isfinite(mul_coeff).all() or not np.isfinite(add_coeff).all():
                 continue
 
@@ -21421,17 +22873,30 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
             bias_tensor.shape = [int(out_channels)]
             bias_tensor.shape_signature = [int(out_channels)]
 
-            add_out_name = str(add_op.outputs[0])
+            if has_add:
+                assert add_op is not None
+                assert add_idx is not None
+                folded_output_name = str(add_op.outputs[0])
+            else:
+                folded_output_name = str(mul_out_name)
             _set_operator_outputs(
                 model_ir=model_ir,
                 op=conv_op,
-                new_outputs=[add_out_name],
+                new_outputs=[folded_output_name],
             )
 
-            for remove_idx in sorted([int(mul_idx), int(add_idx)], reverse=True):
+            remove_indices = [int(mul_idx)]
+            if has_add:
+                assert add_idx is not None
+                remove_indices.append(int(add_idx))
+            for remove_idx in sorted(remove_indices, reverse=True):
                 del model_ir.operators[int(remove_idx)]
 
             folded += 1
+            if has_add:
+                folded_conv_mul_add += 1
+            else:
+                folded_conv_mul_only += 1
             changed = True
             break
 
@@ -21439,7 +22904,11 @@ def _optimize_fold_conv_mul_add_affine_chains(model_ir: ModelIR) -> Dict[str, in
             break
 
     _prune_unused_tensors(model_ir)
-    return {"folded_conv_mul_add_affine_chains": int(folded)}
+    return {
+        "folded_conv_mul_add_affine_chains": int(folded),
+        "folded_conv_mul_only_affine_chains": int(folded_conv_mul_only),
+        "folded_conv_mul_add_only_affine_chains": int(folded_conv_mul_add),
+    }
 
 
 def _sanitize_terminal_transpose_before_dequantize(model_ir: ModelIR) -> Dict[str, int]:
@@ -25670,17 +27139,20 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
+        _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
         _optimize_shufflenet_transpose_shuffle_chains(model_ir)
         _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
+        _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
+        _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
@@ -25725,17 +27197,20 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
+        _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
         _optimize_shufflenet_transpose_shuffle_chains(model_ir)
         _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
+        _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
+        _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
@@ -25783,17 +27258,20 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
+        _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
         _optimize_shufflenet_transpose_shuffle_chains(model_ir)
         _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
+        _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
+        _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
@@ -25855,6 +27333,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
+        _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
         _optimize_shufflenet_transpose_shuffle_chains(model_ir)
         _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
@@ -25865,6 +27344,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
+        _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
@@ -25890,6 +27370,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
+        _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
         _optimize_shufflenet_transpose_shuffle_chains(model_ir)
         _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains(model_ir)
         _optimize_layout_transpose_chains(model_ir)
@@ -25903,6 +27384,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
+        _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _prune_dead_operators(model_ir)

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -36,6 +36,7 @@ from onnx2tf.tflite_builder.op_builders.shape import (
     build_concat_op,
     build_constant_of_shape_op,
     build_depth_to_space_op,
+    build_dropout_op,
     build_eyelike_op,
     build_expand_op,
     build_flatten_op,
@@ -95,6 +96,7 @@ from onnx2tf.tflite_builder.op_builders.index import (
 )
 from onnx2tf.tflite_builder.op_builders.norm import (
     build_batch_normalization_op,
+    build_instance_normalization_op,
     build_l2_normalization_op,
     build_lrn_op,
 )
@@ -154,6 +156,7 @@ __all__ = [
     "build_concat_op",
     "build_constant_of_shape_op",
     "build_depth_to_space_op",
+    "build_dropout_op",
     "build_eyelike_op",
     "build_expand_op",
     "build_flatten_op",
@@ -199,6 +202,7 @@ __all__ = [
     "build_one_hot_op",
     "build_topk_op",
     "build_batch_normalization_op",
+    "build_instance_normalization_op",
     "build_l2_normalization_op",
     "build_lrn_op",
     "build_custom_passthrough_op",

--- a/onnx2tf/tflite_builder/op_builders/index.py
+++ b/onnx2tf/tflite_builder/op_builders/index.py
@@ -99,6 +99,30 @@ def build_gather_op(node: Any, ctx: Any) -> None:
     indices_const = ctx.get_constant_array(indices_name)
     if indices_const is not None:
         indices_const_arr = np.asarray(indices_const)
+        if np.issubdtype(indices_const_arr.dtype, np.integer) and bool(np.any(indices_const_arr < 0)):
+            axis_dim = int(input_shape[int(axis)]) if int(axis) < int(len(input_shape)) else -1
+            if axis_dim <= 0:
+                raise NotImplementedError(
+                    f"Gather negative constant indices require known positive axis dimension. "
+                    f"op={node.name} axis={axis} axis_dim={axis_dim}"
+                )
+            wrapped_indices_i64 = np.where(
+                indices_const_arr.astype(np.int64, copy=False) < 0,
+                indices_const_arr.astype(np.int64, copy=False) + int(axis_dim),
+                indices_const_arr.astype(np.int64, copy=False),
+            )
+            if bool(np.any(wrapped_indices_i64 < 0)) or bool(np.any(wrapped_indices_i64 >= int(axis_dim))):
+                raise NotImplementedError(
+                    f"Gather constant indices are out of bounds after negative-index normalization. "
+                    f"op={node.name} axis={axis} axis_dim={axis_dim}"
+                )
+            indices_const_arr = wrapped_indices_i64.astype(indices_const_arr.dtype, copy=False)
+            scalarized_indices_name = ctx.add_const_tensor(
+                f"{output_name}_gather_indices_wrapped",
+                indices_const_arr,
+            )
+            indices_shape = [int(v) for v in list(indices_const_arr.shape)]
+            indices_signature = [int(v) for v in list(indices_const_arr.shape)]
         scalarize_single_index = indices_const_arr.ndim == 0
         if not scalarize_single_index and int(indices_const_arr.size) == 1 and input_rank > 1:
             expected_rank = len(existing_output_signature)

--- a/onnx2tf/tflite_builder/op_builders/norm.py
+++ b/onnx2tf/tflite_builder/op_builders/norm.py
@@ -8,6 +8,10 @@ from onnx2tf.tflite_builder.ir import OperatorIR
 from onnx2tf.tflite_builder.op_builders.shared import make_transpose
 
 
+def _float_numpy_dtype(dtype: str) -> np.dtype:
+    return np.float16 if str(dtype).upper() == "FLOAT16" else np.float32
+
+
 def build_l2_normalization_op(node: Any, ctx: Any) -> None:
     input_name = node.inputs[0].name
     output_name = node.outputs[0].name
@@ -169,3 +173,241 @@ def build_batch_normalization_op(node: Any, ctx: Any) -> None:
             options={"fusedActivationFunction": "NONE"},
         )
     )
+
+
+def build_instance_normalization_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    scale_name = node.inputs[1].name
+    bias_name = node.inputs[2].name
+    output_name = node.outputs[0].name
+
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+    if ctx.model_ir.tensors[output_name].shape == [1] and ctx.model_ir.tensors[input_name].shape != [1]:
+        ctx.model_ir.tensors[output_name].shape = list(ctx.model_ir.tensors[input_name].shape)
+        ctx.model_ir.tensors[output_name].shape_signature = (
+            list(ctx.model_ir.tensors[input_name].shape_signature)
+            if ctx.model_ir.tensors[input_name].shape_signature is not None
+            else list(ctx.model_ir.tensors[input_name].shape)
+        )
+
+    scale = ctx.get_constant_array(scale_name)
+    bias = ctx.get_constant_array(bias_name)
+    if scale is None or bias is None:
+        raise NotImplementedError(
+            "InstanceNormalization requires constant scale/bias in flatbuffer_direct. "
+            f"op={node.name}"
+        )
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(input_name)]
+    rank = len(input_shape)
+    if rank < 3:
+        raise NotImplementedError(
+            f"InstanceNormalization requires input rank >= 3 in flatbuffer_direct. op={node.name} input_shape={input_shape}"
+        )
+
+    input_dtype = str(ctx.get_tensor_dtype(input_name)).upper()
+    output_dtype = str(ctx.get_tensor_dtype(output_name)).upper()
+    if input_dtype not in {"FLOAT16", "FLOAT32"} or output_dtype not in {"FLOAT16", "FLOAT32"}:
+        raise NotImplementedError(
+            "InstanceNormalization supports FLOAT16/FLOAT32 only in flatbuffer_direct. "
+            f"op={node.name} input_dtype={input_dtype} output_dtype={output_dtype}"
+        )
+
+    compute_dtype = input_dtype
+    np_compute_dtype = _float_numpy_dtype(compute_dtype)
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+
+    x_name = input_name
+    if input_dtype != compute_dtype:
+        cast_in_name = ctx.add_intermediate_tensor(
+            f"{node.name}_instnorm_input_cast",
+            dtype=compute_dtype,
+            shape=input_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[input_name],
+                outputs=[cast_in_name],
+                options={"inDataType": input_dtype, "outDataType": compute_dtype},
+            )
+        )
+        x_name = cast_in_name
+
+    axes_name = ctx.add_const_tensor(
+        f"{node.name}_instnorm_axes",
+        np.asarray([int(v) for v in range(2, rank)], dtype=np.int32),
+    )
+    reduced_shape = [int(input_shape[0]), int(input_shape[1])] + [1 for _ in range(rank - 2)]
+
+    mean_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_mean",
+        dtype=compute_dtype,
+        shape=reduced_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="MEAN",
+            inputs=[x_name, axes_name],
+            outputs=[mean_name],
+            options={"keepDims": True},
+        )
+    )
+
+    centered_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_centered",
+        dtype=compute_dtype,
+        shape=input_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SUB",
+            inputs=[x_name, mean_name],
+            outputs=[centered_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    squared_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_squared",
+        dtype=compute_dtype,
+        shape=input_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="MUL",
+            inputs=[centered_name, centered_name],
+            outputs=[squared_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    var_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_var",
+        dtype=compute_dtype,
+        shape=reduced_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="MEAN",
+            inputs=[squared_name, axes_name],
+            outputs=[var_name],
+            options={"keepDims": True},
+        )
+    )
+
+    eps_name = ctx.add_const_tensor(
+        f"{node.name}_instnorm_eps",
+        np.asarray(epsilon, dtype=np_compute_dtype),
+    )
+    var_eps_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_var_eps",
+        dtype=compute_dtype,
+        shape=reduced_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="ADD",
+            inputs=[var_name, eps_name],
+            outputs=[var_eps_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    std_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_std",
+        dtype=compute_dtype,
+        shape=reduced_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SQRT",
+            inputs=[var_eps_name],
+            outputs=[std_name],
+        )
+    )
+
+    one_name = ctx.add_const_tensor(
+        f"{node.name}_instnorm_one",
+        np.asarray(1.0, dtype=np_compute_dtype),
+    )
+    inv_std_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_inv_std",
+        dtype=compute_dtype,
+        shape=reduced_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="DIV",
+            inputs=[one_name, std_name],
+            outputs=[inv_std_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    normalized_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_normalized",
+        dtype=compute_dtype,
+        shape=input_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="MUL",
+            inputs=[centered_name, inv_std_name],
+            outputs=[normalized_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    scale_size = int(np.asarray(scale).size)
+    broadcast_shape = [1, scale_size] + [1 for _ in range(rank - 2)]
+    scale_name_const = ctx.add_const_tensor(
+        f"{node.name}_instnorm_scale",
+        np.asarray(scale, dtype=np_compute_dtype).reshape(broadcast_shape),
+    )
+    bias_name_const = ctx.add_const_tensor(
+        f"{node.name}_instnorm_bias",
+        np.asarray(bias, dtype=np_compute_dtype).reshape(broadcast_shape),
+    )
+
+    scaled_name = ctx.add_intermediate_tensor(
+        f"{node.name}_instnorm_scaled",
+        dtype=compute_dtype,
+        shape=input_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="MUL",
+            inputs=[normalized_name, scale_name_const],
+            outputs=[scaled_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    pre_output_name = output_name
+    if output_dtype != compute_dtype:
+        pre_output_name = ctx.add_intermediate_tensor(
+            f"{node.name}_instnorm_pre_output",
+            dtype=compute_dtype,
+            shape=input_shape,
+        )
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="ADD",
+            inputs=[scaled_name, bias_name_const],
+            outputs=[pre_output_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+
+    if pre_output_name != output_name:
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[pre_output_name],
+                outputs=[output_name],
+                options={"inDataType": compute_dtype, "outDataType": output_dtype},
+            )
+        )

--- a/onnx2tf/tflite_builder/op_builders/reduce.py
+++ b/onnx2tf/tflite_builder/op_builders/reduce.py
@@ -223,13 +223,11 @@ def build_reduce_l2_op(node: Any, ctx: Any) -> None:
         )
     )
 
-    sum_name = output_name
-    if output_dtype != compute_dtype:
-        sum_name = ctx.add_intermediate_tensor(
-            f"{output_name}_reduce_l2_sum",
-            dtype=compute_dtype,
-            shape=[int(v) for v in ctx.get_tensor_shape(output_name)],
-        )
+    sum_name = ctx.add_intermediate_tensor(
+        f"{output_name}_reduce_l2_sum",
+        dtype=compute_dtype,
+        shape=[int(v) for v in ctx.get_tensor_shape(output_name)],
+    )
     _build_sum_reduce_from_input(
         node=node,
         ctx=ctx,
@@ -237,13 +235,11 @@ def build_reduce_l2_op(node: Any, ctx: Any) -> None:
         output_name=sum_name,
     )
 
-    sqrt_name = output_name
-    if output_dtype != compute_dtype:
-        sqrt_name = ctx.add_intermediate_tensor(
-            f"{output_name}_reduce_l2_sqrt",
-            dtype=compute_dtype,
-            shape=[int(v) for v in ctx.get_tensor_shape(output_name)],
-        )
+    sqrt_name = ctx.add_intermediate_tensor(
+        f"{output_name}_reduce_l2_sqrt",
+        dtype=compute_dtype,
+        shape=[int(v) for v in ctx.get_tensor_shape(output_name)],
+    )
     ctx.add_operator(
         OperatorIR(
             op_type="SQRT",
@@ -252,7 +248,7 @@ def build_reduce_l2_op(node: Any, ctx: Any) -> None:
         )
     )
 
-    if sqrt_name != output_name:
+    if output_dtype != compute_dtype:
         ctx.add_operator(
             OperatorIR(
                 op_type="CAST",
@@ -262,5 +258,29 @@ def build_reduce_l2_op(node: Any, ctx: Any) -> None:
                     "inDataType": compute_dtype,
                     "outDataType": output_dtype,
                 },
+            )
+        )
+    else:
+        # Keep SQRT result in a dedicated tensor for graph readability and avoid
+        # in-place aliasing in tooling output.
+        identity_shape_name = ctx.add_intermediate_tensor(
+            f"{output_name}_reduce_l2_identity_shape",
+            dtype="INT32",
+            shape=[int(len(ctx.get_tensor_shape(output_name)))],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SHAPE",
+                inputs=[sqrt_name],
+                outputs=[identity_shape_name],
+                options={"outType": "INT32"},
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[sqrt_name, identity_shape_name],
+                outputs=[output_name],
+                options={"newShape": []},
             )
         )

--- a/onnx2tf/tflite_builder/op_builders/shape.py
+++ b/onnx2tf/tflite_builder/op_builders/shape.py
@@ -377,6 +377,62 @@ def _parse_split_sizes(
     return [int(v) for v in split_sizes]
 
 
+def _find_producer_op(ctx: Any, tensor_name: str) -> Any:
+    for op in reversed(ctx.model_ir.operators):
+        if str(tensor_name) in set(str(v) for v in op.outputs):
+            return op
+    return None
+
+
+def _infer_static_template_from_dynamic_reshape_shape_input(
+    *,
+    ctx: Any,
+    shape_input_name: str,
+) -> list[int] | None:
+    """
+    Infer static reshape template from:
+      CONCATENATION(axis=0, [const_prefix, SHAPE(x)])
+    """
+    concat_op = _find_producer_op(ctx, shape_input_name)
+    if concat_op is None or str(concat_op.op_type) != "CONCATENATION":
+        return None
+    if int(concat_op.options.get("axis", -1)) != 0 or len(concat_op.inputs) != 2:
+        return None
+
+    prefix_tensor = ctx.model_ir.tensors.get(str(concat_op.inputs[0]), None)
+    if prefix_tensor is None or prefix_tensor.data is None:
+        return None
+    prefix_vals = [int(v) for v in np.asarray(prefix_tensor.data).reshape(-1).tolist()]
+    if len(prefix_vals) == 0 or any(int(v) <= 0 for v in prefix_vals):
+        return None
+
+    shape_output_name = str(concat_op.inputs[1])
+    shape_op = _find_producer_op(ctx, shape_output_name)
+    if shape_op is None or str(shape_op.op_type) != "SHAPE" or len(shape_op.inputs) != 1:
+        return None
+
+    source_tensor = ctx.model_ir.tensors.get(str(shape_op.inputs[0]), None)
+    if source_tensor is None:
+        return None
+    source_signature = (
+        [int(v) for v in list(source_tensor.shape_signature)]
+        if source_tensor.shape_signature is not None
+        else [int(v) for v in list(source_tensor.shape)]
+    )
+    if len(source_signature) == 0:
+        return None
+
+    template = [int(v) for v in prefix_vals]
+    template.extend(int(v) if int(v) >= 0 else -1 for v in source_signature)
+    if any(int(v) == 0 for v in template):
+        return None
+    if sum(1 for v in template if int(v) < 0) > 1:
+        return None
+    if not any(int(v) < 0 for v in template):
+        template[-1] = -1
+    return [int(v) for v in template]
+
+
 def build_split_op(node: Any, ctx: Any) -> None:
     input_name = node.inputs[0].name
     output_names = [o.name for o in node.outputs]
@@ -520,33 +576,76 @@ def build_reshape_op(node: Any, ctx: Any) -> None:
         dst_tensor_name=output_name,
     )
 
-    shape_values = ctx.get_constant_array(shape_name)
-    if shape_values is None:
-        raise NotImplementedError(
-            f"Reshape shape tensor must be constant for flatbuffer_direct. op={node.name}"
-        )
-    raw_new_shape = [int(v) for v in np.asarray(shape_values).reshape(-1).tolist()]
-    new_shape = list(raw_new_shape)
     allowzero = bool(node.attrs.get("allowzero", 0))
     input_tensor = ctx.model_ir.tensors[input_name]
     output_tensor = ctx.model_ir.tensors[output_name]
-    new_shape = _resolve_reshape_shape_with_static_dims(
-        new_shape=new_shape,
-        input_tensor=input_tensor,
-        output_tensor=output_tensor,
-        allowzero=allowzero,
-    )
-    if len(new_shape) > 0 and all(int(dim) >= 0 for dim in new_shape):
-        output_tensor.shape = [int(dim) for dim in new_shape]
-        output_tensor.shape_signature = [int(dim) for dim in new_shape]
-    shape_const = ctx.add_const_tensor(
-        f"{output_name}_reshape_shape",
-        np.asarray(new_shape, dtype=np.int32),
-    )
+    shape_values = ctx.get_constant_array(shape_name)
+    raw_new_shape: list[int] = []
+    new_shape: list[int] = []
+    reshape_shape_input_name = shape_name
+
+    if shape_values is not None:
+        raw_new_shape = [int(v) for v in np.asarray(shape_values).reshape(-1).tolist()]
+        new_shape = _resolve_reshape_shape_with_static_dims(
+            new_shape=list(raw_new_shape),
+            input_tensor=input_tensor,
+            output_tensor=output_tensor,
+            allowzero=allowzero,
+        )
+        if len(new_shape) > 0 and all(int(dim) >= 0 for dim in new_shape):
+            output_tensor.shape = [int(dim) for dim in new_shape]
+            output_tensor.shape_signature = [int(dim) for dim in new_shape]
+        reshape_shape_input_name = ctx.add_const_tensor(
+            f"{output_name}_reshape_shape",
+            np.asarray(new_shape, dtype=np.int32),
+        )
+    else:
+        inferred_template = _infer_static_template_from_dynamic_reshape_shape_input(
+            ctx=ctx,
+            shape_input_name=shape_name,
+        )
+        if inferred_template is not None:
+            new_shape = [int(v) for v in inferred_template]
+            raw_new_shape = [int(v) for v in inferred_template]
+            output_tensor.shape_signature = [int(v) for v in inferred_template]
+            output_tensor.shape = [int(v) if int(v) >= 0 else 1 for v in inferred_template]
+            reshape_shape_input_name = ctx.add_const_tensor(
+                f"{output_name}_reshape_shape",
+                np.asarray(inferred_template, dtype=np.int32),
+            )
+        else:
+            shape_dtype = str(ctx.get_tensor_dtype(shape_name)).upper()
+            if shape_dtype not in {"INT32", "INT64"}:
+                raise NotImplementedError(
+                    f"Reshape dynamic shape input dtype must be INT32/INT64. "
+                    f"op={node.name} tensor={shape_name} dtype={shape_dtype}"
+                )
+            if shape_dtype == "INT64":
+                reshape_shape_input_name = ctx.add_intermediate_tensor(
+                    f"{output_name}_reshape_shape_i32",
+                    dtype="INT32",
+                    shape=[int(v) for v in ctx.get_tensor_shape(shape_name)],
+                )
+                ctx.add_operator(
+                    OperatorIR(
+                        op_type="CAST",
+                        inputs=[shape_name],
+                        outputs=[reshape_shape_input_name],
+                        options={
+                            "inDataType": "INT64",
+                            "outDataType": "INT32",
+                        },
+                    )
+                )
+            # Dynamic shape input drives runtime reshape dimensions. Keep options empty
+            # to avoid static-shape rewrite passes from clobbering this tensor.
+            new_shape = []
+            raw_new_shape = []
+
     ctx.add_operator(
         OperatorIR(
             op_type="RESHAPE",
-            inputs=[input_name, shape_const],
+            inputs=[input_name, reshape_shape_input_name],
             outputs=[output_name],
             options={
                 "newShape": new_shape,
@@ -647,6 +746,57 @@ def build_identity_op(node: Any, ctx: Any) -> None:
             inputs=[input_name, shape_const],
             outputs=[output_name],
             options={"newShape": [int(v) for v in output_shape]},
+        )
+    )
+
+
+def build_dropout_op(node: Any, ctx: Any) -> None:
+    # Dropout is treated as inference-time no-op in flatbuffer_direct.
+    build_identity_op(node, ctx)
+
+    if len(node.outputs) < 2:
+        return
+
+    input_name = node.inputs[0].name
+    mask_output_name = node.outputs[1].name
+    if str(mask_output_name) == "":
+        return
+
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(mask_output_name)
+    _propagate_passthrough_shape_signature(
+        ctx=ctx,
+        src_tensor_name=input_name,
+        dst_tensor_name=mask_output_name,
+    )
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(input_name)]
+    input_rank = len(input_shape)
+    shape_name = ctx.add_intermediate_tensor(
+        f"{mask_output_name}_dropout_mask_shape",
+        dtype="INT32",
+        shape=[int(input_rank)],
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SHAPE",
+            inputs=[input_name],
+            outputs=[shape_name],
+        )
+    )
+
+    mask_dtype = str(ctx.get_tensor_dtype(mask_output_name)).upper()
+    mask_np_dtype = _numpy_dtype_from_tflite_dtype(mask_dtype)
+    fill_value = True if mask_dtype == "BOOL" else 1
+    fill_value_name = ctx.add_const_tensor(
+        f"{mask_output_name}_dropout_mask_fill_value",
+        np.asarray(fill_value, dtype=mask_np_dtype),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="FILL",
+            inputs=[shape_name, fill_value_name],
+            outputs=[mask_output_name],
         )
     )
 
@@ -1352,7 +1502,31 @@ def build_squeeze_op(node: Any, ctx: Any) -> None:
     )
     rank = len(input_shape)
     axes = _resolve_axes_from_attr_or_input(node, ctx)
-    explicit_axes = len(axes) > 0
+    axes_source_provided = (
+        (len(node.inputs) >= 2 and str(node.inputs[1].name) != "")
+        or ("axes" in node.attrs)
+    )
+    if len(axes) == 0 and not axes_source_provided:
+        # ONNX Squeeze without axes removes all runtime singleton dimensions.
+        # Preserve this behavior by passing empty squeezeDims.
+        existing_output_signature = (
+            [int(v) for v in list(output_tensor.shape_signature)]
+            if output_tensor.shape_signature is not None
+            else [int(v) for v in list(output_tensor.shape)]
+        )
+        output_tensor.shape_signature = [int(v) for v in existing_output_signature]
+        output_tensor.shape = [int(v) if int(v) >= 0 else 1 for v in existing_output_signature]
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SQUEEZE",
+                inputs=[input_name],
+                outputs=[output_name],
+                options={"squeezeDims": []},
+            )
+        )
+        return
+
+    explicit_axes = axes_source_provided and len(axes) > 0
     if len(axes) == 0:
         axes = []
         for idx in range(rank):
@@ -1413,6 +1587,15 @@ def build_unsqueeze_op(node: Any, ctx: Any) -> None:
 
     axes = _resolve_axes_from_attr_or_input(node, ctx)
     input_rank = len(ctx.get_tensor_shape(input_name))
+    output_tensor = ctx.model_ir.tensors[output_name]
+    output_shape = ctx.get_tensor_shape(output_name)
+    output_signature = (
+        [int(v) for v in list(output_tensor.shape_signature)]
+        if output_tensor.shape_signature is not None
+        else [int(v) for v in list(output_shape)]
+    )
+    if input_rank == 0 and len(output_signature) > 0:
+        input_rank = int(max(len(output_signature) - len(axes), 0))
     normalized_axes: list[int] = []
     for axis in axes:
         a = int(axis)
@@ -1426,29 +1609,20 @@ def build_unsqueeze_op(node: Any, ctx: Any) -> None:
             normalized_axes.append(a)
     normalized_axes = sorted([int(v) for v in normalized_axes])
     input_tensor = ctx.model_ir.tensors[input_name]
-    output_tensor = ctx.model_ir.tensors[output_name]
     input_signature = (
         [int(v) for v in list(input_tensor.shape_signature)]
         if input_tensor.shape_signature is not None
         else [int(v) for v in list(ctx.get_tensor_shape(input_name))]
     )
-    if (
-        input_rank == 1
-        and len(normalized_axes) == 1
-        and any(int(v) < 0 for v in input_signature)
-    ):
-        axis = int(normalized_axes[0])
-        if axis not in (0, 1):
-            raise NotImplementedError(
-                f"Unsqueeze axis out of range for dynamic rank-1 input in flatbuffer_direct. "
-                f"op={node.name} axis={axis}"
-            )
-        reshape_shape = [1, -1] if axis == 0 else [-1, 1]
-        inferred_signature = (
-            [1, int(input_signature[0])] if axis == 0 else [int(input_signature[0]), 1]
+    if input_rank == 0 and len(output_signature) > 0:
+        reshape_shape = [int(v) for v in output_signature]
+        output_tensor.shape_signature = [int(v) for v in reshape_shape]
+        output_tensor.shape = [int(v) if int(v) >= 0 else 1 for v in reshape_shape]
+        reshape_options_shape = (
+            []
+            if any(int(v) < 0 for v in reshape_shape)
+            else [int(v) for v in reshape_shape]
         )
-        output_tensor.shape_signature = [int(v) for v in inferred_signature]
-        output_tensor.shape = [int(v) if int(v) >= 0 else 1 for v in inferred_signature]
         reshape_shape_name = ctx.add_const_tensor(
             f"{output_name}_unsqueeze_shape",
             np.asarray(reshape_shape, dtype=np.int32),
@@ -1458,20 +1632,43 @@ def build_unsqueeze_op(node: Any, ctx: Any) -> None:
                 op_type="RESHAPE",
                 inputs=[input_name, reshape_shape_name],
                 outputs=[output_name],
-                options={"newShape": [int(v) for v in reshape_shape]},
+                options={"newShape": reshape_options_shape},
+            )
+        )
+        return
+    if input_rank == 1 and len(normalized_axes) == 1:
+        axis = int(normalized_axes[0])
+        if axis not in (0, 1):
+            raise NotImplementedError(
+                f"Unsqueeze axis out of range for dynamic rank-1 input in flatbuffer_direct. "
+                f"op={node.name} axis={axis}"
+            )
+        reshape_shape = [1, -1] if axis == 0 else [-1, 1]
+        inferred_signature = [1, -1] if axis == 0 else [-1, 1]
+        output_tensor.shape_signature = [int(v) for v in inferred_signature]
+        output_tensor.shape = [int(v) if int(v) >= 0 else 1 for v in inferred_signature]
+        reshape_options_shape = (
+            []
+            if any(int(v) < 0 for v in reshape_shape)
+            else [int(v) for v in reshape_shape]
+        )
+        reshape_shape_name = ctx.add_const_tensor(
+            f"{output_name}_unsqueeze_shape",
+            np.asarray(reshape_shape, dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[input_name, reshape_shape_name],
+                outputs=[output_name],
+                options={"newShape": reshape_options_shape},
             )
         )
         return
 
-    output_shape = ctx.get_tensor_shape(output_name)
-    output_signature = (
-        [int(v) for v in list(output_tensor.shape_signature)]
-        if output_tensor.shape_signature is not None
-        else [int(v) for v in list(output_shape)]
-    )
     has_dynamic_dim = any(int(v) < 0 for v in output_signature)
 
-    if all(int(v) >= 0 for v in input_signature):
+    if len(input_signature) == int(input_rank) and all(int(v) >= 0 for v in input_signature):
         inferred_shape: list[int] = []
         src_dim_idx = 0
         output_rank = int(input_rank + len(normalized_axes))

--- a/onnx2tf/tflite_builder/op_registry.py
+++ b/onnx2tf/tflite_builder/op_registry.py
@@ -15,6 +15,7 @@ from onnx2tf.tflite_builder.op_builders import (
     build_atan_op,
     build_atanh_op,
     build_batch_normalization_op,
+    build_instance_normalization_op,
     build_binary_op,
     build_bitshift_op,
     build_bitwise_not_op,
@@ -26,6 +27,7 @@ from onnx2tf.tflite_builder.op_builders import (
     build_conv2d_or_depthwise_op,
     build_conv_transpose_op,
     build_fused_conv_op,
+    build_dropout_op,
     build_cosh_op,
     build_custom_passthrough_op,
     build_dequantize_linear_op,
@@ -922,7 +924,34 @@ def _validate_softmax(node: Any, ctx: Any) -> None:
 
 
 def _validate_reshape(node: Any, ctx: Any) -> None:
-    _require_const_input(node, ctx, 1, "reshape shape")
+    shape_name = node.inputs[1].name
+    shape_const = ctx.get_constant_array(shape_name)
+    if shape_const is not None:
+        return
+
+    shape_dtype = str(ctx.get_tensor_dtype(shape_name)).upper()
+    if shape_dtype not in {"INT32", "INT64"}:
+        raise NodeValidationError(
+            reason_code="unsupported_input_type",
+            message=(
+                "Reshape dynamic shape input must be INT32 or INT64 for flatbuffer_direct. "
+                f"dtype={shape_dtype} tensor={shape_name}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    shape_tensor_shape = [int(v) for v in ctx.get_tensor_shape(shape_name)]
+    if len(shape_tensor_shape) != 1:
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "Reshape dynamic shape input must be rank-1 for flatbuffer_direct. "
+                f"shape={shape_tensor_shape} tensor={shape_name}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
 
 
 def _validate_slice(node: Any, ctx: Any) -> None:
@@ -1991,6 +2020,10 @@ def _validate_unsqueeze(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
+    if input_rank == 0:
+        output_rank = len(ctx.get_tensor_shape(node.outputs[0].name))
+        if output_rank > 0:
+            input_rank = int(max(output_rank - len(axes), 0))
     for axis in axes:
         a = int(axis)
         if a < 0:
@@ -3007,6 +3040,98 @@ def _validate_batch_norm(node: Any, ctx: Any) -> None:
         )
 
 
+def _validate_instance_norm(node: Any, ctx: Any) -> None:
+    if len(node.inputs) < 3:
+        raise NodeValidationError(
+            reason_code="invalid_input_count",
+            message="InstanceNormalization expects 3 inputs.",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    scale = _require_const_input(node, ctx, 1, "InstanceNormalization scale")
+    bias = _require_const_input(node, ctx, 2, "InstanceNormalization bias")
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(node.inputs[0].name)]
+    input_rank = len(input_shape)
+    if input_rank < 3:
+        raise NodeValidationError(
+            reason_code="unsupported_input_rank",
+            message=f"InstanceNormalization input rank must be >= 3. rank={input_rank}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    input_dtype = str(ctx.get_tensor_dtype(node.inputs[0].name)).upper()
+    output_dtype = str(ctx.get_tensor_dtype(node.outputs[0].name)).upper()
+    if input_dtype not in {"FLOAT16", "FLOAT32"}:
+        raise NodeValidationError(
+            reason_code="unsupported_input_dtype",
+            message=(
+                "InstanceNormalization input dtype must be FLOAT16/FLOAT32 for builtin lowering. "
+                f"input_dtype={input_dtype}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if output_dtype not in {"FLOAT16", "FLOAT32"}:
+        raise NodeValidationError(
+            reason_code="unsupported_output_dtype",
+            message=(
+                "InstanceNormalization output dtype must be FLOAT16/FLOAT32 for builtin lowering. "
+                f"output_dtype={output_dtype}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    scale_size = int(np.asarray(scale).size)
+    bias_size = int(np.asarray(bias).size)
+    if scale_size <= 0 or bias_size <= 0:
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "InstanceNormalization scale/bias must be non-empty. "
+                f"scale_size={scale_size} bias_size={bias_size}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if scale_size != bias_size:
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "InstanceNormalization scale/bias sizes must match. "
+                f"scale_size={scale_size} bias_size={bias_size}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    input_tensor = ctx.model_ir.tensors.get(node.inputs[0].name, None)
+    if input_tensor is not None and input_tensor.shape_signature is not None and len(input_tensor.shape_signature) >= 2:
+        channel_dim = int(input_tensor.shape_signature[1])
+        if channel_dim > 0 and scale_size != channel_dim:
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "InstanceNormalization scale/bias size must match input channel dimension. "
+                    f"channels={channel_dim} scale_size={scale_size} bias_size={bias_size}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+
+    epsilon = float(node.attrs.get("epsilon", 1e-5))
+    if not np.isfinite(epsilon) or epsilon < 0.0:
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=f"InstanceNormalization epsilon must be finite and >= 0. got={epsilon}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
 def _validate_flatten(node: Any, ctx: Any) -> None:
     input_rank = len(ctx.get_tensor_shape(node.inputs[0].name))
     if input_rank < 1:
@@ -4014,6 +4139,13 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         validation=ValidationSpec(min_inputs=5, max_inputs=5, min_outputs=1, max_outputs=1),
         extra_validator=_validate_batch_norm,
     ),
+    "InstanceNormalization": DispatchEntry(
+        onnx_op="InstanceNormalization",
+        tflite_ops=["MEAN", "SUB", "MUL", "ADD", "SQRT", "DIV"],
+        builder=build_instance_normalization_op,
+        validation=ValidationSpec(min_inputs=3, max_inputs=3, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_instance_norm,
+    ),
     "ReduceMean": DispatchEntry(
         onnx_op="ReduceMean",
         tflite_ops=["MEAN"],
@@ -4360,6 +4492,12 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         builder=build_flatten_op,
         validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
         extra_validator=_validate_flatten,
+    ),
+    "Dropout": DispatchEntry(
+        onnx_op="Dropout",
+        tflite_ops=["RESHAPE", "SHAPE", "FILL"],
+        builder=build_dropout_op,
+        validation=ValidationSpec(min_inputs=1, max_inputs=3, min_outputs=1, max_outputs=2),
     ),
     "Transpose": DispatchEntry(
         onnx_op="Transpose",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.21"
+version = "2.0.22"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -35,8 +35,8 @@ dependencies = [
     "ai-edge-litert==2.1.2",
     "tensorflow==2.19.0",
     "tf-keras==2.19.0",
-    "sne4onnx==2.0.0",
-    "sng4onnx==2.0.0",
+    "sne4onnx==2.0.1",
+    "sng4onnx==2.0.1",
     "psutil==5.9.5",
     "protobuf==4.25.5",
     "h5py==3.12.1",

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -25,6 +25,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_singleton_reshape_concat_post_transpose_nhwc_chains,
     _optimize_transpose_conv_attention_nhwc_propagation_chains,
     _optimize_transpose_elementwise_concat_conv_nhwc_groups,
+    _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains,
     _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains,
     _optimize_shufflenet_transpose_shuffle_chains,
     _optimize_sinet_concat_resize_affine_transpose_chains,
@@ -33,8 +34,10 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_transpose_mean_prepost_nhwc_passthrough_chains,
     _optimize_transpose_se_fc_mul_prepost_nhwc_chains,
     _optimize_transpose_input_chains_pre_concat_to_single_post_adapter,
+    _optimize_transpose_logistic_muladd_prepost_nhwc_chains,
     _optimize_transpose_pre_add_nhwc_chains,
     _optimize_transpose_pre_add_mul_add_prelu_nhwc_chains,
+    _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains,
     _optimize_transpose_pre_concat_nhwc_chains,
     _optimize_transpose_mul_add_const_prepost_nhwc_chains,
     _optimize_transpose_mul_add_const_prelu_prepost_nhwc_terminal_chains,
@@ -146,6 +149,26 @@ def _make_add_model() -> onnx.ModelProto:
     z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])
     node = helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")
     graph = helper.make_graph([node], "add_graph", [x, y], [z])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_dropout_model(*, with_mask_output: bool = False) -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 4, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 4, 4])
+    outputs = ["y"]
+    graph_outputs = [y]
+    if with_mask_output:
+        m = helper.make_tensor_value_info("m", TensorProto.BOOL, [1, 3, 4, 4])
+        outputs.append("m")
+        graph_outputs.append(m)
+
+    node = helper.make_node(
+        "Dropout",
+        ["x"],
+        outputs,
+        name="DropoutNode",
+    )
+    graph = helper.make_graph([node], "dropout_graph", [x], graph_outputs)
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -502,6 +525,21 @@ def _make_pool_model() -> onnx.ModelProto:
         pads=[0, 0, 0, 0],
     )
     graph = helper.make_graph([node], "pool_graph", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_reduce_l2_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 4, 5])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1, 4, 5])
+    node = helper.make_node(
+        "ReduceL2",
+        ["x"],
+        ["y"],
+        name="ReduceL2Node",
+        axes=[1],
+        keepdims=1,
+    )
+    graph = helper.make_graph([node], "reduce_l2_graph", [x], [y])
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -2854,6 +2892,27 @@ def _make_gather_singleton_indices_rank_reduced_model() -> onnx.ModelProto:
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
+def _make_gather_singleton_negative_indices_rank_reduced_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
+    indices = numpy_helper.from_array(np.array([-1], dtype=np.int64), name="indices")
+    node = helper.make_node(
+        "Gather",
+        ["x", "indices"],
+        ["y"],
+        name="GatherSingletonNegativeIndicesNode",
+        axis=2,
+    )
+    graph = helper.make_graph(
+        [node],
+        "gather_singleton_negative_indices_rank_reduced_graph",
+        [x],
+        [y],
+        initializer=[indices],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
 def _make_l2_norm_model() -> onnx.ModelProto:
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4])
@@ -2883,6 +2942,34 @@ def _make_lrn_model() -> onnx.ModelProto:
         bias=1.0,
     )
     graph = helper.make_graph([node], "lrn_graph", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_instance_normalization_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 5, 5])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 5, 5])
+    scale = numpy_helper.from_array(
+        np.asarray([1.0, 0.5, 2.0], dtype=np.float32),
+        name="inst_scale",
+    )
+    bias = numpy_helper.from_array(
+        np.asarray([0.1, -0.2, 0.3], dtype=np.float32),
+        name="inst_bias",
+    )
+    node = helper.make_node(
+        "InstanceNormalization",
+        ["x", "inst_scale", "inst_bias"],
+        ["y"],
+        name="InstanceNormNode",
+        epsilon=1e-5,
+    )
+    graph = helper.make_graph(
+        [node],
+        "instance_norm_graph",
+        [x],
+        [y],
+        initializer=[scale, bias],
+    )
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -3153,6 +3240,8 @@ def test_tflite_backend_matrix_hardswish_rewrite_on_off(monkeypatch: pytest.Monk
         ("gather", _make_gather_model),
         ("l2_norm", _make_l2_norm_model),
         ("lrn", _make_lrn_model),
+        ("dropout", _make_dropout_model),
+        ("instance_norm", _make_instance_normalization_model),
         ("relu", lambda: _make_unary_model("Relu", name="relu")),
         ("tanh", lambda: _make_unary_model("Tanh", name="tanh")),
         ("atan", lambda: _make_unary_model("Atan", name="atan")),
@@ -4025,6 +4114,50 @@ def test_flatbuffer_direct_lrn_lowering() -> None:
     assert op_types.count("CUSTOM") == 0
 
 
+def test_flatbuffer_direct_dropout_lowering() -> None:
+    model = _make_dropout_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="dropout_lowering_test",
+        allow_custom_ops=False,
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("RESHAPE") == 1
+    assert op_types.count("CUSTOM") == 0
+
+
+def test_flatbuffer_direct_dropout_with_mask_output_lowering() -> None:
+    model = _make_dropout_model(with_mask_output=True)
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="dropout_mask_lowering_test",
+        allow_custom_ops=False,
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("RESHAPE") == 1
+    assert op_types.count("SHAPE") == 1
+    assert op_types.count("FILL") == 1
+    assert op_types.count("CUSTOM") == 0
+
+
+def test_flatbuffer_direct_instance_normalization_lowering() -> None:
+    model = _make_instance_normalization_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="instance_normalization_lowering_test",
+        allow_custom_ops=False,
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("MEAN") == 2
+    assert op_types.count("CUSTOM") == 0
+
+
 def test_flatbuffer_direct_pow_lowering() -> None:
     model = _make_pow_general_model()
     register_default_preprocess_rules()
@@ -4457,6 +4590,25 @@ def test_flatbuffer_direct_fused_matmul_lowering() -> None:
     assert op_types.count("CUSTOM") == 0
 
 
+def test_flatbuffer_direct_reduce_l2_sqrt_emits_separate_tensor() -> None:
+    model = _make_reduce_l2_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="reduce_l2_sqrt_separate_tensor_test",
+        allow_custom_ops=False,
+    )
+
+    sqrt_ops = [op for op in model_ir.operators if str(op.op_type) == "SQRT"]
+    assert len(sqrt_ops) == 1
+    sqrt_op = sqrt_ops[0]
+    assert len(list(sqrt_op.inputs)) == 1
+    assert len(list(sqrt_op.outputs)) == 1
+    assert str(sqrt_op.inputs[0]) != str(sqrt_op.outputs[0])
+    assert str(sqrt_op.outputs[0]) != "y"
+
+
 def test_flatbuffer_direct_resolve_dynamic_reshape_zero_copy_dims_pass() -> None:
     model_ir = ModelIR(name="reshape_zero_copy_fixup_test")
     model_ir.inputs = ["x"]
@@ -4853,6 +5005,52 @@ def test_flatbuffer_direct_reconcile_batch_matmul_propagates_output_shape_signat
     assert list(model_ir.tensors["y"].shape_signature) == [-1, 2, 3]
 
 
+def test_flatbuffer_direct_reconcile_slice_preserves_dynamic_full_extent_size() -> None:
+    model_ir = ModelIR(name="reconcile_slice_dynamic_full_extent_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 2],
+        shape_signature=[1, 1, -1, 2],
+    )
+    model_ir.tensors["slice_begin"] = TensorIR(
+        name="slice_begin",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 0, 0, 0], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["slice_size"] = TensorIR(
+        name="slice_size",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([-1, -1, -1, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 1],
+        shape_signature=[1, 1, -1, 1],
+    )
+    model_ir.operators = [
+        OperatorIR(
+            op_type="SLICE",
+            inputs=["x", "slice_begin", "slice_size"],
+            outputs=["y"],
+        )
+    ]
+
+    _ = _reconcile_static_tensor_shapes(model_ir)
+    slice_size_values = np.asarray(model_ir.tensors["slice_size"].data, dtype=np.int32).reshape(-1).tolist()
+    assert slice_size_values == [-1, -1, -1, 1]
+    assert list(model_ir.tensors["y"].shape_signature) == [1, 1, -1, 1]
+
+
 def test_flatbuffer_direct_transpose_mul_add_const_rewrite_keeps_nhwc_consts_stable() -> None:
     model_ir = ModelIR(name="transpose_mul_add_const_rewrite_idempotent_const_shape_test")
     model_ir.inputs = ["x_nhwc"]
@@ -5211,6 +5409,224 @@ def test_flatbuffer_direct_transpose_pre_add_mul_add_prelu_nhwc_chain_optimized(
     )
 
 
+def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_logistic_muladd_prepost_nhwc_chain_opt_test")
+    model_ir.inputs = ["skip_nhwc", "data_nhwc", "gate_nhwc"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["skip_nhwc"] = TensorIR(
+        name="skip_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 8],
+        shape_signature=[1, 6, 6, 8],
+    )
+    model_ir.tensors["data_nhwc"] = TensorIR(
+        name="data_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 8],
+        shape_signature=[1, 6, 6, 8],
+    )
+    model_ir.tensors["gate_nhwc"] = TensorIR(
+        name="gate_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 8],
+        shape_signature=[1, 1, 1, 8],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["skip_nchw"] = TensorIR(
+        name="skip_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["data_nchw"] = TensorIR(
+        name="data_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["gate_nchw"] = TensorIR(
+        name="gate_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 1],
+        shape_signature=[1, 8, 1, 1],
+    )
+    model_ir.tensors["sig_nchw"] = TensorIR(
+        name="sig_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 1],
+        shape_signature=[1, 8, 1, 1],
+    )
+    model_ir.tensors["mul_nchw"] = TensorIR(
+        name="mul_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["add_nchw"] = TensorIR(
+        name="add_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["y_nhwc"] = TensorIR(
+        name="y_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 8],
+        shape_signature=[1, 6, 6, 8],
+    )
+    model_ir.tensors["reshape_shape"] = TensorIR(
+        name="reshape_shape",
+        dtype="INT64",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([1, 36, 8], dtype=np.int64),
+        is_variable=False,
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 36, 8],
+        shape_signature=[1, 36, 8],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["skip_nhwc", "pre_perm"], outputs=["skip_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["data_nhwc", "pre_perm"], outputs=["data_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["gate_nhwc", "pre_perm"], outputs=["gate_nchw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["gate_nchw"], outputs=["sig_nchw"]),
+        OperatorIR(op_type="MUL", inputs=["data_nchw", "sig_nchw"], outputs=["mul_nchw"]),
+        OperatorIR(op_type="ADD", inputs=["mul_nchw", "skip_nchw"], outputs=["add_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["add_nchw", "post_perm"], outputs=["y_nhwc"]),
+        OperatorIR(op_type="RESHAPE", inputs=["y_nhwc", "reshape_shape"], outputs=["z"]),
+    ]
+
+    stats = _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_logistic_muladd_prepost_nhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+
+    logistic_op = next(op for op in model_ir.operators if str(op.op_type) == "LOGISTIC")
+    assert [str(v) for v in list(logistic_op.inputs)] == ["gate_nhwc"]
+
+    mul_op = next(op for op in model_ir.operators if str(op.op_type) == "MUL")
+    assert set(str(v) for v in list(mul_op.inputs)) == {"data_nhwc", "sig_nchw"}
+
+    add_op = next(op for op in model_ir.operators if str(op.op_type) == "ADD")
+    assert list(add_op.outputs) == ["y_nhwc"]
+    assert set(str(v) for v in list(add_op.inputs)) == {"mul_nchw", "skip_nhwc"}
+
+    reshape_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE")
+    assert [str(v) for v in list(reshape_op.inputs)] == ["y_nhwc", "reshape_shape"]
+
+    assert list(model_ir.tensors["sig_nchw"].shape) == [1, 1, 1, 8]
+    assert list(model_ir.tensors["mul_nchw"].shape) == [1, 6, 6, 8]
+
+
+def test_flatbuffer_direct_transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_opt_test")
+    model_ir.inputs = ["x_nhwc"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 5, 7, 4],
+        shape_signature=[1, 5, 7, 4],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([0, 2, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["reshape_shape"] = TensorIR(
+        name="reshape_shape",
+        dtype="INT64",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([1, 4, 35], dtype=np.int64),
+        is_variable=False,
+    )
+    model_ir.tensors["x_nchw"] = TensorIR(
+        name="x_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 7],
+        shape_signature=[1, 4, 5, 7],
+    )
+    model_ir.tensors["u_nchw"] = TensorIR(
+        name="u_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 7],
+        shape_signature=[1, 4, 5, 7],
+    )
+    model_ir.tensors["r_nchw"] = TensorIR(
+        name="r_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 35],
+        shape_signature=[1, 4, 35],
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 35, 4],
+        shape_signature=[1, 35, 4],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "pre_perm"], outputs=["x_nchw"]),
+        OperatorIR(op_type="LEAKY_RELU", inputs=["x_nchw"], outputs=["u_nchw"], options={"alpha": 0.1}),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["u_nchw", "reshape_shape"],
+            outputs=["r_nchw"],
+            options={"newShape": [1, 4, 35], "onnxRawNewShape": [1, 4, -1]},
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["r_nchw", "post_perm"], outputs=["z"]),
+    ]
+
+    stats = _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+
+    unary_op = next(op for op in model_ir.operators if str(op.op_type) == "LEAKY_RELU")
+    assert [str(v) for v in list(unary_op.inputs)] == ["x_nhwc"]
+
+    reshape_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE")
+    assert [str(v) for v in list(reshape_op.inputs)] == ["u_nchw", "reshape_shape"]
+    assert [str(v) for v in list(reshape_op.outputs)] == ["z"]
+    assert list(np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1)) == [1, 35, 4]
+    assert reshape_op.options.get("newShape") == [1, 35, 4]
+    assert reshape_op.options.get("onnxRawNewShape") == [1, -1, 4]
+
+    assert list(model_ir.tensors["u_nchw"].shape) == [1, 5, 7, 4]
+    assert list(model_ir.tensors["z"].shape) == [1, 35, 4]
+
+
 def test_flatbuffer_direct_transpose_mul_add_const_prelu_prepost_terminal_optimized() -> None:
     model_ir = ModelIR(name="transpose_mul_add_const_prelu_prepost_terminal_opt_test")
     model_ir.inputs = ["x_nhwc", "legacy_nchw"]
@@ -5405,6 +5821,89 @@ def test_flatbuffer_direct_singleton_spatial_transpose_before_flatten_reshape_re
     assert not any(str(op.op_type) == "TRANSPOSE" for op in model_ir.operators)
     reshape_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE")
     assert list(reshape_op.inputs) == ["x_nhwc", "flat_shape"]
+
+
+def test_flatbuffer_direct_singleton_spatial_transpose_identity_reshape_flatten_removed() -> None:
+    model_ir = ModelIR(name="singleton_spatial_transpose_identity_reshape_flatten_test")
+    model_ir.inputs = ["x_nhwc"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 48],
+        shape_signature=[1, 1, 1, 48],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["x_nchw"] = TensorIR(
+        name="x_nchw",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["keep_shape"] = TensorIR(
+        name="keep_shape",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([1, 48, 1, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["x_keep"] = TensorIR(
+        name="x_keep",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["flat_shape"] = TensorIR(
+        name="flat_shape",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([1, 48], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 48],
+        shape_signature=[1, 48],
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 48],
+        shape_signature=[1, 48],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "pre_perm"], outputs=["x_nchw"]),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["x_nchw", "keep_shape"],
+            outputs=["x_keep"],
+            options={"newShape": [1, 48, 1, 1]},
+        ),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["x_keep", "flat_shape"],
+            outputs=["y"],
+            options={"newShape": [1, 48]},
+        ),
+        OperatorIR(op_type="RELU", inputs=["y"], outputs=["z"]),
+    ]
+
+    stats = _optimize_singleton_spatial_nhwc_transpose_reshape_flatten(model_ir)
+    assert stats["optimized_singleton_spatial_nhwc_transpose_reshape_flatten"] == 1
+    assert not any(str(op.op_type) == "TRANSPOSE" for op in model_ir.operators)
+    reshape_ops = [op for op in model_ir.operators if str(op.op_type) == "RESHAPE"]
+    assert len(reshape_ops) == 1
+    assert list(reshape_ops[0].inputs) == ["x_nhwc", "flat_shape"]
 
 
 def test_flatbuffer_direct_sinet_concat_resize_affine_transpose_chain_optimized() -> None:
@@ -6352,6 +6851,402 @@ def test_flatbuffer_direct_shufflenet_transpose_shuffle_chain_optimized() -> Non
     assert all(int(op.options.get("axis", -1)) == 3 for op in gather_ops[:2])
 
 
+def test_flatbuffer_direct_shufflenet_transpose_slice_shuffle_chain_optimized() -> None:
+    model_ir = ModelIR(name="shufflenet_transpose_slice_shuffle_chain_opt_test")
+    model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
+    model_ir.outputs = ["out_nchw"]
+
+    model_ir.tensors["x0_nhwc"] = TensorIR(
+        name="x0_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 4],
+        shape_signature=[1, 2, 2, 4],
+    )
+    model_ir.tensors["x1_nhwc"] = TensorIR(
+        name="x1_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 4],
+        shape_signature=[1, 2, 2, 4],
+    )
+    model_ir.tensors["to_nchw_perm"] = TensorIR(
+        name="to_nchw_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["to_nhwc_perm"] = TensorIR(
+        name="to_nhwc_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["perm_swap"] = TensorIR(
+        name="perm_swap",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 2, 1, 3, 4], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["shape_r1"] = TensorIR(
+        name="shape_r1",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([1, 2, 4, 2, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["shape_r2"] = TensorIR(
+        name="shape_r2",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([1, 8, 2, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["slice0_begin"] = TensorIR(
+        name="slice0_begin",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 0, 0, 0], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["slice0_size"] = TensorIR(
+        name="slice0_size",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([-1, 4, -1, -1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["slice1_begin"] = TensorIR(
+        name="slice1_begin",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 4, 0, 0], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["slice1_size"] = TensorIR(
+        name="slice1_size",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([-1, 4, -1, -1], dtype=np.int32),
+        is_variable=False,
+    )
+
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 8],
+        shape_signature=[1, 2, 2, 8],
+    )
+    model_ir.tensors["x_nchw"] = TensorIR(
+        name="x_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 2, 2],
+        shape_signature=[1, 8, 2, 2],
+    )
+    model_ir.tensors["r1"] = TensorIR(
+        name="r1",
+        dtype="FLOAT32",
+        shape=[1, 2, 4, 2, 2],
+        shape_signature=[1, 2, 4, 2, 2],
+    )
+    model_ir.tensors["t1"] = TensorIR(
+        name="t1",
+        dtype="FLOAT32",
+        shape=[1, 4, 2, 2, 2],
+        shape_signature=[1, 4, 2, 2, 2],
+    )
+    model_ir.tensors["r2"] = TensorIR(
+        name="r2",
+        dtype="FLOAT32",
+        shape=[1, 8, 2, 2],
+        shape_signature=[1, 8, 2, 2],
+    )
+    model_ir.tensors["s0_nchw"] = TensorIR(
+        name="s0_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 2, 2],
+        shape_signature=[1, 4, 2, 2],
+    )
+    model_ir.tensors["s1_nchw"] = TensorIR(
+        name="s1_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 2, 2],
+        shape_signature=[1, 4, 2, 2],
+    )
+    model_ir.tensors["s1_nhwc"] = TensorIR(
+        name="s1_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 4],
+        shape_signature=[1, 2, 2, 4],
+    )
+    model_ir.tensors["b1"] = TensorIR(
+        name="b1",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 4],
+        shape_signature=[1, 2, 2, 4],
+    )
+    model_ir.tensors["b2"] = TensorIR(
+        name="b2",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 4],
+        shape_signature=[1, 2, 2, 4],
+    )
+    model_ir.tensors["b3"] = TensorIR(
+        name="b3",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 4],
+        shape_signature=[1, 2, 2, 4],
+    )
+    model_ir.tensors["b3_nchw"] = TensorIR(
+        name="b3_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 2, 2],
+        shape_signature=[1, 4, 2, 2],
+    )
+    model_ir.tensors["b3_relu_nchw"] = TensorIR(
+        name="b3_relu_nchw",
+        dtype="FLOAT32",
+        shape=[1, 4, 2, 2],
+        shape_signature=[1, 4, 2, 2],
+    )
+    model_ir.tensors["out_nchw"] = TensorIR(
+        name="out_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 2, 2],
+        shape_signature=[1, 8, 2, 2],
+    )
+
+    model_ir.operators = [
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=["x0_nhwc", "x1_nhwc"],
+            outputs=["x_nhwc"],
+            options={"axis": 3, "fusedActivationFunction": "NONE"},
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "to_nchw_perm"], outputs=["x_nchw"]),
+        OperatorIR(op_type="RESHAPE", inputs=["x_nchw", "shape_r1"], outputs=["r1"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["r1", "perm_swap"], outputs=["t1"]),
+        OperatorIR(op_type="RESHAPE", inputs=["t1", "shape_r2"], outputs=["r2"]),
+        OperatorIR(op_type="SLICE", inputs=["r2", "slice0_begin", "slice0_size"], outputs=["s0_nchw"]),
+        OperatorIR(op_type="SLICE", inputs=["r2", "slice1_begin", "slice1_size"], outputs=["s1_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["s1_nchw", "to_nhwc_perm"], outputs=["s1_nhwc"]),
+        OperatorIR(op_type="CONV_2D", inputs=["s1_nhwc"], outputs=["b1"], options={"padding": "SAME", "strideH": 1, "strideW": 1, "filterHeight": 1, "filterWidth": 1, "fusedActivationFunction": "NONE"}),
+        OperatorIR(op_type="DEPTHWISE_CONV_2D", inputs=["b1"], outputs=["b2"], options={"padding": "SAME", "strideH": 1, "strideW": 1, "depthMultiplier": 1, "dilationHFactor": 1, "dilationWFactor": 1, "fusedActivationFunction": "NONE"}),
+        OperatorIR(op_type="CONV_2D", inputs=["b2"], outputs=["b3"], options={"padding": "SAME", "strideH": 1, "strideW": 1, "filterHeight": 1, "filterWidth": 1, "fusedActivationFunction": "NONE"}),
+        OperatorIR(op_type="TRANSPOSE", inputs=["b3", "to_nchw_perm"], outputs=["b3_nchw"]),
+        OperatorIR(op_type="RELU", inputs=["b3_nchw"], outputs=["b3_relu_nchw"]),
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=["s0_nchw", "b3_relu_nchw"],
+            outputs=["out_nchw"],
+            options={"axis": 1, "fusedActivationFunction": "NONE"},
+        ),
+    ]
+
+    stats = _optimize_shufflenet_transpose_shuffle_chains(model_ir)
+    assert stats["optimized_shufflenet_transpose_shuffle_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("SLICE") == 0
+
+    concat_ops = [op for op in model_ir.operators if str(op.op_type) == "CONCATENATION"]
+    assert len(concat_ops) == 2
+    assert int(concat_ops[1].options.get("axis", -1)) == 3
+    tail_concat_idx = op_types.index("CONCATENATION", op_types.index("CONCATENATION") + 1)
+    assert str(model_ir.operators[tail_concat_idx + 1].op_type) == "TRANSPOSE"
+    assert model_ir.operators[tail_concat_idx + 1].outputs == ["out_nchw"]
+
+    gather_ops = [op for op in model_ir.operators if str(op.op_type) == "GATHER"]
+    assert len(gather_ops) >= 2
+    assert all(int(op.options.get("axis", -1)) == 3 for op in gather_ops[:2])
+    gather0_indices = np.asarray(model_ir.tensors[str(gather_ops[0].inputs[1])].data, dtype=np.int32).reshape(-1)
+    gather1_indices = np.asarray(model_ir.tensors[str(gather_ops[1].inputs[1])].data, dtype=np.int32).reshape(-1)
+    assert np.array_equal(gather0_indices, np.asarray([0, 4, 1, 5], dtype=np.int32))
+    assert np.array_equal(gather1_indices, np.asarray([2, 6, 3, 7], dtype=np.int32))
+
+
+def test_flatbuffer_direct_transpose_slice_logistic_concat_reshape_tail_nhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_slice_logistic_concat_reshape_tail_nhwc_opt_test")
+    model_ir.inputs = ["x0_nhwc", "x1_nhwc", "x2_nhwc", "x3_nhwc"]
+    model_ir.outputs = ["out_nchw"]
+
+    def _add_tensor(name: str, dtype: str, shape: list[int], data: np.ndarray | None = None) -> None:
+        model_ir.tensors[name] = TensorIR(
+            name=name,
+            dtype=dtype,
+            shape=[int(v) for v in list(shape)],
+            shape_signature=[int(v) for v in list(shape)],
+            data=(None if data is None else np.asarray(data)),
+            is_variable=False,
+        )
+
+    _add_tensor(
+        "to_nchw_perm",
+        "INT32",
+        [4],
+        np.asarray([0, 3, 1, 2], dtype=np.int32),
+    )
+
+    branch_specs = [
+        ("x0", 52, 52, 2704),
+        ("x1", 26, 26, 676),
+        ("x2", 13, 13, 169),
+        ("x3", 7, 7, 49),
+    ]
+
+    operators: list[OperatorIR] = []
+    reshape_outputs: list[str] = []
+    for branch_name, height, width, spatial in branch_specs:
+        x_nhwc = f"{branch_name}_nhwc"
+        x_nchw = f"{branch_name}_nchw"
+        slice0_out = f"{branch_name}_slice0"
+        slice1_out = f"{branch_name}_slice1"
+        sig_out = f"{branch_name}_sig"
+        cat_out = f"{branch_name}_cat"
+        reshape_out = f"{branch_name}_reshape"
+        reshape_shape = f"{branch_name}_reshape_shape"
+        split0_begin = f"{branch_name}_split0_begin"
+        split0_size = f"{branch_name}_split0_size"
+        split1_begin = f"{branch_name}_split1_begin"
+        split1_size = f"{branch_name}_split1_size"
+
+        _add_tensor(x_nhwc, "FLOAT32", [1, int(height), int(width), 37])
+        _add_tensor(x_nchw, "FLOAT32", [1, 37, int(height), int(width)])
+        _add_tensor(slice0_out, "FLOAT32", [1, 5, int(height), int(width)])
+        _add_tensor(slice1_out, "FLOAT32", [1, 32, int(height), int(width)])
+        _add_tensor(sig_out, "FLOAT32", [1, 5, int(height), int(width)])
+        _add_tensor(cat_out, "FLOAT32", [1, 37, int(height), int(width)])
+        _add_tensor(reshape_out, "FLOAT32", [1, 37, int(spatial)])
+        _add_tensor(
+            reshape_shape,
+            "INT32",
+            [3],
+            np.asarray([1, 37, int(spatial)], dtype=np.int32),
+        )
+        _add_tensor(
+            split0_begin,
+            "INT32",
+            [4],
+            np.asarray([0, 0, 0, 0], dtype=np.int32),
+        )
+        _add_tensor(
+            split0_size,
+            "INT32",
+            [4],
+            np.asarray([1, 5, int(height), int(width)], dtype=np.int32),
+        )
+        _add_tensor(
+            split1_begin,
+            "INT32",
+            [4],
+            np.asarray([0, 5, 0, 0], dtype=np.int32),
+        )
+        _add_tensor(
+            split1_size,
+            "INT32",
+            [4],
+            np.asarray([1, 32, int(height), int(width)], dtype=np.int32),
+        )
+
+        operators.extend(
+            [
+                OperatorIR(
+                    op_type="TRANSPOSE",
+                    inputs=[x_nhwc, "to_nchw_perm"],
+                    outputs=[x_nchw],
+                ),
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[x_nchw, split0_begin, split0_size],
+                    outputs=[slice0_out],
+                ),
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[x_nchw, split1_begin, split1_size],
+                    outputs=[slice1_out],
+                ),
+                OperatorIR(
+                    op_type="LOGISTIC",
+                    inputs=[slice0_out],
+                    outputs=[sig_out],
+                ),
+                OperatorIR(
+                    op_type="CONCATENATION",
+                    inputs=[sig_out, slice1_out],
+                    outputs=[cat_out],
+                    options={"axis": 1, "fusedActivationFunction": "NONE"},
+                ),
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[cat_out, reshape_shape],
+                    outputs=[reshape_out],
+                    options={
+                        "newShape": [1, 37, int(spatial)],
+                        "onnxRawNewShape": [1, 37, -1],
+                        "allowZero": False,
+                    },
+                ),
+            ]
+        )
+        reshape_outputs.append(reshape_out)
+
+    _add_tensor("out_nchw", "FLOAT32", [1, 37, 3598])
+    operators.append(
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=[str(v) for v in reshape_outputs],
+            outputs=["out_nchw"],
+            options={"axis": 2, "fusedActivationFunction": "NONE"},
+        )
+    )
+    model_ir.operators = list(operators)
+
+    stats = _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_slice_logistic_concat_reshape_tail_nhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 1
+
+    transpose_op = next(op for op in model_ir.operators if str(op.op_type) == "TRANSPOSE")
+    assert list(transpose_op.outputs) == ["out_nchw"]
+    perm_vals = np.asarray(model_ir.tensors[str(transpose_op.inputs[1])].data, dtype=np.int32).reshape(-1).tolist()
+    assert perm_vals == [0, 2, 1]
+
+    tail_concat = next(
+        op
+        for op in model_ir.operators
+        if str(op.op_type) == "CONCATENATION"
+        and len(list(op.inputs)) == len(reshape_outputs)
+        and set(str(v) for v in list(op.inputs)) == set(str(v) for v in reshape_outputs)
+    )
+    assert int(tail_concat.options.get("axis", -1)) == 1
+    assert list(tail_concat.outputs) == [str(transpose_op.inputs[0])]
+
+    for branch_name, height, width, spatial in branch_specs:
+        cat_op = next(op for op in model_ir.operators if list(op.outputs) == [f"{branch_name}_cat"])
+        assert int(cat_op.options.get("axis", -1)) == 3
+        reshape_op = next(op for op in model_ir.operators if list(op.outputs) == [f"{branch_name}_reshape"])
+        assert list(reshape_op.options.get("newShape", [])) == [1, int(spatial), 37]
+        assert list(reshape_op.options.get("onnxRawNewShape", [])) == [1, -1, 37]
+        shape_vals = np.asarray(model_ir.tensors[f"{branch_name}_reshape_shape"].data, dtype=np.int32).reshape(-1).tolist()
+        assert shape_vals == [1, int(spatial), 37]
+
+        split1_begin_vals = np.asarray(model_ir.tensors[f"{branch_name}_split1_begin"].data, dtype=np.int32).reshape(-1).tolist()
+        split1_size_vals = np.asarray(model_ir.tensors[f"{branch_name}_split1_size"].data, dtype=np.int32).reshape(-1).tolist()
+        assert split1_begin_vals == [0, 0, 0, 5]
+        assert split1_size_vals == [1, int(height), int(width), 32]
+
+
 def test_flatbuffer_direct_shufflenet_reshape_transpose_shuffle_nhwc_chain_optimized() -> None:
     model_ir = ModelIR(name="shufflenet_reshape_transpose_shuffle_nhwc_opt_test")
     model_ir.inputs = ["x_nhwc"]
@@ -6575,6 +7470,116 @@ def test_flatbuffer_direct_transpose_pre_add_nhwc_shared_concat_and_unary_input(
         str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["sum_nchw"]
         for op in model_ir.operators
     )
+
+
+def test_flatbuffer_direct_transpose_pre_add_nhwc_with_leakyrelu_inputs() -> None:
+    model_ir = ModelIR(name="transpose_pre_add_nhwc_with_leakyrelu_inputs_test")
+    model_ir.inputs = ["a_nhwc", "b_nhwc"]
+    model_ir.outputs = ["tail"]
+    model_ir.tensors["a_nhwc"] = TensorIR(
+        name="a_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 8, 8, 16],
+        shape_signature=[1, 8, 8, 16],
+    )
+    model_ir.tensors["b_nhwc"] = TensorIR(
+        name="b_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 8, 8, 16],
+        shape_signature=[1, 8, 8, 16],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["a_nchw"] = TensorIR(
+        name="a_nchw",
+        dtype="FLOAT32",
+        shape=[1, 16, 8, 8],
+        shape_signature=[1, 16, 8, 8],
+    )
+    model_ir.tensors["b_nchw"] = TensorIR(
+        name="b_nchw",
+        dtype="FLOAT32",
+        shape=[1, 16, 8, 8],
+        shape_signature=[1, 16, 8, 8],
+    )
+    model_ir.tensors["a_lrelu"] = TensorIR(
+        name="a_lrelu",
+        dtype="FLOAT32",
+        shape=[1, 16, 8, 8],
+        shape_signature=[1, 16, 8, 8],
+    )
+    model_ir.tensors["b_lrelu"] = TensorIR(
+        name="b_lrelu",
+        dtype="FLOAT32",
+        shape=[1, 16, 8, 8],
+        shape_signature=[1, 16, 8, 8],
+    )
+    model_ir.tensors["sum_nchw"] = TensorIR(
+        name="sum_nchw",
+        dtype="FLOAT32",
+        shape=[1, 16, 8, 8],
+        shape_signature=[1, 16, 8, 8],
+    )
+    model_ir.tensors["z_nhwc"] = TensorIR(
+        name="z_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 8, 8, 16],
+        shape_signature=[1, 8, 8, 16],
+    )
+    model_ir.tensors["tail"] = TensorIR(
+        name="tail",
+        dtype="FLOAT32",
+        shape=[1, 8, 8, 16],
+        shape_signature=[1, 8, 8, 16],
+    )
+
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["a_nhwc", "pre_perm"], outputs=["a_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["b_nhwc", "pre_perm"], outputs=["b_nchw"]),
+        OperatorIR(op_type="LEAKY_RELU", inputs=["a_nchw"], outputs=["a_lrelu"], options={"alpha": 0.1}),
+        OperatorIR(op_type="LEAKY_RELU", inputs=["b_nchw"], outputs=["b_lrelu"], options={"alpha": 0.1}),
+        OperatorIR(
+            op_type="ADD",
+            inputs=["a_lrelu", "b_lrelu"],
+            outputs=["sum_nchw"],
+            options={"fusedActivationFunction": "NONE"},
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["sum_nchw", "post_perm"], outputs=["z_nhwc"]),
+        OperatorIR(op_type="RELU", inputs=["z_nhwc"], outputs=["tail"]),
+    ]
+
+    stats = _optimize_transpose_pre_add_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_pre_add_nhwc_chains"] == 1
+
+    # Input transposes are removed and LEAKY_RELU runs in NHWC.
+    assert not any(
+        str(op.op_type) == "TRANSPOSE" and list(op.outputs) in (["a_nchw"], ["b_nchw"])
+        for op in model_ir.operators
+    )
+    assert list(model_ir.tensors["a_lrelu"].shape) == [1, 8, 8, 16]
+    assert list(model_ir.tensors["b_lrelu"].shape) == [1, 8, 8, 16]
+    add_op = next(op for op in model_ir.operators if str(op.op_type) == "ADD")
+    assert list(add_op.inputs) == ["a_lrelu", "b_lrelu"]
+    # Post transpose is removed and downstream consumer uses NHWC tensor directly.
+    assert not any(str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["z_nhwc"] for op in model_ir.operators)
+    relu_op = next(op for op in model_ir.operators if str(op.op_type) == "RELU")
+    relu_input_name = str(relu_op.inputs[0])
+    assert relu_input_name in {"sum_nchw", "z_nhwc"}
+    assert list(model_ir.tensors[relu_input_name].shape) == [1, 8, 8, 16]
 
 
 def test_flatbuffer_direct_transpose_pre_concat_nhwc_shared_direct_and_nested_add_optimized() -> None:
@@ -8155,6 +9160,105 @@ def test_flatbuffer_direct_fold_conv_mul_add_affine_chain_skips_conv_fanout() ->
     assert op_types == ["CONV_2D", "MUL", "ADD", "RELU", "RELU"]
 
 
+def test_flatbuffer_direct_fold_conv_mul_affine_chain_single_path() -> None:
+    model_ir = ModelIR(name="fold_conv_mul_affine_single_path_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 4, 4, 2],
+        shape_signature=[1, 4, 4, 2],
+    )
+    base_filter = np.asarray(
+        [
+            [[[1.0, 2.0]]],
+            [[[3.0, 4.0]]],
+            [[[5.0, 6.0]]],
+        ],
+        dtype=np.float32,
+    )  # [O,H,W,I] = [3,1,1,2]
+    base_bias = np.asarray([0.1, 0.2, 0.3], dtype=np.float32)
+    mul_coeff = np.asarray([2.0, 3.0, 4.0], dtype=np.float32)
+    model_ir.tensors["w"] = TensorIR(
+        name="w",
+        dtype="FLOAT32",
+        shape=[3, 1, 1, 2],
+        shape_signature=[3, 1, 1, 2],
+        data=np.asarray(base_filter),
+        is_variable=False,
+    )
+    model_ir.tensors["b"] = TensorIR(
+        name="b",
+        dtype="FLOAT32",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray(base_bias),
+        is_variable=False,
+    )
+    model_ir.tensors["mul_c"] = TensorIR(
+        name="mul_c",
+        dtype="FLOAT32",
+        shape=[1, 1, 3],
+        shape_signature=[1, 1, 3],
+        data=np.asarray(mul_coeff).reshape(1, 1, 3),
+        is_variable=False,
+    )
+    model_ir.tensors["conv_out"] = TensorIR(
+        name="conv_out",
+        dtype="FLOAT32",
+        shape=[1, 4, 4, 3],
+        shape_signature=[1, 4, 4, 3],
+    )
+    model_ir.tensors["mul_out"] = TensorIR(
+        name="mul_out",
+        dtype="FLOAT32",
+        shape=[1, 4, 4, 3],
+        shape_signature=[1, 4, 4, 3],
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 4, 4, 3],
+        shape_signature=[1, 4, 4, 3],
+    )
+    conv_options = {
+        "padding": "SAME",
+        "strideH": 1,
+        "strideW": 1,
+        "dilationHFactor": 1,
+        "dilationWFactor": 1,
+        "fusedActivationFunction": "NONE",
+    }
+    model_ir.operators = [
+        OperatorIR(op_type="CONV_2D", inputs=["x", "w", "b"], outputs=["conv_out"], options=conv_options),
+        OperatorIR(
+            op_type="MUL",
+            inputs=["conv_out", "mul_c"],
+            outputs=["mul_out"],
+            options={"fusedActivationFunction": "NONE"},
+        ),
+        OperatorIR(op_type="RELU", inputs=["mul_out"], outputs=["y"]),
+    ]
+
+    stats = _optimize_fold_conv_mul_add_affine_chains(model_ir)
+    assert stats["folded_conv_mul_add_affine_chains"] == 1
+    assert stats["folded_conv_mul_only_affine_chains"] == 1
+    assert stats["folded_conv_mul_add_only_affine_chains"] == 0
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types == ["CONV_2D", "RELU"]
+    conv_op = model_ir.operators[0]
+    assert list(conv_op.outputs) == ["mul_out"]
+    relu_op = model_ir.operators[1]
+    assert list(relu_op.inputs) == ["mul_out"]
+
+    expected_w = base_filter * mul_coeff.reshape(3, 1, 1, 1)
+    expected_b = base_bias * mul_coeff
+    assert np.allclose(np.asarray(model_ir.tensors["w"].data), expected_w, rtol=0.0, atol=1e-7)
+    assert np.allclose(np.asarray(model_ir.tensors["b"].data), expected_b, rtol=0.0, atol=1e-7)
+
+
 def test_flatbuffer_direct_transpose_mean_prepost_nhwc_passthrough_chain() -> None:
     model_ir = ModelIR(name="transpose_mean_prepost_nhwc_passthrough_test")
     model_ir.inputs = ["x_nhwc"]
@@ -8571,6 +9675,39 @@ def test_flatbuffer_direct_non_singleton_channel_transpose_kept() -> None:
         dtype="FLOAT32",
         shape=[1, 2, 8, 8],
         shape_signature=[1, 2, 8, 8],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "perm_nhwc_to_nchw"], outputs=["x_nchw"]),
+    ]
+
+    stats = _optimize_singleton_channel_layout_transpose_to_reshape(model_ir)
+    assert stats["rewritten_singleton_channel_layout_transpose_to_reshape"] == 0
+    assert [str(op.op_type) for op in model_ir.operators] == ["TRANSPOSE"]
+
+
+def test_flatbuffer_direct_singleton_channel_dynamic_signature_transpose_kept() -> None:
+    model_ir = ModelIR(name="singleton_channel_dynamic_signature_transpose_kept_test")
+    model_ir.inputs = ["x_nhwc"]
+    model_ir.outputs = ["x_nchw"]
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 1],
+        shape_signature=[1, 1, -1, 1],
+    )
+    model_ir.tensors["perm_nhwc_to_nchw"] = TensorIR(
+        name="perm_nhwc_to_nchw",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["x_nchw"] = TensorIR(
+        name="x_nchw",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 1],
+        shape_signature=[1, 1, 1, -1],
     )
     model_ir.operators = [
         OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "perm_nhwc_to_nchw"], outputs=["x_nchw"]),
@@ -9526,6 +10663,26 @@ def test_flatbuffer_direct_gather_singleton_const_indices_scalarized_for_rank_re
 
     gather_output_tensor = model_ir.tensors[str(gather_op.outputs[0])]
     assert list(gather_output_tensor.shape_signature) == [1, 3]
+
+
+def test_flatbuffer_direct_gather_singleton_negative_const_indices_wrapped_before_scalarization() -> None:
+    model = _make_gather_singleton_negative_indices_rank_reduced_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="gather_singleton_negative_indices_scalarized_test",
+    )
+    gather_ops = [op for op in model_ir.operators if str(op.op_type) == "GATHER"]
+    assert len(gather_ops) == 1
+    gather_op = gather_ops[0]
+    gather_indices_name = str(gather_op.inputs[1])
+    gather_indices_tensor = model_ir.tensors[gather_indices_name]
+    assert gather_indices_name != "indices"
+    assert list(gather_indices_tensor.shape) == []
+    assert list(gather_indices_tensor.shape_signature) == []
+    gather_indices = np.asarray(gather_indices_tensor.data, dtype=np.int64).reshape(-1)
+    assert gather_indices.tolist() == [3]
 
 
 def test_flatbuffer_direct_nms_scalar_const_inputs_do_not_emit_squeeze() -> None:
@@ -10646,6 +11803,62 @@ def test_flatbuffer_direct_leakyrelu_emits_builtin_leaky_relu() -> None:
         tflite_path = _convert(model_path, out_dir, "flatbuffer_direct")
         op_names = _collect_builtin_op_names(tflite_path)
         assert "LEAKY_RELU" in op_names
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires flatc and curl")
+def test_flatbuffer_direct_instance_normalization_emits_builtin_chain() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_instance_normalization_model()
+        model_path = _save_model(tmpdir, "instance_norm_builtin", model)
+        out_dir = os.path.join(tmpdir, "out")
+        tflite_path = _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            report_op_coverage=True,
+        )
+        op_names = _collect_builtin_op_names(tflite_path)
+        custom_codes = _collect_custom_codes(tflite_path)
+        assert "MEAN" in op_names
+        assert "SUB" in op_names
+        assert "SQRT" in op_names
+        assert "ONNX_INSTANCENORMALIZATION" not in custom_codes
+        report_path = os.path.join(out_dir, "instance_norm_builtin_op_coverage_report.json")
+        assert os.path.isfile(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["conversion_error"] is None
+        assert report["graph_summary"]["custom_lowered_nodes"] == 0
+        assert any(
+            r["onnx_op"] == "InstanceNormalization" and r["dispatch_mode"] == "builtin"
+            for r in report["graph_node_reports"]
+        )
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires flatc and curl")
+def test_flatbuffer_direct_dropout_emits_builtin_chain() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_dropout_model()
+        model_path = _save_model(tmpdir, "dropout_builtin", model)
+        out_dir = os.path.join(tmpdir, "out")
+        tflite_path = _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            report_op_coverage=True,
+        )
+        custom_codes = _collect_custom_codes(tflite_path)
+        assert "ONNX_DROPOUT" not in custom_codes
+        report_path = os.path.join(out_dir, "dropout_builtin_op_coverage_report.json")
+        assert os.path.isfile(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["conversion_error"] is None
+        assert report["graph_summary"]["custom_lowered_nodes"] == 0
+        assert any(
+            r["onnx_op"] == "Dropout" and r["dispatch_mode"] == "builtin"
+            for r in report["graph_node_reports"]
+        )
 
 
 @pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires flatc and curl")

--- a/uv.lock
+++ b/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "onnx2tf"
-version = "2.0.19"
+version = "2.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },
@@ -510,8 +510,8 @@ requires-dist = [
     { name = "protobuf", specifier = "==4.25.5" },
     { name = "psutil", specifier = "==5.9.5" },
     { name = "requests", specifier = "==2.32.5" },
-    { name = "sne4onnx", specifier = "==2.0.0" },
-    { name = "sng4onnx", specifier = "==2.0.0" },
+    { name = "sne4onnx", specifier = "==2.0.1" },
+    { name = "sng4onnx", specifier = "==2.0.1" },
     { name = "tensorflow", specifier = "==2.19.0" },
     { name = "tf-keras", specifier = "==2.19.0" },
 ]
@@ -771,20 +771,20 @@ wheels = [
 
 [[package]]
 name = "sne4onnx"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d3/c342932baf64a3f0f23e4c9973e2021144ee869136fae8e2e58027de119e/sne4onnx-2.0.0.tar.gz", hash = "sha256:f70ece102a249fbbc126b38090c61fb835f207bd880a41d68d41b2a98991c63a", size = 13229, upload-time = "2026-02-06T10:44:56.119Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/66/0d4b261c30d381b563405714f5fc18491c66bb8891b4cd69065021c9a037/sne4onnx-2.0.1.tar.gz", hash = "sha256:3fb4c166044fe11a480c5b739f78f8c10a28bd60163617dc549bcbeee6628ee9", size = 13412, upload-time = "2026-02-24T12:47:55.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/cf/cea7c9ae642958b65e2cc21c452ecfe593fed7239a3a7f28bef2f7bdcb13/sne4onnx-2.0.0-py3-none-any.whl", hash = "sha256:1e05af6d3e5f5da98e9dffd8aabac33765665c5a7f5c320e4c9ee115d6181bf6", size = 12022, upload-time = "2026-02-06T10:44:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/59/01/47cfa97ff6605ffaa7c72db514dc0900dd458529c17692d78a5c3c8d1374/sne4onnx-2.0.1-py3-none-any.whl", hash = "sha256:d25597a0684884f3764ad06dc1e81d9e0e5892a8edf48dc538a992379701f164", size = 12237, upload-time = "2026-02-24T12:47:54.845Z" },
 ]
 
 [[package]]
 name = "sng4onnx"
-version = "2.0.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/47/04174bca0a7205e169861f91f8931ef31258507277dc6182ee105fde607c/sng4onnx-2.0.0.tar.gz", hash = "sha256:e6775729ab31c7f6fe9577322bbaede921ce6e36fa0bf5193159af8eba96b426", size = 11437, upload-time = "2026-02-06T10:37:40.97Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/b2/7ecba71e1639b4e6e17abf52d1f9632c48dd64629e49b9d2524ea6b8ecaa/sng4onnx-2.0.1.tar.gz", hash = "sha256:698269a4315c5e8ae242f5d54df7ecdf1b1b07317b15e0e91257893b473e7409", size = 11630, upload-time = "2026-02-24T12:52:18.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/07/cd0be9b7899a933dbc9b8f5f811e36ac4d3395a5d563c783e01e25e4a622/sng4onnx-2.0.0-py3-none-any.whl", hash = "sha256:17cb57c47348ab8fc0efc3ef55652565378fb046641f7f089fa7ef9a6e19b373", size = 10872, upload-time = "2026-02-06T10:37:39.755Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/51/3811b2e41946dade6f7c79d015b37d6dcbb867bfcb7551ab844b3f88d4bf/sng4onnx-2.0.1-py3-none-any.whl", hash = "sha256:3bcbdaf79c8c4f107a340802f9562620ac5b3c83b3b8e8d08a553276d754168f", size = 11084, upload-time = "2026-02-24T12:52:17.811Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
This PR improves `flatbuffer_direct` lowering coverage and removes redundant layout conversion chains.

### 1) Builtin lowering coverage
- Add ONNX `InstanceNormalization` lowering to builtin TFLite ops (`MEAN/SUB/MUL/ADD/SQRT/DIV` chain)
- Add ONNX `Dropout` lowering (inference-time no-op + optional mask generation path)
- Register/import new builders and validators in dispatch registry

### 2) Reshape/shape robustness
- Allow `Reshape` dynamic shape input (`INT32/INT64`, rank-1) in validation/lowering
- Add static-template inference for dynamic reshape patterns built from `CONCAT + SHAPE`
- Avoid clobbering dynamic reshape options in runtime-shape cases

### 3) Layout/transpose optimization improvements
- Add/extend transpose-chain rewrites including:
  - `transpose_slice_logistic_concat_reshape_tail` NHWC rewrite
  - ShuffleNet-style transpose/shuffle chain rewrites
  - Pre-ADD / MUL-const / reshape-suffix rewrite refinements
  - New `transpose_pre_unary_reshape_transpose_suffix` rewrite
  - New `transpose_logistic_muladd_prepost` rewrite
- Re-run optimization sequences in recovery sweeps where needed

### 4) Shape reconciliation safety
- Prevent unsafe static rewrite of dynamic `SLICE` begin/size when input dimensions are dynamic

### 5) Tests and docs
- Expand `tests/test_tflite_builder_direct.py` with new coverage for:
  - Dropout, InstanceNormalization
  - Dynamic-slice reconciliation safety
  - New transpose optimization patterns
- Update README op coverage table and container/version references
- Bump version to `2.0.22` and sync dependency/lock updates (`sne4onnx/sng4onnx 2.0.1`)

## Validation
- `pytest -q tests/test_tflite_builder_direct.py -k "transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_optimized or transpose_logistic_muladd_prepost_nhwc_chain_optimized"`
- `pytest -q tests/test_tflite_builder_direct.py -k "transpose_add_reshape_transpose_suffix_optimization or transpose_mulconst_add_reshape_transpose_suffix_optimization or transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_optimized or transpose_pre_add_mul_add_prelu_nhwc_chain_optimized or transpose_logistic_muladd_prepost_nhwc_chain_optimized"`
- Manual conversion check:
  - `onnx2tf -i shadowformer_istd_160x240_split.onnx -cotof -tb flatbuffer_direct --report_op_coverage`
