### PR TITLE
Improve flatbuffer_direct builtin coverage and stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ Notes:
 
 |ONNX OP|TFLite OP|Key constraints (flatbuffer_direct)|
 |:-|:-|:-|
-|Abs|ABS|-|
+|Abs|ABS (or NEG + MAXIMUM for INT64)|For `INT64` input, lowered as `NEG + MAXIMUM` because TFLite `ABS` kernel does not support `INT64`|
 |Acos|MUL + SUB + SQRT + ATAN2|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |Acosh|SUB + ADD + SQRT + MUL + LOG|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |Add|ADD|-|
@@ -335,8 +335,8 @@ Notes:
 |Clip|RELU / RELU6 / MAXIMUM + MINIMUM|General constant clip ranges are supported via `MAXIMUM`/`MINIMUM` decomposition. ReLU fast-path: `min=0,max=+inf`; ReLU6 fast-path: `min=0,max=6`|
 |Concat|CONCATENATION|-|
 |ConstantOfShape|CAST + FILL|Shape input must be rank-1 integer tensor; `value` attribute must be scalar (or omitted for zero-fill)|
-|Conv|CONV_2D / DEPTHWISE_CONV_2D|2D only (rank=4), weights must be constant, grouped conv only regular/depthwise, zero pads or `auto_pad=SAME_*`|
-|ConvTranspose|TRANSPOSE_CONV (+ optional ADD bias)|2D only (input rank=4), weight must be constant rank=4, `group=1`, `dilations=[1,1]`, `output_padding=[0,0]`, and padding must be `auto_pad=SAME_*` or zero pads (`auto_pad` in `{NOTSET,VALID}`)|
+|Conv|CONV_2D / DEPTHWISE_CONV_2D / CONV_3D|2D: rank=4, constant weights, grouped conv only regular/depthwise, zero pads or `auto_pad=SAME_*`. 3D: rank=5, constant rank-5 weights, `group=1`, strides/dilations length=3, `auto_pad` in `{NOTSET,VALID,SAME_UPPER}` (`SAME_LOWER` unsupported); explicit pads are handled via VALID+pad/crop path|
+|ConvTranspose|TRANSPOSE_CONV / CONV_3D_TRANSPOSE (+ optional ADD bias; 1D uses `EXPAND_DIMS/SQUEEZE` shim)|1D/2D/3D supported (1D: input rank=3 + weight rank=3 const, 2D: input rank=4 + weight rank=4 const, 3D: input rank=5 + weight rank=5 const), `group=1`, dilations must be all-ones, and `output_padding` must satisfy `0 <= output_padding < stride` (1D len=1, 2D len=2, 3D len=3). `auto_pad` supports `SAME_*`, `VALID`, and `NOTSET`; explicit non-zero pads are handled by post-crop when output shape is static|
 |Cos|COS|-|
 |Cosh|SUB + EXP + ADD + MUL|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |DequantizeLinear|DEQUANTIZE|`scale` must be constant, `zero_point` (if provided) must be constant, per-axis `axis` must be in range|
@@ -360,7 +360,10 @@ Notes:
 |Gelu|GELU|-|
 |Gemm|FULLY_CONNECTED|Input rank=2, weight rank=2 + constant, `transA=0` only|
 |Greater|GREATER|-|
+|GreaterOrEqual|GREATER_EQUAL|-|
+|GridSample|PAD + RESHAPE + TRANSPOSE + SQUEEZE + SLICE + ADD/SUB/MUL + FLOOR + MAXIMUM/MINIMUM + CAST + GATHER (2D bilinear decomposition, linear-index gather path)|Rank-4 only with static positive dims. `mode=bilinear`, `padding_mode=zeros`, `align_corners` in `{0,1}`. Grid shape must be `[N, out_h, out_w, 2]` and output `[N, C, out_h, out_w]`. When `grid` is graph input, keep shape metadata (e.g. `-kat grid`)|
 |GlobalAveragePool|MEAN|Input rank must be `>=3`|
+|GlobalMaxPool|REDUCE_MAX|Input rank must be `>=3`|
 |GRU|TRANSPOSE + SLICE + SQUEEZE + BATCH_MATMUL + ADD + MUL + SUB + LOGISTIC + TANH + RESHAPE + CONCATENATION + EXPAND_DIMS|`layout=0`; `direction` in `{forward, reverse, bidirectional}`; `sequence_lens` unsupported; `W/R` must be constant rank-3; `linear_before_reset` in `{0,1}`; activations `[Sigmoid,Tanh]`; `clip=0`|
 |Hardmax|TRANSPOSE + ARG_MAX + ONE_HOT|`axis` must be in range; target axis size must be static positive|
 |HardSigmoid|MUL + ADD + MAXIMUM + MINIMUM|Input/output dtype must be FLOAT16 or FLOAT32|
@@ -372,7 +375,7 @@ Notes:
 |LogSoftmax|SOFTMAX + LOG (+ transpose in/out for non-last axis)|`axis` must be in range (negative axis normalized)|
 |LpNormalization|L2_NORMALIZATION|`p=2`, `axis=last` only|
 |LRN|LOCAL_RESPONSE_NORMALIZATION (+ transpose in/out)|Input rank must be 4, `size` must be a positive odd integer|
-|LSTM|UNIDIRECTIONAL_SEQUENCE_LSTM / BIDIRECTIONAL_SEQUENCE_LSTM + SPLIT + RESHAPE/EXPAND_DIMS + CONCATENATION|`direction` in `{forward,bidirectional}`, `layout=0`, `input_forget=0`; `W/R` must be constant rank-3 with `num_directions` matching `direction`; optional `B` must be constant shape `[num_directions, 8*hidden_size]`; `initial_h/initial_c` are required as constant zero tensors of shape `[num_directions, batch, hidden]`; `sequence_lens` and peephole input `P` unsupported; projection (`R.shape[2] != hidden_size`) unsupported; outputs `Y_h`/`Y_c` unsupported when consumed|
+|LSTM|UNIDIRECTIONAL_SEQUENCE_LSTM / BIDIRECTIONAL_SEQUENCE_LSTM + REVERSE_V2 + SPLIT + SQUEEZE + SLICE + RESHAPE/EXPAND_DIMS + CONCATENATION|`direction` in `{forward,reverse,bidirectional}`, `layout=0`, `input_forget=0`; `W/R` must be constant rank-3 with `num_directions` matching `direction`; optional `B` must be constant shape `[num_directions, 8*hidden_size]`; `initial_h/initial_c` are optional (when provided, shape must be `[num_directions, batch, hidden]`; runtime tensor inputs are supported); `sequence_lens` and peephole input `P` unsupported; projection (`R.shape[2] != hidden_size`) unsupported|
 |MatMul|BATCH_MATMUL|Input rank >= 2. Dynamic rhs input is supported (no constant-weight requirement)|
 |MatMulInteger|CAST + SUB + BATCH_MATMUL|A/B input rank must be >=2 (rank=1 placeholder allowed), A/B dtypes must be integer tensor types (`INT8/UINT8/INT16/UINT16/INT32`), output dtype must be `INT32/INT64`; optional zero-point inputs must be scalar/1D and shape-compatible|
 |MaxPool|MAX_POOL_2D|2D only (rank=4), `ceil_mode=0`, zero pads or `auto_pad=SAME_*`|
@@ -386,7 +389,7 @@ Notes:
 |Not|LOGICAL_NOT|-|
 |OneHot|CAST + ADD + FLOOR_MOD + ONE_HOT|`depth` input must be constant scalar and `>0`; `values` input must be constant 2-element tensor `[off_value,on_value]`; normalized `axis` must be in range|
 |Or|LOGICAL_OR|-|
-|Pad|PAD (+ dynamic pads bridge: CAST + RESHAPE + TRANSPOSE)|`mode=constant` only; `pads` may be constant or dynamic rank-1 tensor of length `2*rank` (integer type, internally cast to `INT32`); constant pad value (if provided) must be constant zero|
+|Pad|PAD / MIRROR_PAD (+ dynamic pads bridge: CAST + RESHAPE + TRANSPOSE)|`mode` in `{constant,reflect}`; `reflect` is lowered to `MIRROR_PAD(REFLECT)`. `pads` may be constant or dynamic rank-1 tensor of length `2*rank` (integer type, internally cast to `INT32`); for `mode=constant`, pad value (if provided) must be constant zero|
 |Pow|POW|Output dtype must be `FLOAT16` or `FLOAT32`|
 |PRelu|PRELU|`slope` must be constant (scalar or per-channel)|
 |QGemm|FULLY_CONNECTED|Input rank=1 or 2, weight must be constant rank=2, bias must be constant, quantization params must be constant, `transA=0`, `transB` in `{0,1}`|
@@ -401,17 +404,19 @@ Notes:
 |QLinearSigmoid|DEQUANTIZE + LOGISTIC + QUANTIZE|All quantization params (`x scale/zero_point`, `y scale/zero_point`) must be constant|
 |QLinearSoftmax|DEQUANTIZE + SOFTMAX + QUANTIZE|All quantization params (`x/y scale`, `x/y zero_point`) must be constant; `axis` must be last dimension|
 |QuantizeLinear|QUANTIZE|`scale` must be constant, `zero_point` (if provided) must be constant, per-axis `axis` must be in range|
+|RandomNormalLike|SHAPE + RANDOM_STANDARD_NORMAL (+ optional MUL + ADD + CAST)|Rank inferred from input shape; output dtype must be supported numeric type (`FLOAT16/FLOAT32/INT*`/`UINT*`). `seed` is mapped to TFLite random options when provided|
 |Range|CAST + SQUEEZE + RANGE|Each of `start/limit/delta` must be scalar-like rank-1 length-1 tensor|
 |Reciprocal|DIV|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |ReduceL1|ABS + SUM|Reduce axes must be constant when provided via input tensor|
 |ReduceL2|MUL + SUM + SQRT + CAST|Reduce axes must be constant when provided via input tensor|
 |ReduceMax|REDUCE_MAX|Reduce axes must be constant when provided via input tensor|
 |ReduceMean|MEAN|Reduce axes must be constant when provided via input tensor|
+|ReduceProd|REDUCE_PROD|Reduce axes must be constant when provided via input tensor|
 |ReduceSum|SUM|Reduce axes must be constant when provided via input tensor|
 |Relu|RELU|-|
 |Reshape|RESHAPE|Shape input must be constant|
 |Resize|RESIZE_NEAREST_NEIGHBOR / RESIZE_BILINEAR / (cubic) RESHAPE + BATCH_MATMUL + RESHAPE + BATCH_MATMUL|Rank-4 only. `nearest`/`linear`: builtin resize path (limited attr combinations), parameters must be constant `scales/sizes` or dynamic rank-1 integer `sizes` (INT32/INT64). `cubic`: strict ONNX cubic decomposition (no FlexResizeBicubic), supports `coordinate_transformation_mode` in `{align_corners, asymmetric, half_pixel, pytorch_half_pixel}` and honors `cubic_coeff_a`/`exclude_outside`; requires static input C/H/W and static output H/W. Batch dimension is preserved through the cubic decomposition path|
-|RNN|UNIDIRECTIONAL_SEQUENCE_RNN + TRANSPOSE + EXPAND_DIMS + SLICE + RESHAPE|`direction=forward`, `layout=0`; `sequence_lens` unsupported; `W/R` must be constant rank-3 with `num_directions=1`; activations in `{tanh,relu,sigmoid}`; `clip=0`|
+|RNN|UNIDIRECTIONAL_SEQUENCE_RNN + REVERSE_V2 + CONCATENATION + TRANSPOSE + EXPAND_DIMS + SLICE + SQUEEZE + RESHAPE|`direction` in `{forward,reverse,bidirectional}`, `layout=0`; `sequence_lens` unsupported; `W/R` must be constant rank-3 with `num_directions` matching `direction`; optional `B` must be constant shape `[num_directions, 2*hidden_size]`; optional `initial_h` shape must be `[num_directions, batch, hidden]` (runtime tensor inputs are supported); activations in `{tanh,relu,sigmoid}`; `clip=0`|
 |Round|ROUND|-|
 |ScatterND|CAST + SHAPE + FILL + MUL + SCATTER_ND + SUB + ADD|`reduction=none` only; data/updates/output dtypes must match (numeric), indices dtype must be integer, indices last dim must be static positive and `<= data rank`|
 |Selu|MAXIMUM + MINIMUM + EXP + SUB + MUL + ADD|Input/output dtype must be `FLOAT16` or `FLOAT32`|
@@ -420,7 +425,7 @@ Notes:
 |Sign|SIGN|-|
 |Sin|SIN|-|
 |Sinh|SUB + EXP + MUL|Input/output dtype must be `FLOAT16` or `FLOAT32`|
-|Slice|SLICE / STRIDED_SLICE|`starts/ends` must be provided as constant inputs or attrs and lengths must match (`axes/steps` too when specified); negative/zero `steps` are unsupported|
+|Slice|SLICE / STRIDED_SLICE / REVERSE_V2|`starts` must be constant input/attr. `ends` is usually constant input/attr; dynamic `ends` is supported only for rank-1 axis-0 prefix slice (`start=0`, `step=1`). `steps=0` unsupported. Negative `steps` are supported only for full-axis reverse pattern (`start=-1`, very negative `end`, `step=-1`) via `REVERSE_V2`|
 |Softmax|SOFTMAX (+ transpose in/out for non-last axis)|`axis` must be in range (negative axis normalized)|
 |Softplus|EXP + ADD + LOG|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |Softsign|ABS + ADD + DIV|Input/output dtype must be `FLOAT16` or `FLOAT32`|
@@ -446,7 +451,7 @@ Notes:
 |ONNX OP|Default policy|When enabled|
 |:-|:-|:-|
 |DeformConv|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
-|GridSample|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
+|GridSample|builtin_supported on constrained 2D pattern; otherwise explicit_error (`custom_op_candidate_disabled`)|Unsupported GridSample patterns can be lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |If|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |Loop|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |RoiAlign|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
@@ -465,13 +470,17 @@ Notes:
 - `Einsum` is now treated as `builtin_supported` when it matches builtin constraints; unsupported `Einsum` patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `QLinearConv` is treated as `builtin_supported` for regular/depthwise patterns; unsupported grouped patterns may still fallback to `CUSTOM` when custom-op mode is enabled.
 - `LogSoftmax` is now treated as `builtin_supported` when builtin constraints pass; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
-- `LSTM` is now treated as `builtin_supported` for constrained forward/bidirectional patterns; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
+- `LSTM` is now treated as `builtin_supported` for constrained forward/reverse/bidirectional patterns; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `NonMaxSuppression` is now treated as `builtin_supported` when builtin constraints pass; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `DynamicQuantizeLinear` is now treated as `builtin_supported` for constrained float-input/uint8-output patterns; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `OneHot`, `MatMulInteger`, `Pow`, and `Reciprocal` are now treated as `builtin_supported` when builtin constraints pass.
 - `Min` and `TopK` are now treated as `builtin_supported` under builtin constraints, reducing `ONNX_MIN` / `ONNX_TOPK` custom-op fallbacks.
 - `DepthToSpace` and `HardSwish` are now treated as `builtin_supported` under builtin constraints (`HardSwish` is lowered directly as TFLite `HARD_SWISH`).
 - `Pad` builtin path now supports dynamic `pads` input (rank-1 length `2*rank`) via `CAST + RESHAPE + TRANSPOSE` bridge before `PAD`.
+- `Pad` builtin path now supports `mode=reflect` by lowering to TFLite `MIRROR_PAD` (`REFLECT` mode).
+- `ConvTranspose` builtin path has been expanded: constrained 1D lowering (`EXPAND_DIMS -> TRANSPOSE_CONV -> SQUEEZE`), relaxed `output_padding` handling (`0 <= output_padding < stride`), and explicit non-zero pad handling via post-crop when output shape is static.
+- `Conv` now includes rank-5 `CONV_3D` builtin lowering (`group=1`, constant weights), reducing `ONNX_CONV` custom-op fallbacks on 3D conv subgraphs.
+- `ConvTranspose` now includes rank-5 `CONV_3D_TRANSPOSE` builtin lowering (`group=1`, `dilations=[1,1,1]`, constrained `output_padding`), reducing `ONNX_CONVTRANSPOSE` custom-op fallbacks on 3D deconv subgraphs.
 - `NonMaxSuppression` builtin path now supports class dim `>1` without forcing `--output_nms_with_argmax` by using per-class `NON_MAX_SUPPRESSION_V4` and concatenating `[batch, class, index]` triplets (matching default `onnx2tf/ops/NonMaxSuppression.py` behavior when `-onwa` is not set).
 - `AveragePool` builtin path now supports explicit pads and `count_include_pad` in `{0,1}`; when `count_include_pad=0` with non-zero effective pads, divisor correction is applied to keep ONNX semantics.
 - Leading input transpose passthrough optimization now treats `CAST` as passthrough, reducing redundant `Transpose -> Cast -> (Sub/Mul/...) -> Transpose` chains.
@@ -483,13 +492,16 @@ Notes:
   `RNN`, `Round`, `Selu`, `Sign`, `Sin`, `Sinh`, `Softplus`, `Softsign`, `Tan`, `Trilu`,
   `Where`, and `Xor`.
 - Additional builtin-covered ops added in subsequent commits include:
-  `Erf`, `GlobalAveragePool`, `QLinearLeakyRelu`, `QLinearSoftmax`, `ScatterND`, `Slice`,
+  `Erf`, `GlobalAveragePool`, `GlobalMaxPool`, `QLinearLeakyRelu`, `QLinearSoftmax`, `ScatterND`, `Slice`,
   `Split`, and `Tile`.
 - `Resize` builtin path now accepts dynamic rank-1 integer `sizes` input in addition to constant `scales/sizes`.
 - `Resize(cubic)` now uses strict ONNX cubic semantics (including `cubic_coeff_a` and `exclude_outside`) in both `tf_converter` and `flatbuffer_direct`.
+- `GreaterOrEqual`, `RandomNormalLike`, and constrained `GridSample` (`2D`, `bilinear`, `zeros`, `align_corners` in `{0,1}`) are now treated as `builtin_supported` under builtin constraints.
+- `Slice` builtin path now supports additional constrained patterns: rank-1 dynamic-end prefix slice and full-axis reverse (`step=-1`) via `REVERSE_V2`.
+- `Abs` builtin path now avoids unsupported `ABS(INT64)` by lowering `INT64` input to `NEG + MAXIMUM`.
 - `tf_converter` now prefers a non-Flex cubic lowering (`RESHAPE + BATCH_MATMUL + RESHAPE + BATCH_MATMUL`) when rank-4 input and static spatial sizes are available, reducing `FlexResizeBicubic` generation.
 - `flatbuffer_direct` cubic lowering now preserves batch metadata on intermediate tensors and output tensors (no batch-dimension drop in `RESHAPE`/`BATCH_MATMUL` chain).
-- NHWC propagation around Conv-family outputs has been tightened: `CONV_2D` / `DEPTHWISE_CONV_2D` outputs now avoid redundant immediate post-transpose insertion when layout is already NHWC.
+- NHWC propagation around Conv-family outputs has been tightened: `CONV_2D` / `DEPTHWISE_CONV_2D` / `TRANSPOSE_CONV` outputs now avoid redundant immediate post-transpose insertion when layout is already NHWC.
 - Added direct NHWC passthrough optimization for `TRANSPOSE(0,3,1,2) -> MEAN(keepDims=True) -> TRANSPOSE(0,2,3,1)` by removing both transposes and remapping reduction axes.
 - HardSigmoid-related transpose passthrough has been strengthened (including expanded `MUL+ADD+RELU_0_TO_1` form), reducing redundant transpose wrappers in activation/residual chains.
 - Added PReLU transpose passthrough optimization for `TRANSPOSE(0,3,1,2) -> PRELU -> TRANSPOSE(0,2,3,1)` style chains (including per-channel slope remap).
@@ -498,8 +510,9 @@ Notes:
 - Added SiNet-tail NHWC optimization for Softmax-mask residual blocks: removes redundant pre/post transpose adapters around `MUL/ADD/PRELU + SOFTMAX + REDUCE_MAX + RESHAPE + MUL + ADD` and remaps axis/shape constants to NHWC to avoid terminal transpose bridges.
 - Added affine fold for single-path conv chains: `CONV_2D -> MUL(const) -> ADD(const)` is folded into Conv weights/bias when the Conv output is not multi-fanout.
 - Added clamp canonicalization: `MAXIMUM(0.0) -> MINIMUM(1.0)` is rewritten to `RELU_0_TO_1` to reduce op count and improve downstream transpose/activation fusion opportunities.
+- Added unary clamp canonicalization: `MAXIMUM(x, 0.0)` is rewritten to `RELU(x)` when the second input is singleton zero (`input2=0`) to reduce op count.
 - Recurrent lowering practical notes:
-  - `LSTM` builtin requires zero-initialized `initial_h/initial_c` and rejects consumed `Y_h`/`Y_c` (`reason_code=unsupported_output_usage`).
+  - `LSTM` builtin supports `direction` in `{forward, reverse, bidirectional}` and supports optional runtime `initial_h/initial_c` inputs and `Y_h`/`Y_c` outputs (under builtin shape constraints).
   - `GRU` builtin supports `forward/reverse/bidirectional`, but requires activations `[Sigmoid,Tanh]`, `clip=0`, and no `sequence_lens`.
   - `RNN` builtin supports `direction=forward` only (`layout=0`, no `sequence_lens`).
 
@@ -612,7 +625,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.22
+  ghcr.io/pinto0309/onnx2tf:2.0.23
 
   or
 
@@ -621,7 +634,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.22
+  docker.io/pinto0309/onnx2tf:2.0.23
 
   or
 
@@ -631,7 +644,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.0.22 \
+  docker.io/pinto0309/onnx2tf:2.0.23 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or
@@ -1977,9 +1990,10 @@ optional arguments:
        `MEAN`, `SUM`, `REDUCE_MAX`, `RESHAPE`, `TRANSPOSE`, `SQUEEZE`, `SLICE`, `STRIDED_SLICE`,
        `CONCATENATION`, `GATHER`, `GATHER_ND`, `ONE_HOT`,
        `ARG_MAX`, `CAST`, `SHAPE`, `FILL`,
+       `PAD`, `MIRROR_PAD`,
        `LOGISTIC`, `RELU`, `RELU6`, `TANH`, `EXP`, `SQRT`, `NEG`, `LOG`,
        `SOFTMAX`, `L2_NORMALIZATION`, `LOCAL_RESPONSE_NORMALIZATION`,
-       `CONV_2D`, `DEPTHWISE_CONV_2D`, `TRANSPOSE_CONV`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`, `BATCH_MATMUL`,
+       `CONV_2D`, `DEPTHWISE_CONV_2D`, `CONV_3D`, `TRANSPOSE_CONV`, `CONV_3D_TRANSPOSE`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`, `BATCH_MATMUL`,
        `RESIZE_NEAREST_NEIGHBOR`, `RESIZE_BILINEAR`,
        `BIDIRECTIONAL_SEQUENCE_LSTM`, `SPLIT`, `EXPAND_DIMS`,
        `DEQUANTIZE`, `QUANTIZE`.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.22'
+__version__ = '2.0.23'

--- a/onnx2tf/tflite_builder/accuracy_evaluator.py
+++ b/onnx2tf/tflite_builder/accuracy_evaluator.py
@@ -81,12 +81,47 @@ def _generate_seeded_input(
     if np.issubdtype(np_dtype, np.bool_):
         return (rng.random(shape) > 0.5).astype(np_dtype)
     if np.issubdtype(np_dtype, np.floating):
+        distribution = _resolve_float_seeded_distribution(shape=shape)
+        if distribution == "uniform_0_1":
+            return rng.uniform(0.0, 1.0, size=shape).astype(np_dtype)
+        if distribution == "uniform_-1_1":
+            return rng.uniform(-1.0, 1.0, size=shape).astype(np_dtype)
         return rng.standard_normal(shape).astype(np_dtype)
     if np.issubdtype(np_dtype, np.signedinteger):
         return rng.integers(low=-8, high=9, size=shape, dtype=np_dtype)
     if np.issubdtype(np_dtype, np.unsignedinteger):
         return rng.integers(low=0, high=17, size=shape, dtype=np_dtype)
     return rng.standard_normal(shape).astype(np.float32).astype(np_dtype)
+
+
+def _is_likely_image_tensor_shape(shape: Tuple[int, ...]) -> bool:
+    if len(shape) != 4:
+        return False
+    c_first = int(shape[1]) if int(shape[1]) > 0 else -1
+    c_last = int(shape[3]) if int(shape[3]) > 0 else -1
+    return (c_first in (1, 3, 4)) or (c_last in (1, 3, 4))
+
+
+def _resolve_float_seeded_distribution(*, shape: Tuple[int, ...]) -> str:
+    env_value = str(
+        os.environ.get("ONNX2TF_EVAL_FLOAT_RANDOM_DISTRIBUTION", "auto")
+    ).strip().lower()
+    if env_value in {"", "auto"}:
+        # Most image models expect normalized non-negative inputs.
+        if _is_likely_image_tensor_shape(shape):
+            return "uniform_0_1"
+        return "normal"
+    if env_value in {"normal", "gaussian", "standard_normal"}:
+        return "normal"
+    if env_value in {"uniform_0_1", "uniform01", "0_1"}:
+        return "uniform_0_1"
+    if env_value in {"uniform_-1_1", "uniform_m1_p1", "uniform11", "-1_1"}:
+        return "uniform_-1_1"
+    raise ValueError(
+        "Invalid ONNX2TF_EVAL_FLOAT_RANDOM_DISTRIBUTION. "
+        "Expected one of: auto, normal, uniform_0_1, uniform_-1_1. "
+        f"got: {env_value}"
+    )
 
 
 def _extract_sample_from_custom(

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -429,6 +429,8 @@ class _NodeWrap:
                 self.attrs[a.name] = [float(v) for v in a.floats]
             elif a.type == onnx.AttributeProto.STRING:
                 self.attrs[a.name] = a.s.decode("utf-8")
+            elif a.type == onnx.AttributeProto.STRINGS:
+                self.attrs[a.name] = [v.decode("utf-8") for v in a.strings]
             else:
                 pass
         remap = input_name_remap if isinstance(input_name_remap, dict) else {}
@@ -890,8 +892,6 @@ def _resolve_reshape_new_shape_from_static_input(
     if len(new_shape) == 0:
         return None
     candidate = [int(v) for v in new_shape]
-    if all(int(dim) >= 0 for dim in candidate):
-        return list(candidate)
 
     if any(int(dim) == 0 for dim in candidate):
         # Without allowzero metadata we avoid rewriting zero-dim requests.
@@ -910,6 +910,9 @@ def _resolve_reshape_new_shape_from_static_input(
             if in_dim <= 0:
                 return None
             candidate[idx] = int(in_dim)
+
+    if all(int(dim) >= 0 for dim in candidate):
+        return list(candidate)
 
     minus_one_indices = [idx for idx, dim in enumerate(candidate) if int(dim) == -1]
     if len(minus_one_indices) != 1:
@@ -4835,6 +4838,58 @@ def _optimize_maximum_minimum_relu0to1_chains(model_ir: ModelIR) -> Dict[str, in
     return {"rewritten_maximum_minimum_relu0to1_chains": int(rewritten)}
 
 
+def _optimize_maximum_with_zero_input2_to_relu(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Rewrite MAXIMUM(x, 0) into RELU(x) when the second input is singleton zero.
+
+    Target:
+      X --MAXIMUM(X, 0.0)--> Y
+
+    Rewrite:
+      X --RELU--> Y
+
+    Notes:
+    - This pass intentionally checks input2 only to match ONNX Max patterns that
+      lower as MAXIMUM(data, const_zero).
+    - Restrict to FLOAT16/FLOAT32 tensors for safety.
+    """
+    rewritten = 0
+    atol = 1e-6
+
+    for op in model_ir.operators:
+        if str(op.op_type) != "MAXIMUM" or len(op.inputs) != 2 or len(op.outputs) != 1:
+            continue
+
+        data_name = str(op.inputs[0])
+        const_name = str(op.inputs[1])
+        if not _is_singleton_constant_tensor(model_ir, const_name):
+            continue
+        const_value = _read_singleton_constant_float(model_ir, const_name)
+        if const_value is None or not np.isclose(float(const_value), 0.0, atol=atol):
+            continue
+
+        data_tensor = model_ir.tensors.get(data_name, None)
+        if data_tensor is None:
+            continue
+        data_dtype = str(data_tensor.dtype).upper()
+        if data_dtype not in {"FLOAT16", "FLOAT32"}:
+            continue
+
+        op.op_type = "RELU"
+        op.version = 1
+        _set_operator_inputs(
+            model_ir=model_ir,
+            op=op,
+            new_inputs=[data_name],
+        )
+        op.options = {}
+        rewritten += 1
+
+    if rewritten > 0:
+        _prune_unused_tensors(model_ir)
+    return {"rewritten_maximum_with_zero_input2_to_relu": int(rewritten)}
+
+
 def _optimize_fuse_pseudo_leakyrelu_chains(model_ir: ModelIR) -> Dict[str, int]:
     """
     Fuse pseudo-op-expanded LeakyReLU chain into single LEAKY_RELU op.
@@ -8657,6 +8712,265 @@ def _optimize_transpose_pre_concat_nhwc_chains(model_ir: ModelIR) -> Dict[str, i
 
     _prune_unused_tensors(model_ir)
     return {"optimized_transpose_pre_concat_nhwc_chains": int(optimized)}
+
+
+def _optimize_transpose_pre_concat_ndhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Convert NCDHW concat blocks back to NDHWC when they are wrapped by transpose adapters.
+
+    Target:
+      ... -> t_i_ncdhw (some inputs may be unary outputs from transpose-wrapped NDHWC)
+      CONCAT(axis=1, [t_0_ncdhw, ...]) -> y_ncdhw
+      y_ncdhw -> TRANSPOSE(0,2,3,4,1) -> y_ndhwc
+
+    Rewrite:
+      ... -> t_i_ndhwc
+      CONCAT(axis=4, [t_0_ndhwc, ...]) -> y_ndhwc
+    """
+    optimized = 0
+    perm_ndhwc_to_ncdhw = [0, 4, 1, 2, 3]
+    perm_ncdhw_to_ndhwc = [0, 2, 3, 4, 1]
+    unary_ops = {
+        "LOGISTIC",
+        "RELU",
+        "RELU6",
+        "RELU_0_TO_1",
+        "LEAKY_RELU",
+        "TANH",
+        "GELU",
+        "HARD_SWISH",
+        "ABS",
+        "EXP",
+        "NEG",
+        "SQRT",
+    }
+
+    def _project_shape_after_ncdhw_to_ndhwc(tensor_name: str) -> Optional[List[int]]:
+        tensor = model_ir.tensors.get(str(tensor_name), None)
+        if tensor is None:
+            return None
+        shape = [int(v) for v in list(tensor.shape)]
+        if len(shape) != 5:
+            return None
+        return _permute_shape(shape, perm_ncdhw_to_ndhwc)
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for concat_idx, concat_op in enumerate(model_ir.operators):
+            if str(concat_op.op_type) != "CONCATENATION" or len(concat_op.outputs) != 1:
+                continue
+
+            concat_axis_old = int(concat_op.options.get("axis", 1))
+            if concat_axis_old < 0:
+                concat_axis_old += 5
+            if concat_axis_old != 1:
+                continue
+
+            concat_out_name = str(concat_op.outputs[0])
+            if concat_out_name in model_outputs:
+                continue
+
+            concat_input_actions: List[Dict[str, Any]] = []
+            rewritable = True
+            for input_name in [str(v) for v in list(concat_op.inputs)]:
+                input_producer_idx = producers.get(str(input_name), None)
+                if input_producer_idx is None:
+                    rewritable = False
+                    break
+                input_producer = model_ir.operators[int(input_producer_idx)]
+
+                if (
+                    str(input_producer.op_type) == "TRANSPOSE"
+                    and len(input_producer.inputs) >= 2
+                    and len(input_producer.outputs) == 1
+                    and str(input_producer.outputs[0]) == str(input_name)
+                    and _read_transpose_perm(model_ir, input_producer) == perm_ndhwc_to_ncdhw
+                    and set(int(v) for v in consumers.get(str(input_name), [])) == {int(concat_idx)}
+                    and str(input_name) not in model_outputs
+                ):
+                    concat_input_actions.append(
+                        {
+                            "kind": "direct",
+                            "new_input_name": str(input_producer.inputs[0]),
+                            "remove_index": int(input_producer_idx),
+                        }
+                    )
+                    continue
+
+                if (
+                    str(input_producer.op_type) in unary_ops
+                    and len(input_producer.inputs) == 1
+                    and len(input_producer.outputs) == 1
+                    and str(input_producer.outputs[0]) == str(input_name)
+                    and set(int(v) for v in consumers.get(str(input_name), [])) == {int(concat_idx)}
+                    and str(input_name) not in model_outputs
+                ):
+                    unary_input_name = str(input_producer.inputs[0])
+                    pre_idx = producers.get(unary_input_name, None)
+                    if pre_idx is None:
+                        rewritable = False
+                        break
+                    pre_op = model_ir.operators[int(pre_idx)]
+                    if (
+                        str(pre_op.op_type) != "TRANSPOSE"
+                        or len(pre_op.inputs) < 2
+                        or len(pre_op.outputs) != 1
+                        or str(pre_op.outputs[0]) != unary_input_name
+                        or _read_transpose_perm(model_ir, pre_op) != perm_ndhwc_to_ncdhw
+                        or unary_input_name in model_outputs
+                        or set(int(v) for v in consumers.get(unary_input_name, [])) != {int(input_producer_idx)}
+                    ):
+                        rewritable = False
+                        break
+                    concat_input_actions.append(
+                        {
+                            "kind": "unary",
+                            "input_name": str(input_name),
+                            "unary_index": int(input_producer_idx),
+                            "new_unary_input_name": str(pre_op.inputs[0]),
+                            "remove_index": int(pre_idx),
+                        }
+                    )
+                    continue
+
+                rewritable = False
+                break
+
+            if not rewritable or len(concat_input_actions) == 0:
+                continue
+
+            concat_users = [int(v) for v in consumers.get(concat_out_name, [])]
+            if len(concat_users) == 0:
+                continue
+            post_indices: List[int] = []
+            post_output_names: List[str] = []
+            for user_idx in concat_users:
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) == "TRANSPOSE"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == concat_out_name
+                    and _read_transpose_perm(model_ir, user_op) == perm_ncdhw_to_ndhwc
+                    and str(user_op.outputs[0]) not in model_outputs
+                ):
+                    post_indices.append(int(user_idx))
+                    post_output_names.append(str(user_op.outputs[0]))
+                    continue
+                rewritable = False
+                break
+            if not rewritable or len(post_indices) == 0:
+                continue
+
+            nhwc_ref_shape: Optional[List[int]] = None
+            nhwc_inputs_ok = True
+            for action in concat_input_actions:
+                action_kind = str(action.get("kind", ""))
+                if action_kind == "direct":
+                    projected_input_name = str(action["new_input_name"])
+                    input_tensor = model_ir.tensors.get(projected_input_name, None)
+                    if input_tensor is None or len(list(input_tensor.shape)) != 5:
+                        nhwc_inputs_ok = False
+                        break
+                    shape = [int(v) for v in list(input_tensor.shape)]
+                elif action_kind == "unary":
+                    projected_shape = _project_shape_after_ncdhw_to_ndhwc(str(action["input_name"]))
+                    if projected_shape is None:
+                        nhwc_inputs_ok = False
+                        break
+                    shape = [int(v) for v in list(projected_shape)]
+                else:
+                    nhwc_inputs_ok = False
+                    break
+                if nhwc_ref_shape is None:
+                    nhwc_ref_shape = list(shape)
+                else:
+                    for dim_idx in [0, 1, 2, 3]:
+                        if int(shape[dim_idx]) != int(nhwc_ref_shape[dim_idx]):
+                            nhwc_inputs_ok = False
+                            break
+                if not nhwc_inputs_ok:
+                    break
+            if not nhwc_inputs_ok:
+                continue
+
+            new_concat_inputs: List[str] = []
+            remove_indices: List[int] = []
+            for action in concat_input_actions:
+                action_kind = str(action.get("kind", ""))
+                remove_indices.append(int(action["remove_index"]))
+                if action_kind == "direct":
+                    new_concat_inputs.append(str(action["new_input_name"]))
+                    continue
+                if action_kind == "unary":
+                    unary_idx = int(action["unary_index"])
+                    _set_operator_inputs(
+                        model_ir=model_ir,
+                        op=model_ir.operators[int(unary_idx)],
+                        new_inputs=[str(action["new_unary_input_name"])],
+                    )
+                    _permute_tensor_metadata_if_rank_matches(
+                        model_ir.tensors.get(str(action["input_name"]), None),
+                        perm_ncdhw_to_ndhwc,
+                    )
+                    new_concat_inputs.append(str(action["input_name"]))
+                    continue
+                rewritable = False
+                break
+            if not rewritable:
+                continue
+
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=concat_op,
+                new_inputs=[str(v) for v in new_concat_inputs],
+            )
+            concat_op.options["axis"] = 4
+
+            canonical_post_output_name = str(post_output_names[0])
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=concat_op,
+                new_outputs=[canonical_post_output_name],
+            )
+            for alias_post_output_name in post_output_names[1:]:
+                _replace_tensor_inputs(model_ir, alias_post_output_name, canonical_post_output_name)
+
+            old_concat_tensor = model_ir.tensors.get(concat_out_name, None)
+            canonical_post_tensor = model_ir.tensors.get(canonical_post_output_name, None)
+            if old_concat_tensor is not None and canonical_post_tensor is not None:
+                canonical_post_tensor.dtype = str(old_concat_tensor.dtype)
+                canonical_post_tensor.quantization = _clone_quantization(old_concat_tensor.quantization)
+                canonical_post_tensor.shape = [int(v) for v in list(old_concat_tensor.shape)]
+                canonical_post_tensor.shape_signature = (
+                    [int(v) for v in list(old_concat_tensor.shape_signature)]
+                    if old_concat_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_concat_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    canonical_post_tensor,
+                    perm_ncdhw_to_ndhwc,
+                )
+
+            remove_indices.extend(post_indices)
+            for remove_idx in sorted(list({int(v) for v in remove_indices}), reverse=True):
+                if int(remove_idx) == int(concat_idx):
+                    continue
+                del model_ir.operators[int(remove_idx)]
+
+            optimized += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_pre_concat_ndhwc_chains": int(optimized)}
 
 
 def _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -17726,21 +18040,25 @@ def _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir: ModelIR) -
             if gate_nhwc_name in model_outputs or gate_pre_out_name in model_outputs:
                 continue
 
-            # Three pre-transpose outputs must be local to this chain.
-            if set(int(v) for v in consumers.get(skip_input_name, [])) != {int(add_idx)}:
+            # The chain user must exist; extra legacy users are allowed and preserved.
+            skip_pre_users = [int(v) for v in consumers.get(skip_input_name, [])]
+            if int(add_idx) not in set(skip_pre_users):
                 continue
-            if set(int(v) for v in consumers.get(pre_data_out_name, [])) != {int(mul_idx)}:
+            data_pre_users = [int(v) for v in consumers.get(pre_data_out_name, [])]
+            if int(mul_idx) not in set(data_pre_users):
                 continue
-            if set(int(v) for v in consumers.get(gate_pre_out_name, [])) != {int(logistic_idx)}:
+            gate_pre_users = [int(v) for v in consumers.get(gate_pre_out_name, [])]
+            if int(logistic_idx) not in set(gate_pre_users):
                 continue
 
-            # ADD output must fan out only to inverse post-transposes.
+            # ADD output must have at least one inverse post-transpose. Non-post users
+            # are kept via one retained adapter transpose.
             add_out_users = [int(v) for v in consumers.get(add_output_name, [])]
             if len(add_out_users) == 0:
                 continue
             post_indices: List[int] = []
             post_output_names: List[str] = []
-            valid_posts = True
+            legacy_users: List[int] = []
             for user_idx in add_out_users:
                 user_op = model_ir.operators[int(user_idx)]
                 if (
@@ -17754,9 +18072,8 @@ def _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir: ModelIR) -
                     post_indices.append(int(user_idx))
                     post_output_names.append(str(user_op.outputs[0]))
                 else:
-                    valid_posts = False
-                    break
-            if not valid_posts or len(post_indices) == 0:
+                    legacy_users.append(int(user_idx))
+            if len(post_indices) == 0:
                 continue
 
             # Rewire LOGISTIC/MUL/ADD to NHWC sources.
@@ -17832,12 +18149,35 @@ def _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir: ModelIR) -
                     perm_nchw_to_nhwc,
                 )
 
-            remove_indices = {
-                int(skip_pre_idx),
-                int(pre_data_idx),
-                int(gate_pre_idx),
-                *[int(v) for v in post_indices],
-            }
+            if len(legacy_users) > 0:
+                keep_post_idx = int(post_indices[0])
+                keep_post_op = model_ir.operators[int(keep_post_idx)]
+                keep_perm_name = str(keep_post_op.inputs[1])
+                keep_perm_tensor = model_ir.tensors.get(keep_perm_name, None)
+                if keep_perm_tensor is not None:
+                    keep_perm_tensor.data = np.asarray(perm_nhwc_to_nchw, dtype=np.int32)
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=keep_post_op,
+                    new_inputs=[canonical_post_output_name, keep_perm_name],
+                )
+                _set_operator_outputs(
+                    model_ir=model_ir,
+                    op=keep_post_op,
+                    new_outputs=[add_output_name],
+                )
+                post_remove_indices = [int(v) for v in post_indices[1:]]
+            else:
+                post_remove_indices = [int(v) for v in post_indices]
+
+            remove_indices = set(int(v) for v in post_remove_indices)
+            # Remove pre-transposes only when no remaining users need the NCHW view.
+            if len([int(v) for v in skip_pre_users if int(v) != int(add_idx)]) == 0:
+                remove_indices.add(int(skip_pre_idx))
+            if len([int(v) for v in data_pre_users if int(v) != int(mul_idx)]) == 0:
+                remove_indices.add(int(pre_data_idx))
+            if len([int(v) for v in gate_pre_users if int(v) != int(logistic_idx)]) == 0:
+                remove_indices.add(int(gate_pre_idx))
             for remove_idx in sorted(remove_indices, reverse=True):
                 del model_ir.operators[int(remove_idx)]
 
@@ -18175,6 +18515,1153 @@ def _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir: 
 
     _prune_unused_tensors(model_ir)
     return {"optimized_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains": int(rewritten)}
+
+
+def _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate NDHWC<->NCDHW bridges around 3D LEAKY/ADD + LOGISTIC/MUL/ADD blocks.
+
+    Target:
+      base_nhwc --T(0,3,1,2)--> base_nchw --RESHAPE--> base_ncdhw
+      skip_nhdwc --T(0,4,1,2,3)--> skip_ncdhw --LEAKY_RELU--> skip_leaky_ncdhw
+      ADD(skip_leaky_ncdhw, base_ncdhw) -> add0_ncdhw --T(0,2,3,4,1)--> add0_ndhwc
+      gate_ndhwc --T(0,4,1,2,3)--> gate_ncdhw --LOGISTIC--> gate_sig_ncdhw
+      MUL(gate_sig_ncdhw, base_ncdhw) -> mul1_ncdhw
+      ADD(mul1_ncdhw, skip_leaky_ncdhw) -> add1_ncdhw --T(0,2,3,4,1)--> add1_ndhwc
+
+    Rewrite:
+      - Remove the 5D pre/post transposes and keep the chain in NDHWC.
+      - Rewrite base RESHAPE to consume base_nhwc directly and emit NDHWC.
+      - Remove the 4D base transpose feeding that RESHAPE.
+
+    Safety:
+      - Uses a strict single-path motif with local consumers only.
+      - Refuses graph/model-output boundary tensors.
+    """
+    rewritten = 0
+    perm_ndhwc_to_ncdhw = [0, 4, 1, 2, 3]
+    perm_ncdhw_to_ndhwc = [0, 2, 3, 4, 1]
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+
+    def _copy_tensor_metadata_with_perm(
+        *,
+        src_name: str,
+        dst_name: str,
+        perm: List[int],
+    ) -> None:
+        src_tensor = model_ir.tensors.get(str(src_name), None)
+        dst_tensor = model_ir.tensors.get(str(dst_name), None)
+        if src_tensor is None or dst_tensor is None:
+            return
+        dst_tensor.dtype = str(src_tensor.dtype)
+        dst_tensor.quantization = _clone_quantization(src_tensor.quantization)
+        dst_tensor.shape = [int(v) for v in list(src_tensor.shape)]
+        dst_tensor.shape_signature = (
+            [int(v) for v in list(src_tensor.shape_signature)]
+            if src_tensor.shape_signature is not None
+            else [int(v) for v in list(src_tensor.shape)]
+        )
+        _permute_tensor_metadata_if_rank_matches(
+            dst_tensor,
+            perm,
+        )
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for post1_idx, post1_op in enumerate(model_ir.operators):
+            if str(post1_op.op_type) != "TRANSPOSE" or len(post1_op.inputs) < 2 or len(post1_op.outputs) != 1:
+                continue
+            if _read_transpose_perm(model_ir, post1_op) != perm_ncdhw_to_ndhwc:
+                continue
+
+            add1_out_name = str(post1_op.inputs[0])
+            add1_post_out_name = str(post1_op.outputs[0])
+            if add1_out_name in model_outputs or add1_post_out_name in model_outputs:
+                continue
+
+            add1_idx = producers.get(add1_out_name, None)
+            if add1_idx is None:
+                continue
+            add1_op = model_ir.operators[int(add1_idx)]
+            if (
+                str(add1_op.op_type) != "ADD"
+                or len(add1_op.inputs) != 2
+                or len(add1_op.outputs) != 1
+                or str(add1_op.outputs[0]) != add1_out_name
+            ):
+                continue
+            if set(int(v) for v in consumers.get(add1_out_name, [])) != {int(post1_idx)}:
+                continue
+
+            add1_inputs = [str(v) for v in list(add1_op.inputs)]
+
+            skip_name: Optional[str] = None
+            base_name: Optional[str] = None
+            for lhs_name, rhs_name in [(add1_inputs[0], add1_inputs[1]), (add1_inputs[1], add1_inputs[0])]:
+                lhs_prod_idx = producers.get(str(lhs_name), None)
+                if lhs_prod_idx is None:
+                    continue
+                lhs_prod_op = model_ir.operators[int(lhs_prod_idx)]
+                if str(lhs_prod_op.op_type) != "LEAKY_RELU":
+                    continue
+                skip_name = str(lhs_name)
+                base_name = str(rhs_name)
+                break
+            if skip_name is None or base_name is None:
+                continue
+
+            # Skip path: NDHWC -> TRANSPOSE -> LEAKY_RELU
+            skip_leaky_idx = producers.get(skip_name, None)
+            if skip_leaky_idx is None:
+                continue
+            skip_leaky_op = model_ir.operators[int(skip_leaky_idx)]
+            if (
+                str(skip_leaky_op.op_type) != "LEAKY_RELU"
+                or len(skip_leaky_op.inputs) != 1
+                or len(skip_leaky_op.outputs) != 1
+                or str(skip_leaky_op.outputs[0]) != skip_name
+            ):
+                continue
+            pre_skip_out_name = str(skip_leaky_op.inputs[0])
+            if pre_skip_out_name in model_outputs:
+                continue
+            pre_skip_idx = producers.get(pre_skip_out_name, None)
+            if pre_skip_idx is None:
+                continue
+            pre_skip_op = model_ir.operators[int(pre_skip_idx)]
+            if (
+                str(pre_skip_op.op_type) != "TRANSPOSE"
+                or len(pre_skip_op.inputs) < 2
+                or len(pre_skip_op.outputs) != 1
+                or str(pre_skip_op.outputs[0]) != pre_skip_out_name
+                or _read_transpose_perm(model_ir, pre_skip_op) != perm_ndhwc_to_ncdhw
+            ):
+                continue
+            skip_ndhwc_name = str(pre_skip_op.inputs[0])
+            if skip_ndhwc_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(pre_skip_out_name, [])) != {int(skip_leaky_idx)}:
+                continue
+
+            # Find second block:
+            #   ADD(mul, skip_name) -> post2 transpose
+            add2_candidates = [
+                int(v)
+                for v in consumers.get(skip_name, [])
+                if int(v) != int(add1_idx)
+                and str(model_ir.operators[int(v)].op_type) == "ADD"
+            ]
+            if len(add2_candidates) != 1:
+                continue
+            add2_idx = int(add2_candidates[0])
+            add2_op = model_ir.operators[int(add2_idx)]
+            if len(add2_op.inputs) != 2 or len(add2_op.outputs) != 1:
+                continue
+            add2_out_name = str(add2_op.outputs[0])
+            if add2_out_name in model_outputs:
+                continue
+            add2_users = [int(v) for v in consumers.get(add2_out_name, [])]
+            if len(add2_users) != 1:
+                continue
+            post2_idx = int(add2_users[0])
+            post2_op = model_ir.operators[int(post2_idx)]
+            if (
+                str(post2_op.op_type) != "TRANSPOSE"
+                or len(post2_op.inputs) < 2
+                or len(post2_op.outputs) != 1
+                or str(post2_op.inputs[0]) != add2_out_name
+                or _read_transpose_perm(model_ir, post2_op) != perm_ncdhw_to_ndhwc
+                or str(post2_op.outputs[0]) in model_outputs
+            ):
+                continue
+            add2_post_out_name = str(post2_op.outputs[0])
+
+            # add2 must be ADD(mul2, skip_name)
+            add2_inputs = [str(v) for v in list(add2_op.inputs)]
+            mul2_idx: Optional[int] = None
+            if str(add2_inputs[0]) == str(skip_name):
+                cand_idx = producers.get(str(add2_inputs[1]), None)
+                if cand_idx is not None and str(model_ir.operators[int(cand_idx)].op_type) == "MUL":
+                    mul2_idx = int(cand_idx)
+            elif str(add2_inputs[1]) == str(skip_name):
+                cand_idx = producers.get(str(add2_inputs[0]), None)
+                if cand_idx is not None and str(model_ir.operators[int(cand_idx)].op_type) == "MUL":
+                    mul2_idx = int(cand_idx)
+            if mul2_idx is None:
+                continue
+            mul2_op = model_ir.operators[int(mul2_idx)]
+            if len(mul2_op.inputs) != 2 or len(mul2_op.outputs) != 1:
+                continue
+            mul2_out_name = str(mul2_op.outputs[0])
+            if mul2_out_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(mul2_out_name, [])) != {int(add2_idx)}:
+                continue
+
+            # mul2 must consume LOGISTIC(pre_gate) and base_name.
+            mul2_inputs = [str(v) for v in list(mul2_op.inputs)]
+            logistic_idx: Optional[int] = None
+            if str(mul2_inputs[0]) == str(base_name):
+                cand_idx = producers.get(str(mul2_inputs[1]), None)
+                if cand_idx is not None and str(model_ir.operators[int(cand_idx)].op_type) == "LOGISTIC":
+                    logistic_idx = int(cand_idx)
+            elif str(mul2_inputs[1]) == str(base_name):
+                cand_idx = producers.get(str(mul2_inputs[0]), None)
+                if cand_idx is not None and str(model_ir.operators[int(cand_idx)].op_type) == "LOGISTIC":
+                    logistic_idx = int(cand_idx)
+            if logistic_idx is None:
+                continue
+            logistic_op = model_ir.operators[int(logistic_idx)]
+            if (
+                str(logistic_op.op_type) != "LOGISTIC"
+                or len(logistic_op.inputs) != 1
+                or len(logistic_op.outputs) != 1
+            ):
+                continue
+            logistic_out_name = str(logistic_op.outputs[0])
+            pre_gate_out_name = str(logistic_op.inputs[0])
+            if pre_gate_out_name in model_outputs or logistic_out_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(logistic_out_name, [])) != {int(mul2_idx)}:
+                continue
+            pre_gate_idx = producers.get(pre_gate_out_name, None)
+            if pre_gate_idx is None:
+                continue
+            pre_gate_op = model_ir.operators[int(pre_gate_idx)]
+            if (
+                str(pre_gate_op.op_type) != "TRANSPOSE"
+                or len(pre_gate_op.inputs) < 2
+                or len(pre_gate_op.outputs) != 1
+                or str(pre_gate_op.outputs[0]) != pre_gate_out_name
+                or _read_transpose_perm(model_ir, pre_gate_op) != perm_ndhwc_to_ncdhw
+            ):
+                continue
+            gate_ndhwc_name = str(pre_gate_op.inputs[0])
+            if gate_ndhwc_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(pre_gate_out_name, [])) != {int(logistic_idx)}:
+                continue
+
+            # base path:
+            #   base_nhwc --T(0,3,1,2)--> base_nchw --RESHAPE--> base_name(NCDHW)
+            base_reshape_idx = producers.get(base_name, None)
+            if base_reshape_idx is None:
+                continue
+            base_reshape_op = model_ir.operators[int(base_reshape_idx)]
+            if (
+                str(base_reshape_op.op_type) != "RESHAPE"
+                or len(base_reshape_op.inputs) < 2
+                or len(base_reshape_op.outputs) != 1
+                or str(base_reshape_op.outputs[0]) != str(base_name)
+            ):
+                continue
+            base_shape_name = str(base_reshape_op.inputs[1])
+            base_shape_tensor = model_ir.tensors.get(base_shape_name, None)
+            base_shape_vals = _read_const_ints_from_tensor(base_shape_tensor)
+            if base_shape_vals is None or len(base_shape_vals) != 5:
+                continue
+            pre_base_out_name = str(base_reshape_op.inputs[0])
+            if pre_base_out_name in model_outputs:
+                continue
+            pre_base_idx = producers.get(pre_base_out_name, None)
+            if pre_base_idx is None:
+                continue
+            pre_base_op = model_ir.operators[int(pre_base_idx)]
+            if (
+                str(pre_base_op.op_type) != "TRANSPOSE"
+                or len(pre_base_op.inputs) < 2
+                or len(pre_base_op.outputs) != 1
+                or str(pre_base_op.outputs[0]) != pre_base_out_name
+                or _read_transpose_perm(model_ir, pre_base_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            base_nhwc_name = str(pre_base_op.inputs[0])
+            if base_nhwc_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(pre_base_out_name, [])) != {int(base_reshape_idx)}:
+                continue
+
+            # Strict local-consumer checks for safety.
+            if set(int(v) for v in consumers.get(str(base_name), [])) != {int(add1_idx), int(mul2_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(str(skip_name), [])) != {int(add1_idx), int(add2_idx)}:
+                continue
+
+            # Rewrite base reshape to NDHWC.
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=base_reshape_op,
+                new_inputs=[str(base_nhwc_name), str(base_shape_name)],
+            )
+            mapped_base_shape = _permute_shape(
+                [int(v) for v in list(base_shape_vals)],
+                perm_ncdhw_to_ndhwc,
+            )
+            if mapped_base_shape is None:
+                continue
+            _write_const_ints_to_tensor(base_shape_tensor, [int(v) for v in list(mapped_base_shape)])
+            if isinstance(base_reshape_op.options, dict):
+                reshape_opts = dict(base_reshape_op.options)
+                reshape_opts_changed = False
+                for key in ["newShape", "onnxRawNewShape"]:
+                    value = reshape_opts.get(key, None)
+                    if isinstance(value, list) and len(value) == 5:
+                        remapped = _permute_shape([int(v) for v in list(value)], perm_ncdhw_to_ndhwc)
+                        if remapped is not None and [int(v) for v in remapped] != [int(v) for v in value]:
+                            reshape_opts[key] = [int(v) for v in list(remapped)]
+                            reshape_opts_changed = True
+                if reshape_opts_changed:
+                    base_reshape_op.options = reshape_opts
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(base_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+
+            # Bypass 5D pre-transposes.
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=skip_leaky_op,
+                new_inputs=[str(skip_ndhwc_name)],
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(skip_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=logistic_op,
+                new_inputs=[str(gate_ndhwc_name)],
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(logistic_out_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(mul2_out_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+
+            # Bypass post-transpose outputs by letting ADD emit NDHWC tensors directly.
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=add1_op,
+                new_outputs=[str(add1_post_out_name)],
+            )
+            _copy_tensor_metadata_with_perm(
+                src_name=str(add1_out_name),
+                dst_name=str(add1_post_out_name),
+                perm=perm_ncdhw_to_ndhwc,
+            )
+
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=add2_op,
+                new_outputs=[str(add2_post_out_name)],
+            )
+            _copy_tensor_metadata_with_perm(
+                src_name=str(add2_out_name),
+                dst_name=str(add2_post_out_name),
+                perm=perm_ncdhw_to_ndhwc,
+            )
+
+            remove_indices = sorted(
+                list(
+                    {
+                        int(pre_base_idx),
+                        int(pre_skip_idx),
+                        int(pre_gate_idx),
+                        int(post1_idx),
+                        int(post2_idx),
+                    }
+                ),
+                reverse=True,
+            )
+            for remove_idx in remove_indices:
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_3d_leaky_logistic_muladd_ndhwc_chains": int(rewritten)}
+
+
+def _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate NCDHW bridge transposes around CONV_3D->LEAKY_RELU gated by Unsqueeze(RESHAPE)+MUL.
+
+    Target:
+      conv_ndhwc --T(0,4,1,2,3)--> conv_ncdhw --LEAKY_RELU--> act_ncdhw
+      sem_ndhwc  --T(0,4,1,2,3)--> sem_ncdhw --RESHAPE--> gate_ncdhw
+      MUL(act_ncdhw, gate_ncdhw) -> mul_ncdhw --T(0,2,3,4,1)--> mul_ndhwc
+
+    Rewrite:
+      conv_ndhwc --LEAKY_RELU--> act_ndhwc
+      sem_ndhwc  --RESHAPE(remapped shape)--> gate_ndhwc
+      MUL(act_ndhwc, gate_ndhwc) -> mul_ndhwc
+    """
+    rewritten = 0
+    perm_ndhwc_to_ncdhw = [0, 4, 1, 2, 3]
+    perm_ncdhw_to_ndhwc = [0, 2, 3, 4, 1]
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for post_idx, post_op in enumerate(model_ir.operators):
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or _read_transpose_perm(model_ir, post_op) != perm_ncdhw_to_ndhwc
+            ):
+                continue
+
+            mul_out_name = str(post_op.inputs[0])
+            mul_ndhwc_name = str(post_op.outputs[0])
+            if mul_out_name in model_outputs or mul_ndhwc_name in model_outputs:
+                continue
+
+            mul_idx = producers.get(mul_out_name, None)
+            if mul_idx is None:
+                continue
+            mul_op = model_ir.operators[int(mul_idx)]
+            if (
+                str(mul_op.op_type) != "MUL"
+                or len(mul_op.inputs) != 2
+                or len(mul_op.outputs) != 1
+                or str(mul_op.outputs[0]) != mul_out_name
+            ):
+                continue
+            if set(int(v) for v in consumers.get(mul_out_name, [])) != {int(post_idx)}:
+                continue
+
+            mul_in0 = str(mul_op.inputs[0])
+            mul_in1 = str(mul_op.inputs[1])
+            leaky_idx: Optional[int] = None
+            reshape_idx: Optional[int] = None
+            if (
+                mul_in0 in producers
+                and str(model_ir.operators[int(producers[mul_in0])].op_type) == "LEAKY_RELU"
+                and mul_in1 in producers
+                and str(model_ir.operators[int(producers[mul_in1])].op_type) == "RESHAPE"
+            ):
+                leaky_idx = int(producers[mul_in0])
+                reshape_idx = int(producers[mul_in1])
+            elif (
+                mul_in1 in producers
+                and str(model_ir.operators[int(producers[mul_in1])].op_type) == "LEAKY_RELU"
+                and mul_in0 in producers
+                and str(model_ir.operators[int(producers[mul_in0])].op_type) == "RESHAPE"
+            ):
+                leaky_idx = int(producers[mul_in1])
+                reshape_idx = int(producers[mul_in0])
+            if leaky_idx is None or reshape_idx is None:
+                continue
+
+            leaky_op = model_ir.operators[int(leaky_idx)]
+            if len(leaky_op.inputs) != 1 or len(leaky_op.outputs) != 1:
+                continue
+            leaky_out_name = str(leaky_op.outputs[0])
+            if set(int(v) for v in consumers.get(leaky_out_name, [])) != {int(mul_idx)}:
+                continue
+            if leaky_out_name in model_outputs:
+                continue
+
+            leaky_pre_name = str(leaky_op.inputs[0])
+            leaky_pre_idx = producers.get(leaky_pre_name, None)
+            if leaky_pre_idx is None:
+                continue
+            leaky_pre_op = model_ir.operators[int(leaky_pre_idx)]
+            if (
+                str(leaky_pre_op.op_type) != "TRANSPOSE"
+                or len(leaky_pre_op.inputs) < 2
+                or len(leaky_pre_op.outputs) != 1
+                or str(leaky_pre_op.outputs[0]) != leaky_pre_name
+                or _read_transpose_perm(model_ir, leaky_pre_op) != perm_ndhwc_to_ncdhw
+            ):
+                continue
+            conv_ndhwc_name = str(leaky_pre_op.inputs[0])
+            if conv_ndhwc_name in model_outputs or leaky_pre_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(leaky_pre_name, [])) != {int(leaky_idx)}:
+                continue
+
+            reshape_op = model_ir.operators[int(reshape_idx)]
+            if len(reshape_op.inputs) < 2 or len(reshape_op.outputs) != 1:
+                continue
+            reshape_out_name = str(reshape_op.outputs[0])
+            if reshape_out_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(reshape_out_name, [])) != {int(mul_idx)}:
+                continue
+
+            sem_ncdhw_name = str(reshape_op.inputs[0])
+            sem_pre_idx = producers.get(sem_ncdhw_name, None)
+            if sem_pre_idx is None:
+                continue
+            sem_pre_op = model_ir.operators[int(sem_pre_idx)]
+            sem_pre_perm = _read_transpose_perm(model_ir, sem_pre_op)
+            if (
+                str(sem_pre_op.op_type) != "TRANSPOSE"
+                or len(sem_pre_op.inputs) < 2
+                or len(sem_pre_op.outputs) != 1
+                or str(sem_pre_op.outputs[0]) != sem_ncdhw_name
+                or (
+                    sem_pre_perm != perm_nhwc_to_nchw
+                    and sem_pre_perm != perm_ndhwc_to_ncdhw
+                )
+            ):
+                continue
+            sem_ndhwc_name = str(sem_pre_op.inputs[0])
+            if sem_ndhwc_name in model_outputs or sem_ncdhw_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(sem_ncdhw_name, [])) != {int(reshape_idx)}:
+                continue
+
+            reshape_shape_name = str(reshape_op.inputs[1])
+            reshape_shape_tensor = model_ir.tensors.get(reshape_shape_name, None)
+            reshape_shape_vals = _read_const_ints_from_tensor(reshape_shape_tensor)
+            if reshape_shape_vals is None or len(reshape_shape_vals) != 5:
+                continue
+            mapped_shape = _permute_shape(
+                [int(v) for v in list(reshape_shape_vals)],
+                perm_ncdhw_to_ndhwc,
+            )
+            if mapped_shape is None:
+                continue
+
+            if not _write_const_ints_to_tensor(
+                reshape_shape_tensor,
+                [int(v) for v in list(mapped_shape)],
+            ):
+                continue
+            if isinstance(reshape_op.options, dict):
+                reshape_opts = dict(reshape_op.options)
+                reshape_opts_changed = False
+                for key in ["newShape", "onnxRawNewShape"]:
+                    value = reshape_opts.get(key, None)
+                    if isinstance(value, list) and len(value) == 5:
+                        remapped = _permute_shape([int(v) for v in list(value)], perm_ncdhw_to_ndhwc)
+                        if remapped is not None and [int(v) for v in list(remapped)] != [int(v) for v in list(value)]:
+                            reshape_opts[key] = [int(v) for v in list(remapped)]
+                            reshape_opts_changed = True
+                if reshape_opts_changed:
+                    reshape_op.options = reshape_opts
+
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=reshape_op,
+                new_inputs=[str(sem_ndhwc_name), str(reshape_shape_name)],
+            )
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=leaky_op,
+                new_inputs=[str(conv_ndhwc_name)],
+            )
+
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(reshape_out_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(leaky_out_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(str(mul_out_name), None),
+                perm_ncdhw_to_ndhwc,
+            )
+
+            old_mul_out_tensor = model_ir.tensors.get(str(mul_out_name), None)
+            mul_ndhwc_tensor = model_ir.tensors.get(str(mul_ndhwc_name), None)
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=mul_op,
+                new_outputs=[str(mul_ndhwc_name)],
+            )
+            if old_mul_out_tensor is not None and mul_ndhwc_tensor is not None:
+                mul_ndhwc_tensor.dtype = str(old_mul_out_tensor.dtype)
+                mul_ndhwc_tensor.quantization = _clone_quantization(old_mul_out_tensor.quantization)
+                mul_ndhwc_tensor.shape = [int(v) for v in list(old_mul_out_tensor.shape)]
+                mul_ndhwc_tensor.shape_signature = (
+                    [int(v) for v in list(old_mul_out_tensor.shape_signature)]
+                    if old_mul_out_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_mul_out_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    mul_ndhwc_tensor,
+                    perm_ncdhw_to_ndhwc,
+                )
+
+            for remove_idx in sorted(
+                list({int(sem_pre_idx), int(leaky_pre_idx), int(post_idx)}),
+                reverse=True,
+            ):
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains": int(rewritten)}
+
+
+def _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Remove NCHW/NCDHW adapter transposes in cost-volume ScatterND accumulation motifs.
+
+    Target:
+      desc0_nhwc --T(0,3,1,2)--> desc0_nchw
+      desc1_nhwc --T(0,3,1,2)--> desc1_nchw
+      (SLICE/SUM/SQRT/DIV/MEAN/RESHAPE/SCATTER_ND chain in NCHW+NCDHW space)
+      vol_ncdhw --T(0,2,3,4,1)--> vol_ndhwc --CONV_3D-->
+
+    Rewrite:
+      - Keep rank-4 path in NHWC: rewrite SLICE and reduce axes accordingly.
+      - Keep ScatterND result tensors in NDHWC: rewrite ScatterND shape and indices.
+      - Remove the two leading NHWC->NCHW transposes and trailing NCDHW->NDHWC transpose.
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    perm_ncdhw_to_ndhwc = [0, 2, 3, 4, 1]
+    perm_ndhwc_to_ncdhw = [0, 4, 1, 2, 3]
+    reduce_ops = {"SUM", "MEAN", "REDUCE_MAX"}
+    scatter_layout_ops = {"SCATTER_ND", "ADD", "SUB", "MUL"}
+    scatter_const_input_layout_ops = {"ADD", "SUB", "MUL"}
+    allowed_ops = {
+        "SLICE",
+        "MUL",
+        "SUM",
+        "SQRT",
+        "DIV",
+        "MEAN",
+        "RESHAPE",
+        "CAST",
+        "SCATTER_ND",
+        "SUB",
+        "ADD",
+        "CONCATENATION",
+        "REDUCE_MAX",
+    }
+
+    def _unique_tensor_name(base: str) -> str:
+        name = str(base)
+        suffix = 1
+        while name in model_ir.tensors:
+            name = f"{base}_{suffix}"
+            suffix += 1
+        return name
+
+    def _ensure_exclusive_const_input(
+        *,
+        op: OperatorIR,
+        op_idx: int,
+        input_index: int,
+        consumers: Dict[str, List[int]],
+    ) -> Optional[TensorIR]:
+        if int(input_index) < 0 or int(input_index) >= len(op.inputs):
+            return None
+        tensor_name = str(op.inputs[int(input_index)])
+        tensor = model_ir.tensors.get(tensor_name, None)
+        if tensor is None or tensor.data is None:
+            return None
+        tensor_consumers = [int(v) for v in consumers.get(tensor_name, [])]
+        if len(tensor_consumers) <= 1:
+            return tensor
+        if set(tensor_consumers) == {int(op_idx)}:
+            return tensor
+        new_name = _unique_tensor_name(f"{tensor_name}_layout")
+        new_data = np.asarray(tensor.data).copy()
+        new_shape_signature = (
+            [int(v) for v in list(tensor.shape_signature)]
+            if tensor.shape_signature is not None
+            else [int(v) for v in list(tensor.shape)]
+        )
+        model_ir.tensors[new_name] = TensorIR(
+            name=new_name,
+            dtype=str(tensor.dtype),
+            shape=[int(v) for v in list(tensor.shape)],
+            shape_signature=[int(v) for v in list(new_shape_signature)],
+            data=new_data,
+            is_variable=bool(tensor.is_variable),
+            quantization=_clone_quantization(tensor.quantization),
+        )
+        _replace_operator_input_at(
+            model_ir=model_ir,
+            op=op,
+            input_index=int(input_index),
+            new_input_name=str(new_name),
+        )
+        return model_ir.tensors.get(str(new_name), None)
+
+    def _normalize_axis(axis: int, rank: int) -> Optional[int]:
+        value = int(axis)
+        if value < 0:
+            value += int(rank)
+        if value < 0 or value >= int(rank):
+            return None
+        return int(value)
+
+    def _remap_axes_const(
+        *,
+        op: OperatorIR,
+        op_idx: int,
+        consumers: Dict[str, List[int]],
+        input_index: int,
+        rank: int,
+        axis_map: List[int],
+    ) -> bool:
+        axes_tensor = _ensure_exclusive_const_input(
+            op=op,
+            op_idx=int(op_idx),
+            input_index=int(input_index),
+            consumers=consumers,
+        )
+        axes_vals = _read_const_ints_from_tensor(axes_tensor)
+        if axes_vals is None or len(axes_vals) == 0:
+            return False
+        mapped_axes: List[int] = []
+        for axis in axes_vals:
+            normalized = _normalize_axis(int(axis), int(rank))
+            if normalized is None:
+                return False
+            mapped_axes.append(int(axis_map[int(normalized)]))
+        _write_const_ints_to_tensor(axes_tensor, [int(v) for v in mapped_axes])
+        return True
+
+    def _remap_slice_consts(
+        *,
+        op: OperatorIR,
+        op_idx: int,
+        consumers: Dict[str, List[int]],
+    ) -> bool:
+        if len(op.inputs) < 3:
+            return False
+        begin_tensor = _ensure_exclusive_const_input(
+            op=op,
+            op_idx=int(op_idx),
+            input_index=1,
+            consumers=consumers,
+        )
+        size_tensor = _ensure_exclusive_const_input(
+            op=op,
+            op_idx=int(op_idx),
+            input_index=2,
+            consumers=consumers,
+        )
+        begin_vals = _read_const_ints_from_tensor(begin_tensor)
+        size_vals = _read_const_ints_from_tensor(size_tensor)
+        if begin_vals is None or size_vals is None:
+            return False
+        if len(begin_vals) != 4 or len(size_vals) != 4:
+            return False
+        new_begin = [int(begin_vals[int(idx)]) for idx in perm_nchw_to_nhwc]
+        new_size = [int(size_vals[int(idx)]) for idx in perm_nchw_to_nhwc]
+        _write_const_ints_to_tensor(begin_tensor, new_begin)
+        _write_const_ints_to_tensor(size_tensor, new_size)
+        return True
+
+    def _remap_concat_axis(
+        *,
+        op: OperatorIR,
+        rank: int,
+        axis_map: List[int],
+    ) -> bool:
+        if not isinstance(op.options, dict):
+            return False
+        raw_axis = int(op.options.get("axis", 1))
+        if raw_axis < 0:
+            raw_axis += int(rank)
+        if raw_axis < 0 or raw_axis >= int(rank):
+            return False
+        op.options["axis"] = int(axis_map[int(raw_axis)])
+        return True
+
+    def _remap_scatter_shape_const(
+        *,
+        op: OperatorIR,
+        op_idx: int,
+        consumers: Dict[str, List[int]],
+    ) -> Optional[List[int]]:
+        if len(op.inputs) < 3:
+            return None
+        shape_tensor = _ensure_exclusive_const_input(
+            op=op,
+            op_idx=int(op_idx),
+            input_index=2,
+            consumers=consumers,
+        )
+        shape_vals = _read_const_ints_from_tensor(shape_tensor)
+        if shape_vals is None or len(shape_vals) != 5:
+            return None
+        mapped_shape = _permute_shape(
+            [int(v) for v in list(shape_vals)],
+            perm_ncdhw_to_ndhwc,
+        )
+        if mapped_shape is None:
+            return None
+        _write_const_ints_to_tensor(shape_tensor, [int(v) for v in list(mapped_shape)])
+        return [int(v) for v in list(mapped_shape)]
+
+    def _remap_scatter_indices_const(
+        *,
+        op: OperatorIR,
+        op_idx: int,
+        producers: Dict[str, int],
+        consumers: Dict[str, List[int]],
+        target_shape: List[int],
+    ) -> bool:
+        if len(op.inputs) < 1:
+            return False
+        indices_name = str(op.inputs[0])
+        const_owner_op = op
+        const_owner_idx = int(op_idx)
+        const_input_index = 0
+
+        indices_prod_idx = producers.get(indices_name, None)
+        if indices_prod_idx is not None:
+            indices_prod_op = model_ir.operators[int(indices_prod_idx)]
+            if str(indices_prod_op.op_type) == "CAST" and len(indices_prod_op.inputs) == 1:
+                const_owner_op = indices_prod_op
+                const_owner_idx = int(indices_prod_idx)
+                const_input_index = 0
+
+        const_tensor = _ensure_exclusive_const_input(
+            op=const_owner_op,
+            op_idx=int(const_owner_idx),
+            input_index=int(const_input_index),
+            consumers=consumers,
+        )
+        if const_tensor is None or const_tensor.data is None:
+            return False
+
+        coord_array = np.asarray(const_tensor.data)
+        if int(coord_array.size) == 0:
+            return False
+        if int(coord_array.shape[-1]) != 5:
+            return False
+        flat = coord_array.reshape(-1, 5).copy()
+
+        def _indices_in_bounds(coords: np.ndarray, shape: List[int]) -> bool:
+            if int(coords.shape[1]) != int(len(shape)):
+                return False
+            for axis in range(int(len(shape))):
+                dim = int(shape[axis])
+                if dim <= 0:
+                    return False
+                axis_vals = coords[:, int(axis)]
+                if np.any(axis_vals < 0):
+                    return False
+                if np.any(axis_vals >= dim):
+                    return False
+            return True
+
+        remapped_flat = flat[:, [int(v) for v in perm_ncdhw_to_ndhwc]]
+        selected_flat = flat
+        if _indices_in_bounds(flat, target_shape):
+            selected_flat = flat
+        elif _indices_in_bounds(remapped_flat, target_shape):
+            selected_flat = remapped_flat
+        else:
+            return False
+
+        remapped = selected_flat.reshape(coord_array.shape).astype(coord_array.dtype, copy=False)
+        if not np.array_equal(remapped, coord_array):
+            const_tensor.data = np.asarray(remapped)
+            const_tensor.shape = [int(v) for v in list(remapped.shape)]
+            const_tensor.shape_signature = [int(v) for v in list(remapped.shape)]
+        return True
+
+    def _permute_tensor_data_and_metadata_if_rank_matches(
+        tensor: Optional[TensorIR],
+        perm: List[int],
+    ) -> None:
+        if tensor is None:
+            return
+        if tensor.data is not None:
+            try:
+                data_array = np.asarray(tensor.data)
+                if int(data_array.ndim) == int(len(perm)):
+                    transposed = np.transpose(data_array, axes=perm)
+                    tensor.data = np.asarray(transposed)
+                    tensor.shape = [int(v) for v in list(transposed.shape)]
+                    tensor.shape_signature = [int(v) for v in list(transposed.shape)]
+                    return
+            except Exception:
+                pass
+        _permute_tensor_metadata_if_rank_matches(tensor, perm)
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for post_idx, post_op in enumerate(model_ir.operators):
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or _read_transpose_perm(model_ir, post_op) != perm_ncdhw_to_ndhwc
+            ):
+                continue
+
+            post_in_name = str(post_op.inputs[0])
+            post_out_name = str(post_op.outputs[0])
+            if (
+                post_in_name in model_outputs
+                or post_out_name in model_outputs
+            ):
+                continue
+            if set(int(v) for v in consumers.get(post_in_name, [])) != {int(post_idx)}:
+                continue
+
+            post_users = [int(v) for v in consumers.get(post_out_name, [])]
+            if len(post_users) != 1:
+                continue
+            conv_idx = int(post_users[0])
+            conv_op = model_ir.operators[int(conv_idx)]
+            if (
+                str(conv_op.op_type) != "CONV_3D"
+                or len(conv_op.inputs) < 1
+                or str(conv_op.inputs[0]) != post_out_name
+            ):
+                continue
+
+            root_idx = producers.get(post_in_name, None)
+            if root_idx is None:
+                continue
+
+            candidate_indices: set[int] = set()
+            boundary_indices: set[int] = set()
+            traversal_ok = True
+            stack: List[int] = [int(root_idx)]
+            visited: set[int] = set()
+
+            while len(stack) > 0:
+                current_idx = int(stack.pop())
+                if int(current_idx) in visited:
+                    continue
+                visited.add(int(current_idx))
+                current_op = model_ir.operators[int(current_idx)]
+
+                if str(current_op.op_type) == "TRANSPOSE":
+                    current_perm = _read_transpose_perm(model_ir, current_op)
+                    if current_perm == perm_nhwc_to_nchw:
+                        boundary_indices.add(int(current_idx))
+                        continue
+                    traversal_ok = False
+                    break
+
+                if str(current_op.op_type) not in allowed_ops:
+                    traversal_ok = False
+                    break
+
+                candidate_indices.add(int(current_idx))
+                for input_name in list(current_op.inputs):
+                    parent_idx = producers.get(str(input_name), None)
+                    if parent_idx is not None:
+                        stack.append(int(parent_idx))
+
+            if not traversal_ok:
+                continue
+            if len(candidate_indices) == 0:
+                continue
+            if len(boundary_indices) != 2:
+                continue
+
+            boundary_plans: List[Tuple[int, str, str]] = []
+            for boundary_idx in sorted(list(boundary_indices)):
+                boundary_op = model_ir.operators[int(boundary_idx)]
+                if (
+                    str(boundary_op.op_type) != "TRANSPOSE"
+                    or len(boundary_op.inputs) < 2
+                    or len(boundary_op.outputs) != 1
+                    or _read_transpose_perm(model_ir, boundary_op) != perm_nhwc_to_nchw
+                ):
+                    traversal_ok = False
+                    break
+                boundary_in = str(boundary_op.inputs[0])
+                boundary_out = str(boundary_op.outputs[0])
+                if boundary_in in model_outputs or boundary_out in model_outputs:
+                    traversal_ok = False
+                    break
+                boundary_users = set(int(v) for v in consumers.get(boundary_out, []))
+                if len(boundary_users) == 0:
+                    traversal_ok = False
+                    break
+                if any(int(user_idx) not in candidate_indices for user_idx in boundary_users):
+                    traversal_ok = False
+                    break
+                boundary_plans.append((int(boundary_idx), str(boundary_in), str(boundary_out)))
+            if not traversal_ok:
+                continue
+
+            apply_ok = True
+            for op_idx in sorted(list(candidate_indices)):
+                op = model_ir.operators[int(op_idx)]
+                op_type = str(op.op_type)
+                if op_type == "SLICE":
+                    if not _remap_slice_consts(
+                        op=op,
+                        op_idx=int(op_idx),
+                        consumers=consumers,
+                    ):
+                        apply_ok = False
+                        break
+                elif op_type in reduce_ops:
+                    if not _remap_axes_const(
+                        op=op,
+                        op_idx=int(op_idx),
+                        consumers=consumers,
+                        input_index=1,
+                        rank=4,
+                        axis_map=perm_nhwc_to_nchw,
+                    ):
+                        apply_ok = False
+                        break
+                elif op_type == "CONCATENATION":
+                    rank_hint = 4
+                    if len(op.inputs) > 0:
+                        in_tensor = model_ir.tensors.get(str(op.inputs[0]), None)
+                        if in_tensor is not None and in_tensor.shape is not None:
+                            rank_hint = int(len(list(in_tensor.shape)))
+                    if int(rank_hint) == 4:
+                        if not _remap_concat_axis(
+                            op=op,
+                            rank=4,
+                            axis_map=perm_nhwc_to_nchw,
+                        ):
+                            apply_ok = False
+                            break
+                elif op_type == "SCATTER_ND":
+                    mapped_shape = _remap_scatter_shape_const(
+                        op=op,
+                        op_idx=int(op_idx),
+                        consumers=consumers,
+                    )
+                    if mapped_shape is None:
+                        apply_ok = False
+                        break
+                    if not _remap_scatter_indices_const(
+                        op=op,
+                        op_idx=int(op_idx),
+                        producers=producers,
+                        consumers=consumers,
+                        target_shape=[int(v) for v in list(mapped_shape)],
+                    ):
+                        apply_ok = False
+                        break
+
+            if not apply_ok:
+                continue
+
+            for _, boundary_in, boundary_out in boundary_plans:
+                _replace_tensor_inputs(
+                    model_ir=model_ir,
+                    src_name=str(boundary_out),
+                    dst_name=str(boundary_in),
+                )
+
+            conv_inputs = [
+                str(post_in_name) if str(v) == str(post_out_name) else str(v)
+                for v in list(conv_op.inputs)
+            ]
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=conv_op,
+                new_inputs=conv_inputs,
+            )
+
+            for op_idx in sorted(list(candidate_indices)):
+                op = model_ir.operators[int(op_idx)]
+                if str(op.op_type) not in scatter_const_input_layout_ops:
+                    continue
+                for input_name in list(op.inputs):
+                    input_tensor = model_ir.tensors.get(str(input_name), None)
+                    if input_tensor is None:
+                        continue
+                    rank = (
+                        len(list(input_tensor.shape))
+                        if input_tensor.shape is not None
+                        else (
+                            len(list(input_tensor.shape_signature))
+                            if input_tensor.shape_signature is not None
+                            else 0
+                        )
+                    )
+                    if int(rank) != 5:
+                        continue
+                    producer_idx = producers.get(str(input_name), None)
+                    if producer_idx is not None:
+                        continue
+                    _permute_tensor_data_and_metadata_if_rank_matches(
+                        input_tensor,
+                        perm_ncdhw_to_ndhwc,
+                    )
+
+            for op_idx in sorted(list(candidate_indices)):
+                op = model_ir.operators[int(op_idx)]
+                for output_name in list(op.outputs):
+                    output_tensor = model_ir.tensors.get(str(output_name), None)
+                    if output_tensor is None:
+                        continue
+                    rank = (
+                        len(list(output_tensor.shape))
+                        if output_tensor.shape is not None
+                        else (
+                            len(list(output_tensor.shape_signature))
+                            if output_tensor.shape_signature is not None
+                            else 0
+                        )
+                    )
+                    if int(rank) == 4:
+                        _permute_tensor_metadata_if_rank_matches(
+                            output_tensor,
+                            perm_nchw_to_nhwc,
+                        )
+                    elif int(rank) == 5 and str(op.op_type) in scatter_layout_ops:
+                        _permute_tensor_metadata_if_rank_matches(
+                            output_tensor,
+                            perm_ncdhw_to_ndhwc,
+                        )
+
+            remove_indices = sorted(
+                [int(post_idx)] + [int(v[0]) for v in list(boundary_plans)],
+                reverse=True,
+            )
+            for remove_idx in remove_indices:
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_cost_volume_scatter_ndhwc_chains": int(rewritten)}
 
 
 def _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -18877,6 +20364,2191 @@ def _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir: ModelIR
 
     _prune_unused_tensors(model_ir)
     return {"optimized_transpose_conv_attention_nhwc_propagation_chains": int(rewritten)}
+
+
+def _optimize_transpose_csp_attention_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate RTMDet-like CSP attention NCHW/NHWC bridge chains.
+
+    Strict target motif (rank-4):
+      short_nhwc --T(0,3,1,2)--> short_nchw --LOGISTIC--> s_sig --MUL(short_nchw, s_sig)--> short_branch
+      main_nhwc  --T(0,3,1,2)--> main_nchw
+      point_nhwc --T(0,3,1,2)--> point_nchw --LOGISTIC--> p_sig --MUL(point_nchw, p_sig)--> point_branch
+      ADD(main_nchw, point_branch) -> add_nchw
+      CONCAT(axis=1, [add_nchw, short_branch]) -> feat_nchw
+      MEAN(keepDims=True, axes=[2,3]) -> gap_nchw --T(0,2,3,1)--> gap_nhwc --CONV_2D--> gate_nhwc
+      gate_nhwc --T(0,3,1,2)--> gate_in_nchw --(LOGISTIC|HardSigmoid expansion)--> gate_nchw
+      MUL(feat_nchw, gate_nchw) -> out_nchw --T(0,2,3,1)--> out_nhwc
+
+    Rewrite:
+      - keep all branch tensors in NHWC
+      - remap CONCAT axis to NHWC channel axis and MEAN axes to NHWC
+      - remove bridge transposes in the motif
+      - preserve post-transpose output tensor names
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+
+    def _match_sigmoid_self_mul_from_transpose_output(
+        branch_output_name: str,
+        consumers: Dict[str, List[int]],
+        producers: Dict[str, int],
+    ) -> Optional[Dict[str, Any]]:
+        mul_idx = producers.get(str(branch_output_name), None)
+        if mul_idx is None:
+            return None
+        mul_op = model_ir.operators[int(mul_idx)]
+        if (
+            str(mul_op.op_type) != "MUL"
+            or len(mul_op.inputs) != 2
+            or len(mul_op.outputs) != 1
+            or str(mul_op.outputs[0]) != str(branch_output_name)
+        ):
+            return None
+
+        mul_inputs = [str(v) for v in list(mul_op.inputs)]
+        for candidate_input_idx in [0, 1]:
+            transpose_output_name = str(mul_inputs[int(candidate_input_idx)])
+            sigmoid_output_name = str(mul_inputs[1 - int(candidate_input_idx)])
+
+            pre_idx = producers.get(transpose_output_name, None)
+            if pre_idx is None:
+                continue
+            pre_op = model_ir.operators[int(pre_idx)]
+            if (
+                str(pre_op.op_type) != "TRANSPOSE"
+                or len(pre_op.inputs) < 2
+                or len(pre_op.outputs) != 1
+                or str(pre_op.outputs[0]) != transpose_output_name
+                or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+
+            sig_idx = producers.get(sigmoid_output_name, None)
+            if sig_idx is None:
+                continue
+            sig_op = model_ir.operators[int(sig_idx)]
+            if (
+                str(sig_op.op_type) != "LOGISTIC"
+                or len(sig_op.inputs) != 1
+                or len(sig_op.outputs) != 1
+                or str(sig_op.inputs[0]) != transpose_output_name
+                or str(sig_op.outputs[0]) != sigmoid_output_name
+            ):
+                continue
+
+            if set(int(v) for v in consumers.get(sigmoid_output_name, [])) != {int(mul_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(transpose_output_name, [])) != {int(sig_idx), int(mul_idx)}:
+                continue
+
+            return {
+                "transpose_idx": int(pre_idx),
+                "transpose_output_name": str(transpose_output_name),
+                "source_nhwc_name": str(pre_op.inputs[0]),
+                "sigmoid_idx": int(sig_idx),
+                "sigmoid_output_name": str(sigmoid_output_name),
+                "mul_idx": int(mul_idx),
+                "branch_output_name": str(branch_output_name),
+            }
+        return None
+
+    def _match_hardsigmoid_gate_from_output(
+        gate_output_name: str,
+        consumers: Dict[str, List[int]],
+        producers: Dict[str, int],
+    ) -> Optional[Dict[str, Any]]:
+        gate_idx = producers.get(str(gate_output_name), None)
+        if gate_idx is None:
+            return None
+        gate_op = model_ir.operators[int(gate_idx)]
+        gate_type = str(gate_op.op_type)
+        add_output_name: Optional[str] = None
+        chain_indices: List[int] = []
+        metadata_names: List[str] = []
+
+        if gate_type == "LOGISTIC":
+            if len(gate_op.inputs) != 1 or len(gate_op.outputs) != 1:
+                return None
+            return {
+                "head_idx": int(gate_idx),
+                "head_input_name": str(gate_op.inputs[0]),
+                "head_input_index": 0,
+                "output_name": str(gate_output_name),
+                "chain_indices": [int(gate_idx)],
+                "metadata_names": [str(gate_output_name)],
+            }
+
+        if gate_type == "RELU_0_TO_1":
+            if len(gate_op.inputs) != 1 or len(gate_op.outputs) != 1:
+                return None
+            add_output_name = str(gate_op.inputs[0])
+            if set(int(v) for v in consumers.get(add_output_name, [])) != {int(gate_idx)}:
+                return None
+            chain_indices.append(int(gate_idx))
+            metadata_names.append(str(gate_output_name))
+        elif gate_type == "MINIMUM":
+            if len(gate_op.inputs) != 2 or len(gate_op.outputs) != 1:
+                return None
+            min_inputs = [str(v) for v in list(gate_op.inputs)]
+            max_output_name: Optional[str] = None
+            min_side_name: Optional[str] = None
+            for candidate_name, other_name in [(min_inputs[0], min_inputs[1]), (min_inputs[1], min_inputs[0])]:
+                producer_idx = producers.get(candidate_name, None)
+                if producer_idx is None:
+                    continue
+                producer_op = model_ir.operators[int(producer_idx)]
+                if str(producer_op.op_type) != "MAXIMUM":
+                    continue
+                max_output_name = str(candidate_name)
+                min_side_name = str(other_name)
+                break
+            if max_output_name is None or min_side_name is None:
+                return None
+            if not _is_singleton_constant_tensor(model_ir, min_side_name):
+                return None
+            if set(int(v) for v in consumers.get(max_output_name, [])) != {int(gate_idx)}:
+                return None
+
+            max_idx = producers.get(max_output_name, None)
+            if max_idx is None:
+                return None
+            max_op = model_ir.operators[int(max_idx)]
+            if str(max_op.op_type) != "MAXIMUM" or len(max_op.inputs) != 2 or len(max_op.outputs) != 1:
+                return None
+            max_inputs = [str(v) for v in list(max_op.inputs)]
+            for candidate_name, other_name in [(max_inputs[0], max_inputs[1]), (max_inputs[1], max_inputs[0])]:
+                producer_idx = producers.get(candidate_name, None)
+                if producer_idx is None:
+                    continue
+                producer_op = model_ir.operators[int(producer_idx)]
+                if str(producer_op.op_type) != "ADD":
+                    continue
+                add_output_name = str(candidate_name)
+                if not _is_singleton_constant_tensor(model_ir, str(other_name)):
+                    return None
+                break
+            if add_output_name is None:
+                return None
+            if set(int(v) for v in consumers.get(add_output_name, [])) != {int(max_idx)}:
+                return None
+            chain_indices.extend([int(max_idx), int(gate_idx)])
+            metadata_names.extend([str(max_output_name), str(gate_output_name)])
+        else:
+            return None
+
+        add_idx = producers.get(str(add_output_name), None)
+        if add_idx is None:
+            return None
+        add_op = model_ir.operators[int(add_idx)]
+        if str(add_op.op_type) != "ADD" or len(add_op.inputs) != 2 or len(add_op.outputs) != 1:
+            return None
+        add_inputs = [str(v) for v in list(add_op.inputs)]
+        mul_output_name: Optional[str] = None
+        for candidate_name, other_name in [(add_inputs[0], add_inputs[1]), (add_inputs[1], add_inputs[0])]:
+            producer_idx = producers.get(candidate_name, None)
+            if producer_idx is None:
+                continue
+            producer_op = model_ir.operators[int(producer_idx)]
+            if str(producer_op.op_type) != "MUL":
+                continue
+            if not _is_singleton_constant_tensor(model_ir, str(other_name)):
+                return None
+            mul_output_name = str(candidate_name)
+            break
+        if mul_output_name is None:
+            return None
+        if set(int(v) for v in consumers.get(mul_output_name, [])) != {int(add_idx)}:
+            return None
+        chain_indices.append(int(add_idx))
+        metadata_names.insert(0, str(add_output_name))
+
+        mul_idx = producers.get(mul_output_name, None)
+        if mul_idx is None:
+            return None
+        mul_op = model_ir.operators[int(mul_idx)]
+        if str(mul_op.op_type) != "MUL" or len(mul_op.inputs) != 2 or len(mul_op.outputs) != 1:
+            return None
+        mul_inputs = [str(v) for v in list(mul_op.inputs)]
+        main_input_name: Optional[str] = None
+        main_input_index: Optional[int] = None
+        for input_index, input_name in enumerate(mul_inputs):
+            side_name = str(mul_inputs[1 - input_index])
+            if _is_singleton_constant_tensor(model_ir, side_name):
+                main_input_name = str(input_name)
+                main_input_index = int(input_index)
+                break
+        if main_input_name is None or main_input_index is None:
+            return None
+
+        chain_indices.append(int(mul_idx))
+        metadata_names.insert(0, str(mul_output_name))
+        return {
+            "head_idx": int(mul_idx),
+            "head_input_name": str(main_input_name),
+            "head_input_index": int(main_input_index),
+            "output_name": str(gate_output_name),
+            "chain_indices": [int(v) for v in chain_indices],
+            "metadata_names": [str(v) for v in metadata_names],
+        }
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for candidate_post_idx, candidate_post_op in enumerate(model_ir.operators):
+            if (
+                str(candidate_post_op.op_type) != "TRANSPOSE"
+                or len(candidate_post_op.inputs) < 2
+                or len(candidate_post_op.outputs) != 1
+                or _read_transpose_perm(model_ir, candidate_post_op) != perm_nchw_to_nhwc
+            ):
+                continue
+
+            mul_output_name = str(candidate_post_op.inputs[0])
+            if mul_output_name in model_outputs:
+                continue
+            mul_idx = producers.get(mul_output_name, None)
+            if mul_idx is None:
+                continue
+            mul_op = model_ir.operators[int(mul_idx)]
+            if str(mul_op.op_type) != "MUL" or len(mul_op.inputs) != 2 or len(mul_op.outputs) != 1:
+                continue
+            if str(mul_op.outputs[0]) != mul_output_name:
+                continue
+
+            mul_output_users = [int(v) for v in consumers.get(mul_output_name, [])]
+            post_pairs: List[Tuple[int, OperatorIR]] = []
+            valid_posts = len(mul_output_users) > 0
+            for user_idx in mul_output_users:
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) != "TRANSPOSE"
+                    or len(user_op.inputs) < 2
+                    or len(user_op.outputs) != 1
+                    or str(user_op.inputs[0]) != mul_output_name
+                    or _read_transpose_perm(model_ir, user_op) != perm_nchw_to_nhwc
+                    or str(user_op.outputs[0]) in model_outputs
+                ):
+                    valid_posts = False
+                    break
+                post_pairs.append((int(user_idx), user_op))
+            if not valid_posts or len(post_pairs) == 0:
+                continue
+            post_pairs = sorted(post_pairs, key=lambda v: int(v[0]))
+            post_indices = [int(v[0]) for v in post_pairs]
+            post_output_names = [str(v[1].outputs[0]) for v in post_pairs]
+
+            concat_name: Optional[str] = None
+            gate_output_name: Optional[str] = None
+            input0_name = str(mul_op.inputs[0])
+            input1_name = str(mul_op.inputs[1])
+            for lhs_name, rhs_name in [(input0_name, input1_name), (input1_name, input0_name)]:
+                lhs_prod_idx = producers.get(lhs_name, None)
+                if lhs_prod_idx is None:
+                    continue
+                lhs_prod_op = model_ir.operators[int(lhs_prod_idx)]
+                if str(lhs_prod_op.op_type) != "CONCATENATION":
+                    continue
+                concat_name = str(lhs_name)
+                gate_output_name = str(rhs_name)
+                break
+            if concat_name is None or gate_output_name is None:
+                continue
+
+            concat_idx = producers.get(concat_name, None)
+            if concat_idx is None:
+                continue
+            concat_op = model_ir.operators[int(concat_idx)]
+            if (
+                str(concat_op.op_type) != "CONCATENATION"
+                or len(concat_op.inputs) != 2
+                or len(concat_op.outputs) != 1
+                or str(concat_op.outputs[0]) != concat_name
+                or int(concat_op.options.get("axis", 1)) != 1
+                or concat_name in model_outputs
+            ):
+                continue
+
+            gate_match = _match_hardsigmoid_gate_from_output(
+                gate_output_name=gate_output_name,
+                consumers=consumers,
+                producers=producers,
+            )
+            if gate_match is None:
+                continue
+            gate_head_idx = int(gate_match["head_idx"])
+            gate_head_input_name = str(gate_match["head_input_name"])
+            gate_head_input_index = int(gate_match["head_input_index"])
+            gate_metadata_names = [str(v) for v in list(gate_match.get("metadata_names", []))]
+            gate_head_op = model_ir.operators[int(gate_head_idx)]
+            if gate_head_input_name in model_outputs or gate_output_name in model_outputs:
+                continue
+
+            pre_gate_idx = producers.get(gate_head_input_name, None)
+            if pre_gate_idx is None:
+                continue
+            pre_gate_op = model_ir.operators[int(pre_gate_idx)]
+            if (
+                str(pre_gate_op.op_type) != "TRANSPOSE"
+                or len(pre_gate_op.inputs) < 2
+                or len(pre_gate_op.outputs) != 1
+                or str(pre_gate_op.outputs[0]) != gate_head_input_name
+                or _read_transpose_perm(model_ir, pre_gate_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            gate_conv_output_name = str(pre_gate_op.inputs[0])
+            if gate_conv_output_name in model_outputs:
+                continue
+
+            concat_users = set(int(v) for v in consumers.get(concat_name, []))
+            if concat_users != {int(mul_idx)} and len(concat_users) != 2:
+                continue
+            mean_idx_candidates = [int(v) for v in concat_users if int(v) != int(mul_idx)]
+            if len(mean_idx_candidates) != 1:
+                continue
+            mean_idx = int(mean_idx_candidates[0])
+            mean_op = model_ir.operators[int(mean_idx)]
+            if str(mean_op.op_type) != "MEAN" or len(mean_op.inputs) < 2 or len(mean_op.outputs) != 1:
+                continue
+            if str(mean_op.inputs[0]) != concat_name or not bool(mean_op.options.get("keepDims", False)):
+                continue
+            mean_output_name = str(mean_op.outputs[0])
+            if mean_output_name in model_outputs:
+                continue
+
+            mean_post_users = [int(v) for v in consumers.get(mean_output_name, [])]
+            if len(mean_post_users) != 1:
+                continue
+            mean_post_idx = int(mean_post_users[0])
+            mean_post_op = model_ir.operators[int(mean_post_idx)]
+            if (
+                str(mean_post_op.op_type) != "TRANSPOSE"
+                or len(mean_post_op.inputs) < 2
+                or len(mean_post_op.outputs) != 1
+                or str(mean_post_op.inputs[0]) != mean_output_name
+                or _read_transpose_perm(model_ir, mean_post_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            conv_input_name = str(mean_post_op.outputs[0])
+            if conv_input_name in model_outputs:
+                continue
+
+            conv_idx_candidates = [int(v) for v in consumers.get(conv_input_name, [])]
+            if len(conv_idx_candidates) != 1:
+                continue
+            conv_idx = int(conv_idx_candidates[0])
+            conv_op = model_ir.operators[int(conv_idx)]
+            if (
+                str(conv_op.op_type) != "CONV_2D"
+                or len(conv_op.inputs) < 1
+                or len(conv_op.outputs) != 1
+                or str(conv_op.inputs[0]) != conv_input_name
+            ):
+                continue
+            if str(conv_op.outputs[0]) != gate_conv_output_name:
+                continue
+
+            concat_input_names = [str(v) for v in list(concat_op.inputs)]
+            use_add_main_path = False
+            add_idx: Optional[int] = None
+            add_op: Optional[OperatorIR] = None
+            add_output_name: Optional[str] = None
+            main_pre_idx: Optional[int] = None
+            main_transpose_output_name: Optional[str] = None
+            main_source_nhwc_name: Optional[str] = None
+            point_branch_output_name: Optional[str] = None
+            short_branch_output_name: Optional[str] = None
+
+            # Variant A: CONCAT(ADD(main_nchw, point_branch_nchw), short_branch_nchw)
+            for a_name, b_name in [(concat_input_names[0], concat_input_names[1]), (concat_input_names[1], concat_input_names[0])]:
+                add_candidate_idx = producers.get(a_name, None)
+                if add_candidate_idx is None:
+                    continue
+                add_candidate_op = model_ir.operators[int(add_candidate_idx)]
+                if str(add_candidate_op.op_type) != "ADD":
+                    continue
+                add_input_names = [str(v) for v in list(add_candidate_op.inputs)]
+                for m_name, p_name in [(add_input_names[0], add_input_names[1]), (add_input_names[1], add_input_names[0])]:
+                    pre_idx = producers.get(m_name, None)
+                    if pre_idx is None:
+                        continue
+                    pre_op = model_ir.operators[int(pre_idx)]
+                    if (
+                        str(pre_op.op_type) != "TRANSPOSE"
+                        or len(pre_op.inputs) < 2
+                        or len(pre_op.outputs) != 1
+                        or str(pre_op.outputs[0]) != m_name
+                        or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+                    ):
+                        continue
+                    add_idx = int(add_candidate_idx)
+                    add_op = add_candidate_op
+                    add_output_name = str(a_name)
+                    short_branch_output_name = str(b_name)
+                    main_pre_idx = int(pre_idx)
+                    main_transpose_output_name = str(m_name)
+                    main_source_nhwc_name = str(pre_op.inputs[0])
+                    point_branch_output_name = str(p_name)
+                    use_add_main_path = True
+                    break
+                if use_add_main_path:
+                    break
+
+            # Variant B: CONCAT(point_branch_nchw, short_branch_nchw)
+            if not use_add_main_path:
+                point_branch_output_name = str(concat_input_names[0])
+                short_branch_output_name = str(concat_input_names[1])
+
+            if point_branch_output_name is None or short_branch_output_name is None:
+                continue
+
+            if use_add_main_path:
+                if (
+                    add_idx is None
+                    or add_op is None
+                    or add_output_name is None
+                    or main_pre_idx is None
+                    or main_transpose_output_name is None
+                    or main_source_nhwc_name is None
+                ):
+                    continue
+                if (
+                    str(add_op.op_type) != "ADD"
+                    or len(add_op.inputs) != 2
+                    or len(add_op.outputs) != 1
+                    or str(add_op.outputs[0]) != add_output_name
+                    or add_output_name in model_outputs
+                    or main_source_nhwc_name in model_outputs
+                ):
+                    continue
+
+            point_match = _match_sigmoid_self_mul_from_transpose_output(
+                branch_output_name=str(point_branch_output_name),
+                consumers=consumers,
+                producers=producers,
+            )
+            short_match = _match_sigmoid_self_mul_from_transpose_output(
+                branch_output_name=str(short_branch_output_name),
+                consumers=consumers,
+                producers=producers,
+            )
+            if point_match is None or short_match is None:
+                # Try swapped interpretation for variant-B.
+                if not use_add_main_path:
+                    point_match = _match_sigmoid_self_mul_from_transpose_output(
+                        branch_output_name=str(short_branch_output_name),
+                        consumers=consumers,
+                        producers=producers,
+                    )
+                    short_match = _match_sigmoid_self_mul_from_transpose_output(
+                        branch_output_name=str(point_branch_output_name),
+                        consumers=consumers,
+                        producers=producers,
+                    )
+                    if point_match is not None and short_match is not None:
+                        point_branch_output_name, short_branch_output_name = (
+                            str(short_branch_output_name),
+                            str(point_branch_output_name),
+                        )
+                if point_match is None or short_match is None:
+                    continue
+
+            if int(point_match["transpose_idx"]) == int(short_match["transpose_idx"]):
+                continue
+            if use_add_main_path and (
+                int(point_match["transpose_idx"]) == int(main_pre_idx)
+                or int(short_match["transpose_idx"]) == int(main_pre_idx)
+            ):
+                continue
+
+            if use_add_main_path:
+                if set(int(v) for v in consumers.get(str(main_transpose_output_name), [])) != {int(add_idx)}:
+                    continue
+                if set(int(v) for v in consumers.get(str(point_branch_output_name), [])) != {int(add_idx)}:
+                    continue
+                if set(int(v) for v in consumers.get(str(short_branch_output_name), [])) != {int(concat_idx)}:
+                    continue
+            else:
+                if set(int(v) for v in consumers.get(str(point_branch_output_name), [])) != {int(concat_idx)}:
+                    continue
+                if set(int(v) for v in consumers.get(str(short_branch_output_name), [])) != {int(concat_idx)}:
+                    continue
+            if set(int(v) for v in consumers.get(mean_output_name, [])) != {int(mean_post_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(conv_input_name, [])) != {int(conv_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(gate_conv_output_name, [])) != {int(pre_gate_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(gate_head_input_name, [])) != {int(gate_head_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(gate_output_name, [])) != {int(mul_idx)}:
+                continue
+
+            mean_axes_tensor = model_ir.tensors.get(str(mean_op.inputs[1]), None)
+            mean_axes_vals = _read_const_ints_from_tensor(mean_axes_tensor)
+            if mean_axes_vals is None or len(mean_axes_vals) == 0:
+                continue
+            normalized_axes: List[int] = []
+            valid_axes = True
+            for axis in mean_axes_vals:
+                a = int(axis)
+                if a < 0:
+                    a += 4
+                if a < 0 or a >= 4:
+                    valid_axes = False
+                    break
+                normalized_axes.append(int(a))
+            if not valid_axes:
+                continue
+            mapped_axes = [int(perm_nhwc_to_nchw[int(axis)]) for axis in normalized_axes]
+            if not _write_const_ints_to_tensor(mean_axes_tensor, [int(v) for v in mapped_axes]):
+                continue
+
+            short_sig_op = model_ir.operators[int(short_match["sigmoid_idx"])]
+            short_mul_op = model_ir.operators[int(short_match["mul_idx"])]
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=short_sig_op,
+                new_inputs=[str(short_match["source_nhwc_name"])],
+            )
+            short_mul_inputs = [
+                str(short_match["source_nhwc_name"])
+                if str(v) == str(short_match["transpose_output_name"])
+                else str(v)
+                for v in list(short_mul_op.inputs)
+            ]
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=short_mul_op,
+                new_inputs=short_mul_inputs,
+            )
+
+            point_sig_op = model_ir.operators[int(point_match["sigmoid_idx"])]
+            point_mul_op = model_ir.operators[int(point_match["mul_idx"])]
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=point_sig_op,
+                new_inputs=[str(point_match["source_nhwc_name"])],
+            )
+            point_mul_inputs = [
+                str(point_match["source_nhwc_name"])
+                if str(v) == str(point_match["transpose_output_name"])
+                else str(v)
+                for v in list(point_mul_op.inputs)
+            ]
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=point_mul_op,
+                new_inputs=point_mul_inputs,
+            )
+
+            if use_add_main_path and add_op is not None:
+                add_inputs = [
+                    str(main_source_nhwc_name)
+                    if str(v) == str(main_transpose_output_name)
+                    else str(v)
+                    for v in list(add_op.inputs)
+                ]
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=add_op,
+                    new_inputs=add_inputs,
+                )
+
+            concat_op.options = dict(concat_op.options) if isinstance(concat_op.options, dict) else {}
+            concat_op.options["axis"] = 3
+
+            conv_inputs = [str(v) for v in list(conv_op.inputs)]
+            conv_inputs[0] = str(mean_output_name)
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=conv_op,
+                new_inputs=conv_inputs,
+            )
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=gate_head_op,
+                input_index=int(gate_head_input_index),
+                new_input_name=str(gate_conv_output_name),
+            )
+
+            old_mul_tensor = model_ir.tensors.get(mul_output_name, None)
+            old_mul_shape = (
+                [int(v) for v in list(old_mul_tensor.shape)]
+                if old_mul_tensor is not None and old_mul_tensor.shape is not None
+                else None
+            )
+            old_mul_signature = (
+                [int(v) for v in list(old_mul_tensor.shape_signature)]
+                if old_mul_tensor is not None and old_mul_tensor.shape_signature is not None
+                else (
+                    [int(v) for v in list(old_mul_tensor.shape)]
+                    if old_mul_tensor is not None and old_mul_tensor.shape is not None
+                    else None
+                )
+            )
+
+            metadata_targets = [
+                str(short_match["sigmoid_output_name"]),
+                str(short_match["branch_output_name"]),
+                str(point_match["sigmoid_output_name"]),
+                str(point_match["branch_output_name"]),
+                str(concat_name),
+                str(mean_output_name),
+                *[str(v) for v in gate_metadata_names],
+                str(mul_output_name),
+            ]
+            if use_add_main_path and add_output_name is not None:
+                metadata_targets.insert(4, str(add_output_name))
+            for tensor_name in list(dict.fromkeys(metadata_targets)):
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(tensor_name), None),
+                    perm_nchw_to_nhwc,
+                )
+
+            canonical_post_output_name = str(post_output_names[0])
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=mul_op,
+                new_outputs=[canonical_post_output_name],
+            )
+            _replace_tensor_inputs(model_ir, mul_output_name, canonical_post_output_name)
+            for alias_name in post_output_names[1:]:
+                _replace_tensor_inputs(model_ir, str(alias_name), canonical_post_output_name)
+
+            canonical_tensor = model_ir.tensors.get(canonical_post_output_name, None)
+            if canonical_tensor is not None and old_mul_tensor is not None:
+                canonical_tensor.dtype = str(old_mul_tensor.dtype)
+                canonical_tensor.quantization = _clone_quantization(old_mul_tensor.quantization)
+                if old_mul_shape is not None:
+                    canonical_tensor.shape = [int(v) for v in list(old_mul_shape)]
+                if old_mul_signature is not None:
+                    canonical_tensor.shape_signature = [int(v) for v in list(old_mul_signature)]
+                _permute_tensor_metadata_if_rank_matches(
+                    canonical_tensor,
+                    perm_nchw_to_nhwc,
+                )
+
+            remove_indices = {
+                int(short_match["transpose_idx"]),
+                int(point_match["transpose_idx"]),
+                int(mean_post_idx),
+                int(pre_gate_idx),
+                *[int(v) for v in post_indices],
+            }
+            if use_add_main_path and main_pre_idx is not None:
+                remove_indices.add(int(main_pre_idx))
+            for remove_idx in sorted(remove_indices, reverse=True):
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_csp_attention_nhwc_chains": int(rewritten)}
+
+
+def _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Propagate NHWC across SiNet-like SA/PA attention branches with MIRROR_PAD.
+
+    This pass targets the strict motif:
+      x_nhwc --T(0,3,1,2)--> x_nchw
+      x_nchw -> (MEAN, REDUCE_MAX, RESHAPE[unsqueeze0])
+      MEAN/REDUCE_MAX -> CONCAT(axis=1) -> MIRROR_PAD -> T(0,2,3,1) -> CONV -> RESHAPE
+      CA branch output_nhwc -> T(0,3,1,2)
+      ADD(sa_nchw, ca_nchw) -> RESHAPE[unsqueeze1] -> CONCAT(axis=2) -> RESHAPE -> MIRROR_PAD
+      -> T(0,2,3,1) -> CONV -> LOGISTIC -> MUL(x_nhwc, gate)
+
+    Rewrite:
+      - keep SA/PA branches in NHWC (rewrite axes/pads/reshape-shapes/concat-axis)
+      - remove bridge transposes and redundant SA reshape
+      - keep output tensor names stable for downstream users
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    # For PA unsqueeze/concat branch: [N,C,K,H,W] -> [N,H,W,C,K]
+    # This preserves channel-interleaving order when reshaping [C,2] -> [2C].
+    perm5_nckhw_to_nhwck = [0, 3, 4, 1, 2]
+
+    def _normalize_axis(axis: int, rank: int) -> Optional[int]:
+        value = int(axis)
+        if value < 0:
+            value += int(rank)
+        if value < 0 or value >= int(rank):
+            return None
+        return int(value)
+
+    def _unique_tensor_name(base: str) -> str:
+        candidate = str(base)
+        suffix = 0
+        while candidate in model_ir.tensors:
+            suffix += 1
+            candidate = f"{base}_{suffix}"
+        return str(candidate)
+
+    def _rewrite_reduce_axes_nchw_to_nhwc(op: OperatorIR) -> bool:
+        if len(op.inputs) < 2:
+            return False
+        axes_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+        axes_vals = _read_const_ints_from_tensor(axes_tensor)
+        if axes_vals is None or len(axes_vals) == 0:
+            return False
+        mapped_axes: List[int] = []
+        for axis in axes_vals:
+            normalized = _normalize_axis(int(axis), 4)
+            if normalized is None:
+                return False
+            mapped_axes.append(int(perm_nhwc_to_nchw[int(normalized)]))
+        _write_const_ints_to_tensor(axes_tensor, [int(v) for v in mapped_axes])
+        return True
+
+    def _rewrite_pad_pairs_nchw_to_nhwc(op: OperatorIR) -> bool:
+        if len(op.inputs) < 2:
+            return False
+        pads_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+        if pads_tensor is None or pads_tensor.data is None:
+            return False
+        try:
+            pads_array = np.asarray(pads_tensor.data)
+            pads_pairs = np.asarray(pads_array).reshape(4, 2)
+        except Exception:
+            return False
+        if int(pads_pairs.size) != 8:
+            return False
+        # NCHW [N,C,H,W] -> NHWC [N,H,W,C]
+        pads_nhwc = np.asarray(
+            [
+                pads_pairs[0],
+                pads_pairs[2],
+                pads_pairs[3],
+                pads_pairs[1],
+            ],
+            dtype=pads_array.dtype,
+        )
+        pads_tensor.data = np.asarray(pads_nhwc)
+        pads_tensor.shape = [4, 2]
+        pads_tensor.shape_signature = [4, 2]
+        return True
+
+    def _rewrite_reshape_shape_by_perm(
+        *,
+        reshape_op: OperatorIR,
+        index_perm: List[int],
+    ) -> bool:
+        if len(reshape_op.inputs) < 2:
+            return False
+        shape_tensor = model_ir.tensors.get(str(reshape_op.inputs[1]), None)
+        shape_vals = _read_const_ints_from_tensor(shape_tensor)
+        if shape_vals is None or len(shape_vals) != len(index_perm):
+            return False
+        mapped_shape = [int(shape_vals[int(idx)]) for idx in index_perm]
+        _write_const_ints_to_tensor(shape_tensor, mapped_shape)
+        if isinstance(reshape_op.options, dict):
+            opts = dict(reshape_op.options)
+            opts_changed = False
+            for key in ["newShape", "onnxRawNewShape"]:
+                value = opts.get(key, None)
+                if not isinstance(value, list) or len(value) != len(index_perm):
+                    continue
+                mapped_value = [int(value[int(idx)]) for idx in index_perm]
+                if mapped_value != [int(v) for v in value]:
+                    opts[key] = [int(v) for v in mapped_value]
+                    opts_changed = True
+            if opts_changed:
+                reshape_op.options = opts
+        return True
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for pre_idx, pre_op in enumerate(model_ir.operators):
+            if (
+                str(pre_op.op_type) != "TRANSPOSE"
+                or len(pre_op.inputs) < 2
+                or len(pre_op.outputs) != 1
+                or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            source_nhwc_name = str(pre_op.inputs[0])
+            source_nchw_name = str(pre_op.outputs[0])
+            if source_nchw_name in model_outputs:
+                continue
+
+            source_users = [int(v) for v in consumers.get(source_nchw_name, [])]
+            if len(source_users) < 3 or len(source_users) > 4:
+                continue
+
+            mean_idx: Optional[int] = None
+            max_idx: Optional[int] = None
+            unsq0_idx: Optional[int] = None
+            optional_source_mul_idx: Optional[int] = None
+            invalid_source_fanout = False
+            for user_idx in source_users:
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) == "MEAN"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == source_nchw_name
+                    and bool(user_op.options.get("keepDims", False))
+                ):
+                    mean_idx = int(user_idx)
+                    continue
+                if (
+                    str(user_op.op_type) == "REDUCE_MAX"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == source_nchw_name
+                    and bool(user_op.options.get("keepDims", False))
+                ):
+                    max_idx = int(user_idx)
+                    continue
+                if (
+                    str(user_op.op_type) == "RESHAPE"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == source_nchw_name
+                ):
+                    unsq0_idx = int(user_idx)
+                    continue
+                if optional_source_mul_idx is not None:
+                    invalid_source_fanout = True
+                    break
+                optional_source_mul_idx = int(user_idx)
+            if invalid_source_fanout:
+                continue
+            if mean_idx is None or max_idx is None or unsq0_idx is None:
+                continue
+
+            mean_op = model_ir.operators[int(mean_idx)]
+            max_op = model_ir.operators[int(max_idx)]
+            unsq0_op = model_ir.operators[int(unsq0_idx)]
+
+            mean_out_name = str(mean_op.outputs[0])
+            max_out_name = str(max_op.outputs[0])
+            unsq0_out_name = str(unsq0_op.outputs[0])
+            if (
+                mean_out_name in model_outputs
+                or max_out_name in model_outputs
+                or unsq0_out_name in model_outputs
+            ):
+                continue
+
+            if len(consumers.get(mean_out_name, [])) != 1 or len(consumers.get(max_out_name, [])) != 1:
+                continue
+            concat_sa_idx = int(consumers[mean_out_name][0])
+            if int(consumers[max_out_name][0]) != int(concat_sa_idx):
+                continue
+            concat_sa_op = model_ir.operators[int(concat_sa_idx)]
+            if (
+                str(concat_sa_op.op_type) != "CONCATENATION"
+                or len(concat_sa_op.inputs) != 2
+                or len(concat_sa_op.outputs) != 1
+            ):
+                continue
+            concat_sa_axis = int(concat_sa_op.options.get("axis", 1))
+            if concat_sa_axis < 0:
+                concat_sa_axis += 4
+            if concat_sa_axis != 1:
+                continue
+
+            concat_sa_out_name = str(concat_sa_op.outputs[0])
+            concat_sa_users = [int(v) for v in consumers.get(concat_sa_out_name, [])]
+            if len(concat_sa_users) != 1:
+                continue
+            mirror_sa_idx = int(concat_sa_users[0])
+            mirror_sa_op = model_ir.operators[int(mirror_sa_idx)]
+            if (
+                str(mirror_sa_op.op_type) != "MIRROR_PAD"
+                or len(mirror_sa_op.inputs) < 2
+                or len(mirror_sa_op.outputs) != 1
+                or str(mirror_sa_op.inputs[0]) != concat_sa_out_name
+            ):
+                continue
+
+            mirror_sa_out_name = str(mirror_sa_op.outputs[0])
+            mirror_sa_users = [int(v) for v in consumers.get(mirror_sa_out_name, [])]
+            if len(mirror_sa_users) != 1:
+                continue
+            trans_sa_idx = int(mirror_sa_users[0])
+            trans_sa_op = model_ir.operators[int(trans_sa_idx)]
+            if (
+                str(trans_sa_op.op_type) != "TRANSPOSE"
+                or len(trans_sa_op.inputs) < 2
+                or len(trans_sa_op.outputs) != 1
+                or str(trans_sa_op.inputs[0]) != mirror_sa_out_name
+                or _read_transpose_perm(model_ir, trans_sa_op) != perm_nchw_to_nhwc
+            ):
+                continue
+
+            sa_conv_in_name = str(trans_sa_op.outputs[0])
+            sa_conv_users = [int(v) for v in consumers.get(sa_conv_in_name, [])]
+            if len(sa_conv_users) != 1:
+                continue
+            sa_conv_idx = int(sa_conv_users[0])
+            sa_conv_op = model_ir.operators[int(sa_conv_idx)]
+            if (
+                str(sa_conv_op.op_type) != "CONV_2D"
+                or len(sa_conv_op.inputs) < 1
+                or len(sa_conv_op.outputs) != 1
+                or str(sa_conv_op.inputs[0]) != sa_conv_in_name
+            ):
+                continue
+
+            sa_conv_out_name = str(sa_conv_op.outputs[0])
+            sa_conv_out_users = [int(v) for v in consumers.get(sa_conv_out_name, [])]
+            if len(sa_conv_out_users) != 1:
+                continue
+            sa_reshape_idx = int(sa_conv_out_users[0])
+            sa_reshape_op = model_ir.operators[int(sa_reshape_idx)]
+            if (
+                str(sa_reshape_op.op_type) != "RESHAPE"
+                or len(sa_reshape_op.inputs) < 1
+                or len(sa_reshape_op.outputs) != 1
+                or str(sa_reshape_op.inputs[0]) != sa_conv_out_name
+            ):
+                continue
+            sa_nchw_name = str(sa_reshape_op.outputs[0])
+            if sa_nchw_name in model_outputs:
+                continue
+
+            sa_add_users = [int(v) for v in consumers.get(sa_nchw_name, [])]
+            if len(sa_add_users) != 1:
+                continue
+            add_idx = int(sa_add_users[0])
+            add_op = model_ir.operators[int(add_idx)]
+            if str(add_op.op_type) != "ADD" or len(add_op.inputs) != 2 or len(add_op.outputs) != 1:
+                continue
+            add_inputs = [str(v) for v in list(add_op.inputs)]
+            if sa_nchw_name not in add_inputs:
+                continue
+            ca_nchw_name = (
+                str(add_inputs[1]) if str(add_inputs[0]) == sa_nchw_name else str(add_inputs[0])
+            )
+
+            trans_ca_idx = producers.get(ca_nchw_name, None)
+            if trans_ca_idx is None:
+                continue
+            trans_ca_op = model_ir.operators[int(trans_ca_idx)]
+            if (
+                str(trans_ca_op.op_type) != "TRANSPOSE"
+                or len(trans_ca_op.inputs) < 2
+                or len(trans_ca_op.outputs) != 1
+                or str(trans_ca_op.outputs[0]) != ca_nchw_name
+                or _read_transpose_perm(model_ir, trans_ca_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            ca_nhwc_name = str(trans_ca_op.inputs[0])
+            if ca_nhwc_name in model_outputs:
+                continue
+            if set(int(v) for v in consumers.get(ca_nchw_name, [])) != {int(add_idx)}:
+                continue
+
+            add_out_name = str(add_op.outputs[0])
+            if add_out_name in model_outputs:
+                continue
+            add_out_users = [int(v) for v in consumers.get(add_out_name, [])]
+            if len(add_out_users) != 1:
+                continue
+            unsq1_idx = int(add_out_users[0])
+            unsq1_op = model_ir.operators[int(unsq1_idx)]
+            if (
+                str(unsq1_op.op_type) != "RESHAPE"
+                or len(unsq1_op.inputs) < 2
+                or len(unsq1_op.outputs) != 1
+                or str(unsq1_op.inputs[0]) != add_out_name
+            ):
+                continue
+
+            unsq1_out_name = str(unsq1_op.outputs[0])
+            if unsq1_out_name in model_outputs:
+                continue
+            if len(consumers.get(unsq0_out_name, [])) != 1 or len(consumers.get(unsq1_out_name, [])) != 1:
+                continue
+            concat_pa_idx = int(consumers[unsq0_out_name][0])
+            if int(consumers[unsq1_out_name][0]) != int(concat_pa_idx):
+                continue
+            concat_pa_op = model_ir.operators[int(concat_pa_idx)]
+            if (
+                str(concat_pa_op.op_type) != "CONCATENATION"
+                or len(concat_pa_op.inputs) != 2
+                or len(concat_pa_op.outputs) != 1
+            ):
+                continue
+            concat_pa_axis = int(concat_pa_op.options.get("axis", 2))
+            if concat_pa_axis < 0:
+                concat_pa_axis += 5
+            if concat_pa_axis != 2:
+                continue
+            concat_pa_inputs = [str(v) for v in list(concat_pa_op.inputs)]
+            if set(concat_pa_inputs) != {str(unsq0_out_name), str(unsq1_out_name)}:
+                continue
+
+            concat_pa_out_name = str(concat_pa_op.outputs[0])
+            if concat_pa_out_name in model_outputs:
+                continue
+            concat_pa_users = [int(v) for v in consumers.get(concat_pa_out_name, [])]
+            if len(concat_pa_users) != 1:
+                continue
+            reshape_pa_idx = int(concat_pa_users[0])
+            reshape_pa_op = model_ir.operators[int(reshape_pa_idx)]
+            if (
+                str(reshape_pa_op.op_type) != "RESHAPE"
+                or len(reshape_pa_op.inputs) < 2
+                or len(reshape_pa_op.outputs) != 1
+                or str(reshape_pa_op.inputs[0]) != concat_pa_out_name
+            ):
+                continue
+
+            reshape_pa_out_name = str(reshape_pa_op.outputs[0])
+            if reshape_pa_out_name in model_outputs:
+                continue
+            reshape_pa_users = [int(v) for v in consumers.get(reshape_pa_out_name, [])]
+            if len(reshape_pa_users) != 1:
+                continue
+            mirror_pa_idx = int(reshape_pa_users[0])
+            mirror_pa_op = model_ir.operators[int(mirror_pa_idx)]
+            if (
+                str(mirror_pa_op.op_type) != "MIRROR_PAD"
+                or len(mirror_pa_op.inputs) < 2
+                or len(mirror_pa_op.outputs) != 1
+                or str(mirror_pa_op.inputs[0]) != reshape_pa_out_name
+            ):
+                continue
+
+            mirror_pa_out_name = str(mirror_pa_op.outputs[0])
+            mirror_pa_users = [int(v) for v in consumers.get(mirror_pa_out_name, [])]
+            if len(mirror_pa_users) != 1:
+                continue
+            trans_pa_idx = int(mirror_pa_users[0])
+            trans_pa_op = model_ir.operators[int(trans_pa_idx)]
+            if (
+                str(trans_pa_op.op_type) != "TRANSPOSE"
+                or len(trans_pa_op.inputs) < 2
+                or len(trans_pa_op.outputs) != 1
+                or str(trans_pa_op.inputs[0]) != mirror_pa_out_name
+                or _read_transpose_perm(model_ir, trans_pa_op) != perm_nchw_to_nhwc
+            ):
+                continue
+
+            pa_conv_in_name = str(trans_pa_op.outputs[0])
+            pa_conv_users = [int(v) for v in consumers.get(pa_conv_in_name, [])]
+            if len(pa_conv_users) != 1:
+                continue
+            pa_conv_idx = int(pa_conv_users[0])
+            pa_conv_op = model_ir.operators[int(pa_conv_idx)]
+            if (
+                str(pa_conv_op.op_type) != "CONV_2D"
+                or len(pa_conv_op.inputs) < 1
+                or len(pa_conv_op.outputs) != 1
+                or str(pa_conv_op.inputs[0]) != pa_conv_in_name
+            ):
+                continue
+
+            pa_conv_out_name = str(pa_conv_op.outputs[0])
+            pa_conv_out_users = [int(v) for v in consumers.get(pa_conv_out_name, [])]
+            if len(pa_conv_out_users) != 1:
+                continue
+            gate_pre_idx: Optional[int] = None
+            gate_idx = int(pa_conv_out_users[0])
+            gate_op = model_ir.operators[int(gate_idx)]
+            gate_input_name = str(pa_conv_out_name)
+            if str(gate_op.op_type) == "TRANSPOSE":
+                if (
+                    len(gate_op.inputs) < 2
+                    or len(gate_op.outputs) != 1
+                    or str(gate_op.inputs[0]) != pa_conv_out_name
+                    or _read_transpose_perm(model_ir, gate_op) != perm_nhwc_to_nchw
+                ):
+                    continue
+                gate_pre_idx = int(gate_idx)
+                gate_input_name = str(gate_op.outputs[0])
+                if gate_input_name in model_outputs:
+                    continue
+                gate_pre_users = [int(v) for v in consumers.get(gate_input_name, [])]
+                if len(gate_pre_users) != 1:
+                    continue
+                gate_idx = int(gate_pre_users[0])
+                gate_op = model_ir.operators[int(gate_idx)]
+            if (
+                str(gate_op.op_type) != "LOGISTIC"
+                or len(gate_op.inputs) != 1
+                or len(gate_op.outputs) != 1
+                or str(gate_op.inputs[0]) != gate_input_name
+            ):
+                continue
+
+            gate_out_name = str(gate_op.outputs[0])
+            gate_out_users = [int(v) for v in consumers.get(gate_out_name, [])]
+            if len(gate_out_users) != 1:
+                continue
+            mul_idx = int(gate_out_users[0])
+            mul_op = model_ir.operators[int(mul_idx)]
+            if str(mul_op.op_type) != "MUL" or len(mul_op.inputs) != 2 or len(mul_op.outputs) != 1:
+                continue
+            mul_inputs = [str(v) for v in list(mul_op.inputs)]
+            if str(gate_out_name) not in mul_inputs:
+                continue
+            mul_uses_source_nhwc = str(source_nhwc_name) in mul_inputs
+            mul_uses_source_nchw = str(source_nchw_name) in mul_inputs
+            if (not mul_uses_source_nhwc and not mul_uses_source_nchw) or (
+                mul_uses_source_nhwc and mul_uses_source_nchw
+            ):
+                continue
+            if optional_source_mul_idx is None:
+                if mul_uses_source_nchw:
+                    continue
+            else:
+                if int(optional_source_mul_idx) != int(mul_idx) or not mul_uses_source_nchw:
+                    continue
+
+            if source_nchw_name in model_outputs:
+                continue
+
+            # Strict locality guards on branch-only outputs.
+            if set(int(v) for v in consumers.get(sa_conv_out_name, [])) != {int(sa_reshape_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(sa_nchw_name, [])) != {int(add_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(add_out_name, [])) != {int(unsq1_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(concat_sa_out_name, [])) != {int(mirror_sa_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(mirror_sa_out_name, [])) != {int(trans_sa_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(pa_conv_in_name, [])) != {int(pa_conv_idx)}:
+                continue
+            if gate_pre_idx is None:
+                if set(int(v) for v in consumers.get(pa_conv_out_name, [])) != {int(gate_idx)}:
+                    continue
+            else:
+                if set(int(v) for v in consumers.get(pa_conv_out_name, [])) != {int(gate_pre_idx)}:
+                    continue
+                if set(int(v) for v in consumers.get(gate_input_name, [])) != {int(gate_idx)}:
+                    continue
+            if set(int(v) for v in consumers.get(gate_out_name, [])) != {int(mul_idx)}:
+                continue
+
+            if not _rewrite_reduce_axes_nchw_to_nhwc(mean_op):
+                continue
+            if not _rewrite_reduce_axes_nchw_to_nhwc(max_op):
+                continue
+            if not _rewrite_pad_pairs_nchw_to_nhwc(mirror_sa_op):
+                continue
+            if not _rewrite_reshape_shape_by_perm(
+                reshape_op=unsq0_op,
+                index_perm=perm5_nckhw_to_nhwck,
+            ):
+                continue
+            if not _rewrite_reshape_shape_by_perm(
+                reshape_op=unsq1_op,
+                index_perm=perm5_nckhw_to_nhwck,
+            ):
+                continue
+            if not _rewrite_reshape_shape_by_perm(
+                reshape_op=reshape_pa_op,
+                index_perm=perm_nchw_to_nhwc,
+            ):
+                continue
+            if not _rewrite_pad_pairs_nchw_to_nhwc(mirror_pa_op):
+                continue
+
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=mean_op,
+                input_index=0,
+                new_input_name=str(source_nhwc_name),
+            )
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=max_op,
+                input_index=0,
+                new_input_name=str(source_nhwc_name),
+            )
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=unsq0_op,
+                input_index=0,
+                new_input_name=str(source_nhwc_name),
+            )
+            concat_sa_op.options["axis"] = 3
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=sa_conv_op,
+                input_index=0,
+                new_input_name=str(mirror_sa_out_name),
+            )
+
+            add_new_inputs = [
+                str(sa_conv_out_name) if str(v) == str(sa_nchw_name) else (
+                    str(ca_nhwc_name) if str(v) == str(ca_nchw_name) else str(v)
+                )
+                for v in list(add_inputs)
+            ]
+            _set_operator_inputs(
+                model_ir=model_ir,
+                op=add_op,
+                new_inputs=add_new_inputs,
+            )
+
+            concat_pa_op.options["axis"] = 4
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=pa_conv_op,
+                input_index=0,
+                new_input_name=str(mirror_pa_out_name),
+            )
+            if gate_pre_idx is not None:
+                _replace_operator_input_at(
+                    model_ir=model_ir,
+                    op=gate_op,
+                    input_index=0,
+                    new_input_name=str(pa_conv_out_name),
+                )
+            if mul_uses_source_nchw:
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=mul_op,
+                    new_inputs=[
+                        str(source_nhwc_name) if str(v) == str(source_nchw_name) else str(v)
+                        for v in list(mul_inputs)
+                    ],
+                )
+
+            for tensor_name in [
+                str(mean_out_name),
+                str(max_out_name),
+                str(concat_sa_out_name),
+                str(mirror_sa_out_name),
+                str(add_out_name),
+                str(reshape_pa_out_name),
+                str(mirror_pa_out_name),
+            ]:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(tensor_name), None),
+                    perm_nchw_to_nhwc,
+                )
+            if gate_pre_idx is not None:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(gate_out_name), None),
+                    perm_nchw_to_nhwc,
+                )
+            for tensor_name in [
+                str(unsq0_out_name),
+                str(unsq1_out_name),
+                str(concat_pa_out_name),
+            ]:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(tensor_name), None),
+                    perm5_nckhw_to_nhwck,
+                )
+
+            if mul_uses_source_nchw:
+                legacy_mul_output_name = str(mul_op.outputs[0])
+                legacy_mul_tensor = model_ir.tensors.get(legacy_mul_output_name, None)
+                mul_nhwc_output_name = _unique_tensor_name(f"{legacy_mul_output_name}_nhwc")
+                _set_operator_outputs(
+                    model_ir=model_ir,
+                    op=mul_op,
+                    new_outputs=[str(mul_nhwc_output_name)],
+                )
+                if legacy_mul_tensor is not None:
+                    model_ir.tensors[str(mul_nhwc_output_name)] = TensorIR(
+                        name=str(mul_nhwc_output_name),
+                        dtype=str(legacy_mul_tensor.dtype),
+                        shape=[int(v) for v in list(legacy_mul_tensor.shape)],
+                        shape_signature=(
+                            [int(v) for v in list(legacy_mul_tensor.shape_signature)]
+                            if legacy_mul_tensor.shape_signature is not None
+                            else [int(v) for v in list(legacy_mul_tensor.shape)]
+                        ),
+                        data=None,
+                        is_variable=False,
+                        quantization=_clone_quantization(legacy_mul_tensor.quantization),
+                    )
+                    _permute_tensor_metadata_if_rank_matches(
+                        model_ir.tensors.get(str(mul_nhwc_output_name), None),
+                        perm_nchw_to_nhwc,
+                    )
+                else:
+                    model_ir.tensors[str(mul_nhwc_output_name)] = TensorIR(
+                        name=str(mul_nhwc_output_name),
+                        dtype="FLOAT32",
+                        shape=[1],
+                        shape_signature=[1],
+                        data=None,
+                        is_variable=False,
+                        quantization=None,
+                    )
+                nhwc_to_nchw_perm_name = _unique_tensor_name(
+                    f"{legacy_mul_output_name}_perm_nhwc_to_nchw"
+                )
+                model_ir.tensors[str(nhwc_to_nchw_perm_name)] = TensorIR(
+                    name=str(nhwc_to_nchw_perm_name),
+                    dtype="INT32",
+                    shape=[4],
+                    shape_signature=[4],
+                    data=np.asarray(perm_nhwc_to_nchw, dtype=np.int32),
+                    is_variable=False,
+                    quantization=None,
+                )
+                model_ir.operators.insert(
+                    int(mul_idx) + 1,
+                    OperatorIR(
+                        op_type="TRANSPOSE",
+                        inputs=[str(mul_nhwc_output_name), str(nhwc_to_nchw_perm_name)],
+                        outputs=[str(legacy_mul_output_name)],
+                    ),
+                )
+
+            remove_indices = sorted(
+                list(
+                    {
+                        int(pre_idx),
+                        int(trans_ca_idx),
+                        int(trans_sa_idx),
+                        int(sa_reshape_idx),
+                        int(trans_pa_idx),
+                        *([int(gate_pre_idx)] if gate_pre_idx is not None else []),
+                    }
+                ),
+                reverse=True,
+            )
+            for remove_idx in remove_indices:
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_sa_pa_mirrorpad_nhwc_propagation_chains": int(rewritten)}
+
+
+def _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate NCHW bridge transposes around SiNet mix attention tails (mix1-like).
+
+    Strict target sketch:
+      src_nchw = ADD(branch_nchw, residual_nchw)
+      (SA/PA attention branches on src_nchw with MIRROR_PAD + TRANSPOSE wrappers)
+      gate_nchw = LOGISTIC(LOGISTIC(T(pa_conv_nhwc)))
+      mix_mul_nchw = MUL(gate_nchw, branch_nchw)
+      mix_add2_nchw = ADD(src_nchw, mix_mul_nchw)
+      mix_mul1_nchw = MUL(SUB(const, gate_nchw), residual_nchw)
+      mix_add3_nchw = ADD(mix_add2_nchw, mix_mul1_nchw)
+      mix_add3_nchw --T(0,2,3,1)--> mix_conv_in_nhwc
+
+      Upstream (strict for this rewrite):
+        branch_nchw = T(branch_nhwc)
+        residual_nchw = ADD(T(residual_a_nhwc), T(residual_b_nhwc))
+
+    Rewrite:
+      - Keep source/attention/tail composition in NHWC.
+      - Remove bridge transposes in SA/PA and tail.
+      - Remove upstream branch/residual adapters when safely local.
+    """
+    optimized = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    perm5_nckhw_to_nhwck = [0, 3, 4, 1, 2]
+
+    def _normalize_axis(axis: int, rank: int) -> Optional[int]:
+        value = int(axis)
+        if value < 0:
+            value += int(rank)
+        if value < 0 or value >= int(rank):
+            return None
+        return int(value)
+
+    def _rewrite_reduce_axes_nchw_to_nhwc(op: OperatorIR) -> bool:
+        if len(op.inputs) < 2:
+            return False
+        axes_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+        axes_vals = _read_const_ints_from_tensor(axes_tensor)
+        if axes_vals is None or len(axes_vals) == 0:
+            return False
+        mapped_axes: List[int] = []
+        for axis in axes_vals:
+            normalized = _normalize_axis(int(axis), 4)
+            if normalized is None:
+                return False
+            mapped_axes.append(int(perm_nhwc_to_nchw[int(normalized)]))
+        return bool(_write_const_ints_to_tensor(axes_tensor, [int(v) for v in mapped_axes]))
+
+    def _rewrite_pad_pairs_nchw_to_nhwc(op: OperatorIR) -> bool:
+        if len(op.inputs) < 2:
+            return False
+        pads_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+        if pads_tensor is None or pads_tensor.data is None:
+            return False
+        try:
+            pads_array = np.asarray(pads_tensor.data)
+            pads_pairs = np.asarray(pads_array).reshape(4, 2)
+        except Exception:
+            return False
+        if int(pads_pairs.size) != 8:
+            return False
+        pads_nhwc = np.asarray(
+            [pads_pairs[0], pads_pairs[2], pads_pairs[3], pads_pairs[1]],
+            dtype=pads_array.dtype,
+        )
+        pads_tensor.data = np.asarray(pads_nhwc)
+        pads_tensor.shape = [4, 2]
+        pads_tensor.shape_signature = [4, 2]
+        return True
+
+    def _rewrite_reshape_shape_by_perm(
+        *,
+        reshape_op: OperatorIR,
+        index_perm: List[int],
+    ) -> bool:
+        if len(reshape_op.inputs) < 2:
+            return False
+        shape_tensor = model_ir.tensors.get(str(reshape_op.inputs[1]), None)
+        shape_vals = _read_const_ints_from_tensor(shape_tensor)
+        if shape_vals is None or len(shape_vals) != len(index_perm):
+            return False
+        mapped_shape = [int(shape_vals[int(idx)]) for idx in index_perm]
+        if not _write_const_ints_to_tensor(shape_tensor, mapped_shape):
+            return False
+        if isinstance(reshape_op.options, dict):
+            opts = dict(reshape_op.options)
+            opts_changed = False
+            for key in ["newShape", "onnxRawNewShape"]:
+                value = opts.get(key, None)
+                if not isinstance(value, list) or len(value) != len(index_perm):
+                    continue
+                mapped_value = [int(value[int(idx)]) for idx in index_perm]
+                if mapped_value != [int(v) for v in value]:
+                    opts[key] = [int(v) for v in mapped_value]
+                    opts_changed = True
+            if opts_changed:
+                reshape_op.options = opts
+        return True
+
+    def _match_input_from_producer_type(
+        *,
+        target_op: OperatorIR,
+        producers: Dict[str, int],
+        required_type: str,
+    ) -> Optional[Tuple[int, int, OperatorIR]]:
+        for input_idx, input_name in enumerate(list(target_op.inputs)):
+            prod_idx = producers.get(str(input_name), None)
+            if prod_idx is None:
+                continue
+            prod_op = model_ir.operators[int(prod_idx)]
+            if str(prod_op.op_type) == str(required_type):
+                return int(input_idx), int(prod_idx), prod_op
+        return None
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for post_idx, post_op in enumerate(model_ir.operators):
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or _read_transpose_perm(model_ir, post_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            post_in_name = str(post_op.inputs[0])
+            post_out_name = str(post_op.outputs[0])
+            if post_in_name in model_outputs:
+                continue
+
+            post_users = [int(v) for v in consumers.get(post_out_name, [])]
+            if len(post_users) != 1:
+                continue
+            post_conv_idx = int(post_users[0])
+            post_conv_op = model_ir.operators[int(post_conv_idx)]
+            if (
+                str(post_conv_op.op_type) != "CONV_2D"
+                or len(post_conv_op.inputs) < 1
+                or str(post_conv_op.inputs[0]) != post_out_name
+            ):
+                continue
+
+            add3_idx = producers.get(post_in_name, None)
+            if add3_idx is None:
+                continue
+            add3_op = model_ir.operators[int(add3_idx)]
+            if str(add3_op.op_type) != "ADD" or len(add3_op.inputs) != 2 or len(add3_op.outputs) != 1:
+                continue
+
+            add3_left_name = str(add3_op.inputs[0])
+            add3_right_name = str(add3_op.inputs[1])
+            add2_idx = producers.get(add3_left_name, None)
+            mul1_idx = producers.get(add3_right_name, None)
+            if add2_idx is None or mul1_idx is None:
+                add2_idx = producers.get(add3_right_name, None)
+                mul1_idx = producers.get(add3_left_name, None)
+                if add2_idx is None or mul1_idx is None:
+                    continue
+                add3_left_name, add3_right_name = add3_right_name, add3_left_name
+            add2_op = model_ir.operators[int(add2_idx)]
+            mul1_op = model_ir.operators[int(mul1_idx)]
+            if str(add2_op.op_type) != "ADD" or len(add2_op.inputs) != 2 or len(add2_op.outputs) != 1:
+                continue
+            if str(mul1_op.op_type) != "MUL" or len(mul1_op.inputs) != 2 or len(mul1_op.outputs) != 1:
+                continue
+            if str(add2_op.outputs[0]) != str(add3_left_name) or str(mul1_op.outputs[0]) != str(add3_right_name):
+                continue
+
+            # add2 = ADD(source, mul0)
+            add2_in0 = str(add2_op.inputs[0])
+            add2_in1 = str(add2_op.inputs[1])
+            add2_prod0 = producers.get(add2_in0, None)
+            add2_prod1 = producers.get(add2_in1, None)
+            if add2_prod0 is None or add2_prod1 is None:
+                continue
+            if str(model_ir.operators[int(add2_prod0)].op_type) == "ADD" and str(model_ir.operators[int(add2_prod1)].op_type) == "MUL":
+                source_idx = int(add2_prod0)
+                mul0_idx = int(add2_prod1)
+                source_name = str(add2_in0)
+                mul0_name = str(add2_in1)
+            elif str(model_ir.operators[int(add2_prod1)].op_type) == "ADD" and str(model_ir.operators[int(add2_prod0)].op_type) == "MUL":
+                source_idx = int(add2_prod1)
+                mul0_idx = int(add2_prod0)
+                source_name = str(add2_in1)
+                mul0_name = str(add2_in0)
+            else:
+                continue
+            source_op = model_ir.operators[int(source_idx)]
+            mul0_op = model_ir.operators[int(mul0_idx)]
+            if len(source_op.inputs) != 2 or len(source_op.outputs) != 1:
+                continue
+            if str(source_op.outputs[0]) != str(source_name):
+                continue
+            if len(mul0_op.inputs) != 2 or len(mul0_op.outputs) != 1:
+                continue
+            if str(mul0_op.outputs[0]) != str(mul0_name):
+                continue
+
+            source_users = set(int(v) for v in consumers.get(source_name, []))
+            if int(add2_idx) not in source_users:
+                continue
+
+            # source inputs
+            source_in0 = str(source_op.inputs[0])
+            source_in1 = str(source_op.inputs[1])
+            if source_in0 in model_outputs or source_in1 in model_outputs:
+                continue
+
+            # mul1 = MUL(sub, residual)
+            mul1_in0 = str(mul1_op.inputs[0])
+            mul1_in1 = str(mul1_op.inputs[1])
+            sub_idx = producers.get(mul1_in0, None)
+            residual_name = str(mul1_in1)
+            if sub_idx is None or str(model_ir.operators[int(sub_idx)].op_type) != "SUB":
+                sub_idx = producers.get(mul1_in1, None)
+                residual_name = str(mul1_in0)
+                if sub_idx is None or str(model_ir.operators[int(sub_idx)].op_type) != "SUB":
+                    continue
+            sub_op = model_ir.operators[int(sub_idx)]
+            if len(sub_op.inputs) != 2 or len(sub_op.outputs) != 1:
+                continue
+            sub_out_name = str(sub_op.outputs[0])
+            if sub_out_name not in {mul1_in0, mul1_in1}:
+                continue
+
+            # residual must be one of source inputs.
+            if residual_name not in {source_in0, source_in1}:
+                continue
+            branch_nchw_name = str(source_in1) if str(source_in0) == str(residual_name) else str(source_in0)
+
+            # mul0 must use branch tensor and gate2 tensor.
+            mul0_inputs = [str(v) for v in list(mul0_op.inputs)]
+            if branch_nchw_name not in mul0_inputs:
+                continue
+            gate2_name = str(mul0_inputs[1]) if str(mul0_inputs[0]) == str(branch_nchw_name) else str(mul0_inputs[0])
+            gate2_idx = producers.get(gate2_name, None)
+            if gate2_idx is None:
+                continue
+            gate2_op = model_ir.operators[int(gate2_idx)]
+            if str(gate2_op.op_type) != "LOGISTIC" or len(gate2_op.inputs) != 1 or len(gate2_op.outputs) != 1:
+                continue
+            if str(gate2_op.outputs[0]) != str(gate2_name):
+                continue
+            gate1_name = str(gate2_op.inputs[0])
+            gate1_idx = producers.get(gate1_name, None)
+            if gate1_idx is None:
+                continue
+            gate1_op = model_ir.operators[int(gate1_idx)]
+            if str(gate1_op.op_type) != "LOGISTIC" or len(gate1_op.inputs) != 1 or len(gate1_op.outputs) != 1:
+                continue
+            if str(gate1_op.outputs[0]) != str(gate1_name):
+                continue
+
+            # sub must consume gate2
+            if str(gate2_name) not in [str(v) for v in list(sub_op.inputs)]:
+                continue
+
+            # branch_nchw = TRANSPOSE(branch_nhwc, NHWC->NCHW)
+            trans_branch_idx = producers.get(branch_nchw_name, None)
+            if trans_branch_idx is None:
+                continue
+            trans_branch_op = model_ir.operators[int(trans_branch_idx)]
+            if (
+                str(trans_branch_op.op_type) != "TRANSPOSE"
+                or len(trans_branch_op.inputs) < 2
+                or len(trans_branch_op.outputs) != 1
+                or str(trans_branch_op.outputs[0]) != branch_nchw_name
+                or _read_transpose_perm(model_ir, trans_branch_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            branch_nhwc_name = str(trans_branch_op.inputs[0])
+
+            # residual_nchw adapter:
+            #   A) residual_nchw = ADD(T(a_nhwc), T(b_nhwc))
+            #   B) residual_nchw = T(residual_nhwc)
+            residual_idx = producers.get(residual_name, None)
+            if residual_idx is None:
+                continue
+            residual_op = model_ir.operators[int(residual_idx)]
+            residual_add_mode = False
+            residual_a_nhwc_name: Optional[str] = None
+            residual_b_nhwc_name: Optional[str] = None
+            residual_a_nchw_name: Optional[str] = None
+            residual_b_nchw_name: Optional[str] = None
+            trans_res_a_idx: Optional[int] = None
+            trans_res_b_idx: Optional[int] = None
+            trans_res_direct_idx: Optional[int] = None
+            residual_direct_nhwc_name: Optional[str] = None
+            if str(residual_op.op_type) == "ADD" and len(residual_op.inputs) == 2 and len(residual_op.outputs) == 1:
+                if str(residual_op.outputs[0]) != str(residual_name):
+                    continue
+                trans_res_a_idx = producers.get(str(residual_op.inputs[0]), None)
+                trans_res_b_idx = producers.get(str(residual_op.inputs[1]), None)
+                if trans_res_a_idx is None or trans_res_b_idx is None:
+                    continue
+                trans_res_a_op = model_ir.operators[int(trans_res_a_idx)]
+                trans_res_b_op = model_ir.operators[int(trans_res_b_idx)]
+                if (
+                    str(trans_res_a_op.op_type) != "TRANSPOSE"
+                    or str(trans_res_b_op.op_type) != "TRANSPOSE"
+                    or len(trans_res_a_op.inputs) < 2
+                    or len(trans_res_b_op.inputs) < 2
+                    or len(trans_res_a_op.outputs) != 1
+                    or len(trans_res_b_op.outputs) != 1
+                    or _read_transpose_perm(model_ir, trans_res_a_op) != perm_nhwc_to_nchw
+                    or _read_transpose_perm(model_ir, trans_res_b_op) != perm_nhwc_to_nchw
+                ):
+                    continue
+                residual_add_mode = True
+                residual_a_nhwc_name = str(trans_res_a_op.inputs[0])
+                residual_b_nhwc_name = str(trans_res_b_op.inputs[0])
+                residual_a_nchw_name = str(trans_res_a_op.outputs[0])
+                residual_b_nchw_name = str(trans_res_b_op.outputs[0])
+            elif (
+                str(residual_op.op_type) == "TRANSPOSE"
+                and len(residual_op.inputs) >= 2
+                and len(residual_op.outputs) == 1
+                and str(residual_op.outputs[0]) == str(residual_name)
+                and _read_transpose_perm(model_ir, residual_op) == perm_nhwc_to_nchw
+            ):
+                trans_res_direct_idx = int(residual_idx)
+                residual_direct_nhwc_name = str(residual_op.inputs[0])
+            else:
+                continue
+
+            # Locality guards for upstream adapters.
+            if set(int(v) for v in consumers.get(branch_nchw_name, [])) != {int(source_idx), int(mul0_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(residual_name, [])) != {int(source_idx), int(mul1_idx)}:
+                continue
+            if residual_add_mode:
+                if residual_a_nchw_name is None or residual_b_nchw_name is None:
+                    continue
+                if set(int(v) for v in consumers.get(residual_a_nchw_name, [])) != {int(residual_idx)}:
+                    continue
+                if set(int(v) for v in consumers.get(residual_b_nchw_name, [])) != {int(residual_idx)}:
+                    continue
+
+            # Parse SA/PA attention branches on source tensor.
+            mean_from_source: List[int] = []
+            max_idx: Optional[int] = None
+            unsq0_idx: Optional[int] = None
+            for user_idx in list(source_users):
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) == "MEAN"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == str(source_name)
+                    and bool(user_op.options.get("keepDims", False))
+                ):
+                    mean_from_source.append(int(user_idx))
+                    continue
+                if (
+                    str(user_op.op_type) == "REDUCE_MAX"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == str(source_name)
+                    and bool(user_op.options.get("keepDims", False))
+                ):
+                    max_idx = int(user_idx)
+                    continue
+                if (
+                    str(user_op.op_type) == "RESHAPE"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == str(source_name)
+                ):
+                    unsq0_idx = int(user_idx)
+                    continue
+            if len(mean_from_source) != 2 or max_idx is None or unsq0_idx is None:
+                continue
+
+            # mean_ca path: MEAN -> T(NCHW->NHWC) -> CONV -> CONV -> T(NHWC->NCHW)
+            mean_ca_idx: Optional[int] = None
+            mean_sa_idx: Optional[int] = None
+            trans_ca0_idx: Optional[int] = None
+            conv_ca0_idx: Optional[int] = None
+            conv_ca2_idx: Optional[int] = None
+            trans_ca2_idx: Optional[int] = None
+            ca_nchw_name: Optional[str] = None
+            ca_conv2_out_nhwc_name: Optional[str] = None
+            for mean_idx in list(mean_from_source):
+                mean_op = model_ir.operators[int(mean_idx)]
+                mean_out = str(mean_op.outputs[0])
+                mean_users = [int(v) for v in consumers.get(mean_out, [])]
+                if len(mean_users) == 1:
+                    t_idx = int(mean_users[0])
+                    t_op = model_ir.operators[int(t_idx)]
+                    if (
+                        str(t_op.op_type) == "TRANSPOSE"
+                        and len(t_op.inputs) >= 2
+                        and len(t_op.outputs) == 1
+                        and str(t_op.inputs[0]) == str(mean_out)
+                        and _read_transpose_perm(model_ir, t_op) == perm_nchw_to_nhwc
+                    ):
+                        ca0_in = str(t_op.outputs[0])
+                        ca0_users = [int(v) for v in consumers.get(ca0_in, [])]
+                        if len(ca0_users) != 1:
+                            continue
+                        c0_idx = int(ca0_users[0])
+                        c0_op = model_ir.operators[int(c0_idx)]
+                        if (
+                            str(c0_op.op_type) != "CONV_2D"
+                            or len(c0_op.inputs) < 1
+                            or len(c0_op.outputs) != 1
+                            or str(c0_op.inputs[0]) != str(ca0_in)
+                        ):
+                            continue
+                        c0_out = str(c0_op.outputs[0])
+                        c0_users = [int(v) for v in consumers.get(c0_out, [])]
+                        if len(c0_users) != 1:
+                            continue
+                        c2_idx = int(c0_users[0])
+                        c2_op = model_ir.operators[int(c2_idx)]
+                        if (
+                            str(c2_op.op_type) != "CONV_2D"
+                            or len(c2_op.inputs) < 1
+                            or len(c2_op.outputs) != 1
+                            or str(c2_op.inputs[0]) != str(c0_out)
+                        ):
+                            continue
+                        c2_out = str(c2_op.outputs[0])
+                        c2_users = [int(v) for v in consumers.get(c2_out, [])]
+                        if len(c2_users) != 1:
+                            continue
+                        t2_idx = int(c2_users[0])
+                        t2_op = model_ir.operators[int(t2_idx)]
+                        if (
+                            str(t2_op.op_type) != "TRANSPOSE"
+                            or len(t2_op.inputs) < 2
+                            or len(t2_op.outputs) != 1
+                            or str(t2_op.inputs[0]) != str(c2_out)
+                            or _read_transpose_perm(model_ir, t2_op) != perm_nhwc_to_nchw
+                        ):
+                            continue
+                        mean_ca_idx = int(mean_idx)
+                        trans_ca0_idx = int(t_idx)
+                        conv_ca0_idx = int(c0_idx)
+                        conv_ca2_idx = int(c2_idx)
+                        trans_ca2_idx = int(t2_idx)
+                        ca_nchw_name = str(t2_op.outputs[0])
+                        ca_conv2_out_nhwc_name = str(c2_out)
+                    else:
+                        mean_sa_idx = int(mean_idx)
+                else:
+                    mean_sa_idx = int(mean_idx)
+            if (
+                mean_ca_idx is None
+                or mean_sa_idx is None
+                or trans_ca0_idx is None
+                or conv_ca0_idx is None
+                or conv_ca2_idx is None
+                or trans_ca2_idx is None
+                or ca_nchw_name is None
+                or ca_conv2_out_nhwc_name is None
+            ):
+                continue
+
+            mean_sa_op = model_ir.operators[int(mean_sa_idx)]
+            max_op = model_ir.operators[int(max_idx)]
+            unsq0_op = model_ir.operators[int(unsq0_idx)]
+            mean_sa_out_name = str(mean_sa_op.outputs[0])
+            max_out_name = str(max_op.outputs[0])
+            unsq0_out_name = str(unsq0_op.outputs[0])
+
+            # SA concat
+            if len(consumers.get(mean_sa_out_name, [])) != 1 or len(consumers.get(max_out_name, [])) != 1:
+                continue
+            concat_sa_idx = int(consumers[mean_sa_out_name][0])
+            if int(consumers[max_out_name][0]) != int(concat_sa_idx):
+                continue
+            concat_sa_op = model_ir.operators[int(concat_sa_idx)]
+            if str(concat_sa_op.op_type) != "CONCATENATION" or len(concat_sa_op.inputs) != 2 or len(concat_sa_op.outputs) != 1:
+                continue
+            concat_sa_axis = int(concat_sa_op.options.get("axis", 1))
+            if concat_sa_axis < 0:
+                concat_sa_axis += 4
+            if concat_sa_axis != 1:
+                continue
+            concat_sa_out_name = str(concat_sa_op.outputs[0])
+            if len(consumers.get(concat_sa_out_name, [])) != 1:
+                continue
+            mirror_sa_idx = int(consumers[concat_sa_out_name][0])
+            mirror_sa_op = model_ir.operators[int(mirror_sa_idx)]
+            if str(mirror_sa_op.op_type) != "MIRROR_PAD" or len(mirror_sa_op.inputs) < 2 or len(mirror_sa_op.outputs) != 1:
+                continue
+            mirror_sa_out_name = str(mirror_sa_op.outputs[0])
+            if str(mirror_sa_op.inputs[0]) != str(concat_sa_out_name):
+                continue
+            if len(consumers.get(mirror_sa_out_name, [])) != 1:
+                continue
+            trans_sa_idx = int(consumers[mirror_sa_out_name][0])
+            trans_sa_op = model_ir.operators[int(trans_sa_idx)]
+            if (
+                str(trans_sa_op.op_type) != "TRANSPOSE"
+                or len(trans_sa_op.inputs) < 2
+                or len(trans_sa_op.outputs) != 1
+                or str(trans_sa_op.inputs[0]) != str(mirror_sa_out_name)
+                or _read_transpose_perm(model_ir, trans_sa_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            sa_conv_in_name = str(trans_sa_op.outputs[0])
+            if len(consumers.get(sa_conv_in_name, [])) != 1:
+                continue
+            sa_conv_idx = int(consumers[sa_conv_in_name][0])
+            sa_conv_op = model_ir.operators[int(sa_conv_idx)]
+            if str(sa_conv_op.op_type) != "CONV_2D" or len(sa_conv_op.inputs) < 1 or len(sa_conv_op.outputs) != 1:
+                continue
+            if str(sa_conv_op.inputs[0]) != str(sa_conv_in_name):
+                continue
+            sa_conv_out_name = str(sa_conv_op.outputs[0])
+            if len(consumers.get(sa_conv_out_name, [])) != 1:
+                continue
+            sa_reshape_idx = int(consumers[sa_conv_out_name][0])
+            sa_reshape_op = model_ir.operators[int(sa_reshape_idx)]
+            if str(sa_reshape_op.op_type) != "RESHAPE" or len(sa_reshape_op.inputs) < 1 or len(sa_reshape_op.outputs) != 1:
+                continue
+            if str(sa_reshape_op.inputs[0]) != str(sa_conv_out_name):
+                continue
+            sa_nchw_name = str(sa_reshape_op.outputs[0])
+
+            # add_attn
+            if len(consumers.get(sa_nchw_name, [])) != 1:
+                continue
+            add_attn_idx = int(consumers[sa_nchw_name][0])
+            add_attn_op = model_ir.operators[int(add_attn_idx)]
+            if str(add_attn_op.op_type) != "ADD" or len(add_attn_op.inputs) != 2 or len(add_attn_op.outputs) != 1:
+                continue
+            add_attn_inputs = [str(v) for v in list(add_attn_op.inputs)]
+            if str(ca_nchw_name) not in add_attn_inputs or str(sa_nchw_name) not in add_attn_inputs:
+                continue
+            add_attn_out_name = str(add_attn_op.outputs[0])
+
+            if len(consumers.get(add_attn_out_name, [])) != 1:
+                continue
+            unsq1_idx = int(consumers[add_attn_out_name][0])
+            unsq1_op = model_ir.operators[int(unsq1_idx)]
+            if str(unsq1_op.op_type) != "RESHAPE" or len(unsq1_op.inputs) < 2 or len(unsq1_op.outputs) != 1:
+                continue
+            if str(unsq1_op.inputs[0]) != str(add_attn_out_name):
+                continue
+            unsq1_out_name = str(unsq1_op.outputs[0])
+
+            if len(consumers.get(unsq0_out_name, [])) != 1 or len(consumers.get(unsq1_out_name, [])) != 1:
+                continue
+            concat_pa_idx = int(consumers[unsq0_out_name][0])
+            if int(consumers[unsq1_out_name][0]) != int(concat_pa_idx):
+                continue
+            concat_pa_op = model_ir.operators[int(concat_pa_idx)]
+            if str(concat_pa_op.op_type) != "CONCATENATION" or len(concat_pa_op.inputs) != 2 or len(concat_pa_op.outputs) != 1:
+                continue
+            concat_pa_axis = int(concat_pa_op.options.get("axis", 2))
+            if concat_pa_axis < 0:
+                concat_pa_axis += 5
+            if concat_pa_axis != 2:
+                continue
+            concat_pa_out_name = str(concat_pa_op.outputs[0])
+            if len(consumers.get(concat_pa_out_name, [])) != 1:
+                continue
+            reshape_pa_idx = int(consumers[concat_pa_out_name][0])
+            reshape_pa_op = model_ir.operators[int(reshape_pa_idx)]
+            if str(reshape_pa_op.op_type) != "RESHAPE" or len(reshape_pa_op.inputs) < 2 or len(reshape_pa_op.outputs) != 1:
+                continue
+            if str(reshape_pa_op.inputs[0]) != str(concat_pa_out_name):
+                continue
+            reshape_pa_out_name = str(reshape_pa_op.outputs[0])
+            if len(consumers.get(reshape_pa_out_name, [])) != 1:
+                continue
+            mirror_pa_idx = int(consumers[reshape_pa_out_name][0])
+            mirror_pa_op = model_ir.operators[int(mirror_pa_idx)]
+            if str(mirror_pa_op.op_type) != "MIRROR_PAD" or len(mirror_pa_op.inputs) < 2 or len(mirror_pa_op.outputs) != 1:
+                continue
+            if str(mirror_pa_op.inputs[0]) != str(reshape_pa_out_name):
+                continue
+            mirror_pa_out_name = str(mirror_pa_op.outputs[0])
+            if len(consumers.get(mirror_pa_out_name, [])) != 1:
+                continue
+            trans_pa_idx = int(consumers[mirror_pa_out_name][0])
+            trans_pa_op = model_ir.operators[int(trans_pa_idx)]
+            if (
+                str(trans_pa_op.op_type) != "TRANSPOSE"
+                or len(trans_pa_op.inputs) < 2
+                or len(trans_pa_op.outputs) != 1
+                or str(trans_pa_op.inputs[0]) != str(mirror_pa_out_name)
+                or _read_transpose_perm(model_ir, trans_pa_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            pa_conv_in_name = str(trans_pa_op.outputs[0])
+            pa_conv_users = [int(v) for v in consumers.get(pa_conv_in_name, [])]
+            if len(pa_conv_users) != 1:
+                continue
+            pa_conv_idx = int(pa_conv_users[0])
+            pa_conv_op = model_ir.operators[int(pa_conv_idx)]
+            if str(pa_conv_op.op_type) != "CONV_2D" or len(pa_conv_op.inputs) < 1 or len(pa_conv_op.outputs) != 1:
+                continue
+            if str(pa_conv_op.inputs[0]) != str(pa_conv_in_name):
+                continue
+            pa_conv_out_nhwc_name = str(pa_conv_op.outputs[0])
+            pa_conv_out_nchw_name = str(gate1_op.inputs[0])
+            trans_pa_out_idx = producers.get(pa_conv_out_nchw_name, None)
+            if trans_pa_out_idx is None or int(trans_pa_out_idx) != int(producers.get(pa_conv_out_nchw_name, -1)):
+                continue
+            trans_pa_out_op = model_ir.operators[int(trans_pa_out_idx)]
+            if (
+                str(trans_pa_out_op.op_type) != "TRANSPOSE"
+                or len(trans_pa_out_op.inputs) < 2
+                or len(trans_pa_out_op.outputs) != 1
+                or str(trans_pa_out_op.inputs[0]) != str(pa_conv_out_nhwc_name)
+                or str(trans_pa_out_op.outputs[0]) != str(pa_conv_out_nchw_name)
+                or _read_transpose_perm(model_ir, trans_pa_out_op) != perm_nhwc_to_nchw
+            ):
+                continue
+
+            # Locality and output guards.
+            if any(
+                t in model_outputs
+                for t in [
+                    str(source_name),
+                    str(residual_name),
+                    str(branch_nchw_name),
+                    str(add_attn_out_name),
+                    str(add3_op.outputs[0]),
+                    str(post_in_name),
+                ]
+            ):
+                continue
+            if set(int(v) for v in consumers.get(post_out_name, [])) != {int(post_conv_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(str(ca_nchw_name), [])) != {int(add_attn_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(str(sa_nchw_name), [])) != {int(add_attn_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(str(pa_conv_out_nchw_name), [])) != {int(gate1_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(str(gate1_name), [])) != {int(gate2_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(str(gate2_name), [])) != {int(mul0_idx), int(sub_idx)}:
+                continue
+
+            # Rewrite constants.
+            mean_ca_op = model_ir.operators[int(mean_ca_idx)]
+            if not _rewrite_reduce_axes_nchw_to_nhwc(mean_ca_op):
+                continue
+            if not _rewrite_reduce_axes_nchw_to_nhwc(mean_sa_op):
+                continue
+            if not _rewrite_reduce_axes_nchw_to_nhwc(max_op):
+                continue
+            if not _rewrite_pad_pairs_nchw_to_nhwc(mirror_sa_op):
+                continue
+            if not _rewrite_reshape_shape_by_perm(reshape_op=unsq0_op, index_perm=perm5_nckhw_to_nhwck):
+                continue
+            if not _rewrite_reshape_shape_by_perm(reshape_op=unsq1_op, index_perm=perm5_nckhw_to_nhwck):
+                continue
+            if not _rewrite_reshape_shape_by_perm(reshape_op=reshape_pa_op, index_perm=perm_nchw_to_nhwc):
+                continue
+            if not _rewrite_pad_pairs_nchw_to_nhwc(mirror_pa_op):
+                continue
+
+            # Rewire upstream residual/branch adapters.
+            residual_nhwc_name = str(residual_name)
+            if residual_add_mode:
+                if residual_a_nhwc_name is None or residual_b_nhwc_name is None:
+                    continue
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=residual_op,
+                    new_inputs=[str(residual_a_nhwc_name), str(residual_b_nhwc_name)],
+                )
+            else:
+                if residual_direct_nhwc_name is None:
+                    continue
+                residual_nhwc_name = str(residual_direct_nhwc_name)
+            source_new_inputs = [
+                str(branch_nhwc_name) if str(v) == str(branch_nchw_name) else (
+                    str(residual_nhwc_name) if str(v) == str(residual_name) else str(v)
+                )
+                for v in list(source_op.inputs)
+            ]
+            _set_operator_inputs(model_ir=model_ir, op=source_op, new_inputs=source_new_inputs)
+
+            mul0_new_inputs = [
+                str(branch_nhwc_name) if str(v) == str(branch_nchw_name) else str(v)
+                for v in list(mul0_op.inputs)
+            ]
+            _set_operator_inputs(model_ir=model_ir, op=mul0_op, new_inputs=mul0_new_inputs)
+            if str(residual_nhwc_name) != str(residual_name):
+                mul1_new_inputs = [
+                    str(residual_nhwc_name) if str(v) == str(residual_name) else str(v)
+                    for v in list(mul1_op.inputs)
+                ]
+                _set_operator_inputs(model_ir=model_ir, op=mul1_op, new_inputs=mul1_new_inputs)
+
+            # Rewire CA/SA/PA branches to NHWC.
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=model_ir.operators[int(conv_ca0_idx)],
+                input_index=0,
+                new_input_name=str(mean_ca_op.outputs[0]),
+            )
+            concat_sa_op.options["axis"] = 3
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=sa_conv_op,
+                input_index=0,
+                new_input_name=str(mirror_sa_out_name),
+            )
+            add_attn_new_inputs = [
+                str(sa_conv_out_name) if str(v) == str(sa_nchw_name) else (
+                    str(ca_conv2_out_nhwc_name) if str(v) == str(ca_nchw_name) else str(v)
+                )
+                for v in list(add_attn_inputs)
+            ]
+            _set_operator_inputs(model_ir=model_ir, op=add_attn_op, new_inputs=add_attn_new_inputs)
+            concat_pa_op.options["axis"] = 4
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=pa_conv_op,
+                input_index=0,
+                new_input_name=str(mirror_pa_out_name),
+            )
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=gate1_op,
+                input_index=0,
+                new_input_name=str(pa_conv_out_nhwc_name),
+            )
+
+            # Remove terminal mix transpose.
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=post_conv_op,
+                input_index=0,
+                new_input_name=str(post_in_name),
+            )
+
+            # Permute metadata for tensors switched from NCHW to NHWC.
+            for tensor_name in [
+                str(residual_name),
+                str(source_name),
+                str(mean_ca_op.outputs[0]),
+                str(mean_sa_out_name),
+                str(max_out_name),
+                str(concat_sa_out_name),
+                str(mirror_sa_out_name),
+                str(add_attn_out_name),
+                str(reshape_pa_out_name),
+                str(mirror_pa_out_name),
+                str(gate1_name),
+                str(gate2_name),
+                str(mul0_name),
+                str(sub_out_name),
+                str(add2_op.outputs[0]),
+                str(mul1_op.outputs[0]),
+                str(add3_op.outputs[0]),
+            ]:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(tensor_name), None),
+                    perm_nchw_to_nhwc,
+                )
+            for tensor_name in [
+                str(unsq0_out_name),
+                str(unsq1_out_name),
+                str(concat_pa_out_name),
+            ]:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(tensor_name), None),
+                    perm5_nckhw_to_nhwck,
+                )
+
+            remove_index_set = {
+                int(trans_branch_idx),
+                int(trans_ca0_idx),
+                int(trans_ca2_idx),
+                int(trans_sa_idx),
+                int(sa_reshape_idx),
+                int(trans_pa_idx),
+                int(trans_pa_out_idx),
+                int(post_idx),
+            }
+            if residual_add_mode:
+                if trans_res_a_idx is None or trans_res_b_idx is None:
+                    continue
+                remove_index_set.add(int(trans_res_a_idx))
+                remove_index_set.add(int(trans_res_b_idx))
+            else:
+                if trans_res_direct_idx is None:
+                    continue
+                remove_index_set.add(int(trans_res_direct_idx))
+            remove_indices = sorted(list(remove_index_set), reverse=True)
+            for remove_idx in remove_indices:
+                del model_ir.operators[int(remove_idx)]
+
+            optimized += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_sinet_mix_attention_double_logistic_nhwc_chains": int(optimized)}
 
 
 def _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -22505,8 +26177,8 @@ def _optimize_fuse_conv_activation_chains(model_ir: ModelIR) -> Dict[str, int]:
     Fuse producer -> Activation chains into producer fusedActivationFunction in flatbuffer_direct IR.
 
     Target:
-      (CONV_2D|DEPTHWISE_CONV_2D, fusedActivationFunction=NONE) -> (RELU|RELU6|TANH)
-      (ADD|SUB|MUL|DIV, fusedActivationFunction=NONE) -> (RELU|RELU6|TANH)
+      (CONV_2D|DEPTHWISE_CONV_2D, fusedActivationFunction=NONE) -> (RELU|RELU6)
+      (ADD|SUB|MUL|DIV, fusedActivationFunction=NONE) -> (RELU|RELU6)
 
     Rewrite:
       (producer, fusedActivationFunction=<activation>)
@@ -22526,7 +26198,6 @@ def _optimize_fuse_conv_activation_chains(model_ir: ModelIR) -> Dict[str, int]:
     binary_activation_map = {
         "RELU": "RELU",
         "RELU6": "RELU6",
-        "TANH": "TANH",
     }
     activation_map_by_producer = {
         "CONV_2D": {
@@ -27137,6 +30808,7 @@ def lower_onnx_to_ir(
         _optimize_prelu_transpose_passthrough_chains(model_ir)
         _optimize_transpose_elementwise_concat_conv_nhwc_groups(model_ir)
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
+        _optimize_transpose_pre_concat_ndhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
@@ -27151,9 +30823,14 @@ def lower_onnx_to_ir(
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
+        _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
+        _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
+        _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+        _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+        _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
@@ -27195,6 +30872,7 @@ def lower_onnx_to_ir(
         _optimize_prelu_transpose_passthrough_chains(model_ir)
         _optimize_transpose_elementwise_concat_conv_nhwc_groups(model_ir)
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
+        _optimize_transpose_pre_concat_ndhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
@@ -27209,9 +30887,14 @@ def lower_onnx_to_ir(
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
+        _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
+        _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
+        _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+        _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+        _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
@@ -27256,6 +30939,7 @@ def lower_onnx_to_ir(
         _optimize_prelu_transpose_passthrough_chains(model_ir)
         _optimize_transpose_elementwise_concat_conv_nhwc_groups(model_ir)
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
+        _optimize_transpose_pre_concat_ndhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
@@ -27270,9 +30954,14 @@ def lower_onnx_to_ir(
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
+        _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
+        _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
+        _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+        _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+        _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
@@ -27331,6 +31020,7 @@ def lower_onnx_to_ir(
         _optimize_prelu_transpose_passthrough_chains(model_ir)
         _optimize_transpose_elementwise_concat_conv_nhwc_groups(model_ir)
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
+        _optimize_transpose_pre_concat_ndhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
@@ -27343,9 +31033,14 @@ def lower_onnx_to_ir(
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
+        _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
+        _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
+        _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+        _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+        _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
@@ -27368,6 +31063,7 @@ def lower_onnx_to_ir(
         # Binary bridge recovery can recreate pre/post transpose wrappers around CONCAT.
         _optimize_transpose_elementwise_concat_conv_nhwc_groups(model_ir)
         _optimize_transpose_pre_concat_nhwc_chains(model_ir)
+        _optimize_transpose_pre_concat_ndhwc_chains(model_ir)
         _optimize_transpose_stridedslice_pre_concat_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
@@ -27383,9 +31079,13 @@ def lower_onnx_to_ir(
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
+        _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_transpose_sum_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
         _optimize_transpose_logistic_sub_muladd_dual_postconv_nhwc_chains(model_ir)
+        _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+        _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+        _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
         _optimize_transpose_add_concat_const_suffix_nhwc_chains(model_ir)
         _prune_dead_operators(model_ir)
         _reconcile_static_tensor_shapes(model_ir)
@@ -27412,6 +31112,7 @@ def lower_onnx_to_ir(
         _optimize_singleton_spatial_nhwc_transpose_reshape_flatten(model_ir)
         _optimize_singleton_reshape_concat_post_transpose_nhwc_chains(model_ir)
     _optimize_maximum_minimum_relu0to1_chains(model_ir)
+    _optimize_maximum_with_zero_input2_to_relu(model_ir)
     _optimize_sinet_shuffle_residual_transpose_chains(model_ir)
     _optimize_transpose_pre_add_mul_add_prelu_nhwc_chains(model_ir)
     # This generic pass can recreate SiNet concat+resize transpose adapters.
@@ -27456,6 +31157,14 @@ def lower_onnx_to_ir(
     _optimize_sinet_dual_resize_affine_transpose_chains(model_ir)
     _optimize_sinet_concat_resize_affine_tail_concat_transpose_chains(model_ir)
     _optimize_sinet_softmax_mask_residual_nhwc_tail_chains(model_ir)
+    # Late SiNet rewrites can recreate SA/PA MIRROR_PAD NCHW<->NHWC bridges.
+    _optimize_transpose_csp_attention_nhwc_chains(model_ir)
+    _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
+    _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
+    _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+    _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+    _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
+    _optimize_layout_transpose_chains(model_ir)
     _prune_dead_operators(model_ir)
     _reconcile_static_tensor_shapes(model_ir)
 

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -282,6 +282,21 @@ def _build_transpose_conv_options(schema_tflite: Dict[str, Any], op: OperatorIR)
     return _enum(schema_tflite, "BuiltinOptions", "TransposeConvOptions"), options
 
 
+def _build_conv3d_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["Conv3DOptionsT"]()
+    options.padding = _enum(schema_tflite, "Padding", str(op.options["padding"]))
+    options.strideD = int(op.options["strideD"])
+    options.strideH = int(op.options["strideH"])
+    options.strideW = int(op.options["strideW"])
+    options.dilationDFactor = int(op.options.get("dilationDFactor", 1))
+    options.dilationHFactor = int(op.options.get("dilationHFactor", 1))
+    options.dilationWFactor = int(op.options.get("dilationWFactor", 1))
+    fused = str(op.options.get("fusedActivationFunction", "NONE"))
+    if hasattr(options, "fusedActivationFunction"):
+        options.fusedActivationFunction = _enum(schema_tflite, "ActivationFunctionType", fused)
+    return _enum(schema_tflite, "BuiltinOptions", "Conv3DOptions"), options
+
+
 def _build_pool2d_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
     options = schema_tflite["Pool2DOptionsT"]()
     options.padding = _enum(schema_tflite, "Padding", str(op.options["padding"]))
@@ -336,6 +351,40 @@ def _build_split_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple
 def _build_expand_dims_options(schema_tflite: Dict[str, Any], _op: OperatorIR) -> Tuple[int, object]:
     options = schema_tflite["ExpandDimsOptionsT"]()
     return _enum(schema_tflite, "BuiltinOptions", "ExpandDimsOptions"), options
+
+
+def _build_mirror_pad_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["MirrorPadOptionsT"]()
+    mode = str(op.options.get("mode", "REFLECT")).upper()
+    options.mode = _enum(schema_tflite, "MirrorPadMode", mode)
+    return _enum(schema_tflite, "BuiltinOptions", "MirrorPadOptions"), options
+
+
+def _build_cumsum_options(schema_tflite: Dict[str, Any], op: OperatorIR) -> Tuple[int, object]:
+    options = schema_tflite["CumsumOptionsT"]()
+    options.exclusive = bool(op.options.get("exclusive", False))
+    options.reverse = bool(op.options.get("reverse", False))
+    return _enum(schema_tflite, "BuiltinOptions", "CumsumOptions"), options
+
+
+def _build_reverse_v2_options(
+    schema_tflite: Dict[str, Any],
+    _op: OperatorIR,
+) -> Tuple[int, object]:
+    options = schema_tflite["ReverseV2OptionsT"]()
+    return _enum(schema_tflite, "BuiltinOptions", "ReverseV2Options"), options
+
+
+def _build_random_options(
+    schema_tflite: Dict[str, Any],
+    op: OperatorIR,
+) -> Tuple[int, object]:
+    options = schema_tflite["RandomOptionsT"]()
+    if hasattr(options, "seed"):
+        options.seed = int(op.options.get("seed", 0))
+    if hasattr(options, "seed2"):
+        options.seed2 = int(op.options.get("seed2", 0))
+    return _enum(schema_tflite, "BuiltinOptions", "RandomOptions"), options
 
 
 def _build_bidirectional_sequence_lstm_options(
@@ -449,7 +498,7 @@ def _build_builtin_options(
         return _build_softmax_options(schema_tflite, op)
     if op.op_type == "TRANSPOSE":
         return _build_transpose_options(schema_tflite, op)
-    if op.op_type in ["MEAN", "SUM", "REDUCE_MAX"]:
+    if op.op_type in ["MEAN", "SUM", "REDUCE_MAX", "REDUCE_PROD"]:
         return _build_reducer_options(schema_tflite, op)
     if op.op_type == "SQUEEZE":
         return _build_squeeze_options(schema_tflite, op)
@@ -491,6 +540,8 @@ def _build_builtin_options(
         return _build_depthwise_conv_options(schema_tflite, op)
     if op.op_type == "TRANSPOSE_CONV":
         return _build_transpose_conv_options(schema_tflite, op)
+    if op.op_type in ["CONV_3D", "CONV_3D_TRANSPOSE"]:
+        return _build_conv3d_options(schema_tflite, op)
     if op.op_type in ["AVERAGE_POOL_2D", "MAX_POOL_2D"]:
         return _build_pool2d_options(schema_tflite, op)
     if op.op_type == "RESIZE_NEAREST_NEIGHBOR":
@@ -507,6 +558,14 @@ def _build_builtin_options(
         return _build_split_options(schema_tflite, op)
     if op.op_type == "EXPAND_DIMS":
         return _build_expand_dims_options(schema_tflite, op)
+    if op.op_type == "MIRROR_PAD":
+        return _build_mirror_pad_options(schema_tflite, op)
+    if op.op_type == "CUMSUM":
+        return _build_cumsum_options(schema_tflite, op)
+    if op.op_type == "REVERSE_V2":
+        return _build_reverse_v2_options(schema_tflite, op)
+    if op.op_type == "RANDOM_STANDARD_NORMAL":
+        return _build_random_options(schema_tflite, op)
     if op.op_type == "FULLY_CONNECTED":
         return _build_fully_connected_options(schema_tflite, op)
     if op.op_type == "BATCH_MATMUL":
@@ -527,6 +586,7 @@ def _build_builtin_options(
         "EQUAL",
         "NOT_EQUAL",
         "GREATER",
+        "GREATER_EQUAL",
         "LESS",
         "LESS_EQUAL",
         "RELU",

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -1,4 +1,5 @@
 from onnx2tf.tflite_builder.op_builders.elementwise import (
+    build_abs_op,
     build_acos_op,
     build_acosh_op,
     build_asin_op,
@@ -40,8 +41,10 @@ from onnx2tf.tflite_builder.op_builders.shape import (
     build_eyelike_op,
     build_expand_op,
     build_flatten_op,
+    build_grid_sample_op,
     build_identity_op,
     build_pad_op,
+    build_random_normal_like_op,
     build_range_op,
     build_resize_op,
     build_reshape_op,
@@ -76,7 +79,9 @@ from onnx2tf.tflite_builder.op_builders.recurrent import (
     build_rnn_op,
 )
 from onnx2tf.tflite_builder.op_builders.reduce import (
+    build_cumsum_op,
     build_global_average_pool_op,
+    build_global_max_pool_op,
     build_reduce_l1_op,
     build_reduce_l2_op,
     build_reduce_op,
@@ -121,6 +126,7 @@ from onnx2tf.tflite_builder.op_builders.quantized import (
 )
 
 __all__ = [
+    "build_abs_op",
     "build_binary_op",
     "build_acos_op",
     "build_acosh_op",
@@ -160,8 +166,10 @@ __all__ = [
     "build_eyelike_op",
     "build_expand_op",
     "build_flatten_op",
+    "build_grid_sample_op",
     "build_identity_op",
     "build_pad_op",
+    "build_random_normal_like_op",
     "build_range_op",
     "build_resize_op",
     "build_reshape_op",
@@ -186,9 +194,11 @@ __all__ = [
     "build_gru_op",
     "build_lstm_op",
     "build_rnn_op",
+    "build_cumsum_op",
     "build_reduce_l1_op",
     "build_reduce_l2_op",
     "build_global_average_pool_op",
+    "build_global_max_pool_op",
     "build_reduce_op",
     "build_argmin_op",
     "build_argmax_op",

--- a/onnx2tf/tflite_builder/op_builders/conv.py
+++ b/onnx2tf/tflite_builder/op_builders/conv.py
@@ -536,9 +536,16 @@ def _build_conv_transpose1d_via_conv2d(node: Any, ctx: Any) -> None:
         )
     if len(output_padding_1d) == 0:
         output_padding_1d = [0]
+    elif len(output_padding_1d) == 2:
+        output_padding_1d = [int(output_padding_1d[1])]
     elif len(output_padding_1d) != 1:
         raise NotImplementedError(
             f"ConvTranspose1D output_padding must have length 1. op={node.name} output_padding={output_padding_1d}"
+        )
+    if output_padding_1d[0] < 0 or output_padding_1d[0] >= int(strides_1d[0]):
+        raise NotImplementedError(
+            "ConvTranspose1D output_padding must satisfy "
+            f"0 <= output_padding < stride. op={node.name} output_padding={output_padding_1d} strides={strides_1d}"
         )
 
     attrs_2d = dict(node.attrs)
@@ -656,9 +663,26 @@ def _infer_conv_transpose_output_shape_nchw(
     else:
         kernel_h, kernel_w = [int(v) for v in list(kernel_shape_attr)]
     strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
+    if len(strides) == 0:
+        strides = [1, 1]
+    elif len(strides) == 1:
+        strides = [int(strides[0]), int(strides[0])]
+    elif len(strides) != 2:
+        raise NotImplementedError(
+            f"ConvTranspose strides must have length 2 for shape inference. op={node.name} strides={strides}"
+        )
     dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
     pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0]))]
-    output_padding = [int(v) for v in list(node.attrs.get("output_padding", [0, 0]))]
+    output_padding = [int(v) for v in list(node.attrs.get("output_padding", []))]
+    if len(output_padding) == 0:
+        output_padding = [0, 0]
+    elif len(output_padding) == 1:
+        output_padding = [int(output_padding[0]), int(output_padding[0])]
+    elif len(output_padding) != 2:
+        raise NotImplementedError(
+            "ConvTranspose output_padding must have length 2 for shape inference. "
+            f"op={node.name} output_padding={output_padding}"
+        )
 
     in_n = int(input_shape_nchw[0])
     in_h = int(input_shape_nchw[2])
@@ -832,6 +856,300 @@ def _resolve_conv_padding_and_explicit_pads(
     )
 
 
+def _resolve_conv3d_padding_and_explicit_pads(
+    *,
+    node: Any,
+    input_shape_ncdhw: list[int],
+    output_shape_ncdhw: list[int],
+) -> tuple[str, list[int] | None]:
+    auto_pad = str(node.attrs.get("auto_pad", "NOTSET")).upper()
+    raw_pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0, 0, 0]))]
+    if len(raw_pads) < 6:
+        raw_pads = [0, 0, 0, 0, 0, 0]
+    pads = [int(raw_pads[0]), int(raw_pads[1]), int(raw_pads[2]), int(raw_pads[3]), int(raw_pads[4]), int(raw_pads[5])]
+    pad_front, pad_top, pad_left, pad_back, pad_bottom, pad_right = pads
+    pads_axes_opposite_same = bool(
+        (pad_front == pad_back)
+        and (pad_top == pad_bottom)
+        and (pad_left == pad_right)
+    )
+
+    if auto_pad == "NOTSET":
+        if (
+            pads_axes_opposite_same
+            and len(input_shape_ncdhw) == 5
+            and len(output_shape_ncdhw) == 5
+            and list(input_shape_ncdhw[2:]) == list(output_shape_ncdhw[2:])
+        ):
+            return "SAME", None
+        if any(int(v) != 0 for v in pads):
+            return "VALID", pads
+        return "VALID", None
+
+    if auto_pad == "SAME_UPPER":
+        return "SAME", None
+    if auto_pad == "VALID":
+        if any(int(v) != 0 for v in pads):
+            return "VALID", pads
+        return "VALID", None
+    if auto_pad == "SAME_LOWER":
+        raise NotImplementedError(
+            f"Conv auto_pad=SAME_LOWER is not supported in flatbuffer_direct. op={node.name}"
+        )
+    raise NotImplementedError(
+        f"Conv auto_pad attribute is invalid for flatbuffer_direct. op={node.name} auto_pad={auto_pad}"
+    )
+
+
+def _build_conv_transpose3d_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    weight_name = node.inputs[1].name
+    output_name = node.outputs[0].name
+
+    input_shape = [int(v) for v in list(ctx.get_tensor_shape(input_name))]
+    output_shape = [int(v) for v in list(ctx.get_tensor_shape(output_name))]
+    if len(input_shape) != 5 or len(output_shape) != 5:
+        raise NotImplementedError(
+            f"ConvTranspose3D supports rank-5 input/output only in flatbuffer_direct. op={node.name} input_shape={input_shape} output_shape={output_shape}"
+        )
+    if any(int(v) <= 0 for v in output_shape):
+        raise NotImplementedError(
+            f"ConvTranspose3D requires static positive output shape in flatbuffer_direct. op={node.name} output_shape={output_shape}"
+        )
+
+    weights = ctx.get_constant_array(weight_name)
+    if weights is None:
+        raise NotImplementedError(
+            f"ConvTranspose weights must be constant for flatbuffer_direct. op={node.name}"
+        )
+    weights = np.asarray(weights)
+    if weights.ndim != 5:
+        raise NotImplementedError(
+            f"ConvTranspose3D weight rank must be 5. op={node.name} weight_shape={list(weights.shape)}"
+        )
+
+    group = int(node.attrs.get("group", 1))
+    if group != 1:
+        raise NotImplementedError(
+            f"ConvTranspose3D currently supports group=1 only. op={node.name} group={group}"
+        )
+
+    strides = [int(v) for v in list(node.attrs.get("strides", [1, 1, 1]))]
+    if len(strides) == 0:
+        strides = [1, 1, 1]
+    elif len(strides) == 1:
+        strides = [int(strides[0]), int(strides[0]), int(strides[0])]
+    elif len(strides) != 3:
+        raise NotImplementedError(
+            f"ConvTranspose3D strides must have length 3 in flatbuffer_direct. op={node.name} strides={strides}"
+        )
+    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1, 1]))]
+    if len(dilations) == 0:
+        dilations = [1, 1, 1]
+    elif len(dilations) == 1:
+        dilations = [int(dilations[0]), int(dilations[0]), int(dilations[0])]
+    elif len(dilations) != 3:
+        raise NotImplementedError(
+            f"ConvTranspose3D dilations must have length 3 in flatbuffer_direct. op={node.name} dilations={dilations}"
+        )
+    if dilations != [1, 1, 1]:
+        raise NotImplementedError(
+            f"ConvTranspose3D dilations must be [1,1,1] in flatbuffer_direct. op={node.name} dilations={dilations}"
+        )
+    output_padding = [int(v) for v in list(node.attrs.get("output_padding", []))]
+    if len(output_padding) == 0:
+        output_padding = [0, 0, 0]
+    elif len(output_padding) == 1:
+        output_padding = [int(output_padding[0]), int(output_padding[0]), int(output_padding[0])]
+    elif len(output_padding) != 3:
+        raise NotImplementedError(
+            "ConvTranspose3D output_padding must have length 3 in flatbuffer_direct. "
+            f"op={node.name} output_padding={output_padding}"
+        )
+    if any(v < 0 for v in output_padding):
+        raise NotImplementedError(
+            f"ConvTranspose3D output_padding must be non-negative in flatbuffer_direct. op={node.name} output_padding={output_padding}"
+        )
+    if any(int(v) >= int(s) for v, s in zip(output_padding, strides)):
+        raise NotImplementedError(
+            "ConvTranspose3D output_padding must satisfy "
+            f"0 <= output_padding < stride in flatbuffer_direct. op={node.name} output_padding={output_padding} strides={strides}"
+        )
+
+    # ONNX ConvTranspose3D weights are [C_in, C_out/group, kD, kH, kW].
+    # TFLite CONV_3D_TRANSPOSE expects [kD, kH, kW, C_out, C_in].
+    w_deconv = np.transpose(weights, (2, 3, 4, 1, 0)).astype(np.float32)
+    w_name = ctx.add_const_tensor(
+        f"{node.name}_conv3d_transpose_filter",
+        w_deconv,
+    )
+
+    ndhwc_input_shape = [
+        int(input_shape[0]),
+        int(input_shape[2]),
+        int(input_shape[3]),
+        int(input_shape[4]),
+        int(input_shape[1]),
+    ]
+    ndhwc_output_shape = [
+        int(output_shape[0]),
+        int(output_shape[2]),
+        int(output_shape[3]),
+        int(output_shape[4]),
+        int(output_shape[1]),
+    ]
+    raw_pads = [int(v) for v in list(node.attrs.get("pads", [0, 0, 0, 0, 0, 0]))]
+    if len(raw_pads) < 6:
+        raw_pads = [0, 0, 0, 0, 0, 0]
+    pad_front, pad_top, pad_left, pad_back, pad_bottom, pad_right = [int(v) for v in raw_pads[:6]]
+    needs_spatial_crop = any(
+        int(v) != 0 for v in [pad_front, pad_top, pad_left, pad_back, pad_bottom, pad_right]
+    )
+    ndhwc_transpose_conv_output_shape = [int(v) for v in list(ndhwc_output_shape)]
+    if needs_spatial_crop:
+        raw_out_d = int(ndhwc_output_shape[1]) + int(pad_front) + int(pad_back) - int(output_padding[0])
+        raw_out_h = int(ndhwc_output_shape[2]) + int(pad_top) + int(pad_bottom) - int(output_padding[1])
+        raw_out_w = int(ndhwc_output_shape[3]) + int(pad_left) + int(pad_right) - int(output_padding[2])
+        if raw_out_d <= 0 or raw_out_h <= 0 or raw_out_w <= 0:
+            raise NotImplementedError(
+                "ConvTranspose3D explicit pads produce invalid pre-crop output shape. "
+                f"op={node.name} output_shape={ndhwc_output_shape} pads={raw_pads} output_padding={output_padding}"
+            )
+        ndhwc_transpose_conv_output_shape = [
+            int(ndhwc_output_shape[0]),
+            int(raw_out_d),
+            int(raw_out_h),
+            int(raw_out_w),
+            int(ndhwc_output_shape[4]),
+        ]
+
+    x_ndhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_input_ndhwc",
+        dtype=ctx.get_tensor_dtype(input_name),
+        shape=ndhwc_input_shape,
+    )
+    x_ndhwc = make_transpose(
+        ctx,
+        input_name,
+        x_ndhwc,
+        [0, 2, 3, 4, 1],
+        allow_elide_inverse_chain=True,
+    )
+
+    out_shape_name = ctx.add_const_tensor(
+        f"{node.name}_conv3d_transpose_output_shape",
+        np.asarray(ndhwc_transpose_conv_output_shape, dtype=np.int32),
+    )
+
+    out_channels = int(ndhwc_output_shape[4])
+    bias_values = None
+    if len(node.inputs) >= 3:
+        bias_values = ctx.get_constant_array(node.inputs[2].name)
+    if bias_values is None:
+        bias_values = np.zeros((out_channels,), dtype=np.float32)
+    bias_values = np.asarray(bias_values, dtype=np.float32).reshape(-1)
+    if int(bias_values.size) != out_channels:
+        raise NotImplementedError(
+            f"ConvTranspose3D bias size must match output channels. op={node.name} bias_size={int(bias_values.size)} out_channels={out_channels}"
+        )
+    b_name = ctx.add_const_tensor(
+        f"{node.name}_conv3d_transpose_bias",
+        bias_values,
+    )
+
+    y_ndhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_output_ndhwc",
+        dtype=ctx.get_tensor_dtype(output_name),
+        shape=ndhwc_transpose_conv_output_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CONV_3D_TRANSPOSE",
+            inputs=[out_shape_name, w_name, x_ndhwc, b_name],
+            outputs=[y_ndhwc],
+            options={
+                "padding": _resolve_conv_transpose_padding(node),
+                "strideD": int(strides[0]),
+                "strideH": int(strides[1]),
+                "strideW": int(strides[2]),
+                "dilationDFactor": int(dilations[0]),
+                "dilationHFactor": int(dilations[1]),
+                "dilationWFactor": int(dilations[2]),
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    )
+
+    y_after_crop_ndhwc = y_ndhwc
+    if needs_spatial_crop:
+        crop_begin_name = ctx.add_const_tensor(
+            f"{node.name}_conv3d_transpose_crop_begin",
+            np.asarray([0, int(pad_front), int(pad_top), int(pad_left), 0], dtype=np.int32),
+        )
+        crop_end_name = ctx.add_const_tensor(
+            f"{node.name}_conv3d_transpose_crop_end",
+            np.asarray(
+                [
+                    int(ndhwc_transpose_conv_output_shape[0]),
+                    int(ndhwc_transpose_conv_output_shape[1]) - int(pad_back) + int(output_padding[0]),
+                    int(ndhwc_transpose_conv_output_shape[2]) - int(pad_bottom) + int(output_padding[1]),
+                    int(ndhwc_transpose_conv_output_shape[3]) - int(pad_right) + int(output_padding[2]),
+                    int(ndhwc_transpose_conv_output_shape[4]),
+                ],
+                dtype=np.int32,
+            ),
+        )
+        crop_stride_name = ctx.add_const_tensor(
+            f"{node.name}_conv3d_transpose_crop_stride",
+            np.asarray([1, 1, 1, 1, 1], dtype=np.int32),
+        )
+        y_cropped_ndhwc = ctx.add_intermediate_tensor(
+            f"{node.name}_output_ndhwc_cropped",
+            dtype=ctx.get_tensor_dtype(output_name),
+            shape=ndhwc_output_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="STRIDED_SLICE",
+                inputs=[y_ndhwc, crop_begin_name, crop_end_name, crop_stride_name],
+                outputs=[y_cropped_ndhwc],
+                options={
+                    "beginMask": 0,
+                    "endMask": 0,
+                    "ellipsisMask": 0,
+                    "newAxisMask": 0,
+                    "shrinkAxisMask": 0,
+                    "offset": False,
+                },
+            )
+        )
+        y_after_crop_ndhwc = y_cropped_ndhwc
+
+    output_tensor = ctx.model_ir.tensors[output_name]
+    output_signature = (
+        list(output_tensor.shape_signature)
+        if output_tensor.shape_signature is not None
+        else list(output_shape)
+    )
+    ndhwc_output_signature = list(ndhwc_output_shape)
+    if len(output_signature) == 5:
+        ndhwc_output_signature = [
+            int(output_signature[0]),
+            int(output_signature[2]),
+            int(output_signature[3]),
+            int(output_signature[4]),
+            int(output_signature[1]),
+        ]
+    ctx.model_ir.tensors[y_after_crop_ndhwc].shape_signature = [int(v) for v in ndhwc_output_signature]
+
+    make_transpose(
+        ctx,
+        y_after_crop_ndhwc,
+        output_name,
+        [0, 4, 1, 2, 3],
+    )
+
+
 def build_conv_transpose_op(node: Any, ctx: Any) -> None:
     input_name = node.inputs[0].name
     weight_name = node.inputs[1].name
@@ -867,6 +1185,14 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
         and np.asarray(weights_1d).ndim == 3
     ):
         _build_conv_transpose1d_via_conv2d(node, ctx)
+        return
+    if (
+        len(input_shape) == 5
+        and len(output_shape) == 5
+        and weights_1d is not None
+        and np.asarray(weights_1d).ndim == 5
+    ):
+        _build_conv_transpose3d_op(node, ctx)
         return
 
     def _shape_from_rank4_signature(signature: list[int]) -> list[int] | None:
@@ -935,15 +1261,38 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
         raise NotImplementedError(
             f"ConvTranspose currently supports group=1 only. op={node.name} group={group}"
         )
+    strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
+    if len(strides) == 0:
+        strides = [1, 1]
+    elif len(strides) == 1:
+        strides = [int(strides[0]), int(strides[0])]
+    elif len(strides) != 2:
+        raise NotImplementedError(
+            f"ConvTranspose strides must have length 2 in flatbuffer_direct. op={node.name} strides={strides}"
+        )
     dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
     if dilations != [1, 1]:
         raise NotImplementedError(
             f"ConvTranspose dilations must be [1,1] in flatbuffer_direct. op={node.name} dilations={dilations}"
         )
-    output_padding = [int(v) for v in list(node.attrs.get("output_padding", [0, 0]))]
-    if any(v != 0 for v in output_padding):
+    output_padding = [int(v) for v in list(node.attrs.get("output_padding", []))]
+    if len(output_padding) == 0:
+        output_padding = [0, 0]
+    elif len(output_padding) == 1:
+        output_padding = [int(output_padding[0]), int(output_padding[0])]
+    elif len(output_padding) != 2:
         raise NotImplementedError(
-            f"ConvTranspose output_padding must be [0,0] in flatbuffer_direct. op={node.name} output_padding={output_padding}"
+            "ConvTranspose output_padding must have length 2 in flatbuffer_direct. "
+            f"op={node.name} output_padding={output_padding}"
+        )
+    if any(v < 0 for v in output_padding):
+        raise NotImplementedError(
+            f"ConvTranspose output_padding must be non-negative in flatbuffer_direct. op={node.name} output_padding={output_padding}"
+        )
+    if any(int(v) >= int(s) for v, s in zip(output_padding, strides)):
+        raise NotImplementedError(
+            "ConvTranspose output_padding must satisfy "
+            f"0 <= output_padding < stride in flatbuffer_direct. op={node.name} output_padding={output_padding} strides={strides}"
         )
 
     output_shape = [int(v) for v in list(ctx.get_tensor_shape(output_name))]
@@ -1087,11 +1436,11 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
         )
         stride_h_vec = ctx.add_const_tensor(
             f"{node.name}_transpose_conv_stride_h",
-            np.asarray([int(dilations[0] * 0 + node.attrs.get('strides', [1, 1])[0])], dtype=np.int32),
+            np.asarray([int(strides[0])], dtype=np.int32),
         )
         stride_w_vec = ctx.add_const_tensor(
             f"{node.name}_transpose_conv_stride_w",
-            np.asarray([int(dilations[1] * 0 + node.attrs.get('strides', [1, 1])[1])], dtype=np.int32),
+            np.asarray([int(strides[1])], dtype=np.int32),
         )
         adjust_h_vec = ctx.add_const_tensor(
             f"{node.name}_transpose_conv_adjust_h",
@@ -1218,13 +1567,13 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
             op_type="TRANSPOSE_CONV",
             inputs=[out_shape_name, w_name, x_nhwc],
             outputs=[y_nhwc],
-            options={
-                "padding": _resolve_conv_transpose_padding(node),
-                "strideH": int(node.attrs.get("strides", [1, 1])[0]),
-                "strideW": int(node.attrs.get("strides", [1, 1])[1]),
-            },
+                options={
+                    "padding": _resolve_conv_transpose_padding(node),
+                    "strideH": int(strides[0]),
+                    "strideW": int(strides[1]),
+                },
+            )
         )
-    )
 
     y_after_crop_nhwc = y_nhwc
     if needs_spatial_crop:
@@ -1334,6 +1683,225 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
     )
 
 
+def _build_conv3d_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    weight_name = node.inputs[1].name
+    output_name = node.outputs[0].name
+
+    input_shape = [int(v) for v in list(ctx.get_tensor_shape(input_name))]
+    output_shape = [int(v) for v in list(ctx.get_tensor_shape(output_name))]
+    if len(input_shape) != 5 or len(output_shape) != 5:
+        raise NotImplementedError(
+            f"Only 3D Conv (rank=5) is supported by CONV_3D lowering. op={node.name} input_shape={input_shape} output_shape={output_shape}"
+        )
+
+    weights = ctx.get_constant_array(weight_name)
+    if weights is None:
+        raise NotImplementedError(
+            f"Conv weights must be constant for flatbuffer_direct. op={node.name}"
+        )
+    weights = np.asarray(weights)
+    if weights.ndim != 5:
+        raise NotImplementedError(
+            f"Conv3D weight rank must be 5. op={node.name} shape={weights.shape}"
+        )
+
+    group = int(node.attrs.get("group", 1))
+    if group != 1:
+        raise NotImplementedError(
+            f"Conv3D currently supports group=1 only. op={node.name} group={group}"
+        )
+
+    strides = [int(v) for v in list(node.attrs.get("strides", [1, 1, 1]))]
+    if len(strides) == 0:
+        strides = [1, 1, 1]
+    elif len(strides) == 1:
+        strides = [int(strides[0]), int(strides[0]), int(strides[0])]
+    elif len(strides) != 3:
+        raise NotImplementedError(
+            f"Conv3D strides must have length 3 in flatbuffer_direct. op={node.name} strides={strides}"
+        )
+    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1, 1]))]
+    if len(dilations) == 0:
+        dilations = [1, 1, 1]
+    elif len(dilations) == 1:
+        dilations = [int(dilations[0]), int(dilations[0]), int(dilations[0])]
+    elif len(dilations) != 3:
+        raise NotImplementedError(
+            f"Conv3D dilations must have length 3 in flatbuffer_direct. op={node.name} dilations={dilations}"
+        )
+
+    padding, explicit_pads = _resolve_conv3d_padding_and_explicit_pads(
+        node=node,
+        input_shape_ncdhw=input_shape,
+        output_shape_ncdhw=output_shape,
+    )
+    ndhwc_input_shape = [
+        int(input_shape[0]),
+        int(input_shape[2]),
+        int(input_shape[3]),
+        int(input_shape[4]),
+        int(input_shape[1]),
+    ]
+    ndhwc_output_shape = [
+        int(output_shape[0]),
+        int(output_shape[2]),
+        int(output_shape[3]),
+        int(output_shape[4]),
+        int(output_shape[1]),
+    ]
+
+    input_tensor = ctx.model_ir.tensors[input_name]
+    output_tensor = ctx.model_ir.tensors[output_name]
+    input_signature = (
+        list(input_tensor.shape_signature)
+        if input_tensor.shape_signature is not None
+        else list(input_shape)
+    )
+    output_signature = (
+        list(output_tensor.shape_signature)
+        if output_tensor.shape_signature is not None
+        else list(output_shape)
+    )
+    ndhwc_output_signature = list(ndhwc_output_shape)
+    if len(output_signature) == 5:
+        ndhwc_output_signature = [
+            int(output_signature[0]),
+            int(output_signature[2]),
+            int(output_signature[3]),
+            int(output_signature[4]),
+            int(output_signature[1]),
+        ]
+        if len(input_signature) == 5:
+            if int(input_signature[0]) < 0:
+                ndhwc_output_signature[0] = -1
+            if int(input_signature[2]) < 0:
+                ndhwc_output_signature[1] = -1
+            if int(input_signature[3]) < 0:
+                ndhwc_output_signature[2] = -1
+            if int(input_signature[4]) < 0:
+                ndhwc_output_signature[3] = -1
+
+    x_ndhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_input_ndhwc",
+        dtype=ctx.get_tensor_dtype(input_name),
+        shape=ndhwc_input_shape,
+    )
+    x_ndhwc = make_transpose(
+        ctx,
+        input_name,
+        x_ndhwc,
+        [0, 2, 3, 4, 1],
+        allow_elide_inverse_chain=True,
+    )
+    x_ndhwc_conv = x_ndhwc
+    if explicit_pads is not None:
+        pad_front, pad_top, pad_left, pad_back, pad_bottom, pad_right = [int(v) for v in explicit_pads]
+        if any(int(v) != 0 for v in [pad_front, pad_top, pad_left, pad_back, pad_bottom, pad_right]):
+            x_tensor = ctx.model_ir.tensors[x_ndhwc_conv]
+            padded_shape = list(x_tensor.shape)
+            padded_shape[1] = int(padded_shape[1]) + int(pad_front) + int(pad_back)
+            padded_shape[2] = int(padded_shape[2]) + int(pad_top) + int(pad_bottom)
+            padded_shape[3] = int(padded_shape[3]) + int(pad_left) + int(pad_right)
+            x_ndhwc_padded = ctx.add_intermediate_tensor(
+                f"{node.name}_input_ndhwc_padded",
+                dtype=ctx.get_tensor_dtype(x_ndhwc_conv),
+                shape=padded_shape,
+            )
+            x_ndhwc_padded_tensor = ctx.model_ir.tensors[x_ndhwc_padded]
+            x_sig = (
+                list(x_tensor.shape_signature)
+                if x_tensor.shape_signature is not None
+                else list(x_tensor.shape)
+            )
+            if len(x_sig) == 5:
+                padded_sig = list(x_sig)
+                if int(padded_sig[1]) >= 0:
+                    padded_sig[1] = int(padded_sig[1]) + int(pad_front) + int(pad_back)
+                if int(padded_sig[2]) >= 0:
+                    padded_sig[2] = int(padded_sig[2]) + int(pad_top) + int(pad_bottom)
+                if int(padded_sig[3]) >= 0:
+                    padded_sig[3] = int(padded_sig[3]) + int(pad_left) + int(pad_right)
+                x_ndhwc_padded_tensor.shape_signature = [int(v) for v in padded_sig]
+
+            pads_name = ctx.add_const_tensor(
+                f"{node.name}_pads_ndhwc",
+                np.asarray(
+                    [
+                        [0, 0],
+                        [pad_front, pad_back],
+                        [pad_top, pad_bottom],
+                        [pad_left, pad_right],
+                        [0, 0],
+                    ],
+                    dtype=np.int32,
+                ),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="PAD",
+                    inputs=[x_ndhwc_conv, pads_name],
+                    outputs=[x_ndhwc_padded],
+                )
+            )
+            x_ndhwc_conv = x_ndhwc_padded
+
+    # ONNX Conv3D weights are OI(DHW); TFLite CONV_3D expects DHWIO.
+    w_conv = np.transpose(weights, (2, 3, 4, 1, 0))
+    w_name = ctx.add_const_tensor(
+        f"{node.name}_conv3d_filter",
+        w_conv.astype(np.float32),
+    )
+
+    out_channels = int(weights.shape[0])
+    bias_values = None
+    if len(node.inputs) >= 3:
+        bias_values = ctx.get_constant_array(node.inputs[2].name)
+    if bias_values is None:
+        bias_values = np.zeros((out_channels,), dtype=np.float32)
+    bias_values = np.asarray(bias_values, dtype=np.float32).reshape(-1)
+    if int(bias_values.size) != out_channels:
+        raise NotImplementedError(
+            "Conv3D bias size must match output channels. "
+            f"op={node.name} bias_size={int(bias_values.size)} out_channels={out_channels}"
+        )
+    b_name = ctx.add_const_tensor(
+        f"{node.name}_conv3d_bias",
+        bias_values,
+    )
+
+    y_ndhwc = ctx.add_intermediate_tensor(
+        f"{node.name}_output_ndhwc",
+        dtype=ctx.get_tensor_dtype(output_name),
+        shape=ndhwc_output_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CONV_3D",
+            inputs=[x_ndhwc_conv, w_name, b_name],
+            outputs=[y_ndhwc],
+            options={
+                "padding": padding,
+                "strideD": int(strides[0]),
+                "strideH": int(strides[1]),
+                "strideW": int(strides[2]),
+                "dilationDFactor": int(dilations[0]),
+                "dilationHFactor": int(dilations[1]),
+                "dilationWFactor": int(dilations[2]),
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    )
+    ctx.model_ir.tensors[y_ndhwc].shape_signature = [int(v) for v in ndhwc_output_signature]
+
+    make_transpose(
+        ctx,
+        y_ndhwc,
+        output_name,
+        [0, 4, 1, 2, 3],
+    )
+
+
 def build_conv2d_or_depthwise_op(node: Any, ctx: Any) -> None:
     input_name = node.inputs[0].name
     weight_name = node.inputs[1].name
@@ -1348,6 +1916,11 @@ def build_conv2d_or_depthwise_op(node: Any, ctx: Any) -> None:
     if len(input_shape) == 3 and len(output_shape) == 3:
         _build_conv1d_via_conv2d(node, ctx)
         return
+    if len(input_shape) == 5 and len(output_shape) == 5:
+        weights_3d = ctx.get_constant_array(weight_name)
+        if weights_3d is not None and np.asarray(weights_3d).ndim == 5:
+            _build_conv3d_op(node, ctx)
+            return
     if len(input_shape) != 4 or len(output_shape) != 4:
         raise NotImplementedError(f"Only 2D Conv (rank=4) is supported. op={node.name}")
 

--- a/onnx2tf/tflite_builder/op_builders/elementwise.py
+++ b/onnx2tf/tflite_builder/op_builders/elementwise.py
@@ -36,6 +36,29 @@ def _normalize_axis_for_rank(axis: int, rank: int) -> int:
     return int(a)
 
 
+def _get_main_onnx_opset(ctx: Any) -> int | None:
+    onnx_model = getattr(ctx, "onnx_model", None)
+    if onnx_model is None:
+        return None
+    for opset in getattr(onnx_model, "opset_import", []):
+        domain = str(getattr(opset, "domain", ""))
+        if domain in {"", "ai.onnx"}:
+            try:
+                return int(opset.version)
+            except Exception:
+                return None
+    return None
+
+
+def _resolve_softmax_axis(node: Any, ctx: Any, rank: int) -> int:
+    if "axis" in node.attrs:
+        raw_axis = int(node.attrs["axis"])
+    else:
+        opset = _get_main_onnx_opset(ctx)
+        raw_axis = -1 if opset is not None and int(opset) >= 13 else 1
+    return _normalize_axis_for_rank(axis=raw_axis, rank=rank)
+
+
 def _axis_to_last_permutations(axis: int, rank: int) -> tuple[list[int], list[int]]:
     perm_to_last = [int(v) for v in range(rank) if int(v) != int(axis)] + [int(axis)]
     perm_from_last = [0] * int(rank)
@@ -45,6 +68,35 @@ def _axis_to_last_permutations(axis: int, rank: int) -> tuple[list[int], list[in
 
 
 _FLOAT_TENSOR_DTYPES = {"FLOAT16", "FLOAT32"}
+
+
+def _numpy_dtype_for_tensor(tflite_dtype: str) -> np.dtype:
+    dt = str(tflite_dtype).upper()
+    if dt == "BOOL":
+        return np.dtype(np.bool_)
+    if dt == "INT8":
+        return np.dtype(np.int8)
+    if dt == "UINT8":
+        return np.dtype(np.uint8)
+    if dt == "INT16":
+        return np.dtype(np.int16)
+    if dt == "UINT16":
+        return np.dtype(np.uint16)
+    if dt == "INT32":
+        return np.dtype(np.int32)
+    if dt == "UINT32":
+        return np.dtype(np.uint32)
+    if dt == "INT64":
+        return np.dtype(np.int64)
+    if dt == "UINT64":
+        return np.dtype(np.uint64)
+    if dt == "FLOAT16":
+        return np.dtype(np.float16)
+    if dt == "FLOAT32":
+        return np.dtype(np.float32)
+    if dt == "FLOAT64":
+        return np.dtype(np.float64)
+    raise NotImplementedError(f"Unsupported dtype for clip lowering: dtype={tflite_dtype}")
 
 
 def _compute_dtype_for_output(output_dtype: str) -> str:
@@ -647,6 +699,49 @@ def build_unary_op(node: Any, ctx: Any, op_type: str) -> None:
     )
 
 
+def build_abs_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+    _propagate_shape(ctx, input_name, output_name)
+
+    input_dtype = str(ctx.get_tensor_dtype(input_name)).upper()
+    output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+
+    # TFLite ABS does not support INT64. Lower to max(x, -x).
+    if input_dtype == "INT64":
+        neg_name = ctx.add_intermediate_tensor(
+            f"{output_name}_abs_neg",
+            dtype=input_dtype,
+            shape=output_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="NEG",
+                inputs=[input_name],
+                outputs=[neg_name],
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MAXIMUM",
+                inputs=[input_name, neg_name],
+                outputs=[output_name],
+                options={},
+            )
+        )
+        return
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="ABS",
+            inputs=[input_name],
+            outputs=[output_name],
+        )
+    )
+
+
 def build_erf_op(node: Any, ctx: Any) -> None:
     (
         compute_input_name,
@@ -941,11 +1036,12 @@ def build_where_op(node: Any, ctx: Any) -> None:
     ctx.ensure_tensor(output_name)
     _propagate_shape(ctx, x_name, output_name)
 
+    output_dtype = str(ctx.get_tensor_dtype(output_name)).upper()
     condition_dtype = str(ctx.get_tensor_dtype(condition_name)).upper()
-    cond_for_select = condition_name
+    cond_bool_name = condition_name
     if condition_dtype != "BOOL":
         cond_shape = [int(v) for v in ctx.get_tensor_shape(condition_name)]
-        cond_for_select = ctx.add_intermediate_tensor(
+        cond_bool_name = ctx.add_intermediate_tensor(
             f"{output_name}_where_condition_bool",
             dtype="BOOL",
             shape=cond_shape,
@@ -954,7 +1050,7 @@ def build_where_op(node: Any, ctx: Any) -> None:
             OperatorIR(
                 op_type="CAST",
                 inputs=[condition_name],
-                outputs=[cond_for_select],
+                outputs=[cond_bool_name],
                 options={
                     "inDataType": condition_dtype,
                     "outDataType": "BOOL",
@@ -962,10 +1058,96 @@ def build_where_op(node: Any, ctx: Any) -> None:
             )
         )
 
+    cond_shape = [int(v) for v in ctx.get_tensor_shape(cond_bool_name)]
+    x_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
+    y_shape = [int(v) for v in ctx.get_tensor_shape(y_name)]
+    select_broadcast_supported = (
+        (cond_shape == x_shape and x_shape == y_shape)
+        or (len(cond_shape) <= 1 and x_shape == y_shape)
+    )
+
+    # TFLite SELECT broadcasting is limited. For unsupported broadcast patterns,
+    # rewrite Where to arithmetic equivalent when output is float.
+    if not select_broadcast_supported and output_dtype in {"FLOAT16", "FLOAT32"}:
+        output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+        x_cast_name = _cast_tensor_if_needed(
+            ctx=ctx,
+            src_name=x_name,
+            dst_dtype=output_dtype,
+            base_name=f"{output_name}_where_x_cast",
+        )
+        y_cast_name = _cast_tensor_if_needed(
+            ctx=ctx,
+            src_name=y_name,
+            dst_dtype=output_dtype,
+            base_name=f"{output_name}_where_y_cast",
+        )
+        cond_cast_name = _cast_tensor_if_needed(
+            ctx=ctx,
+            src_name=cond_bool_name,
+            dst_dtype=output_dtype,
+            base_name=f"{output_name}_where_condition_cast",
+        )
+        one_np_dtype = np.float16 if output_dtype == "FLOAT16" else np.float32
+        one_const_name = ctx.add_const_tensor(
+            f"{output_name}_where_one",
+            np.asarray(1.0, dtype=one_np_dtype),
+        )
+
+        inv_cond_name = ctx.add_intermediate_tensor(
+            f"{output_name}_where_condition_inv",
+            dtype=output_dtype,
+            shape=cond_shape,
+        )
+        x_term_name = ctx.add_intermediate_tensor(
+            f"{output_name}_where_x_term",
+            dtype=output_dtype,
+            shape=output_shape,
+        )
+        y_term_name = ctx.add_intermediate_tensor(
+            f"{output_name}_where_y_term",
+            dtype=output_dtype,
+            shape=output_shape,
+        )
+
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SUB",
+                inputs=[one_const_name, cond_cast_name],
+                outputs=[inv_cond_name],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MUL",
+                inputs=[cond_cast_name, x_cast_name],
+                outputs=[x_term_name],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MUL",
+                inputs=[inv_cond_name, y_cast_name],
+                outputs=[y_term_name],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="ADD",
+                inputs=[x_term_name, y_term_name],
+                outputs=[output_name],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        return
+
     ctx.add_operator(
         OperatorIR(
             op_type="SELECT",
-            inputs=[cond_for_select, x_name, y_name],
+            inputs=[cond_bool_name, x_name, y_name],
             outputs=[output_name],
         )
     )
@@ -2022,6 +2204,10 @@ def build_clip_op(node: Any, ctx: Any) -> None:
     ctx.ensure_tensor(output_name)
     _propagate_shape(ctx, input_name, output_name)
 
+    input_dtype = str(ctx.get_tensor_dtype(input_name)).upper()
+    clip_np_dtype = _numpy_dtype_for_tensor(input_dtype)
+    float_clip_input = input_dtype in {"FLOAT16", "FLOAT32", "FLOAT64"}
+
     clip_min = _get_clip_bound_value(node.attrs.get("min", None), float("-inf"))
     clip_max = _get_clip_bound_value(node.attrs.get("max", None), float("inf"))
     min_arr = None
@@ -2029,22 +2215,35 @@ def build_clip_op(node: Any, ctx: Any) -> None:
     if len(node.inputs) >= 2:
         min_const = ctx.get_constant_array(node.inputs[1].name)
         if min_const is not None:
-            min_arr = np.asarray(min_const, dtype=np.float32)
+            min_arr = np.asarray(min_const, dtype=clip_np_dtype)
             clip_min = _get_clip_bound_value(min_arr, clip_min)
     if len(node.inputs) >= 3:
         max_const = ctx.get_constant_array(node.inputs[2].name)
         if max_const is not None:
-            max_arr = np.asarray(max_const, dtype=np.float32)
+            max_arr = np.asarray(max_const, dtype=clip_np_dtype)
             clip_max = _get_clip_bound_value(max_arr, clip_max)
 
     if min_arr is None and np.isfinite(clip_min):
-        min_arr = np.asarray(clip_min, dtype=np.float32)
+        min_arr = np.asarray(clip_min, dtype=clip_np_dtype)
     if max_arr is None and np.isfinite(clip_max):
-        max_arr = np.asarray(clip_max, dtype=np.float32)
+        max_arr = np.asarray(clip_max, dtype=clip_np_dtype)
 
-    if abs(clip_min - 0.0) <= 1e-6 and abs(clip_max - 6.0) <= 1e-6 and min_arr is not None and max_arr is not None:
+    if (
+        float_clip_input
+        and abs(clip_min - 0.0) <= 1e-6
+        and abs(clip_max - 6.0) <= 1e-6
+        and min_arr is not None
+        and max_arr is not None
+    ):
         op_type = "RELU6"
-    elif abs(clip_min - 0.0) <= 1e-6 and math.isinf(clip_max) and clip_max > 0.0 and min_arr is not None and max_arr is None:
+    elif (
+        float_clip_input
+        and abs(clip_min - 0.0) <= 1e-6
+        and math.isinf(clip_max)
+        and clip_max > 0.0
+        and min_arr is not None
+        and max_arr is None
+    ):
         op_type = "RELU"
     else:
         output_dtype = ctx.get_tensor_dtype(output_name)
@@ -2053,7 +2252,7 @@ def build_clip_op(node: Any, ctx: Any) -> None:
         if min_arr is not None:
             min_name = ctx.add_const_tensor(
                 f"{node.name}_clip_min",
-                np.asarray(min_arr, dtype=np.float32),
+                np.asarray(min_arr, dtype=clip_np_dtype),
             )
             min_output_name = output_name
             if max_arr is not None:
@@ -2082,7 +2281,7 @@ def build_clip_op(node: Any, ctx: Any) -> None:
         if max_arr is not None:
             max_name = ctx.add_const_tensor(
                 f"{node.name}_clip_max",
-                np.asarray(max_arr, dtype=np.float32),
+                np.asarray(max_arr, dtype=clip_np_dtype),
             )
             ctx.add_operator(
                 OperatorIR(
@@ -2129,8 +2328,7 @@ def build_softmax_op(node: Any, ctx: Any) -> None:
     rank = len(input_shape)
     if rank <= 0:
         raise NotImplementedError(f"Softmax requires rank >= 1. op={node.name} shape={input_shape}")
-    axis = int(node.attrs.get("axis", 1))
-    axis = _normalize_axis_for_rank(axis=axis, rank=rank)
+    axis = _resolve_softmax_axis(node=node, ctx=ctx, rank=rank)
 
     if axis == rank - 1:
         ctx.add_operator(
@@ -2189,8 +2387,7 @@ def build_logsoftmax_op(node: Any, ctx: Any) -> None:
     rank = len(input_shape)
     if rank <= 0:
         raise NotImplementedError(f"LogSoftmax requires rank >= 1. op={node.name} shape={input_shape}")
-    axis = int(node.attrs.get("axis", 1))
-    axis = _normalize_axis_for_rank(axis=axis, rank=rank)
+    axis = _resolve_softmax_axis(node=node, ctx=ctx, rank=rank)
 
     output_dtype = str(ctx.get_tensor_dtype(output_name))
     if axis != rank - 1:

--- a/onnx2tf/tflite_builder/op_builders/norm.py
+++ b/onnx2tf/tflite_builder/op_builders/norm.py
@@ -136,9 +136,13 @@ def build_batch_normalization_op(node: Any, ctx: Any) -> None:
 
     input_shape = ctx.get_tensor_shape(input_name)
     input_rank = len(input_shape)
-    if input_rank == 4:
-        bn_mul = bn_mul.reshape(1, -1, 1, 1)
-        bn_add = bn_add.reshape(1, -1, 1, 1)
+    if input_rank >= 3:
+        # ONNX BatchNormalization uses channel axis=1 for rank>=3.
+        # TFLite binary broadcast aligns trailing axes, so channel coefficients
+        # must be materialized as [1, C, 1, ...] to keep channel-wise semantics.
+        coeff_shape = [1, -1] + [1] * int(input_rank - 2)
+        bn_mul = bn_mul.reshape(coeff_shape)
+        bn_add = bn_add.reshape(coeff_shape)
     elif input_rank == 2:
         bn_mul = bn_mul.reshape(1, -1)
         bn_add = bn_add.reshape(1, -1)

--- a/onnx2tf/tflite_builder/op_builders/recurrent.py
+++ b/onnx2tf/tflite_builder/op_builders/recurrent.py
@@ -80,16 +80,22 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
     initial_h_name = _input_name(original_inputs, 5)
     initial_c_name = _input_name(original_inputs, 6)
     direction = str(node.attrs.get("direction", "forward")).lower()
-    if direction not in {"forward", "bidirectional"}:
+    if direction not in {"forward", "reverse", "bidirectional"}:
         raise NotImplementedError(
-            f"LSTM direction must be forward or bidirectional for flatbuffer_direct. op={node.name} direction={direction}"
+            f"LSTM direction must be forward/reverse/bidirectional for flatbuffer_direct. op={node.name} direction={direction}"
         )
     expected_num_directions = 2 if direction == "bidirectional" else 1
 
     y_name = node.outputs[0].name
+    y_h_name = node.outputs[1].name if len(node.outputs) > 1 else ""
+    y_c_name = node.outputs[2].name if len(node.outputs) > 2 else ""
     y_dtype = str(ctx.get_tensor_dtype(y_name))
     ctx.ensure_tensor(x_name)
     ctx.ensure_tensor(y_name)
+    if y_h_name != "":
+        ctx.ensure_tensor(y_h_name)
+    if y_c_name != "":
+        ctx.ensure_tensor(y_c_name)
 
     w_value = ctx.get_constant_array(w_name)
     r_value = ctx.get_constant_array(r_name)
@@ -139,24 +145,46 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
             f"hidden_size={hidden_size} B_shape={list(B.shape)}"
         )
 
-    h0_value = ctx.get_constant_array(initial_h_name)
-    c0_value = ctx.get_constant_array(initial_c_name)
-    if h0_value is None or c0_value is None:
+    has_initial_state_inputs = (
+        initial_h_name != ""
+        and initial_c_name != ""
+    )
+    if (initial_h_name == "") ^ (initial_c_name == ""):
         raise NotImplementedError(
-            f"LSTM initial_h/initial_c must be constant for flatbuffer_direct. op={node.name}"
+            f"LSTM initial_h and initial_c must be both present or both absent. op={node.name}"
         )
-    H0 = np.asarray(h0_value, dtype=np.float32)
-    C0 = np.asarray(c0_value, dtype=np.float32)
-    if H0.ndim != 3 or C0.ndim != 3:
-        raise NotImplementedError(
-            f"LSTM initial_h/initial_c must be rank-3. op={node.name}"
-        )
-    if int(H0.shape[0]) != expected_num_directions or int(C0.shape[0]) != expected_num_directions:
-        raise NotImplementedError(
-            "LSTM initial_h/initial_c first dim must match num_directions. "
-            f"op={node.name} direction={direction} expected_num_directions={expected_num_directions} "
-            f"H0_shape={list(H0.shape)} C0_shape={list(C0.shape)}"
-        )
+    initial_h_shape = [expected_num_directions, 1, hidden_size]
+    initial_c_shape = [expected_num_directions, 1, hidden_size]
+    if has_initial_state_inputs:
+        ctx.ensure_tensor(initial_h_name)
+        ctx.ensure_tensor(initial_c_name)
+        initial_h_shape = [int(v) for v in ctx.get_tensor_shape(initial_h_name)]
+        initial_c_shape = [int(v) for v in ctx.get_tensor_shape(initial_c_name)]
+        if len(initial_h_shape) != 3 or len(initial_c_shape) != 3:
+            raise NotImplementedError(
+                "LSTM initial_h/initial_c must be rank-3. "
+                f"op={node.name} initial_h_shape={initial_h_shape} initial_c_shape={initial_c_shape}"
+            )
+        if (
+            int(initial_h_shape[0]) > 0 and int(initial_h_shape[0]) != expected_num_directions
+        ) or (
+            int(initial_c_shape[0]) > 0 and int(initial_c_shape[0]) != expected_num_directions
+        ):
+            raise NotImplementedError(
+                "LSTM initial_h/initial_c first dim must match num_directions. "
+                f"op={node.name} direction={direction} expected_num_directions={expected_num_directions} "
+                f"initial_h_shape={initial_h_shape} initial_c_shape={initial_c_shape}"
+            )
+        if (
+            int(initial_h_shape[2]) > 0 and int(initial_h_shape[2]) != hidden_size
+        ) or (
+            int(initial_c_shape[2]) > 0 and int(initial_c_shape[2]) != hidden_size
+        ):
+            raise NotImplementedError(
+                "LSTM initial_h/initial_c hidden dim must match hidden_size. "
+                f"op={node.name} hidden_size={hidden_size} "
+                f"initial_h_shape={initial_h_shape} initial_c_shape={initial_c_shape}"
+            )
 
     fw_w_i, fw_w_f, fw_w_c, fw_w_o = _split_onnx_lstm_gates(
         np.asarray(W[0], dtype=np.float32),
@@ -188,6 +216,62 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
         state_tensor.data = None
         return state_name
 
+    def _prepare_lstm_state_input(
+        *,
+        state_input_name: str,
+        dir_index: int,
+        state_tag: str,
+    ) -> str:
+        if state_input_name == "":
+            reference = np.zeros((int(batch_dim), int(hidden_size)), dtype=np.float32)
+            return _add_zero_variable_state(f"{state_tag}_state", reference)
+
+        slice_input_name = state_input_name
+        state_shape = [int(v) for v in ctx.get_tensor_shape(state_input_name)]
+        if len(state_shape) != 3:
+            raise NotImplementedError(
+                f"LSTM {state_tag} must be rank-3. op={node.name} shape={state_shape}"
+            )
+        if not (expected_num_directions == 1 and int(state_shape[0]) == 1):
+            slice_input_name = ctx.add_intermediate_tensor(
+                f"{node.name}_{state_tag}_dir{dir_index}_slice",
+                dtype="FLOAT32",
+                shape=[1, int(batch_dim), int(hidden_size)],
+            )
+            begin_name = _add_const(
+                f"{state_tag}_dir{dir_index}_begin",
+                np.asarray([int(dir_index), 0, 0], dtype=np.int32),
+                dtype=np.int32,
+            )
+            size_name = _add_const(
+                f"{state_tag}_dir{dir_index}_size",
+                np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+                dtype=np.int32,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[state_input_name, begin_name, size_name],
+                    outputs=[slice_input_name],
+                )
+            )
+        state_2d_name = ctx.add_intermediate_tensor(
+            f"{node.name}_{state_tag}_dir{dir_index}_2d",
+            dtype="FLOAT32",
+            shape=[int(batch_dim), int(hidden_size)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SQUEEZE",
+                inputs=[slice_input_name],
+                outputs=[state_2d_name],
+                options={"squeezeDims": [0]},
+            )
+        )
+        state_tensor = ctx.model_ir.tensors[state_2d_name]
+        state_tensor.is_variable = True
+        return state_2d_name
+
     input_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
     x_tensor = ctx.model_ir.tensors.get(x_name, None)
     input_signature = None
@@ -218,6 +302,18 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
             int(batch_signature_dim) if batch_signature_dim is not None else int(batch_dim),
             int(hidden_size),
         ]
+    y_h_shape = [int(expected_num_directions), int(batch_dim), int(hidden_size)]
+    y_c_shape = [int(expected_num_directions), int(batch_dim), int(hidden_size)]
+    if y_h_name != "":
+        y_h_tensor = ctx.model_ir.tensors.get(y_h_name, None)
+        if y_h_tensor is not None:
+            y_h_tensor.shape = [int(v) for v in y_h_shape]
+            y_h_tensor.shape_signature = [int(v) for v in y_h_shape]
+    if y_c_name != "":
+        y_c_tensor = ctx.model_ir.tensors.get(y_c_name, None)
+        if y_c_tensor is not None:
+            y_c_tensor.shape = [int(v) for v in y_c_shape]
+            y_c_tensor.shape_signature = [int(v) for v in y_c_shape]
     use_reshape_expand = (
         seq_signature_dim is not None
         and batch_signature_dim is not None
@@ -225,15 +321,43 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
         and int(batch_signature_dim) > 0
     )
     if expected_num_directions == 1:
-        fw_h0_name = _add_zero_variable_state("fw_h0_state", np.asarray(H0[0], dtype=np.float32))
-        fw_c0_name = _add_zero_variable_state("fw_c0_state", np.asarray(C0[0], dtype=np.float32))
+        lstm_input_name = x_name
+        if direction == "reverse":
+            reverse_axis_input_name = _add_const(
+                "reverse_time_axis_input",
+                np.asarray([0], dtype=np.int32),
+                dtype=np.int32,
+            )
+            lstm_input_name = ctx.add_intermediate_tensor(
+                f"{y_name}_lstm_reverse_input",
+                dtype=str(ctx.get_tensor_dtype(x_name)),
+                shape=[int(v) for v in list(input_shape)],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="REVERSE_V2",
+                    inputs=[x_name, reverse_axis_input_name],
+                    outputs=[lstm_input_name],
+                )
+            )
+
+        fw_h0_name = _prepare_lstm_state_input(
+            state_input_name=initial_h_name if has_initial_state_inputs else "",
+            dir_index=0,
+            state_tag="h0",
+        )
+        fw_c0_name = _prepare_lstm_state_input(
+            state_input_name=initial_c_name if has_initial_state_inputs else "",
+            dir_index=0,
+            state_tag="c0",
+        )
         uni_output_name = ctx.add_intermediate_tensor(
             f"{y_name}_lstm_uni",
             dtype=y_dtype,
             shape=[int(seq_dim), int(batch_dim), int(hidden_size)],
         )
         uni_inputs = [
-            x_name,
+            lstm_input_name,
             _add_const("fw_w_i", fw_w_i),
             _add_const("fw_w_f", fw_w_f),
             _add_const("fw_w_c", fw_w_c),
@@ -277,6 +401,25 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
                 },
             )
         )
+        uni_output_final_name = uni_output_name
+        if direction == "reverse":
+            reverse_axis_output_name = _add_const(
+                "reverse_time_axis_output",
+                np.asarray([0], dtype=np.int32),
+                dtype=np.int32,
+            )
+            uni_output_final_name = ctx.add_intermediate_tensor(
+                f"{y_name}_lstm_reverse_output",
+                dtype=y_dtype,
+                shape=[int(seq_dim), int(batch_dim), int(hidden_size)],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="REVERSE_V2",
+                    inputs=[uni_output_name, reverse_axis_output_name],
+                    outputs=[uni_output_final_name],
+                )
+            )
         if use_reshape_expand:
             expand_shape = np.asarray(
                 [int(seq_dim), 1, int(batch_dim), int(hidden_size)],
@@ -286,7 +429,7 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
             ctx.add_operator(
                 OperatorIR(
                     op_type="RESHAPE",
-                    inputs=[uni_output_name, expand_shape_name],
+                    inputs=[uni_output_final_name, expand_shape_name],
                     outputs=[y_name],
                     options={"newShape": [int(v) for v in list(expand_shape)]},
                 )
@@ -296,8 +439,36 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
             ctx.add_operator(
                 OperatorIR(
                     op_type="EXPAND_DIMS",
-                    inputs=[uni_output_name, expand_axis_name],
+                    inputs=[uni_output_final_name, expand_axis_name],
                     outputs=[y_name],
+                )
+            )
+        if y_h_name != "":
+            y_h_shape_name = _add_const(
+                "y_h_shape",
+                np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+                dtype=np.int32,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[fw_h0_name, y_h_shape_name],
+                    outputs=[y_h_name],
+                    options={"newShape": [1, int(batch_dim), int(hidden_size)]},
+                )
+            )
+        if y_c_name != "":
+            y_c_shape_name = _add_const(
+                "y_c_shape",
+                np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+                dtype=np.int32,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[fw_c0_name, y_c_shape_name],
+                    outputs=[y_c_name],
+                    options={"newShape": [1, int(batch_dim), int(hidden_size)]},
                 )
             )
         return
@@ -315,10 +486,26 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
         hidden_size,
     )
 
-    fw_h0_name = _add_zero_variable_state("fw_h0_state", np.asarray(H0[0], dtype=np.float32))
-    fw_c0_name = _add_zero_variable_state("fw_c0_state", np.asarray(C0[0], dtype=np.float32))
-    bw_h0_name = _add_zero_variable_state("bw_h0_state", np.asarray(H0[1], dtype=np.float32))
-    bw_c0_name = _add_zero_variable_state("bw_c0_state", np.asarray(C0[1], dtype=np.float32))
+    fw_h0_name = _prepare_lstm_state_input(
+        state_input_name=initial_h_name if has_initial_state_inputs else "",
+        dir_index=0,
+        state_tag="h0_fw",
+    )
+    fw_c0_name = _prepare_lstm_state_input(
+        state_input_name=initial_c_name if has_initial_state_inputs else "",
+        dir_index=0,
+        state_tag="c0_fw",
+    )
+    bw_h0_name = _prepare_lstm_state_input(
+        state_input_name=initial_h_name if has_initial_state_inputs else "",
+        dir_index=1,
+        state_tag="h0_bw",
+    )
+    bw_c0_name = _prepare_lstm_state_input(
+        state_input_name=initial_c_name if has_initial_state_inputs else "",
+        dir_index=1,
+        state_tag="c0_bw",
+    )
 
     merged_output_name = ctx.add_intermediate_tensor(
         f"{y_name}_bilstm_merged",
@@ -483,6 +670,132 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
             },
         )
     )
+    if y_h_name != "":
+        fw_h_3d_name = ctx.add_intermediate_tensor(
+            f"{y_h_name}_fw_3d",
+            dtype="FLOAT32",
+            shape=[1, int(batch_dim), int(hidden_size)],
+        )
+        bw_h_3d_name = ctx.add_intermediate_tensor(
+            f"{y_h_name}_bw_3d",
+            dtype="FLOAT32",
+            shape=[1, int(batch_dim), int(hidden_size)],
+        )
+        fw_h_shape_name = _add_const(
+            "y_h_fw_shape",
+            np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+            dtype=np.int32,
+        )
+        bw_h_shape_name = _add_const(
+            "y_h_bw_shape",
+            np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+            dtype=np.int32,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[fw_h0_name, fw_h_shape_name],
+                outputs=[fw_h_3d_name],
+                options={"newShape": [1, int(batch_dim), int(hidden_size)]},
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[bw_h0_name, bw_h_shape_name],
+                outputs=[bw_h_3d_name],
+                options={"newShape": [1, int(batch_dim), int(hidden_size)]},
+            )
+        )
+        y_h_merged_name = ctx.add_intermediate_tensor(
+            f"{y_h_name}_merged",
+            dtype="FLOAT32",
+            shape=[2, int(batch_dim), int(hidden_size)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CONCATENATION",
+                inputs=[fw_h_3d_name, bw_h_3d_name],
+                outputs=[y_h_merged_name],
+                options={"axis": 0, "fusedActivationFunction": "NONE"},
+            )
+        )
+        y_h_shape_name = _add_const(
+            "y_h_shape",
+            np.asarray(y_h_shape, dtype=np.int32),
+            dtype=np.int32,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[y_h_merged_name, y_h_shape_name],
+                outputs=[y_h_name],
+                options={"newShape": [int(v) for v in y_h_shape]},
+            )
+        )
+    if y_c_name != "":
+        fw_c_3d_name = ctx.add_intermediate_tensor(
+            f"{y_c_name}_fw_3d",
+            dtype="FLOAT32",
+            shape=[1, int(batch_dim), int(hidden_size)],
+        )
+        bw_c_3d_name = ctx.add_intermediate_tensor(
+            f"{y_c_name}_bw_3d",
+            dtype="FLOAT32",
+            shape=[1, int(batch_dim), int(hidden_size)],
+        )
+        fw_c_shape_name = _add_const(
+            "y_c_fw_shape",
+            np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+            dtype=np.int32,
+        )
+        bw_c_shape_name = _add_const(
+            "y_c_bw_shape",
+            np.asarray([1, int(batch_dim), int(hidden_size)], dtype=np.int32),
+            dtype=np.int32,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[fw_c0_name, fw_c_shape_name],
+                outputs=[fw_c_3d_name],
+                options={"newShape": [1, int(batch_dim), int(hidden_size)]},
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[bw_c0_name, bw_c_shape_name],
+                outputs=[bw_c_3d_name],
+                options={"newShape": [1, int(batch_dim), int(hidden_size)]},
+            )
+        )
+        y_c_merged_name = ctx.add_intermediate_tensor(
+            f"{y_c_name}_merged",
+            dtype="FLOAT32",
+            shape=[2, int(batch_dim), int(hidden_size)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CONCATENATION",
+                inputs=[fw_c_3d_name, bw_c_3d_name],
+                outputs=[y_c_merged_name],
+                options={"axis": 0, "fusedActivationFunction": "NONE"},
+            )
+        )
+        y_c_shape_name = _add_const(
+            "y_c_shape",
+            np.asarray(y_c_shape, dtype=np.int32),
+            dtype=np.int32,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[y_c_merged_name, y_c_shape_name],
+                outputs=[y_c_name],
+                options={"newShape": [int(v) for v in y_c_shape]},
+            )
+        )
 
 
 def build_rnn_op(node: Any, ctx: Any) -> None:
@@ -493,9 +806,16 @@ def build_rnn_op(node: Any, ctx: Any) -> None:
     b_name = _input_name(original_inputs, 3)
     sequence_lens_name = _input_name(original_inputs, 4)
     initial_h_name = _input_name(original_inputs, 5)
+    direction = str(node.attrs.get("direction", "forward")).lower()
+    if direction not in {"forward", "reverse", "bidirectional"}:
+        raise NotImplementedError(
+            f"RNN direction is not supported in flatbuffer_direct. op={node.name} direction={direction}"
+        )
+    expected_num_directions = 2 if direction == "bidirectional" else 1
 
     y_name = node.outputs[0].name
     y_h_name = node.outputs[1].name if len(node.outputs) > 1 else ""
+    y_dtype = str(ctx.get_tensor_dtype(y_name)).upper()
     ctx.ensure_tensor(x_name)
     ctx.ensure_tensor(y_name)
     if y_h_name != "":
@@ -513,9 +833,11 @@ def build_rnn_op(node: Any, ctx: Any) -> None:
         raise NotImplementedError(
             f"RNN W/R must be rank-3. op={node.name} W_shape={list(W.shape)} R_shape={list(R.shape)}"
         )
-    if int(W.shape[0]) != 1 or int(R.shape[0]) != 1:
+    if int(W.shape[0]) != expected_num_directions or int(R.shape[0]) != expected_num_directions:
         raise NotImplementedError(
-            f"RNN builtin lowering currently supports num_directions=1 only. op={node.name}"
+            "RNN num_directions mismatch for flatbuffer_direct. "
+            f"op={node.name} direction={direction} expected_num_directions={expected_num_directions} "
+            f"W_shape={list(W.shape)} R_shape={list(R.shape)}"
         )
     hidden_size = int(node.attrs.get("hidden_size", int(W.shape[1])))
     if int(W.shape[1]) != hidden_size or int(R.shape[1]) != hidden_size:
@@ -531,6 +853,12 @@ def build_rnn_op(node: Any, ctx: Any) -> None:
         )
 
     input_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
+    x_tensor = ctx.model_ir.tensors.get(x_name, None)
+    input_signature = None
+    if x_tensor is not None and x_tensor.shape_signature is not None:
+        input_signature = [int(v) for v in list(x_tensor.shape_signature)]
+    else:
+        input_signature = [int(v) for v in input_shape]
     if len(input_shape) != 3:
         raise NotImplementedError(
             f"RNN input must be rank-3 [seq,batch,input] in flatbuffer_direct. op={node.name} input_shape={input_shape}"
@@ -554,8 +882,21 @@ def build_rnn_op(node: Any, ctx: Any) -> None:
         )
         x_name = transposed_x_name
         input_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
-    seq_len = int(input_shape[0]) if int(input_shape[0]) > 0 else 1
-    batch = int(input_shape[1]) if int(input_shape[1]) > 0 else 1
+        input_signature = [input_signature[0], input_signature[2], input_signature[1]]
+    seq_signature_dim = input_signature[0] if len(input_signature) >= 1 else None
+    batch_signature_dim = input_signature[1] if len(input_signature) >= 2 else None
+    seq_len = _normalized_shape_dim(
+        seq_signature_dim if seq_signature_dim is not None and int(seq_signature_dim) > 0 else (
+            input_shape[0] if len(input_shape) >= 1 else 1
+        ),
+        fallback=1,
+    )
+    batch = _normalized_shape_dim(
+        batch_signature_dim if batch_signature_dim is not None and int(batch_signature_dim) > 0 else (
+            input_shape[1] if len(input_shape) >= 2 else 1
+        ),
+        fallback=1,
+    )
     if int(input_shape[2]) != input_size:
         raise NotImplementedError(
             "RNN input size mismatch with W in flatbuffer_direct. "
@@ -574,95 +915,366 @@ def build_rnn_op(node: Any, ctx: Any) -> None:
                 f"RNN bias must be constant when provided. op={node.name}"
             )
         B = np.asarray(b_value, dtype=np.float32)
-        if B.ndim != 2 or int(B.shape[0]) != 1 or int(B.shape[1]) != 2 * hidden_size:
+        if (
+            B.ndim != 2
+            or int(B.shape[0]) != expected_num_directions
+            or int(B.shape[1]) != 2 * hidden_size
+        ):
             raise NotImplementedError(
-                "RNN bias shape must be [1, 2*hidden_size] in flatbuffer_direct. "
-                f"op={node.name} B_shape={list(B.shape)} hidden_size={hidden_size}"
+                "RNN bias shape must be [num_directions, 2*hidden_size] in flatbuffer_direct. "
+                f"op={node.name} direction={direction} expected_num_directions={expected_num_directions} "
+                f"B_shape={list(B.shape)} hidden_size={hidden_size}"
             )
-        bias = np.asarray(B[0, :hidden_size] + B[0, hidden_size:], dtype=np.float32)
     else:
-        bias = np.zeros((hidden_size,), dtype=np.float32)
+        B = np.zeros((expected_num_directions, 2 * hidden_size), dtype=np.float32)
 
     if initial_h_name != "":
-        initial_h = ctx.get_constant_array(initial_h_name)
-        if initial_h is None:
+        ctx.ensure_tensor(initial_h_name)
+        initial_h_shape = [int(v) for v in ctx.get_tensor_shape(initial_h_name)]
+        if len(initial_h_shape) != 3:
             raise NotImplementedError(
-                f"RNN initial_h must be constant when provided. op={node.name}"
+                "RNN initial_h must be rank-3 [num_directions, batch, hidden_size] in flatbuffer_direct. "
+                f"op={node.name} initial_h_shape={initial_h_shape}"
             )
-        init_h = np.asarray(initial_h, dtype=np.float32)
-        if init_h.ndim != 3 or int(init_h.shape[0]) != 1 or int(init_h.shape[2]) != hidden_size:
+        if int(initial_h_shape[0]) > 0 and int(initial_h_shape[0]) != expected_num_directions:
             raise NotImplementedError(
-                "RNN initial_h shape must be [1, batch, hidden_size] in flatbuffer_direct. "
-                f"op={node.name} initial_h_shape={list(init_h.shape)} hidden_size={hidden_size}"
+                "RNN initial_h first dimension must match num_directions in flatbuffer_direct. "
+                f"op={node.name} direction={direction} expected_num_directions={expected_num_directions} "
+                f"initial_h_shape={initial_h_shape}"
+            )
+        if int(initial_h_shape[1]) > 0 and int(initial_h_shape[1]) != int(batch):
+            raise NotImplementedError(
+                "RNN initial_h batch dimension must match input batch in flatbuffer_direct. "
+                f"op={node.name} initial_h_shape={initial_h_shape} batch={int(batch)}"
+            )
+        if int(initial_h_shape[2]) > 0 and int(initial_h_shape[2]) != hidden_size:
+            raise NotImplementedError(
+                "RNN initial_h hidden dimension must match hidden_size in flatbuffer_direct. "
+                f"op={node.name} initial_h_shape={initial_h_shape} hidden_size={hidden_size}"
             )
 
     activations = node.attrs.get("activations", ["Tanh"])
     if not isinstance(activations, (list, tuple)) or len(activations) == 0:
         activations = ["Tanh"]
-    activation = str(activations[0]).lower()
-    fused_activation = "TANH"
-    if activation in {"tanh"}:
-        fused_activation = "TANH"
-    elif activation in {"relu"}:
-        fused_activation = "RELU"
-    elif activation in {"sigmoid"}:
-        fused_activation = "LOGISTIC"
-    else:
-        raise NotImplementedError(
-            f"RNN activation is not supported in flatbuffer_direct. op={node.name} activation={activation}"
-        )
+    fused_activations: List[str] = []
+    for dir_index in range(expected_num_directions):
+        activation = str(activations[min(dir_index, len(activations) - 1)]).lower()
+        if activation in {"tanh"}:
+            fused_activations.append("TANH")
+        elif activation in {"relu"}:
+            fused_activations.append("RELU")
+        elif activation in {"sigmoid"}:
+            fused_activations.append("LOGISTIC")
+        else:
+            raise NotImplementedError(
+                "RNN activation is not supported in flatbuffer_direct. "
+                f"op={node.name} direction={direction} direction_index={dir_index} activation={activation}"
+            )
     clip = float(node.attrs.get("clip", 0.0))
     if abs(clip) > 1e-6:
         raise NotImplementedError(
             f"RNN clip is not supported in flatbuffer_direct. op={node.name} clip={clip}"
         )
 
-    input_weights_name = ctx.add_const_tensor(
-        f"{node.name}_rnn_input_weights",
-        np.asarray(W[0], dtype=np.float32),
-    )
-    recurrent_weights_name = ctx.add_const_tensor(
-        f"{node.name}_rnn_recurrent_weights",
-        np.asarray(R[0], dtype=np.float32),
-    )
-    bias_name = ctx.add_const_tensor(
-        f"{node.name}_rnn_bias",
-        np.asarray(bias, dtype=np.float32),
-    )
+    def _prepare_rnn_state_input(*, dir_index: int, dir_tag: str) -> str:
+        if initial_h_name == "":
+            state_name = ctx.add_intermediate_tensor(
+                f"{node.name}_rnn_{dir_tag}_h0_zero",
+                dtype="FLOAT32",
+                shape=[int(batch), int(hidden_size)],
+            )
+            state_tensor = ctx.model_ir.tensors[state_name]
+            state_tensor.is_variable = True
+            state_tensor.data = None
+            return state_name
 
-    hidden_state_name = ctx.add_intermediate_tensor(
-        f"{node.name}_rnn_hidden_state",
-        dtype="FLOAT32",
-        shape=[int(batch), int(hidden_size)],
-    )
-    hidden_state_tensor = ctx.model_ir.tensors[hidden_state_name]
-    hidden_state_tensor.is_variable = True
-    hidden_state_tensor.data = None
-
-    y_seq_name = ctx.add_intermediate_tensor(
-        f"{y_name}_rnn_seq",
-        dtype=str(ctx.get_tensor_dtype(y_name)).upper(),
-        shape=[int(seq_len), int(batch), int(hidden_size)],
-    )
-    ctx.add_operator(
-        OperatorIR(
-            op_type="UNIDIRECTIONAL_SEQUENCE_RNN",
-            inputs=[
-                x_name,
-                input_weights_name,
-                recurrent_weights_name,
-                bias_name,
-                hidden_state_name,
-            ],
-            outputs=[y_seq_name],
-            options={
-                "timeMajor": True,
-                "fusedActivationFunction": fused_activation,
-                "asymmetricQuantizeInputs": False,
-            },
+        state_shape = [int(v) for v in ctx.get_tensor_shape(initial_h_name)]
+        slice_input_name = initial_h_name
+        if not (expected_num_directions == 1 and int(state_shape[0]) == 1):
+            slice_input_name = ctx.add_intermediate_tensor(
+                f"{node.name}_rnn_{dir_tag}_h0_slice",
+                dtype="FLOAT32",
+                shape=[1, int(batch), int(hidden_size)],
+            )
+            begin_name = ctx.add_const_tensor(
+                f"{node.name}_rnn_{dir_tag}_h0_begin",
+                np.asarray([int(dir_index), 0, 0], dtype=np.int32),
+            )
+            size_name = ctx.add_const_tensor(
+                f"{node.name}_rnn_{dir_tag}_h0_size",
+                np.asarray([1, int(batch), int(hidden_size)], dtype=np.int32),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[initial_h_name, begin_name, size_name],
+                    outputs=[slice_input_name],
+                )
+            )
+        state_name = ctx.add_intermediate_tensor(
+            f"{node.name}_rnn_{dir_tag}_h0_2d",
+            dtype="FLOAT32",
+            shape=[int(batch), int(hidden_size)],
         )
-    )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SQUEEZE",
+                inputs=[slice_input_name],
+                outputs=[state_name],
+                options={"squeezeDims": [0]},
+            )
+        )
+        state_tensor = ctx.model_ir.tensors[state_name]
+        state_tensor.is_variable = True
+        return state_name
 
+    def _run_rnn_direction(
+        *,
+        dir_index: int,
+        reverse: bool,
+        dir_tag: str,
+    ) -> Tuple[str, str]:
+        Wd = np.asarray(W[dir_index], dtype=np.float32)
+        Rd = np.asarray(R[dir_index], dtype=np.float32)
+        Bd = np.asarray(B[dir_index], dtype=np.float32)
+        bias = np.asarray(Bd[:hidden_size] + Bd[hidden_size:], dtype=np.float32)
+
+        input_weights_name = ctx.add_const_tensor(
+            f"{node.name}_rnn_{dir_tag}_input_weights",
+            Wd,
+        )
+        recurrent_weights_name = ctx.add_const_tensor(
+            f"{node.name}_rnn_{dir_tag}_recurrent_weights",
+            Rd,
+        )
+        bias_name = ctx.add_const_tensor(
+            f"{node.name}_rnn_{dir_tag}_bias",
+            bias,
+        )
+        hidden_state_name = _prepare_rnn_state_input(dir_index=dir_index, dir_tag=dir_tag)
+
+        rnn_input_name = x_name
+        if reverse:
+            reverse_axis_name = ctx.add_const_tensor(
+                f"{node.name}_rnn_{dir_tag}_reverse_axis_input",
+                np.asarray([0], dtype=np.int32),
+            )
+            reversed_input_name = ctx.add_intermediate_tensor(
+                f"{node.name}_rnn_{dir_tag}_input_reversed",
+                dtype="FLOAT32",
+                shape=[int(seq_len), int(batch), int(input_size)],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="REVERSE_V2",
+                    inputs=[x_name, reverse_axis_name],
+                    outputs=[reversed_input_name],
+                )
+            )
+            rnn_input_name = reversed_input_name
+
+        y_seq_raw_name = ctx.add_intermediate_tensor(
+            f"{y_name}_rnn_{dir_tag}_seq_raw",
+            dtype=y_dtype,
+            shape=[int(seq_len), int(batch), int(hidden_size)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="UNIDIRECTIONAL_SEQUENCE_RNN",
+                inputs=[
+                    rnn_input_name,
+                    input_weights_name,
+                    recurrent_weights_name,
+                    bias_name,
+                    hidden_state_name,
+                ],
+                outputs=[y_seq_raw_name],
+                options={
+                    "timeMajor": True,
+                    "fusedActivationFunction": fused_activations[dir_index],
+                    "asymmetricQuantizeInputs": False,
+                },
+            )
+        )
+        y_seq_aligned_name = y_seq_raw_name
+        if reverse:
+            reverse_axis_output_name = ctx.add_const_tensor(
+                f"{node.name}_rnn_{dir_tag}_reverse_axis_output",
+                np.asarray([0], dtype=np.int32),
+            )
+            y_seq_aligned_name = ctx.add_intermediate_tensor(
+                f"{y_name}_rnn_{dir_tag}_seq_aligned",
+                dtype=y_dtype,
+                shape=[int(seq_len), int(batch), int(hidden_size)],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="REVERSE_V2",
+                    inputs=[y_seq_raw_name, reverse_axis_output_name],
+                    outputs=[y_seq_aligned_name],
+                )
+            )
+        return y_seq_aligned_name, hidden_state_name
+
+    if direction == "bidirectional":
+        fw_seq_name, fw_h_name = _run_rnn_direction(
+            dir_index=0,
+            reverse=False,
+            dir_tag="fw",
+        )
+        bw_seq_name, bw_h_name = _run_rnn_direction(
+            dir_index=1,
+            reverse=True,
+            dir_tag="bw",
+        )
+
+        fw_axis_name = ctx.add_const_tensor(
+            f"{node.name}_rnn_fw_expand_axis",
+            np.asarray(1, dtype=np.int32),
+        )
+        bw_axis_name = ctx.add_const_tensor(
+            f"{node.name}_rnn_bw_expand_axis",
+            np.asarray(1, dtype=np.int32),
+        )
+        fw_seq_4d_name = ctx.add_intermediate_tensor(
+            f"{y_name}_rnn_fw_seq_4d",
+            dtype=y_dtype,
+            shape=[int(seq_len), 1, int(batch), int(hidden_size)],
+        )
+        bw_seq_4d_name = ctx.add_intermediate_tensor(
+            f"{y_name}_rnn_bw_seq_4d",
+            dtype=y_dtype,
+            shape=[int(seq_len), 1, int(batch), int(hidden_size)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="EXPAND_DIMS",
+                inputs=[fw_seq_name, fw_axis_name],
+                outputs=[fw_seq_4d_name],
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="EXPAND_DIMS",
+                inputs=[bw_seq_name, bw_axis_name],
+                outputs=[bw_seq_4d_name],
+            )
+        )
+        y_merged_name = ctx.add_intermediate_tensor(
+            f"{y_name}_rnn_bi_merged",
+            dtype=y_dtype,
+            shape=[int(seq_len), 2, int(batch), int(hidden_size)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CONCATENATION",
+                inputs=[fw_seq_4d_name, bw_seq_4d_name],
+                outputs=[y_merged_name],
+                options={"axis": 1, "fusedActivationFunction": "NONE"},
+            )
+        )
+
+        y_shape = [int(v) for v in ctx.get_tensor_shape(y_name)]
+        if len(y_shape) == 4:
+            y_shape_name = ctx.add_const_tensor(
+                f"{y_name}_rnn_bi_y_shape",
+                np.asarray(y_shape, dtype=np.int32),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[y_merged_name, y_shape_name],
+                    outputs=[y_name],
+                    options={"newShape": [int(v) for v in y_shape]},
+                )
+            )
+        elif len(y_shape) == 3:
+            y_shape_name = ctx.add_const_tensor(
+                f"{y_name}_rnn_bi_y_shape",
+                np.asarray(y_shape, dtype=np.int32),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[y_merged_name, y_shape_name],
+                    outputs=[y_name],
+                    options={"newShape": [int(v) for v in y_shape]},
+                )
+            )
+        else:
+            raise NotImplementedError(
+                f"RNN Y output rank must be 3 or 4 for flatbuffer_direct. op={node.name} y_shape={y_shape}"
+            )
+
+        if y_h_name != "":
+            fw_h_3d_name = ctx.add_intermediate_tensor(
+                f"{y_h_name}_rnn_fw_3d",
+                dtype="FLOAT32",
+                shape=[1, int(batch), int(hidden_size)],
+            )
+            bw_h_3d_name = ctx.add_intermediate_tensor(
+                f"{y_h_name}_rnn_bw_3d",
+                dtype="FLOAT32",
+                shape=[1, int(batch), int(hidden_size)],
+            )
+            fw_h_shape_name = ctx.add_const_tensor(
+                f"{y_h_name}_rnn_fw_shape",
+                np.asarray([1, int(batch), int(hidden_size)], dtype=np.int32),
+            )
+            bw_h_shape_name = ctx.add_const_tensor(
+                f"{y_h_name}_rnn_bw_shape",
+                np.asarray([1, int(batch), int(hidden_size)], dtype=np.int32),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[fw_h_name, fw_h_shape_name],
+                    outputs=[fw_h_3d_name],
+                    options={"newShape": [1, int(batch), int(hidden_size)]},
+                )
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[bw_h_name, bw_h_shape_name],
+                    outputs=[bw_h_3d_name],
+                    options={"newShape": [1, int(batch), int(hidden_size)]},
+                )
+            )
+            y_h_merged_name = ctx.add_intermediate_tensor(
+                f"{y_h_name}_rnn_bi_merged",
+                dtype="FLOAT32",
+                shape=[2, int(batch), int(hidden_size)],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="CONCATENATION",
+                    inputs=[fw_h_3d_name, bw_h_3d_name],
+                    outputs=[y_h_merged_name],
+                    options={"axis": 0, "fusedActivationFunction": "NONE"},
+                )
+            )
+            y_h_shape = [int(v) for v in ctx.get_tensor_shape(y_h_name)]
+            y_h_target_shape = [2, int(batch), int(hidden_size)] if len(y_h_shape) == 0 else y_h_shape
+            y_h_shape_name = ctx.add_const_tensor(
+                f"{y_h_name}_rnn_bi_shape",
+                np.asarray(y_h_target_shape, dtype=np.int32),
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[y_h_merged_name, y_h_shape_name],
+                    outputs=[y_h_name],
+                    options={"newShape": [int(v) for v in y_h_target_shape]},
+                )
+            )
+        return
+
+    y_seq_name, y_h_state_name = _run_rnn_direction(
+        dir_index=0,
+        reverse=(direction == "reverse"),
+        dir_tag="rev" if direction == "reverse" else "fw",
+    )
     y_shape = [int(v) for v in ctx.get_tensor_shape(y_name)]
     if len(y_shape) == 4:
         axis_name = ctx.add_const_tensor(
@@ -695,53 +1307,20 @@ def build_rnn_op(node: Any, ctx: Any) -> None:
         )
 
     if y_h_name != "":
-        begin_name = ctx.add_const_tensor(
-            f"{y_h_name}_rnn_begin",
-            np.asarray([max(seq_len - 1, 0), 0, 0], dtype=np.int32),
-        )
-        size_name = ctx.add_const_tensor(
-            f"{y_h_name}_rnn_size",
-            np.asarray([1, int(batch), int(hidden_size)], dtype=np.int32),
-        )
-        y_h_seq_name = ctx.add_intermediate_tensor(
-            f"{y_h_name}_rnn_seq_slice",
-            dtype=str(ctx.get_tensor_dtype(y_h_name)).upper(),
-            shape=[1, int(batch), int(hidden_size)],
+        y_h_shape = [int(v) for v in ctx.get_tensor_shape(y_h_name)]
+        y_h_target_shape = [1, int(batch), int(hidden_size)] if len(y_h_shape) == 0 else y_h_shape
+        y_h_shape_name = ctx.add_const_tensor(
+            f"{y_h_name}_rnn_shape",
+            np.asarray(y_h_target_shape, dtype=np.int32),
         )
         ctx.add_operator(
             OperatorIR(
-                op_type="SLICE",
-                inputs=[y_seq_name, begin_name, size_name],
-                outputs=[y_h_seq_name],
+                op_type="RESHAPE",
+                inputs=[y_h_state_name, y_h_shape_name],
+                outputs=[y_h_name],
+                options={"newShape": [int(v) for v in y_h_target_shape]},
             )
         )
-        y_h_shape = [int(v) for v in ctx.get_tensor_shape(y_h_name)]
-        if y_h_shape != [1, int(batch), int(hidden_size)]:
-            y_h_shape_name = ctx.add_const_tensor(
-                f"{y_h_name}_rnn_shape",
-                np.asarray(y_h_shape, dtype=np.int32),
-            )
-            ctx.add_operator(
-                OperatorIR(
-                    op_type="RESHAPE",
-                    inputs=[y_h_seq_name, y_h_shape_name],
-                    outputs=[y_h_name],
-                    options={"newShape": y_h_shape},
-                )
-            )
-        else:
-            pass_shape = ctx.add_const_tensor(
-                f"{y_h_name}_rnn_identity_shape",
-                np.asarray(y_h_shape, dtype=np.int32),
-            )
-            ctx.add_operator(
-                OperatorIR(
-                    op_type="RESHAPE",
-                    inputs=[y_h_seq_name, pass_shape],
-                    outputs=[y_h_name],
-                    options={"newShape": y_h_shape},
-                )
-            )
 
 
 def build_gru_op(node: Any, ctx: Any) -> None:

--- a/onnx2tf/tflite_builder/op_builders/reduce.py
+++ b/onnx2tf/tflite_builder/op_builders/reduce.py
@@ -47,6 +47,61 @@ def _resolve_reduce_axes(node: Any, ctx: Any, input_rank: int) -> List[int]:
     return _normalize_axes(axes, input_rank, node.name)
 
 
+def _resolve_cumsum_axis(node: Any, ctx: Any, input_rank: int) -> int:
+    axis_raw: int
+    if len(node.inputs) >= 2 and str(node.inputs[1].name) != "":
+        axis_arr = ctx.get_constant_array(node.inputs[1].name)
+        if axis_arr is None:
+            raise NotImplementedError(
+                f"CumSum axis must be constant for flatbuffer_direct. op={node.name}"
+            )
+        axis_values = np.asarray(axis_arr).reshape(-1)
+        if int(axis_values.size) != 1:
+            raise NotImplementedError(
+                f"CumSum axis must be scalar. op={node.name} axis_shape={list(np.asarray(axis_arr).shape)}"
+            )
+        axis_raw = int(axis_values[0])
+    else:
+        axis_raw = int(node.attrs.get("axis", 0))
+
+    axis = int(axis_raw)
+    if axis < 0:
+        axis += int(input_rank)
+    if axis < 0 or axis >= int(input_rank):
+        raise NotImplementedError(
+            f"CumSum axis is out of range. op={node.name} axis={axis_raw} rank={input_rank}"
+        )
+    return int(axis)
+
+
+def build_cumsum_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(input_name)]
+    axis = _resolve_cumsum_axis(node=node, ctx=ctx, input_rank=len(input_shape))
+    axis_const = ctx.add_const_tensor(
+        f"{output_name}_cumsum_axis",
+        np.asarray([axis], dtype=np.int32),
+    )
+    exclusive = bool(int(node.attrs.get("exclusive", 0)))
+    reverse = bool(int(node.attrs.get("reverse", 0)))
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CUMSUM",
+            inputs=[input_name, axis_const],
+            outputs=[output_name],
+            options={
+                "exclusive": exclusive,
+                "reverse": reverse,
+            },
+        )
+    )
+
+
 def build_reduce_op(node: Any, ctx: Any, op_type: str) -> None:
     input_name = node.inputs[0].name
     output_name = node.outputs[0].name
@@ -106,6 +161,33 @@ def build_global_average_pool_op(node: Any, ctx: Any) -> None:
     ctx.add_operator(
         OperatorIR(
             op_type="MEAN",
+            inputs=[input_name, axes_const],
+            outputs=[output_name],
+            options={"keepDims": True},
+        )
+    )
+
+
+def build_global_max_pool_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+
+    input_shape = [int(v) for v in ctx.get_tensor_shape(input_name)]
+    if len(input_shape) < 3:
+        raise NotImplementedError(
+            f"GlobalMaxPool requires rank>=3. op={node.name} input_shape={input_shape}"
+        )
+
+    spatial_axes = [int(v) for v in range(2, len(input_shape))]
+    axes_const = ctx.add_const_tensor(
+        f"{output_name}_global_max_axes",
+        np.asarray(spatial_axes, dtype=np.int32),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="REDUCE_MAX",
             inputs=[input_name, axes_const],
             outputs=[output_name],
             options={"keepDims": True},
@@ -235,11 +317,13 @@ def build_reduce_l2_op(node: Any, ctx: Any) -> None:
         output_name=sum_name,
     )
 
-    sqrt_name = ctx.add_intermediate_tensor(
-        f"{output_name}_reduce_l2_sqrt",
-        dtype=compute_dtype,
-        shape=[int(v) for v in ctx.get_tensor_shape(output_name)],
-    )
+    sqrt_name = output_name
+    if output_dtype != compute_dtype:
+        sqrt_name = ctx.add_intermediate_tensor(
+            f"{output_name}_reduce_l2_sqrt",
+            dtype=compute_dtype,
+            shape=[int(v) for v in ctx.get_tensor_shape(output_name)],
+        )
     ctx.add_operator(
         OperatorIR(
             op_type="SQRT",
@@ -258,29 +342,5 @@ def build_reduce_l2_op(node: Any, ctx: Any) -> None:
                     "inDataType": compute_dtype,
                     "outDataType": output_dtype,
                 },
-            )
-        )
-    else:
-        # Keep SQRT result in a dedicated tensor for graph readability and avoid
-        # in-place aliasing in tooling output.
-        identity_shape_name = ctx.add_intermediate_tensor(
-            f"{output_name}_reduce_l2_identity_shape",
-            dtype="INT32",
-            shape=[int(len(ctx.get_tensor_shape(output_name)))],
-        )
-        ctx.add_operator(
-            OperatorIR(
-                op_type="SHAPE",
-                inputs=[sqrt_name],
-                outputs=[identity_shape_name],
-                options={"outType": "INT32"},
-            )
-        )
-        ctx.add_operator(
-            OperatorIR(
-                op_type="RESHAPE",
-                inputs=[sqrt_name, identity_shape_name],
-                outputs=[output_name],
-                options={"newShape": []},
             )
         )

--- a/onnx2tf/tflite_builder/op_builders/shape.py
+++ b/onnx2tf/tflite_builder/op_builders/shape.py
@@ -165,13 +165,24 @@ def build_slice_op(node: Any, ctx: Any) -> None:
         attr_name="starts",
         label="starts",
     )
-    ends = _parse_slice_indices(
-        node=node,
-        ctx=ctx,
-        input_index=2,
-        attr_name="ends",
-        label="ends",
-    )
+    dynamic_end_input_name = ""
+    ends: list[int] = []
+    if (
+        len(node.inputs) > 2
+        and str(node.inputs[2].name) != ""
+        and ctx.get_constant_array(node.inputs[2].name) is None
+        and "ends" not in node.attrs
+    ):
+        dynamic_end_input_name = str(node.inputs[2].name)
+        ends = [0 for _ in range(len(starts))]
+    else:
+        ends = _parse_slice_indices(
+            node=node,
+            ctx=ctx,
+            input_index=2,
+            attr_name="ends",
+            label="ends",
+        )
     if len(starts) != len(ends):
         raise NotImplementedError(
             f"Slice starts and ends length mismatch. op={node.name} "
@@ -207,6 +218,120 @@ def build_slice_op(node: Any, ctx: Any) -> None:
             f"Slice starts/axes/steps length mismatch. op={node.name} "
             f"starts_len={len(starts)} axes_len={len(axes)} steps_len={len(steps)}"
         )
+    normalized_axes = [
+        _normalize_axis(axis_raw, rank, op_name=node.name)
+        for axis_raw in axes
+    ]
+
+    if dynamic_end_input_name != "":
+        if not (
+            rank == 1
+            and len(starts) == 1
+            and len(ends) == 1
+            and len(normalized_axes) == 1
+            and len(steps) == 1
+            and int(starts[0]) == 0
+            and int(normalized_axes[0]) == 0
+            and int(steps[0]) == 1
+        ):
+            raise NotImplementedError(
+                "Slice with dynamic end is supported only for rank-1 axis-0 "
+                "prefix slice with start=0 and step=1 in flatbuffer_direct. "
+                f"op={node.name} rank={rank} starts={starts} axes={axes} steps={steps}"
+            )
+        dynamic_end_shape = [int(v) for v in ctx.get_tensor_shape(dynamic_end_input_name)]
+        dynamic_end_name = dynamic_end_input_name
+        dynamic_end_dtype = str(ctx.get_tensor_dtype(dynamic_end_input_name)).upper()
+        if len(dynamic_end_shape) != 1 or int(dynamic_end_shape[0]) != 1:
+            reshape_shape_name = ctx.add_const_tensor(
+                f"{output_name}_stridedslice_end_shape",
+                np.asarray([1], dtype=np.int32),
+            )
+            reshaped_end_name = ctx.add_intermediate_tensor(
+                f"{output_name}_stridedslice_end_flat",
+                dtype=dynamic_end_dtype,
+                shape=[1],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="RESHAPE",
+                    inputs=[dynamic_end_input_name, reshape_shape_name],
+                    outputs=[reshaped_end_name],
+                    options={"newShape": [1]},
+                )
+            )
+            dynamic_end_name = reshaped_end_name
+            dynamic_end_shape = [1]
+        if dynamic_end_dtype != "INT32":
+            dynamic_end_i32 = ctx.add_intermediate_tensor(
+                f"{output_name}_stridedslice_end_i32",
+                dtype="INT32",
+                shape=dynamic_end_shape,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="CAST",
+                    inputs=[dynamic_end_name],
+                    outputs=[dynamic_end_i32],
+                    options={
+                        "inDataType": dynamic_end_dtype,
+                        "outDataType": "INT32",
+                    },
+                )
+            )
+            dynamic_end_name = dynamic_end_i32
+        begin_name = ctx.add_const_tensor(
+            f"{output_name}_stridedslice_begin",
+            np.asarray([0], dtype=np.int32),
+        )
+        strides_name = ctx.add_const_tensor(
+            f"{output_name}_stridedslice_strides",
+            np.asarray([1], dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="STRIDED_SLICE",
+                inputs=[input_name, begin_name, dynamic_end_name, strides_name],
+                outputs=[output_name],
+                options={
+                    "beginMask": 0,
+                    "endMask": 0,
+                    "ellipsisMask": 0,
+                    "newAxisMask": 0,
+                    "shrinkAxisMask": 0,
+                    "offset": False,
+                },
+            )
+        )
+        return
+
+    if any(int(step) < 0 for step in steps):
+        is_supported_full_reverse = (
+            len(starts) == 1
+            and len(ends) == 1
+            and len(normalized_axes) == 1
+            and len(steps) == 1
+            and int(steps[0]) == -1
+            and int(starts[0]) == -1
+            and int(ends[0]) <= -int(np.iinfo(np.int32).max)
+        )
+        if not is_supported_full_reverse:
+            raise NotImplementedError(
+                f"Slice negative step is not supported for flatbuffer_direct. op={node.name} "
+                f"starts={starts} ends={ends} axes={axes} steps={steps}"
+            )
+        axis_name = ctx.add_const_tensor(
+            f"{output_name}_reverse_axis",
+            np.asarray([int(normalized_axes[0])], dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="REVERSE_V2",
+                inputs=[input_name, axis_name],
+                outputs=[output_name],
+            )
+        )
+        return
 
     known_dim_flags = [
         (
@@ -227,16 +352,11 @@ def build_slice_op(node: Any, ctx: Any) -> None:
     large_int = int(np.iinfo(np.int64).max // 2)
     use_strided_slice = any(not flag for flag in known_dim_flags)
 
-    for idx, axis_raw in enumerate(axes):
-        axis = _normalize_axis(axis_raw, rank, op_name=node.name)
+    for idx, axis in enumerate(normalized_axes):
         step = int(steps[idx])
         if step == 0:
             raise NotImplementedError(
                 f"Slice step must not be 0 for flatbuffer_direct. op={node.name} step={step}"
-            )
-        if step < 0:
-            raise NotImplementedError(
-                f"Slice negative step is not supported for flatbuffer_direct. op={node.name} step={step}"
             )
         if step != 1:
             use_strided_slice = True
@@ -1005,6 +1125,125 @@ def build_range_op(node: Any, ctx: Any) -> None:
     )
 
 
+def build_random_normal_like_op(node: Any, ctx: Any) -> None:
+    input_name = node.inputs[0].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(input_name)
+    ctx.ensure_tensor(output_name)
+
+    output_dtype = str(ctx.get_tensor_dtype(output_name)).upper()
+    compute_dtype = "FLOAT16" if output_dtype == "FLOAT16" else "FLOAT32"
+    output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+    input_rank = len(ctx.get_tensor_shape(input_name))
+    scale = float(node.attrs.get("scale", 1.0))
+    mean = float(node.attrs.get("mean", 0.0))
+    has_scale = not np.isclose(scale, 1.0)
+    has_mean = not np.isclose(mean, 0.0)
+
+    shape_name = ctx.add_intermediate_tensor(
+        f"{output_name}_random_shape",
+        dtype="INT32",
+        shape=[int(input_rank)],
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SHAPE",
+            inputs=[input_name],
+            outputs=[shape_name],
+            options={"outType": "INT32"},
+        )
+    )
+
+    random_raw_name = output_name
+    if has_scale or has_mean or output_dtype != compute_dtype:
+        random_raw_name = ctx.add_intermediate_tensor(
+            f"{output_name}_random_raw",
+            dtype=compute_dtype,
+            shape=output_shape,
+        )
+    seed_attr = node.attrs.get("seed", None)
+    random_options: dict[str, Any] = {}
+    if seed_attr is not None:
+        seed = int(float(seed_attr))
+        random_options["seed"] = int(seed)
+        random_options["seed2"] = int(seed)
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RANDOM_STANDARD_NORMAL",
+            inputs=[shape_name],
+            outputs=[random_raw_name],
+            options=random_options,
+        )
+    )
+
+    current_name = random_raw_name
+    if has_scale:
+        scale_name = ctx.add_const_tensor(
+            f"{output_name}_random_scale",
+            np.asarray(scale, dtype=np.float16 if compute_dtype == "FLOAT16" else np.float32),
+        )
+        scaled_name = ctx.add_intermediate_tensor(
+            f"{output_name}_random_scaled",
+            dtype=compute_dtype,
+            shape=output_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MUL",
+                inputs=[current_name, scale_name],
+                outputs=[scaled_name],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        current_name = scaled_name
+
+    if has_mean:
+        mean_name = ctx.add_const_tensor(
+            f"{output_name}_random_mean",
+            np.asarray(mean, dtype=np.float16 if compute_dtype == "FLOAT16" else np.float32),
+        )
+        shifted_name = ctx.add_intermediate_tensor(
+            f"{output_name}_random_shifted",
+            dtype=compute_dtype,
+            shape=output_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="ADD",
+                inputs=[current_name, mean_name],
+                outputs=[shifted_name],
+                options={"fusedActivationFunction": "NONE"},
+            )
+        )
+        current_name = shifted_name
+
+    if output_dtype != compute_dtype:
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[current_name],
+                outputs=[output_name],
+                options={
+                    "inDataType": compute_dtype,
+                    "outDataType": output_dtype,
+                },
+            )
+        )
+    elif current_name != output_name:
+        output_shape_const = ctx.add_const_tensor(
+            f"{output_name}_random_identity_shape",
+            np.asarray(output_shape, dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[current_name, output_shape_const],
+                outputs=[output_name],
+                options={"newShape": [int(v) for v in output_shape]},
+            )
+        )
+
+
 def _normalize_shape_slice_index(index: int, rank: int) -> int:
     normalized = int(index)
     if normalized < 0:
@@ -1348,8 +1587,12 @@ def build_pad_op(node: Any, ctx: Any) -> None:
         dst_tensor_name=output_name,
     )
 
-    mode = str(node.attrs.get("mode", "constant")).lower()
-    if mode != "constant":
+    mode_raw = node.attrs.get("mode", "constant")
+    if isinstance(mode_raw, (bytes, bytearray)):
+        mode = mode_raw.decode("utf-8").lower()
+    else:
+        mode = str(mode_raw).lower()
+    if mode not in ["constant", "reflect"]:
         raise NotImplementedError(
             f"Pad mode is not supported in flatbuffer_direct. op={node.name} mode={mode}"
         )
@@ -1440,27 +1683,36 @@ def build_pad_op(node: Any, ctx: Any) -> None:
             )
         )
 
-    # Keep support minimal/safe: constant zero-padding value only.
-    if len(node.inputs) >= 3:
-        constant_value_arr = ctx.get_constant_array(node.inputs[2].name)
-        if constant_value_arr is None:
-            raise NotImplementedError(
-                f"Pad constant value input must be constant for flatbuffer_direct. op={node.name}"
+    if mode == "constant":
+        # Keep support minimal/safe: constant zero-padding value only.
+        if len(node.inputs) >= 3 and str(node.inputs[2].name) != "":
+            constant_value_arr = ctx.get_constant_array(node.inputs[2].name)
+            if constant_value_arr is None:
+                raise NotImplementedError(
+                    f"Pad constant value input must be constant for flatbuffer_direct. op={node.name}"
+                )
+            constant_value = float(np.asarray(constant_value_arr).reshape(-1)[0])
+            if abs(constant_value) > 1e-12:
+                raise NotImplementedError(
+                    "Pad with non-zero constant value is not supported in flatbuffer_direct. "
+                    f"op={node.name} value={constant_value}"
+                )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="PAD",
+                inputs=[input_name, pads_name],
+                outputs=[output_name],
             )
-        constant_value = float(np.asarray(constant_value_arr).reshape(-1)[0])
-        if abs(constant_value) > 1e-12:
-            raise NotImplementedError(
-                "Pad with non-zero constant value is not supported in flatbuffer_direct. "
-                f"op={node.name} value={constant_value}"
-            )
-
-    ctx.add_operator(
-        OperatorIR(
-            op_type="PAD",
-            inputs=[input_name, pads_name],
-            outputs=[output_name],
         )
-    )
+    else:
+        ctx.add_operator(
+            OperatorIR(
+                op_type="MIRROR_PAD",
+                inputs=[input_name, pads_name],
+                outputs=[output_name],
+                options={"mode": "REFLECT"},
+            )
+        )
 
 
 def _resolve_axes_from_attr_or_input(node: Any, ctx: Any) -> list[int]:
@@ -1715,6 +1967,24 @@ def build_unsqueeze_op(node: Any, ctx: Any) -> None:
         dtype="INT32",
         shape=[input_rank],
     )
+    # Preserve dynamic dimensions in output metadata. Dynamic RESHAPE must not
+    # be pinned to placeholder-1 static dimensions.
+    output_rank = int(input_rank + len(normalized_axes))
+    axes_set = set(int(v) for v in normalized_axes)
+    inferred_signature: list[int] = []
+    src_idx = 0
+    for out_axis in range(output_rank):
+        if out_axis in axes_set:
+            inferred_signature.append(1)
+        else:
+            if src_idx < len(input_signature):
+                inferred_signature.append(int(input_signature[src_idx]))
+            else:
+                inferred_signature.append(-1)
+            src_idx += 1
+    output_tensor.shape_signature = [int(v) for v in inferred_signature]
+    output_tensor.shape = [int(v) if int(v) > 0 else 1 for v in inferred_signature]
+
     ctx.add_operator(
         OperatorIR(
             op_type="SHAPE",
@@ -1798,7 +2068,7 @@ def build_unsqueeze_op(node: Any, ctx: Any) -> None:
             op_type="RESHAPE",
             inputs=[input_name, current_shape_name],
             outputs=[output_name],
-            options={"newShape": [int(v) for v in output_shape]},
+            options={"newShape": []},
         )
     )
 
@@ -2675,6 +2945,585 @@ def _build_resize_cubic_strict_op(
                 },
             )
         )
+
+
+def build_grid_sample_op(node: Any, ctx: Any) -> None:
+    image_name = node.inputs[0].name
+    grid_name = node.inputs[1].name
+    output_name = node.outputs[0].name
+    ctx.ensure_tensor(image_name)
+    ctx.ensure_tensor(grid_name)
+    ctx.ensure_tensor(output_name)
+
+    image_shape = [int(v) for v in ctx.get_tensor_shape(image_name)]
+    grid_shape = [int(v) for v in ctx.get_tensor_shape(grid_name)]
+    output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
+    n, c, h, w = [int(v) for v in image_shape]
+    out_n, out_c, out_h, out_w = [int(v) for v in output_shape]
+    align_corners = bool(int(node.attrs.get("align_corners", 0)))
+
+    image_dtype = str(ctx.get_tensor_dtype(image_name)).upper()
+    grid_dtype = str(ctx.get_tensor_dtype(grid_name)).upper()
+    output_dtype = str(ctx.get_tensor_dtype(output_name)).upper()
+    compute_dtype = (
+        "FLOAT32"
+        if image_dtype == "FLOAT32" or grid_dtype == "FLOAT32"
+        else "FLOAT16"
+    )
+    compute_np_dtype = np.float16 if compute_dtype == "FLOAT16" else np.float32
+
+    def _add_float_const(base_name: str, value: float) -> str:
+        return ctx.add_const_tensor(
+            base_name,
+            np.asarray(value, dtype=compute_np_dtype),
+        )
+
+    def _add_binary_op(op_type: str, lhs: str, rhs: str, out: str) -> None:
+        options: dict[str, Any] = {}
+        if op_type in {"ADD", "SUB", "MUL", "DIV"}:
+            options = {"fusedActivationFunction": "NONE"}
+        ctx.add_operator(
+            OperatorIR(
+                op_type=op_type,
+                inputs=[lhs, rhs],
+                outputs=[out],
+                options=options,
+            )
+        )
+
+    def _squeeze_last_dim(name: str, tag: str, dtype: str) -> str:
+        squeezed = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_{tag}_squeezed",
+            dtype=dtype,
+            shape=[int(n), int(out_h), int(out_w)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SQUEEZE",
+                inputs=[name],
+                outputs=[squeezed],
+                options={"squeezeDims": [3]},
+            )
+        )
+        return squeezed
+
+    def _build_linear_index(y_idx: str, x_idx: str, tag: str, width_const: str) -> str:
+        mul_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_{tag}_mul",
+            dtype="INT32",
+            shape=[int(n), int(out_h), int(out_w)],
+        )
+        linear_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_{tag}_linear",
+            dtype="INT32",
+            shape=[int(n), int(out_h), int(out_w)],
+        )
+        _add_binary_op("MUL", y_idx, width_const, mul_name)
+        _add_binary_op("ADD", mul_name, x_idx, linear_name)
+        return linear_name
+
+    def _build_gather(linear_idx_name: str, tag: str, params_name: str) -> str:
+        gathered_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_{tag}_gather",
+            dtype=compute_dtype,
+            shape=[int(n), int(c), int(out_h), int(out_w)],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="GATHER",
+                inputs=[params_name, linear_idx_name],
+                outputs=[gathered_name],
+                options={
+                    "axis": 2,
+                    "batchDims": 1,
+                },
+            )
+        )
+        return gathered_name
+
+    image_compute_name = image_name
+    if image_dtype != compute_dtype:
+        image_compute_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_image_{compute_dtype.lower()}",
+            dtype=compute_dtype,
+            shape=image_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[image_name],
+                outputs=[image_compute_name],
+                options={
+                    "inDataType": image_dtype,
+                    "outDataType": compute_dtype,
+                },
+            )
+        )
+
+    grid_compute_name = grid_name
+    if grid_dtype != compute_dtype:
+        grid_compute_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_grid_{compute_dtype.lower()}",
+            dtype=compute_dtype,
+            shape=grid_shape,
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[grid_name],
+                outputs=[grid_compute_name],
+                options={
+                    "inDataType": grid_dtype,
+                    "outDataType": compute_dtype,
+                },
+            )
+        )
+
+    # zeros-padding fast path (same idea as tf backend): pad by 1 on H/W to
+    # eliminate explicit in-bound mask ops and gather zeros from border.
+    paddings_name = ctx.add_const_tensor(
+        f"{output_name}_gridsample_paddings",
+        np.asarray([[0, 0], [0, 0], [1, 1], [1, 1]], dtype=np.int32),
+    )
+    image_padded_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_image_padded",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(h + 2), int(w + 2)],
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="PAD",
+            inputs=[image_compute_name, paddings_name],
+            outputs=[image_padded_name],
+        )
+    )
+    image_flat_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_image_flat",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int((h + 2) * (w + 2))],
+    )
+    _add_reshape_operator(
+        ctx=ctx,
+        input_name=image_padded_name,
+        output_name=image_flat_name,
+        new_shape=[int(n), int(c), int((h + 2) * (w + 2))],
+    )
+
+    slice_size_const = ctx.add_const_tensor(
+        f"{output_name}_gridsample_grid_slice_size",
+        np.asarray([int(grid_shape[0]), int(grid_shape[1]), int(grid_shape[2]), 1], dtype=np.int32),
+    )
+    grid_x_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_grid_x",
+        dtype=compute_dtype,
+        shape=[int(grid_shape[0]), int(grid_shape[1]), int(grid_shape[2]), 1],
+    )
+    grid_y_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_grid_y",
+        dtype=compute_dtype,
+        shape=[int(grid_shape[0]), int(grid_shape[1]), int(grid_shape[2]), 1],
+    )
+    grid_x_begin = ctx.add_const_tensor(
+        f"{output_name}_gridsample_grid_x_begin",
+        np.asarray([0, 0, 0, 0], dtype=np.int32),
+    )
+    grid_y_begin = ctx.add_const_tensor(
+        f"{output_name}_gridsample_grid_y_begin",
+        np.asarray([0, 0, 0, 1], dtype=np.int32),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SLICE",
+            inputs=[grid_compute_name, grid_x_begin, slice_size_const],
+            outputs=[grid_x_name],
+        )
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SLICE",
+            inputs=[grid_compute_name, grid_y_begin, slice_size_const],
+            outputs=[grid_y_name],
+        )
+    )
+
+    one_const = _add_float_const(f"{output_name}_gridsample_one", 1.0)
+    zero_const = _add_float_const(f"{output_name}_gridsample_zero", 0.0)
+    half_const = _add_float_const(f"{output_name}_gridsample_half", 0.5)
+    neg_one_const = _add_float_const(f"{output_name}_gridsample_neg_one", -1.0)
+    w_const = _add_float_const(f"{output_name}_gridsample_w", float(w))
+    h_const = _add_float_const(f"{output_name}_gridsample_h", float(h))
+    w_pad_max_const = _add_float_const(f"{output_name}_gridsample_w_pad_max", float(w + 1))
+    h_pad_max_const = _add_float_const(f"{output_name}_gridsample_h_pad_max", float(h + 1))
+    x_scale_const = _add_float_const(
+        f"{output_name}_gridsample_x_scale",
+        float((w - 1) * 0.5 if align_corners else w * 0.5),
+    )
+    y_scale_const = _add_float_const(
+        f"{output_name}_gridsample_y_scale",
+        float((h - 1) * 0.5 if align_corners else h * 0.5),
+    )
+
+    x_plus_one = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x_plus_one",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y_plus_one = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y_plus_one",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    _add_binary_op("ADD", grid_x_name, one_const, x_plus_one)
+    _add_binary_op("ADD", grid_y_name, one_const, y_plus_one)
+    x_name_pre = x_name
+    y_name_pre = y_name
+    if not align_corners:
+        x_name_pre = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_x_pre",
+            dtype=compute_dtype,
+            shape=[int(n), int(out_h), int(out_w), 1],
+        )
+        y_name_pre = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_y_pre",
+            dtype=compute_dtype,
+            shape=[int(n), int(out_h), int(out_w), 1],
+        )
+    _add_binary_op("MUL", x_plus_one, x_scale_const, x_name_pre)
+    _add_binary_op("MUL", y_plus_one, y_scale_const, y_name_pre)
+    if not align_corners:
+        _add_binary_op("SUB", x_name_pre, half_const, x_name)
+        _add_binary_op("SUB", y_name_pre, half_const, y_name)
+
+    x_clip_low_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x_clip_low",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x_clip_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x_clip",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y_clip_low_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y_clip_low",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y_clip_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y_clip",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x_shift_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x_shift",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y_shift_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y_shift",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    _add_binary_op("MAXIMUM", x_name, neg_one_const, x_clip_low_name)
+    _add_binary_op("MINIMUM", x_clip_low_name, w_const, x_clip_name)
+    _add_binary_op("MAXIMUM", y_name, neg_one_const, y_clip_low_name)
+    _add_binary_op("MINIMUM", y_clip_low_name, h_const, y_clip_name)
+    _add_binary_op("ADD", x_clip_name, one_const, x_shift_name)
+    _add_binary_op("ADD", y_clip_name, one_const, y_shift_name)
+
+    x0_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x0",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y0_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y0",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x1_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x1",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y1_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y1",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    ctx.add_operator(OperatorIR(op_type="FLOOR", inputs=[x_shift_name], outputs=[x0_name]))
+    ctx.add_operator(OperatorIR(op_type="FLOOR", inputs=[y_shift_name], outputs=[y0_name]))
+    _add_binary_op("ADD", x0_name, one_const, x1_name)
+    _add_binary_op("ADD", y0_name, one_const, y1_name)
+
+    x0_clip_low_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x0_clip_low",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x0_clip_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x0_clip",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x1_clip_low_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x1_clip_low",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x1_clip_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x1_clip",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y0_clip_low_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y0_clip_low",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y0_clip_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y0_clip",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y1_clip_low_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y1_clip_low",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y1_clip_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y1_clip",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    _add_binary_op("MAXIMUM", x0_name, zero_const, x0_clip_low_name)
+    _add_binary_op("MINIMUM", x0_clip_low_name, w_pad_max_const, x0_clip_name)
+    _add_binary_op("MAXIMUM", x1_name, zero_const, x1_clip_low_name)
+    _add_binary_op("MINIMUM", x1_clip_low_name, w_pad_max_const, x1_clip_name)
+    _add_binary_op("MAXIMUM", y0_name, zero_const, y0_clip_low_name)
+    _add_binary_op("MINIMUM", y0_clip_low_name, h_pad_max_const, y0_clip_name)
+    _add_binary_op("MAXIMUM", y1_name, zero_const, y1_clip_low_name)
+    _add_binary_op("MINIMUM", y1_clip_low_name, h_pad_max_const, y1_clip_name)
+
+    dx_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_dx",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    dy_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_dy",
+        dtype=compute_dtype,
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    _add_binary_op("SUB", x_shift_name, x0_clip_name, dx_name)
+    _add_binary_op("SUB", y_shift_name, y0_clip_name, dy_name)
+
+    x0_i_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x0_i",
+        dtype="INT32",
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    x1_i_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_x1_i",
+        dtype="INT32",
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y0_i_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y0_i",
+        dtype="INT32",
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    y1_i_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_y1_i",
+        dtype="INT32",
+        shape=[int(n), int(out_h), int(out_w), 1],
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CAST",
+            inputs=[x0_clip_name],
+            outputs=[x0_i_name],
+            options={"inDataType": compute_dtype, "outDataType": "INT32"},
+        )
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CAST",
+            inputs=[x1_clip_name],
+            outputs=[x1_i_name],
+            options={"inDataType": compute_dtype, "outDataType": "INT32"},
+        )
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CAST",
+            inputs=[y0_clip_name],
+            outputs=[y0_i_name],
+            options={"inDataType": compute_dtype, "outDataType": "INT32"},
+        )
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CAST",
+            inputs=[y1_clip_name],
+            outputs=[y1_i_name],
+            options={"inDataType": compute_dtype, "outDataType": "INT32"},
+        )
+    )
+
+    x0_3d = _squeeze_last_dim(x0_i_name, "x0", "INT32")
+    x1_3d = _squeeze_last_dim(x1_i_name, "x1", "INT32")
+    y0_3d = _squeeze_last_dim(y0_i_name, "y0", "INT32")
+    y1_3d = _squeeze_last_dim(y1_i_name, "y1", "INT32")
+    linear_width_const = ctx.add_const_tensor(
+        f"{output_name}_gridsample_linear_width",
+        np.asarray(int(w + 2), dtype=np.int32),
+    )
+    idx00_name = _build_linear_index(y0_3d, x0_3d, "idx00", linear_width_const)
+    idx01_name = _build_linear_index(y1_3d, x0_3d, "idx01", linear_width_const)
+    idx10_name = _build_linear_index(y0_3d, x1_3d, "idx10", linear_width_const)
+    idx11_name = _build_linear_index(y1_3d, x1_3d, "idx11", linear_width_const)
+
+    val00_name = _build_gather(idx00_name, "val00", image_flat_name)
+    val01_name = _build_gather(idx01_name, "val01", image_flat_name)
+    val10_name = _build_gather(idx10_name, "val10", image_flat_name)
+    val11_name = _build_gather(idx11_name, "val11", image_flat_name)
+
+    dx_n1hw = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_dx_n1hw",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    dy_n1hw = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_dy_n1hw",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    dx_n1hw = make_transpose(
+        ctx=ctx,
+        input_name=dx_name,
+        output_name=dx_n1hw,
+        perm_values=[0, 3, 1, 2],
+        allow_elide_inverse_chain=True,
+    )
+    dy_n1hw = make_transpose(
+        ctx=ctx,
+        input_name=dy_name,
+        output_name=dy_n1hw,
+        perm_values=[0, 3, 1, 2],
+        allow_elide_inverse_chain=True,
+    )
+
+    one_minus_dx_n1hw = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_one_minus_dx",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    one_minus_dy_n1hw = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_one_minus_dy",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    _add_binary_op("SUB", one_const, dx_n1hw, one_minus_dx_n1hw)
+    _add_binary_op("SUB", one_const, dy_n1hw, one_minus_dy_n1hw)
+
+    w00_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_w00",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    w01_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_w01",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    w10_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_w10",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    w11_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_w11",
+        dtype=compute_dtype,
+        shape=[int(n), 1, int(out_h), int(out_w)],
+    )
+    _add_binary_op("MUL", one_minus_dx_n1hw, one_minus_dy_n1hw, w00_name)
+    _add_binary_op("MUL", one_minus_dx_n1hw, dy_n1hw, w01_name)
+    _add_binary_op("MUL", dx_n1hw, one_minus_dy_n1hw, w10_name)
+    _add_binary_op("MUL", dx_n1hw, dy_n1hw, w11_name)
+
+    term00_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_term00",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(out_h), int(out_w)],
+    )
+    term01_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_term01",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(out_h), int(out_w)],
+    )
+    term10_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_term10",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(out_h), int(out_w)],
+    )
+    term11_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_term11",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(out_h), int(out_w)],
+    )
+    _add_binary_op("MUL", val00_name, w00_name, term00_name)
+    _add_binary_op("MUL", val01_name, w01_name, term01_name)
+    _add_binary_op("MUL", val10_name, w10_name, term10_name)
+    _add_binary_op("MUL", val11_name, w11_name, term11_name)
+
+    sum0_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_sum0",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(out_h), int(out_w)],
+    )
+    sum1_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gridsample_sum1",
+        dtype=compute_dtype,
+        shape=[int(n), int(c), int(out_h), int(out_w)],
+    )
+    output_compute_name = output_name
+    if output_dtype != compute_dtype:
+        output_compute_name = ctx.add_intermediate_tensor(
+            f"{output_name}_gridsample_output_compute",
+            dtype=compute_dtype,
+            shape=[int(out_n), int(out_c), int(out_h), int(out_w)],
+        )
+    _add_binary_op("ADD", term00_name, term01_name, sum0_name)
+    _add_binary_op("ADD", term10_name, term11_name, sum1_name)
+    _add_binary_op("ADD", sum0_name, sum1_name, output_compute_name)
+
+    if output_dtype != compute_dtype:
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[output_compute_name],
+                outputs=[output_name],
+                options={
+                    "inDataType": compute_dtype,
+                    "outDataType": output_dtype,
+                },
+            )
+        )
+
+    in_quant = ctx.model_ir.tensors[image_name].quantization
+    if in_quant is not None and ctx.model_ir.tensors[output_name].quantization is None:
+        ctx.model_ir.tensors[output_name].quantization = _clone_quantization(in_quant)
 
 
 def build_resize_op(node: Any, ctx: Any) -> None:

--- a/onnx2tf/tflite_builder/op_registry.py
+++ b/onnx2tf/tflite_builder/op_registry.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional
 import numpy as np
 
 from onnx2tf.tflite_builder.op_builders import (
+    build_abs_op,
     build_acos_op,
     build_acosh_op,
     build_argmin_op,
@@ -39,6 +40,7 @@ from onnx2tf.tflite_builder.op_builders import (
     build_eyelike_op,
     build_expand_op,
     build_flatten_op,
+    build_grid_sample_op,
     build_fused_matmul_op,
     build_fully_connected_from_gemm_or_matmul,
     build_gru_op,
@@ -51,6 +53,7 @@ from onnx2tf.tflite_builder.op_builders import (
     build_non_max_suppression_op,
     build_hardsigmoid_op,
     build_global_average_pool_op,
+    build_global_max_pool_op,
     build_logsoftmax_op,
     build_min_op,
     build_mish_op,
@@ -80,7 +83,9 @@ from onnx2tf.tflite_builder.op_builders import (
     build_qlinear_sigmoid_op,
     build_qlinear_softmax_op,
     build_quantize_linear_op,
+    build_random_normal_like_op,
     build_range_op,
+    build_cumsum_op,
     build_reduce_l1_op,
     build_reduce_l2_op,
     build_reduce_op,
@@ -292,6 +297,31 @@ def _get_original_node_inputs(node: Any, ctx: Any) -> List[str]:
     return [str(v.name) for v in node.inputs]
 
 
+def _get_main_onnx_opset(ctx: Any) -> Optional[int]:
+    onnx_model = getattr(ctx, "onnx_model", None)
+    if onnx_model is None:
+        return None
+    for opset in getattr(onnx_model, "opset_import", []):
+        domain = str(getattr(opset, "domain", ""))
+        if domain in {"", "ai.onnx"}:
+            try:
+                return int(opset.version)
+            except Exception:
+                return None
+    return None
+
+
+def _resolve_softmax_axis(node: Any, ctx: Any, rank: int) -> int:
+    if "axis" in node.attrs:
+        axis = int(node.attrs["axis"])
+    else:
+        opset = _get_main_onnx_opset(ctx)
+        axis = -1 if opset is not None and int(opset) >= 13 else 1
+    if axis < 0:
+        axis += int(rank)
+    return int(axis)
+
+
 def _is_tensor_consumed_or_graph_output(ctx: Any, tensor_name: str) -> bool:
     normalized_name = str(tensor_name)
     if normalized_name == "":
@@ -305,11 +335,11 @@ def _is_tensor_consumed_or_graph_output(ctx: Any, tensor_name: str) -> bool:
 
 def _validate_lstm(node: Any, ctx: Any) -> None:
     direction = str(node.attrs.get("direction", "forward")).lower()
-    if direction not in {"forward", "bidirectional"}:
+    if direction not in {"forward", "reverse", "bidirectional"}:
         raise NodeValidationError(
             reason_code="unsupported_attribute_value",
             message=(
-                "LSTM direction must be forward or bidirectional for builtin lowering. "
+                "LSTM direction must be one of forward/reverse/bidirectional for builtin lowering. "
                 f"direction={direction}"
             ),
             node_name=node.name,
@@ -357,20 +387,6 @@ def _validate_lstm(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-
-    for output_index in [1, 2]:
-        if output_index < len(node.outputs):
-            output_name = str(node.outputs[output_index].name)
-            if _is_tensor_consumed_or_graph_output(ctx, output_name):
-                raise NodeValidationError(
-                    reason_code="unsupported_output_usage",
-                    message=(
-                        "LSTM output_state/cell_state outputs are not supported by builtin lowering "
-                        f"when consumed. output_name={output_name}"
-                    ),
-                    node_name=node.name,
-                    node_op=node.op,
-                )
 
     w_name = _input_name(1)
     r_name = _input_name(2)
@@ -463,66 +479,70 @@ def _validate_lstm(node: Any, ctx: Any) -> None:
 
     initial_h_name = _input_name(5)
     initial_c_name = _input_name(6)
-    if initial_h_name == "" or initial_c_name == "":
+    if (initial_h_name == "") ^ (initial_c_name == ""):
         raise NodeValidationError(
             reason_code="missing_required_input",
-            message="LSTM builtin lowering requires initial_h and initial_c inputs.",
+            message="LSTM initial_h and initial_c must be both present or both absent for builtin lowering.",
             node_name=node.name,
             node_op=node.op,
         )
-    initial_h = ctx.get_constant_array(initial_h_name)
-    initial_c = ctx.get_constant_array(initial_c_name)
-    if initial_h is None or initial_c is None:
-        raise NodeValidationError(
-            reason_code="requires_constant_input",
-            message="LSTM initial_h and initial_c must be constant tensors for builtin lowering.",
-            node_name=node.name,
-            node_op=node.op,
-        )
-    initial_h = np.asarray(initial_h)
-    initial_c = np.asarray(initial_c)
-    if initial_h.ndim != 3 or initial_c.ndim != 3:
-        raise NodeValidationError(
-            reason_code="unsupported_input_shape",
-            message=(
-                "LSTM initial_h and initial_c must be rank-3 with shape "
-                "[num_directions, batch, hidden]. "
-                f"initial_h_shape={list(initial_h.shape)} initial_c_shape={list(initial_c.shape)}"
-            ),
-            node_name=node.name,
-            node_op=node.op,
-        )
-    if int(initial_h.shape[0]) != expected_num_directions or int(initial_c.shape[0]) != expected_num_directions:
-        raise NodeValidationError(
-            reason_code="unsupported_input_shape",
-            message=(
-                "LSTM initial_h and initial_c first dimension must match num_directions. "
-                f"direction={direction} expected_num_directions={expected_num_directions} "
-                f"initial_h_shape={list(initial_h.shape)} initial_c_shape={list(initial_c.shape)}"
-            ),
-            node_name=node.name,
-            node_op=node.op,
-        )
-    if not np.allclose(initial_h, 0.0, rtol=0.0, atol=1e-7) \
-        or not np.allclose(initial_c, 0.0, rtol=0.0, atol=1e-7):
-        raise NodeValidationError(
-            reason_code="unsupported_input_value",
-            message=(
-                "LSTM builtin lowering currently supports zero-initialized initial_h/initial_c only."
-            ),
-            node_name=node.name,
-            node_op=node.op,
-        )
+    if initial_h_name != "":
+        initial_h_shape = [int(v) for v in ctx.get_tensor_shape(initial_h_name)]
+        initial_c_shape = [int(v) for v in ctx.get_tensor_shape(initial_c_name)]
+        if len(initial_h_shape) != 3 or len(initial_c_shape) != 3:
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "LSTM initial_h and initial_c must be rank-3 with shape "
+                    "[num_directions, batch, hidden]. "
+                    f"initial_h_shape={initial_h_shape} initial_c_shape={initial_c_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if (
+            int(initial_h_shape[0]) > 0 and int(initial_h_shape[0]) != expected_num_directions
+        ) or (
+            int(initial_c_shape[0]) > 0 and int(initial_c_shape[0]) != expected_num_directions
+        ):
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "LSTM initial_h and initial_c first dimension must match num_directions. "
+                    f"direction={direction} expected_num_directions={expected_num_directions} "
+                    f"initial_h_shape={initial_h_shape} initial_c_shape={initial_c_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if (
+            int(initial_h_shape[2]) > 0 and int(initial_h_shape[2]) != hidden_size
+        ) or (
+            int(initial_c_shape[2]) > 0 and int(initial_c_shape[2]) != hidden_size
+        ):
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "LSTM initial_h and initial_c hidden dimension must match hidden_size. "
+                    f"hidden_size={hidden_size} initial_h_shape={initial_h_shape} initial_c_shape={initial_c_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
 
 def _validate_rnn(node: Any, ctx: Any) -> None:
     direction = str(node.attrs.get("direction", "forward")).lower()
-    if direction != "forward":
+    if direction not in {"forward", "reverse", "bidirectional"}:
         raise NodeValidationError(
             reason_code="unsupported_attribute_value",
-            message=f"RNN direction must be forward for builtin lowering. direction={direction}",
+            message=(
+                "RNN direction must be one of forward/reverse/bidirectional for builtin lowering. "
+                f"direction={direction}"
+            ),
             node_name=node.name,
             node_op=node.op,
         )
+    expected_num_directions = 2 if direction == "bidirectional" else 1
     layout = int(node.attrs.get("layout", 0))
     if layout != 0:
         raise NodeValidationError(
@@ -574,11 +594,12 @@ def _validate_rnn(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    if int(W.shape[0]) != 1 or int(R.shape[0]) != 1:
+    if int(W.shape[0]) != expected_num_directions or int(R.shape[0]) != expected_num_directions:
         raise NodeValidationError(
             reason_code="unsupported_input_shape",
             message=(
-                "RNN builtin lowering currently supports num_directions=1 only. "
+                "RNN W/R num_directions mismatch for builtin lowering. "
+                f"direction={direction} expected_num_directions={expected_num_directions} "
                 f"W_shape={list(W.shape)} R_shape={list(R.shape)}"
             ),
             node_name=node.name,
@@ -617,11 +638,16 @@ def _validate_rnn(node: Any, ctx: Any) -> None:
                 node_op=node.op,
             )
         B = np.asarray(B)
-        if B.ndim != 2 or int(B.shape[0]) != 1 or int(B.shape[1]) != 2 * hidden_size:
+        if (
+            B.ndim != 2
+            or int(B.shape[0]) != expected_num_directions
+            or int(B.shape[1]) != 2 * hidden_size
+        ):
             raise NodeValidationError(
                 reason_code="unsupported_input_shape",
                 message=(
-                    "RNN B must have shape [1, 2*hidden_size]. "
+                    "RNN B must have shape [num_directions, 2*hidden_size]. "
+                    f"direction={direction} expected_num_directions={expected_num_directions} "
                     f"B_shape={list(B.shape)} hidden_size={hidden_size}"
                 ),
                 node_name=node.name,
@@ -630,51 +656,54 @@ def _validate_rnn(node: Any, ctx: Any) -> None:
 
     initial_h_name = _input_name(5)
     if initial_h_name != "":
-        initial_h = ctx.get_constant_array(initial_h_name)
-        if initial_h is None:
-            raise NodeValidationError(
-                reason_code="requires_constant_input",
-                message="RNN initial_h must be constant when provided.",
-                node_name=node.name,
-                node_op=node.op,
-            )
-        initial_h = np.asarray(initial_h)
-        if initial_h.ndim != 3 or int(initial_h.shape[0]) != 1:
+        initial_h_shape = [int(v) for v in ctx.get_tensor_shape(initial_h_name)]
+        if len(initial_h_shape) != 3:
             raise NodeValidationError(
                 reason_code="unsupported_input_shape",
                 message=(
-                    "RNN initial_h must be rank-3 [1, batch, hidden] in builtin lowering. "
-                    f"initial_h_shape={list(initial_h.shape)}"
+                    "RNN initial_h must be rank-3 [num_directions, batch, hidden] in builtin lowering. "
+                    f"initial_h_shape={initial_h_shape}"
                 ),
                 node_name=node.name,
                 node_op=node.op,
             )
-        if int(initial_h.shape[2]) != hidden_size:
+        if int(initial_h_shape[0]) > 0 and int(initial_h_shape[0]) != expected_num_directions:
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "RNN initial_h first dimension must match num_directions in builtin lowering. "
+                    f"direction={direction} expected_num_directions={expected_num_directions} "
+                    f"initial_h_shape={initial_h_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if int(initial_h_shape[2]) > 0 and int(initial_h_shape[2]) != hidden_size:
             raise NodeValidationError(
                 reason_code="unsupported_input_shape",
                 message=(
                     "RNN initial_h hidden dimension must match hidden_size in builtin lowering. "
-                    f"initial_h_shape={list(initial_h.shape)} hidden_size={hidden_size}"
+                    f"initial_h_shape={initial_h_shape} hidden_size={hidden_size}"
                 ),
                 node_name=node.name,
                 node_op=node.op,
             )
 
     activations = node.attrs.get("activations", ["Tanh"])
-    if isinstance(activations, (list, tuple)) and len(activations) > 0:
-        activation = str(activations[0]).lower()
-    else:
-        activation = "tanh"
-    if activation not in {"tanh", "relu", "sigmoid"}:
-        raise NodeValidationError(
-            reason_code="unsupported_attribute_value",
-            message=(
-                "RNN activation must be one of tanh/relu/sigmoid for builtin lowering. "
-                f"activation={activation}"
-            ),
-            node_name=node.name,
-            node_op=node.op,
-        )
+    if not isinstance(activations, (list, tuple)) or len(activations) == 0:
+        activations = ["Tanh"]
+    for dir_index in range(expected_num_directions):
+        activation = str(activations[min(dir_index, len(activations) - 1)]).lower()
+        if activation not in {"tanh", "relu", "sigmoid"}:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=(
+                    "RNN activation must be one of tanh/relu/sigmoid for builtin lowering. "
+                    f"direction={direction} direction_index={dir_index} activation={activation}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
     clip = float(node.attrs.get("clip", 0.0))
     if abs(clip) > 1e-6:
         raise NodeValidationError(
@@ -911,9 +940,7 @@ def _validate_softmax(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    axis = int(node.attrs.get("axis", 1))
-    if axis < 0:
-        axis += int(rank)
+    axis = _resolve_softmax_axis(node=node, ctx=ctx, rank=rank)
     if axis < 0 or axis >= int(rank):
         raise NodeValidationError(
             reason_code="unsupported_attribute_value",
@@ -974,13 +1001,31 @@ def _validate_slice(node: Any, ctx: Any) -> None:
         attr_name="starts",
         label="slice starts",
     )
-    ends_values = _extract_slice_indices(
-        node=node,
-        ctx=ctx,
-        input_index=2,
-        attr_name="ends",
-        label="slice ends",
-    )
+    ends_values: List[int]
+    dynamic_end_name = ""
+    try:
+        ends_values = _extract_slice_indices(
+            node=node,
+            ctx=ctx,
+            input_index=2,
+            attr_name="ends",
+            label="slice ends",
+        )
+    except NodeValidationError as exc:
+        can_use_dynamic_end = (
+            len(node.inputs) > 2
+            and str(node.inputs[2].name) != ""
+            and ctx.get_constant_array(node.inputs[2].name) is None
+            and "ends" not in node.attrs
+            and exc.reason_code in {
+                "requires_constant_input",
+                "missing_required_attribute",
+            }
+        )
+        if not can_use_dynamic_end:
+            raise
+        dynamic_end_name = str(node.inputs[2].name)
+        ends_values = [0 for _ in range(len(starts_values))]
     if len(starts_values) != len(ends_values):
         raise NodeValidationError(
             reason_code="invalid_input_shape",
@@ -1043,13 +1088,55 @@ def _validate_slice(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    if any(int(step) < 0 for step in steps):
-        raise NodeValidationError(
-            reason_code="unsupported_attribute_value",
-            message=f"Slice negative steps are not supported. steps={steps}",
-            node_name=node.name,
-            node_op=node.op,
+
+    if dynamic_end_name != "":
+        dynamic_end_shape = [int(v) for v in ctx.get_tensor_shape(dynamic_end_name)]
+        is_supported_dynamic_end = (
+            rank == 1
+            and len(dynamic_end_shape) >= 1
+            and len(starts_values) == 1
+            and len(normalized_axes) == 1
+            and len(steps) == 1
+            and int(starts_values[0]) == 0
+            and int(normalized_axes[0]) == 0
+            and int(steps[0]) == 1
         )
+        if not is_supported_dynamic_end:
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "Slice dynamic-end lowering supports rank-1 axis-0 prefix slice "
+                    "with start=0 and step=1 only. "
+                    f"rank={rank} dynamic_end_shape={dynamic_end_shape} "
+                    f"starts={starts_values} axes={normalized_axes} steps={steps}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+
+    if any(int(step) < 0 for step in steps):
+        is_supported_full_reverse = (
+            dynamic_end_name == ""
+            and len(starts_values) == 1
+            and len(ends_values) == 1
+            and len(normalized_axes) == 1
+            and len(steps) == 1
+            and int(steps[0]) == -1
+            and int(starts_values[0]) == -1
+            and int(ends_values[0]) <= -int(np.iinfo(np.int32).max)
+        )
+        if not is_supported_full_reverse:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=(
+                    "Slice negative steps are not supported except full-axis reverse "
+                    "(start=-1,end<=-int32_max,step=-1). "
+                    f"starts={starts_values} ends={ends_values} "
+                    f"axes={normalized_axes} steps={steps}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
 
 
 def _validate_split(node: Any, ctx: Any) -> None:
@@ -1138,10 +1225,10 @@ def _validate_transpose(node: Any, ctx: Any) -> None:
 
 def _validate_conv(node: Any, ctx: Any) -> None:
     weights = _require_const_input(node, ctx, 1, "conv weights")
-    if weights.ndim not in [3, 4]:
+    if weights.ndim not in [3, 4, 5]:
         raise NodeValidationError(
             reason_code="unsupported_weight_rank",
-            message=f"Conv weight rank must be 3 or 4. weight_shape={list(weights.shape)}",
+            message=f"Conv weight rank must be 3, 4, or 5. weight_shape={list(weights.shape)}",
             node_name=node.name,
             node_op=node.op,
         )
@@ -1155,11 +1242,19 @@ def _validate_conv(node: Any, ctx: Any) -> None:
                 node_name=node.name,
                 node_op=node.op,
             )
-    else:
+    elif int(weights.ndim) == 3:
         if len(input_shape) != 3 or len(output_shape) != 3:
             raise NodeValidationError(
                 reason_code="unsupported_tensor_rank",
                 message=f"Conv1D input/output rank must be 3. input_shape={input_shape} output_shape={output_shape}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+    else:
+        if len(input_shape) != 5 or len(output_shape) != 5:
+            raise NodeValidationError(
+                reason_code="unsupported_tensor_rank",
+                message=f"Conv3D input/output rank must be 5. input_shape={input_shape} output_shape={output_shape}",
                 node_name=node.name,
                 node_op=node.op,
             )
@@ -1168,6 +1263,17 @@ def _validate_conv(node: Any, ctx: Any) -> None:
         raise NodeValidationError(
             reason_code="unsupported_attribute_value",
             message=f"Conv group must be > 0. group={group}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if int(weights.ndim) == 5 and group != 1:
+        raise NodeValidationError(
+            reason_code="unsupported_grouped_convolution",
+            message=(
+                "Conv3D currently supports group=1 only. "
+                f"group={group} input_shape={input_shape} output_shape={output_shape} "
+                f"weight_shape={list(weights.shape)}"
+            ),
             node_name=node.name,
             node_op=node.op,
         )
@@ -1437,12 +1543,23 @@ def _validate_global_average_pool(node: Any, ctx: Any) -> None:
         )
 
 
+def _validate_global_max_pool(node: Any, ctx: Any) -> None:
+    input_shape = ctx.get_tensor_shape(node.inputs[0].name)
+    if len(input_shape) < 3:
+        raise NodeValidationError(
+            reason_code="unsupported_input_rank",
+            message=f"GlobalMaxPool input rank must be >=3. input_shape={input_shape}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
 def _validate_conv_transpose(node: Any, ctx: Any) -> None:
     weights = _require_const_input(node, ctx, 1, "convtranspose weights")
-    if weights.ndim not in [3, 4]:
+    if weights.ndim not in [3, 4, 5]:
         raise NodeValidationError(
             reason_code="unsupported_weight_rank",
-            message=f"ConvTranspose weight rank must be 3 or 4. weight_shape={list(weights.shape)}",
+            message=f"ConvTranspose weight rank must be 3, 4, or 5. weight_shape={list(weights.shape)}",
             node_name=node.name,
             node_op=node.op,
         )
@@ -1461,6 +1578,13 @@ def _validate_conv_transpose(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
+    if int(weights.ndim) == 5 and len(input_shape) not in [1, 5]:
+        raise NodeValidationError(
+            reason_code="unsupported_input_rank",
+            message=f"ConvTranspose3D input rank must be 5 (or unknown placeholder rank=1). input_shape={input_shape}",
+            node_name=node.name,
+            node_op=node.op,
+        )
     group = int(node.attrs.get("group", 1))
     if group != 1:
         raise NodeValidationError(
@@ -1469,9 +1593,21 @@ def _validate_conv_transpose(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
-    output_padding = [int(v) for v in list(node.attrs.get("output_padding", [0, 0]))]
     if int(weights.ndim) == 3:
+        dilations = [int(v) for v in list(node.attrs.get("dilations", [1]))]
+        output_padding = [int(v) for v in list(node.attrs.get("output_padding", []))]
+        strides = [int(v) for v in list(node.attrs.get("strides", [1]))]
+        if len(strides) == 0:
+            strides = [1]
+        if len(strides) == 2:
+            strides = [int(strides[1])]
+        elif len(strides) != 1:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose1D strides must have length 1. strides={strides}",
+                node_name=node.name,
+                node_op=node.op,
+            )
         if dilations not in [[1], [1, 1]]:
             raise NodeValidationError(
                 reason_code="unsupported_attribute_value",
@@ -1479,14 +1615,42 @@ def _validate_conv_transpose(node: Any, ctx: Any) -> None:
                 node_name=node.name,
                 node_op=node.op,
             )
-        if output_padding not in [[], [0], [0, 0]]:
+        if len(output_padding) == 0:
+            output_padding = [0]
+        elif len(output_padding) == 2:
+            output_padding = [int(output_padding[1])]
+        elif len(output_padding) != 1:
             raise NodeValidationError(
                 reason_code="unsupported_attribute_value",
-                message=f"ConvTranspose1D output_padding must be [0]. output_padding={output_padding}",
+                message=f"ConvTranspose1D output_padding must have length 1. output_padding={output_padding}",
                 node_name=node.name,
                 node_op=node.op,
             )
-    else:
+        if output_padding[0] < 0 or output_padding[0] >= int(strides[0]):
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=(
+                    "ConvTranspose1D output_padding must satisfy "
+                    f"0 <= output_padding < stride. output_padding={output_padding} strides={strides}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+    elif int(weights.ndim) == 4:
+        dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1]))]
+        output_padding = [int(v) for v in list(node.attrs.get("output_padding", []))]
+        strides = [int(v) for v in list(node.attrs.get("strides", [1, 1]))]
+        if len(strides) == 0:
+            strides = [1, 1]
+        elif len(strides) == 1:
+            strides = [int(strides[0]), int(strides[0])]
+        elif len(strides) != 2:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose strides must have length 2. strides={strides}",
+                node_name=node.name,
+                node_op=node.op,
+            )
         if dilations != [1, 1]:
             raise NodeValidationError(
                 reason_code="unsupported_attribute_value",
@@ -1494,10 +1658,81 @@ def _validate_conv_transpose(node: Any, ctx: Any) -> None:
                 node_name=node.name,
                 node_op=node.op,
             )
-        if any(v != 0 for v in output_padding):
+        if len(output_padding) == 0:
+            output_padding = [0, 0]
+        elif len(output_padding) == 1:
+            output_padding = [int(output_padding[0]), int(output_padding[0])]
+        elif len(output_padding) != 2:
             raise NodeValidationError(
                 reason_code="unsupported_attribute_value",
-                message=f"ConvTranspose output_padding must be [0,0]. output_padding={output_padding}",
+                message=f"ConvTranspose output_padding must have length 2. output_padding={output_padding}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if any(v < 0 for v in output_padding):
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose output_padding must be non-negative. output_padding={output_padding}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if any(int(v) >= int(s) for v, s in zip(output_padding, strides)):
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=(
+                    "ConvTranspose output_padding must satisfy "
+                    f"0 <= output_padding < stride. output_padding={output_padding} strides={strides}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+    else:
+        dilations = [int(v) for v in list(node.attrs.get("dilations", [1, 1, 1]))]
+        output_padding = [int(v) for v in list(node.attrs.get("output_padding", []))]
+        strides = [int(v) for v in list(node.attrs.get("strides", [1, 1, 1]))]
+        if len(strides) == 0:
+            strides = [1, 1, 1]
+        elif len(strides) == 1:
+            strides = [int(strides[0]), int(strides[0]), int(strides[0])]
+        elif len(strides) != 3:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose3D strides must have length 3. strides={strides}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if dilations != [1, 1, 1]:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose3D dilations must be [1,1,1]. dilations={dilations}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if len(output_padding) == 0:
+            output_padding = [0, 0, 0]
+        elif len(output_padding) == 1:
+            output_padding = [int(output_padding[0]), int(output_padding[0]), int(output_padding[0])]
+        elif len(output_padding) != 3:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose3D output_padding must have length 3. output_padding={output_padding}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if any(v < 0 for v in output_padding):
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"ConvTranspose3D output_padding must be non-negative. output_padding={output_padding}",
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if any(int(v) >= int(s) for v, s in zip(output_padding, strides)):
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=(
+                    "ConvTranspose3D output_padding must satisfy "
+                    f"0 <= output_padding < stride. output_padding={output_padding} strides={strides}"
+                ),
                 node_name=node.name,
                 node_op=node.op,
             )
@@ -1990,6 +2225,55 @@ def _validate_reduce(node: Any, ctx: Any) -> None:
     if len(axes) == 0 and int(node.attrs.get("noop_with_empty_axes", 0)) == 1:
         return
     _normalize_axes_for_rank(axes=axes, rank=input_rank, node=node)
+
+
+def _validate_cumsum(node: Any, ctx: Any) -> None:
+    input_rank = len(ctx.get_tensor_shape(node.inputs[0].name))
+    if input_rank <= 0:
+        raise NodeValidationError(
+            reason_code="unsupported_input_rank",
+            message=f"CumSum input rank must be >= 1. input_rank={input_rank}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    if len(node.inputs) >= 2 and str(node.inputs[1].name) != "":
+        axis_arr = _require_const_input(node, ctx, 1, "CumSum axis")
+        axis_values = np.asarray(axis_arr).reshape(-1)
+        if int(axis_values.size) != 1:
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "CumSum axis must be scalar or single-element tensor. "
+                    f"axis_shape={list(np.asarray(axis_arr).shape)}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+        axis_raw = int(axis_values[0])
+    else:
+        axis_raw = int(node.attrs.get("axis", 0))
+
+    axis = int(axis_raw)
+    if axis < 0:
+        axis += int(input_rank)
+    if axis < 0 or axis >= int(input_rank):
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=f"CumSum axis out of range. axis={axis_raw} normalized={axis} rank={input_rank}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    for attr_name in ["exclusive", "reverse"]:
+        attr_value = int(node.attrs.get(attr_name, 0))
+        if attr_value not in [0, 1]:
+            raise NodeValidationError(
+                reason_code="unsupported_attribute_value",
+                message=f"CumSum {attr_name} must be 0 or 1. got={attr_value}",
+                node_name=node.name,
+                node_op=node.op,
+            )
 
 
 def _validate_squeeze(node: Any, ctx: Any) -> None:
@@ -2757,6 +3041,32 @@ def _validate_range(node: Any, ctx: Any) -> None:
                 node_name=node.name,
                 node_op=node.op,
             )
+
+
+def _validate_random_normal_like(node: Any, ctx: Any) -> None:
+    output_dtype = str(ctx.get_tensor_dtype(node.outputs[0].name)).upper()
+    if output_dtype in {
+        "FLOAT16",
+        "FLOAT32",
+        "INT8",
+        "UINT8",
+        "INT16",
+        "UINT16",
+        "INT32",
+        "UINT32",
+        "INT64",
+        "UINT64",
+    }:
+        return
+    raise NodeValidationError(
+        reason_code="unsupported_output_type",
+        message=(
+            "RandomNormalLike output dtype is not supported in flatbuffer_direct. "
+            f"dtype={output_dtype}"
+        ),
+        node_name=node.name,
+        node_op=node.op,
+    )
 
 
 def _validate_bitwise_not(node: Any, ctx: Any) -> None:
@@ -3683,6 +3993,130 @@ def _validate_resize(node: Any, ctx: Any) -> None:
         )
 
 
+def _validate_grid_sample(node: Any, ctx: Any) -> None:
+    mode = str(node.attrs.get("mode", "bilinear")).lower()
+    padding_mode = str(node.attrs.get("padding_mode", "zeros")).lower()
+    align_corners = int(node.attrs.get("align_corners", 0))
+    if mode != "bilinear":
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=f"GridSample supports mode=bilinear only in flatbuffer_direct. mode={mode}",
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if padding_mode != "zeros":
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=(
+                "GridSample supports padding_mode=zeros only in flatbuffer_direct. "
+                f"padding_mode={padding_mode}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if align_corners not in {0, 1}:
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=(
+                "GridSample supports align_corners in {0,1} only in flatbuffer_direct. "
+                f"align_corners={align_corners}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    image_shape = [int(v) for v in ctx.get_tensor_shape(node.inputs[0].name)]
+    grid_shape = [int(v) for v in ctx.get_tensor_shape(node.inputs[1].name)]
+    output_shape = [int(v) for v in ctx.get_tensor_shape(node.outputs[0].name)]
+    if len(image_shape) != 4 or len(grid_shape) != 4 or len(output_shape) != 4:
+        raise NodeValidationError(
+            reason_code="unsupported_input_rank",
+            message=(
+                "GridSample supports rank-4 tensors only in flatbuffer_direct. "
+                f"image_shape={image_shape} grid_shape={grid_shape} output_shape={output_shape}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if any(int(v) <= 0 for v in image_shape + grid_shape + output_shape):
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "GridSample requires static positive dimensions in flatbuffer_direct. "
+                f"image_shape={image_shape} grid_shape={grid_shape} output_shape={output_shape}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    if int(grid_shape[3]) != 2:
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "GridSample grid last dimension must be 2 ([x,y]) in flatbuffer_direct. "
+                f"grid_shape={grid_shape}. "
+                "When grid is a model input, pass -kat/--keep_shape_absolutely_input_names for it."
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    n, c, h, w = [int(v) for v in image_shape]
+    out_n, out_c, out_h, out_w = [int(v) for v in output_shape]
+    grid_n, grid_h, grid_w, _ = [int(v) for v in grid_shape]
+    if not (
+        n == out_n == grid_n
+        and c == out_c
+        and out_h == grid_h
+        and out_w == grid_w
+        and h >= 1
+        and w >= 1
+    ):
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "GridSample input/grid/output shapes are inconsistent for built-in lowering. "
+                f"image_shape={image_shape} grid_shape={grid_shape} output_shape={output_shape}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+    image_dtype = str(ctx.get_tensor_dtype(node.inputs[0].name)).upper()
+    grid_dtype = str(ctx.get_tensor_dtype(node.inputs[1].name)).upper()
+    output_dtype = str(ctx.get_tensor_dtype(node.outputs[0].name)).upper()
+    if image_dtype not in {"FLOAT16", "FLOAT32"}:
+        raise NodeValidationError(
+            reason_code="unsupported_input_type",
+            message=(
+                "GridSample input dtype must be FLOAT16/FLOAT32 in flatbuffer_direct. "
+                f"image_dtype={image_dtype}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if grid_dtype not in {"FLOAT16", "FLOAT32"}:
+        raise NodeValidationError(
+            reason_code="unsupported_input_type",
+            message=(
+                "GridSample grid dtype must be FLOAT16/FLOAT32 in flatbuffer_direct. "
+                f"grid_dtype={grid_dtype}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if output_dtype not in {"FLOAT16", "FLOAT32"}:
+        raise NodeValidationError(
+            reason_code="unsupported_output_type",
+            message=(
+                "GridSample output dtype must be FLOAT16/FLOAT32 in flatbuffer_direct. "
+                f"output_dtype={output_dtype}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
 def _validate_prelu(node: Any, ctx: Any) -> None:
     slope = _require_const_input(node, ctx, 1, "PRelu slope")
     input_shape = ctx.get_tensor_shape(node.inputs[0].name)
@@ -3898,8 +4332,8 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
     ),
     "Abs": DispatchEntry(
         onnx_op="Abs",
-        tflite_ops=["ABS"],
-        builder=_make_unary_builder("ABS"),
+        tflite_ops=["ABS", "NEG", "MAXIMUM"],
+        builder=build_abs_op,
         validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
     ),
     "Acos": DispatchEntry(
@@ -4160,10 +4594,24 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         validation=ValidationSpec(min_inputs=1, max_inputs=2, min_outputs=1, max_outputs=1),
         extra_validator=_validate_reduce,
     ),
+    "CumSum": DispatchEntry(
+        onnx_op="CumSum",
+        tflite_ops=["CUMSUM"],
+        builder=build_cumsum_op,
+        validation=ValidationSpec(min_inputs=1, max_inputs=2, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_cumsum,
+    ),
     "ReduceMax": DispatchEntry(
         onnx_op="ReduceMax",
         tflite_ops=["REDUCE_MAX"],
         builder=lambda node, ctx: build_reduce_op(node, ctx, "REDUCE_MAX"),
+        validation=ValidationSpec(min_inputs=1, max_inputs=2, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_reduce,
+    ),
+    "ReduceProd": DispatchEntry(
+        onnx_op="ReduceProd",
+        tflite_ops=["REDUCE_PROD"],
+        builder=lambda node, ctx: build_reduce_op(node, ctx, "REDUCE_PROD"),
         validation=ValidationSpec(min_inputs=1, max_inputs=2, min_outputs=1, max_outputs=1),
         extra_validator=_validate_reduce,
     ),
@@ -4215,6 +4663,12 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         onnx_op="Greater",
         tflite_ops=["GREATER"],
         builder=_make_binary_builder("GREATER"),
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+    ),
+    "GreaterOrEqual": DispatchEntry(
+        onnx_op="GreaterOrEqual",
+        tflite_ops=["GREATER_EQUAL"],
+        builder=_make_binary_builder("GREATER_EQUAL"),
         validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
     ),
     "Less": DispatchEntry(
@@ -4398,7 +4852,7 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
     ),
     "Pad": DispatchEntry(
         onnx_op="Pad",
-        tflite_ops=["PAD"],
+        tflite_ops=["PAD", "MIRROR_PAD"],
         builder=build_pad_op,
         validation=ValidationSpec(min_inputs=2, max_inputs=3, min_outputs=1, max_outputs=1),
     ),
@@ -4464,6 +4918,13 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         builder=build_range_op,
         validation=ValidationSpec(min_inputs=3, max_inputs=3, min_outputs=1, max_outputs=1),
         extra_validator=_validate_range,
+    ),
+    "RandomNormalLike": DispatchEntry(
+        onnx_op="RandomNormalLike",
+        tflite_ops=["SHAPE", "RANDOM_STANDARD_NORMAL", "MUL", "ADD", "CAST"],
+        builder=build_random_normal_like_op,
+        validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_random_normal_like,
     ),
     "EyeLike": DispatchEntry(
         onnx_op="EyeLike",
@@ -4623,7 +5084,7 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
     ),
     "Slice": DispatchEntry(
         onnx_op="Slice",
-        tflite_ops=["SLICE", "STRIDED_SLICE"],
+        tflite_ops=["SLICE", "STRIDED_SLICE", "REVERSE_V2"],
         builder=build_slice_op,
         validation=ValidationSpec(min_inputs=1, max_inputs=5, min_outputs=1, max_outputs=1),
         extra_validator=_validate_slice,
@@ -4647,6 +5108,27 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         builder=build_resize_op,
         validation=ValidationSpec(min_inputs=1, max_inputs=4, min_outputs=1, max_outputs=1),
         extra_validator=_validate_resize,
+    ),
+    "GridSample": DispatchEntry(
+        onnx_op="GridSample",
+        tflite_ops=[
+            "PAD",
+            "RESHAPE",
+            "TRANSPOSE",
+            "SQUEEZE",
+            "SLICE",
+            "ADD",
+            "SUB",
+            "MUL",
+            "FLOOR",
+            "MAXIMUM",
+            "MINIMUM",
+            "CAST",
+            "GATHER",
+        ],
+        builder=build_grid_sample_op,
+        validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
+        extra_validator=_validate_grid_sample,
     ),
     "SpaceToDepth": DispatchEntry(
         onnx_op="SpaceToDepth",
@@ -4678,15 +5160,15 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
     ),
     "Conv": DispatchEntry(
         onnx_op="Conv",
-        tflite_ops=["CONV_2D", "DEPTHWISE_CONV_2D"],
+        tflite_ops=["CONV_2D", "DEPTHWISE_CONV_2D", "CONV_3D"],
         builder=build_conv2d_or_depthwise_op,
         validation=ValidationSpec(
             min_inputs=2,
             max_inputs=3,
             min_outputs=1,
             max_outputs=1,
-            input_rank={0: [3, 4]},
-            output_rank={0: [3, 4]},
+            input_rank={0: [3, 4, 5]},
+            output_rank={0: [3, 4, 5]},
         ),
         extra_validator=_validate_conv,
     ),
@@ -4718,7 +5200,7 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
     ),
     "ConvTranspose": DispatchEntry(
         onnx_op="ConvTranspose",
-        tflite_ops=["TRANSPOSE_CONV", "ADD"],
+        tflite_ops=["TRANSPOSE_CONV", "ADD", "CONV_3D_TRANSPOSE"],
         builder=build_conv_transpose_op,
         validation=ValidationSpec(
             min_inputs=2,
@@ -4739,6 +5221,18 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
             max_outputs=1,
         ),
         extra_validator=_validate_global_average_pool,
+    ),
+    "GlobalMaxPool": DispatchEntry(
+        onnx_op="GlobalMaxPool",
+        tflite_ops=["REDUCE_MAX"],
+        builder=build_global_max_pool_op,
+        validation=ValidationSpec(
+            min_inputs=1,
+            max_inputs=1,
+            min_outputs=1,
+            max_outputs=1,
+        ),
+        extra_validator=_validate_global_max_pool,
     ),
     "AveragePool": DispatchEntry(
         onnx_op="AveragePool",
@@ -4822,9 +5316,12 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         onnx_op="RNN",
         tflite_ops=[
             "UNIDIRECTIONAL_SEQUENCE_RNN",
+            "REVERSE_V2",
+            "CONCATENATION",
             "TRANSPOSE",
             "EXPAND_DIMS",
             "SLICE",
+            "SQUEEZE",
             "RESHAPE",
         ],
         builder=build_rnn_op,
@@ -4836,6 +5333,7 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         tflite_ops=[
             "UNIDIRECTIONAL_SEQUENCE_LSTM",
             "BIDIRECTIONAL_SEQUENCE_LSTM",
+            "REVERSE_V2",
             "SPLIT",
             "EXPAND_DIMS",
             "RESHAPE",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.22"
+version = "2.0.23"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_accuracy_evaluator_seeded_input.py
+++ b/tests/test_accuracy_evaluator_seeded_input.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from onnx2tf.tflite_builder.accuracy_evaluator import _generate_seeded_input
+
+
+def test_generate_seeded_input_float_image_shape_defaults_uniform_0_1(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("ONNX2TF_EVAL_FLOAT_RANDOM_DISTRIBUTION", raising=False)
+    x = _generate_seeded_input(
+        shape=(1, 3, 8, 8),
+        np_dtype=np.dtype(np.float32),
+        rng=np.random.default_rng(0),
+    )
+    assert x.dtype == np.float32
+    assert float(np.min(x)) >= 0.0
+    assert float(np.max(x)) <= 1.0
+
+
+def test_generate_seeded_input_float_non_image_shape_defaults_normal(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("ONNX2TF_EVAL_FLOAT_RANDOM_DISTRIBUTION", raising=False)
+    rng_actual = np.random.default_rng(123)
+    rng_expected = np.random.default_rng(123)
+    actual = _generate_seeded_input(
+        shape=(1, 16),
+        np_dtype=np.dtype(np.float32),
+        rng=rng_actual,
+    )
+    expected = rng_expected.standard_normal((1, 16)).astype(np.float32)
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_generate_seeded_input_float_env_override_uniform_m1_p1(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("ONNX2TF_EVAL_FLOAT_RANDOM_DISTRIBUTION", "uniform_-1_1")
+    x = _generate_seeded_input(
+        shape=(1, 16),
+        np_dtype=np.dtype(np.float32),
+        rng=np.random.default_rng(0),
+    )
+    assert x.dtype == np.float32
+    assert float(np.min(x)) >= -1.0
+    assert float(np.max(x)) <= 1.0
+

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -19,11 +19,16 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_fold_conv_mul_add_affine_chains,
     _optimize_hardsigmoid_mul_transpose_passthrough_chains,
     _optimize_layout_transpose_chains,
+    _optimize_maximum_with_zero_input2_to_relu,
     _optimize_maximum_minimum_relu0to1_chains,
     _optimize_singleton_channel_layout_transpose_to_reshape,
     _optimize_singleton_spatial_nhwc_transpose_reshape_flatten,
     _optimize_singleton_reshape_concat_post_transpose_nhwc_chains,
+    _optimize_transpose_csp_attention_nhwc_chains,
     _optimize_transpose_conv_attention_nhwc_propagation_chains,
+    _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains,
+    _optimize_transpose_cost_volume_scatter_ndhwc_chains,
+    _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains,
     _optimize_transpose_elementwise_concat_conv_nhwc_groups,
     _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains,
     _optimize_shufflenet_reshape_transpose_shuffle_nhwc_chains,
@@ -38,6 +43,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_transpose_pre_add_nhwc_chains,
     _optimize_transpose_pre_add_mul_add_prelu_nhwc_chains,
     _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains,
+    _optimize_transpose_pre_concat_ndhwc_chains,
     _optimize_transpose_pre_concat_nhwc_chains,
     _optimize_transpose_mul_add_const_prepost_nhwc_chains,
     _optimize_transpose_mul_add_const_prelu_prepost_nhwc_terminal_chains,
@@ -453,6 +459,74 @@ def _make_convtranspose1d_model() -> onnx.ModelProto:
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
+def _make_convtranspose2d_output_padding_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2, 4, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 8, 8])
+    w = numpy_helper.from_array(np.ones((2, 3, 3, 3), dtype=np.float32), name="W")
+    b = numpy_helper.from_array(np.zeros((3,), dtype=np.float32), name="B")
+    node = helper.make_node(
+        "ConvTranspose",
+        ["x", "W", "B"],
+        ["y"],
+        name="ConvTranspose2DOutputPaddingNode",
+        pads=[1, 1, 1, 1],
+        strides=[2, 2],
+        dilations=[1, 1],
+        output_padding=[1, 1],
+    )
+    graph = helper.make_graph(
+        [node],
+        "convtranspose2d_output_padding_graph",
+        [x],
+        [y],
+        initializer=[w, b],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_conv3d_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2, 5, 6, 7])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 5, 6, 7])
+    w = numpy_helper.from_array(np.ones((3, 2, 3, 3, 3), dtype=np.float32), name="W")
+    b = numpy_helper.from_array(np.zeros((3,), dtype=np.float32), name="B")
+    node = helper.make_node(
+        "Conv",
+        ["x", "W", "B"],
+        ["y"],
+        name="Conv3DNode",
+        pads=[1, 1, 1, 1, 1, 1],
+        strides=[1, 1, 1],
+        dilations=[1, 1, 1],
+    )
+    graph = helper.make_graph([node], "conv3d_graph", [x], [y], initializer=[w, b])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_convtranspose3d_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 3, 3, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2, 6, 6, 6])
+    w = numpy_helper.from_array(np.ones((3, 2, 4, 4, 4), dtype=np.float32), name="W")
+    b = numpy_helper.from_array(np.zeros((2,), dtype=np.float32), name="B")
+    node = helper.make_node(
+        "ConvTranspose",
+        ["x", "W", "B"],
+        ["y"],
+        name="ConvTranspose3DNode",
+        pads=[1, 1, 1, 1, 1, 1],
+        strides=[2, 2, 2],
+        dilations=[1, 1, 1],
+        output_padding=[0, 0, 0],
+    )
+    graph = helper.make_graph(
+        [node],
+        "convtranspose3d_graph",
+        [x],
+        [y],
+        initializer=[w, b],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
 def _make_conv_dynamic_batch_model() -> onnx.ModelProto:
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, ["N", 1, 4, 4])
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, ["N", 1, 2, 2])
@@ -525,6 +599,19 @@ def _make_pool_model() -> onnx.ModelProto:
         pads=[0, 0, 0, 0],
     )
     graph = helper.make_graph([node], "pool_graph", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_global_max_pool_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 4, 5])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 1, 1])
+    node = helper.make_node(
+        "GlobalMaxPool",
+        ["x"],
+        ["y"],
+        name="GlobalMaxPoolNode",
+    )
+    graph = helper.make_graph([node], "global_max_pool_graph", [x], [y])
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -694,6 +781,264 @@ def _make_forward_lstm_model() -> onnx.ModelProto:
         [x],
         [y],
         initializer=[W, R, B, initial_h, initial_c],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_reverse_lstm_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [3, 1, 2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [3, 1, 1, 2])
+    W = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.20, -0.10],
+                    [0.05, 0.15],
+                    [0.30, -0.25],
+                    [0.10, 0.12],
+                    [-0.18, 0.08],
+                    [0.11, -0.09],
+                    [0.04, 0.07],
+                    [-0.06, 0.03],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="W",
+    )
+    R = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.05, -0.02],
+                    [0.03, 0.01],
+                    [0.02, -0.04],
+                    [0.01, 0.03],
+                    [-0.02, 0.02],
+                    [0.04, -0.01],
+                    [0.03, 0.02],
+                    [-0.01, 0.01],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="R",
+    )
+    B = numpy_helper.from_array(
+        np.asarray(
+            [[0.01, -0.02, 0.03, 0.01, -0.01, 0.00, 0.02, -0.03, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        name="B",
+    )
+    initial_h = numpy_helper.from_array(np.zeros((1, 1, 2), dtype=np.float32), name="initial_h")
+    initial_c = numpy_helper.from_array(np.zeros((1, 1, 2), dtype=np.float32), name="initial_c")
+    lstm = helper.make_node(
+        "LSTM",
+        ["x", "W", "R", "B", "", "initial_h", "initial_c"],
+        ["y"],
+        name="ReverseLSTMNode",
+        hidden_size=2,
+        direction="reverse",
+    )
+    graph = helper.make_graph(
+        [lstm],
+        "reverse_lstm_graph",
+        [x],
+        [y],
+        initializer=[W, R, B, initial_h, initial_c],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_forward_lstm_with_state_io_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 1, 2])
+    h_in = helper.make_tensor_value_info("h_in", TensorProto.FLOAT, [1, 1, 2])
+    c_in = helper.make_tensor_value_info("c_in", TensorProto.FLOAT, [1, 1, 2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 1, 1, 2])
+    h_out = helper.make_tensor_value_info("h_out", TensorProto.FLOAT, [1, 1, 2])
+    c_out = helper.make_tensor_value_info("c_out", TensorProto.FLOAT, [1, 1, 2])
+    W = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.20, -0.10],
+                    [0.05, 0.15],
+                    [0.30, -0.25],
+                    [0.10, 0.12],
+                    [-0.18, 0.08],
+                    [0.11, -0.09],
+                    [0.04, 0.07],
+                    [-0.06, 0.03],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="W",
+    )
+    R = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.05, -0.02],
+                    [0.03, 0.01],
+                    [0.02, -0.04],
+                    [0.01, 0.03],
+                    [-0.02, 0.02],
+                    [0.04, -0.01],
+                    [0.03, 0.02],
+                    [-0.01, 0.01],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="R",
+    )
+    B = numpy_helper.from_array(
+        np.asarray(
+            [[0.01, -0.02, 0.03, 0.01, -0.01, 0.00, 0.02, -0.03, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+            dtype=np.float32,
+        ),
+        name="B",
+    )
+    lstm = helper.make_node(
+        "LSTM",
+        ["x", "W", "R", "B", "", "h_in", "c_in"],
+        ["y", "h_out", "c_out"],
+        name="ForwardLSTMStateIONode",
+        hidden_size=2,
+        direction="forward",
+    )
+    graph = helper.make_graph(
+        [lstm],
+        "forward_lstm_state_io_graph",
+        [x, h_in, c_in],
+        [y, h_out, c_out],
+        initializer=[W, R, B],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_reverse_rnn_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 1, 2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 1, 1, 3])
+    y_h = helper.make_tensor_value_info("y_h", TensorProto.FLOAT, [1, 1, 3])
+    W = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.20, -0.10],
+                    [0.03, 0.07],
+                    [-0.04, 0.12],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="W",
+    )
+    R = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.05, -0.02, 0.01],
+                    [0.02, 0.04, -0.03],
+                    [-0.01, 0.03, 0.02],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="R",
+    )
+    B = numpy_helper.from_array(
+        np.asarray([[0.01, -0.02, 0.03, 0.00, 0.00, 0.00]], dtype=np.float32),
+        name="B",
+    )
+    initial_h = numpy_helper.from_array(np.zeros((1, 1, 3), dtype=np.float32), name="initial_h")
+    rnn = helper.make_node(
+        "RNN",
+        ["x", "W", "R", "B", "", "initial_h"],
+        ["y", "y_h"],
+        name="ReverseRNNNode",
+        hidden_size=3,
+        direction="reverse",
+        activations=["Relu"],
+    )
+    graph = helper.make_graph(
+        [rnn],
+        "reverse_rnn_graph",
+        [x],
+        [y, y_h],
+        initializer=[W, R, B, initial_h],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_bidirectional_rnn_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [4, 1, 2])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [4, 2, 1, 3])
+    y_h = helper.make_tensor_value_info("y_h", TensorProto.FLOAT, [2, 1, 3])
+    W = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.20, -0.10],
+                    [0.03, 0.07],
+                    [-0.04, 0.12],
+                ],
+                [
+                    [0.11, -0.05],
+                    [0.06, 0.02],
+                    [-0.03, 0.09],
+                ],
+            ],
+            dtype=np.float32,
+        ),
+        name="W",
+    )
+    R = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.05, -0.02, 0.01],
+                    [0.02, 0.04, -0.03],
+                    [-0.01, 0.03, 0.02],
+                ],
+                [
+                    [0.03, -0.01, 0.02],
+                    [0.01, 0.02, -0.02],
+                    [-0.02, 0.02, 0.01],
+                ],
+            ],
+            dtype=np.float32,
+        ),
+        name="R",
+    )
+    B = numpy_helper.from_array(
+        np.asarray(
+            [
+                [0.01, -0.02, 0.03, 0.00, 0.00, 0.00],
+                [0.02, -0.01, 0.01, 0.00, 0.00, 0.00],
+            ],
+            dtype=np.float32,
+        ),
+        name="B",
+    )
+    initial_h = numpy_helper.from_array(np.zeros((2, 1, 3), dtype=np.float32), name="initial_h")
+    rnn = helper.make_node(
+        "RNN",
+        ["x", "W", "R", "B", "", "initial_h"],
+        ["y", "y_h"],
+        name="BidirectionalRNNNode",
+        hidden_size=3,
+        direction="bidirectional",
+        activations=["Tanh", "Relu"],
+    )
+    graph = helper.make_graph(
+        [rnn],
+        "bidirectional_rnn_graph",
+        [x],
+        [y, y_h],
+        initializer=[W, R, B, initial_h],
     )
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
@@ -1017,6 +1362,51 @@ def _make_pad_dynamic_pads_model() -> onnx.ModelProto:
         [x],
         [y],
         initializer=[width_index, pad_limit, pad_zeros],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_pad_reflect_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 6])
+    pads = numpy_helper.from_array(np.asarray([0, 1, 0, 1], dtype=np.int64), name="pad_reflect_pads")
+    node = helper.make_node(
+        "Pad",
+        ["x", "pad_reflect_pads"],
+        ["y"],
+        name="PadReflectNode",
+        mode="reflect",
+    )
+    graph = helper.make_graph(
+        [node],
+        "pad_reflect_graph",
+        [x],
+        [y],
+        initializer=[pads],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_batchnorm_rank3_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 1536, 351])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1536, 351])
+    scale = numpy_helper.from_array(np.ones((1536,), dtype=np.float32), name="bn_rank3_scale")
+    bias = numpy_helper.from_array(np.zeros((1536,), dtype=np.float32), name="bn_rank3_bias")
+    mean = numpy_helper.from_array(np.zeros((1536,), dtype=np.float32), name="bn_rank3_mean")
+    var = numpy_helper.from_array(np.ones((1536,), dtype=np.float32), name="bn_rank3_var")
+    bn = helper.make_node(
+        "BatchNormalization",
+        ["x", "bn_rank3_scale", "bn_rank3_bias", "bn_rank3_mean", "bn_rank3_var"],
+        ["y"],
+        name="BNRank3",
+        epsilon=1e-5,
+    )
+    graph = helper.make_graph(
+        [bn],
+        "batchnorm_rank3_graph",
+        [x],
+        [y],
+        initializer=[scale, bias, mean, var],
     )
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
@@ -2803,6 +3193,22 @@ def _make_logsoftmax_model() -> onnx.ModelProto:
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
+def _make_softmax_default_axis_opset13_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 4])
+    node = helper.make_node("Softmax", ["x"], ["y"], name="SoftmaxDefaultAxisOpset13Node")
+    graph = helper.make_graph([node], "softmax_default_axis_opset13_graph", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_softmax_default_axis_opset11_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3, 4])
+    node = helper.make_node("Softmax", ["x"], ["y"], name="SoftmaxDefaultAxisOpset11Node")
+    graph = helper.make_graph([node], "softmax_default_axis_opset11_graph", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 11)])
+
+
 def _make_reduce_axes_concat_const_model() -> onnx.ModelProto:
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2, 3])
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1, 3])
@@ -2844,6 +3250,21 @@ def _make_reduce_sum_model() -> onnx.ModelProto:
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
+def _make_reduce_prod_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1, 3])
+    axes = numpy_helper.from_array(np.array([1], dtype=np.int64), name="axes")
+    node = helper.make_node(
+        "ReduceProd",
+        ["x", "axes"],
+        ["y"],
+        name="ReduceProdNode",
+        keepdims=1,
+    )
+    graph = helper.make_graph([node], "reduce_prod_graph", [x], [y], initializer=[axes])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
 def _make_squeeze_model() -> onnx.ModelProto:
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 1, 3])
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
@@ -2859,6 +3280,21 @@ def _make_unsqueeze_model() -> onnx.ModelProto:
     axes = numpy_helper.from_array(np.array([1], dtype=np.int64), name="axes")
     node = helper.make_node("Unsqueeze", ["x", "axes"], ["y"], name="UnsqueezeNode")
     graph = helper.make_graph([node], "unsqueeze_graph", [x], [y], initializer=[axes])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_unsqueeze_dynamic_axis2_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, "N"])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, "N", 1])
+    axes = numpy_helper.from_array(np.array([2], dtype=np.int64), name="unsq_dyn_axes")
+    node = helper.make_node("Unsqueeze", ["x", "unsq_dyn_axes"], ["y"], name="UnsqueezeDynamicAxis2Node")
+    graph = helper.make_graph(
+        [node],
+        "unsqueeze_dynamic_axis2_graph",
+        [x],
+        [y],
+        initializer=[axes],
+    )
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -3230,11 +3666,16 @@ def test_tflite_backend_matrix_hardswish_rewrite_on_off(monkeypatch: pytest.Monk
     [
         ("conv", _make_conv_model),
         ("conv1d", _make_conv1d_model),
+        ("conv3d", _make_conv3d_model),
         ("convtranspose1d", _make_convtranspose1d_model),
+        ("convtranspose2d_output_padding", _make_convtranspose2d_output_padding_model),
+        ("convtranspose3d", _make_convtranspose3d_model),
         ("pool", _make_pool_model),
+        ("global_max_pool", _make_global_max_pool_model),
         ("gemm", _make_gemm_model),
         ("reduce_mean", _make_reduce_mean_model),
         ("reduce_sum", _make_reduce_sum_model),
+        ("reduce_prod", _make_reduce_prod_model),
         ("squeeze", _make_squeeze_model),
         ("unsqueeze", _make_unsqueeze_model),
         ("gather", _make_gather_model),
@@ -4085,6 +4526,50 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_pass() -> None:
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, 1600, 1]
 
 
+def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_zero_copy_dims_pass() -> None:
+    model_ir = ModelIR(name="reshape_fixup_zero_copy_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[10, 1, 1, 3],
+        shape_signature=[10, 1, 1, 3],
+    )
+    model_ir.tensors["reshape_shape"] = TensorIR(
+        name="reshape_shape",
+        dtype="INT32",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([0, 1, 3], dtype=np.int32),
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[-1],
+    )
+    model_ir.operators.append(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["x", "reshape_shape"],
+            outputs=["y"],
+            options={
+                "newShape": [10, 1, 3],
+                "onnxRawNewShape": [0, 1, 3],
+                "allowZero": False,
+            },
+        )
+    )
+
+    stats = _resolve_dynamic_reshape_shapes(model_ir)
+    assert stats["resolved_dynamic_reshape_shapes"] == 1
+    assert list(model_ir.operators[0].options["newShape"]) == [10, 1, 3]
+    assert list(model_ir.tensors["y"].shape) == [10, 1, 3]
+    assert list(model_ir.tensors["y"].shape_signature) == [10, 1, 3]
+    assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [10, 1, 3]
+
+
 def test_flatbuffer_direct_logsoftmax_lowering() -> None:
     model = _make_logsoftmax_model()
     register_default_preprocess_rules()
@@ -4097,6 +4582,48 @@ def test_flatbuffer_direct_logsoftmax_lowering() -> None:
     op_types = [str(op.op_type) for op in model_ir.operators]
     assert op_types.count("SOFTMAX") == 1
     assert op_types.count("LOG") == 1
+    assert op_types.count("CUSTOM") == 0
+
+
+def test_flatbuffer_direct_global_max_pool_lowering() -> None:
+    model = _make_global_max_pool_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="global_max_pool_lowering_test",
+        allow_custom_ops=False,
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("REDUCE_MAX") == 1
+    assert op_types.count("CUSTOM") == 0
+
+
+def test_flatbuffer_direct_softmax_default_axis_respects_opset13() -> None:
+    model = _make_softmax_default_axis_opset13_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="softmax_default_axis_opset13_lowering_test",
+        allow_custom_ops=False,
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("SOFTMAX") == 1
+    assert op_types.count("TRANSPOSE") == 0
+    assert op_types.count("CUSTOM") == 0
+
+
+def test_flatbuffer_direct_softmax_default_axis_respects_opset11() -> None:
+    model = _make_softmax_default_axis_opset11_model()
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=model,
+        output_file_name="softmax_default_axis_opset11_lowering_test",
+        allow_custom_ops=False,
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("SOFTMAX") == 1
+    assert op_types.count("TRANSPOSE") == 2
     assert op_types.count("CUSTOM") == 0
 
 
@@ -4260,6 +4787,24 @@ def test_flatbuffer_direct_shape_lowering() -> None:
     assert op_types.count("CUSTOM") == 0
 
 
+def test_flatbuffer_direct_unsqueeze_dynamic_axis2_preserves_dynamic_signature() -> None:
+    model = _make_unsqueeze_dynamic_axis2_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="unsqueeze_dynamic_axis2_signature_test",
+        allow_custom_ops=False,
+    )
+
+    y_tensor = model_ir.tensors["y"]
+    assert list(y_tensor.shape_signature) == [1, -1, 1]
+
+    y_prod = next(op for op in model_ir.operators if str(op.outputs[0]) == "y")
+    assert str(y_prod.op_type) == "RESHAPE"
+    assert list(y_prod.options.get("newShape", [])) == []
+
+
 def test_flatbuffer_direct_min_topk_dynamic_k_lowering() -> None:
     model = _make_min_topk_dynamic_k_model()
     register_default_preprocess_rules()
@@ -4338,6 +4883,114 @@ def test_flatbuffer_direct_pad_dynamic_pads_lowering() -> None:
     pads_cast = producers.get(pads_vector_name)
     assert pads_cast is not None
     assert str(pads_cast.op_type) == "CAST"
+
+
+def test_flatbuffer_direct_pad_reflect_lowering() -> None:
+    model = _make_pad_reflect_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="pad_reflect_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("MIRROR_PAD") == 1
+    assert op_types.count("CUSTOM") == 0
+
+    mirror_pad_op = next(op for op in model_ir.operators if str(op.op_type) == "MIRROR_PAD")
+    assert str(mirror_pad_op.options.get("mode", "")).upper() == "REFLECT"
+
+    pads_name = str(mirror_pad_op.inputs[1])
+    pads_tensor = model_ir.tensors[pads_name]
+    assert str(pads_tensor.dtype).upper() == "INT32"
+    assert list(pads_tensor.shape) == [2, 2]
+    assert pads_tensor.data is not None
+    np.testing.assert_array_equal(
+        pads_tensor.data,
+        np.asarray([[0, 0], [1, 1]], dtype=np.int32),
+    )
+
+
+def test_flatbuffer_direct_batch_normalization_rank3_broadcast_coeff_shape() -> None:
+    model = _make_batchnorm_rank3_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="batchnorm_rank3_broadcast_shape_test",
+        allow_custom_ops=False,
+    )
+
+    mul_ops = [op for op in model_ir.operators if str(op.op_type) == "MUL"]
+    add_ops = [op for op in model_ir.operators if str(op.op_type) == "ADD"]
+    assert len(mul_ops) == 1
+    assert len(add_ops) == 1
+
+    mul_const = model_ir.tensors[str(mul_ops[0].inputs[1])]
+    add_const = model_ir.tensors[str(add_ops[0].inputs[1])]
+    assert list(mul_const.shape) == [1, 1536, 1]
+    assert list(add_const.shape) == [1, 1536, 1]
+
+
+def test_flatbuffer_direct_convtranspose2d_output_padding_lowering() -> None:
+    model = _make_convtranspose2d_output_padding_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="convtranspose2d_output_padding_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE_CONV") == 1
+    assert op_types.count("CUSTOM") == 0
+
+    transpose_conv_op = next(op for op in model_ir.operators if str(op.op_type) == "TRANSPOSE_CONV")
+    assert int(transpose_conv_op.options["strideH"]) == 2
+    assert int(transpose_conv_op.options["strideW"]) == 2
+
+
+def test_flatbuffer_direct_conv3d_lowering() -> None:
+    model = _make_conv3d_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="conv3d_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("CONV_3D") == 1
+    assert op_types.count("CUSTOM") == 0
+
+    conv3d_op = next(op for op in model_ir.operators if str(op.op_type) == "CONV_3D")
+    assert int(conv3d_op.options["strideD"]) == 1
+    assert int(conv3d_op.options["strideH"]) == 1
+    assert int(conv3d_op.options["strideW"]) == 1
+
+
+def test_flatbuffer_direct_convtranspose3d_lowering() -> None:
+    model = _make_convtranspose3d_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="convtranspose3d_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("CONV_3D_TRANSPOSE") == 1
+    assert op_types.count("CUSTOM") == 0
+
+    conv3dt_op = next(op for op in model_ir.operators if str(op.op_type) == "CONV_3D_TRANSPOSE")
+    assert int(conv3dt_op.options["strideD"]) == 2
+    assert int(conv3dt_op.options["strideH"]) == 2
+    assert int(conv3dt_op.options["strideW"]) == 2
 
 
 def test_flatbuffer_direct_legacy_slice_attr_lowering() -> None:
@@ -4590,15 +5243,19 @@ def test_flatbuffer_direct_fused_matmul_lowering() -> None:
     assert op_types.count("CUSTOM") == 0
 
 
-def test_flatbuffer_direct_reduce_l2_sqrt_emits_separate_tensor() -> None:
+def test_flatbuffer_direct_reduce_l2_avoids_redundant_shape_reshape_identity() -> None:
     model = _make_reduce_l2_model()
     register_default_preprocess_rules()
     preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
     model_ir = lower_onnx_to_ir(
         onnx_graph=preprocessed_model,
-        output_file_name="reduce_l2_sqrt_separate_tensor_test",
+        output_file_name="reduce_l2_identity_shape_reshape_elision_test",
         allow_custom_ops=False,
     )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("SHAPE") == 0
+    assert op_types.count("RESHAPE") == 0
 
     sqrt_ops = [op for op in model_ir.operators if str(op.op_type) == "SQRT"]
     assert len(sqrt_ops) == 1
@@ -4606,7 +5263,7 @@ def test_flatbuffer_direct_reduce_l2_sqrt_emits_separate_tensor() -> None:
     assert len(list(sqrt_op.inputs)) == 1
     assert len(list(sqrt_op.outputs)) == 1
     assert str(sqrt_op.inputs[0]) != str(sqrt_op.outputs[0])
-    assert str(sqrt_op.outputs[0]) != "y"
+    assert str(sqrt_op.outputs[0]) == "y"
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_zero_copy_dims_pass() -> None:
@@ -5537,6 +6194,362 @@ def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimize
     assert list(model_ir.tensors["mul_nchw"].shape) == [1, 6, 6, 8]
 
 
+def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimized_with_legacy_users() -> None:
+    model_ir = ModelIR(name="transpose_logistic_muladd_prepost_nhwc_chain_opt_legacy_test")
+    model_ir.inputs = ["skip_nhwc", "data_nhwc", "gate_nhwc"]
+    model_ir.outputs = ["z", "legacy_z"]
+    model_ir.tensors["skip_nhwc"] = TensorIR(
+        name="skip_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 8],
+        shape_signature=[1, 6, 6, 8],
+    )
+    model_ir.tensors["data_nhwc"] = TensorIR(
+        name="data_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 8],
+        shape_signature=[1, 6, 6, 8],
+    )
+    model_ir.tensors["gate_nhwc"] = TensorIR(
+        name="gate_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 8],
+        shape_signature=[1, 1, 1, 8],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["mean_axes"] = TensorIR(
+        name="mean_axes",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["reshape_shape"] = TensorIR(
+        name="reshape_shape",
+        dtype="INT64",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([1, 36, 8], dtype=np.int64),
+        is_variable=False,
+    )
+    model_ir.tensors["legacy_bias"] = TensorIR(
+        name="legacy_bias",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+        data=np.ones((1, 8, 6, 6), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["skip_nchw"] = TensorIR(
+        name="skip_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["data_nchw"] = TensorIR(
+        name="data_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["gate_nchw"] = TensorIR(
+        name="gate_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 1],
+        shape_signature=[1, 8, 1, 1],
+    )
+    model_ir.tensors["sig_nchw"] = TensorIR(
+        name="sig_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 1],
+        shape_signature=[1, 8, 1, 1],
+    )
+    model_ir.tensors["mul_nchw"] = TensorIR(
+        name="mul_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["add_nchw"] = TensorIR(
+        name="add_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["y_nhwc"] = TensorIR(
+        name="y_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 8],
+        shape_signature=[1, 6, 6, 8],
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 36, 8],
+        shape_signature=[1, 36, 8],
+    )
+    model_ir.tensors["data_stats_nchw"] = TensorIR(
+        name="data_stats_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 1],
+        shape_signature=[1, 8, 1, 1],
+    )
+    model_ir.tensors["legacy_sum"] = TensorIR(
+        name="legacy_sum",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.tensors["legacy_z"] = TensorIR(
+        name="legacy_z",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6],
+        shape_signature=[1, 8, 6, 6],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["skip_nhwc", "pre_perm"], outputs=["skip_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["data_nhwc", "pre_perm"], outputs=["data_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["gate_nhwc", "pre_perm"], outputs=["gate_nchw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["gate_nchw"], outputs=["sig_nchw"]),
+        OperatorIR(op_type="MUL", inputs=["data_nchw", "sig_nchw"], outputs=["mul_nchw"]),
+        OperatorIR(
+            op_type="MEAN",
+            inputs=["data_nchw", "mean_axes"],
+            outputs=["data_stats_nchw"],
+            options={"keepDims": True},
+        ),
+        OperatorIR(op_type="ADD", inputs=["mul_nchw", "skip_nchw"], outputs=["add_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["add_nchw", "post_perm"], outputs=["y_nhwc"]),
+        OperatorIR(op_type="ADD", inputs=["add_nchw", "legacy_bias"], outputs=["legacy_sum"]),
+        OperatorIR(op_type="RELU", inputs=["legacy_sum"], outputs=["legacy_z"]),
+        OperatorIR(op_type="RESHAPE", inputs=["y_nhwc", "reshape_shape"], outputs=["z"]),
+    ]
+
+    stats = _optimize_transpose_logistic_muladd_prepost_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_logistic_muladd_prepost_nhwc_chains"] == 1
+
+    logistic_op = next(op for op in model_ir.operators if str(op.op_type) == "LOGISTIC")
+    assert [str(v) for v in list(logistic_op.inputs)] == ["gate_nhwc"]
+
+    mul_op = next(op for op in model_ir.operators if str(op.op_type) == "MUL")
+    assert set(str(v) for v in list(mul_op.inputs)) == {"data_nhwc", "sig_nchw"}
+
+    add_op = next(op for op in model_ir.operators if str(op.op_type) == "ADD" and list(op.outputs) == ["y_nhwc"])
+    assert set(str(v) for v in list(add_op.inputs)) == {"mul_nchw", "skip_nhwc"}
+
+    # Legacy NCHW path is preserved via one retained adapter transpose.
+    adapter_transpose = next(
+        op
+        for op in model_ir.operators
+        if str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["add_nchw"]
+    )
+    assert [str(v) for v in list(adapter_transpose.inputs)] == ["y_nhwc", "post_perm"]
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["post_perm"].data, dtype=np.int32),
+        np.asarray([0, 3, 1, 2], dtype=np.int32),
+    )
+
+    # data_nchw transpose remains because MEAN still consumes NCHW.
+    assert any(str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["data_nchw"] for op in model_ir.operators)
+    assert not any(str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["skip_nchw"] for op in model_ir.operators)
+    assert not any(str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["gate_nchw"] for op in model_ir.operators)
+
+    reshape_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE")
+    assert [str(v) for v in list(reshape_op.inputs)] == ["y_nhwc", "reshape_shape"]
+
+
+def test_flatbuffer_direct_transpose_3d_leaky_logistic_muladd_ndhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_3d_leaky_logistic_muladd_ndhwc_chain_opt_test")
+    model_ir.inputs = ["base_nhwc", "skip_ndhwc", "gate_ndhwc"]
+    model_ir.outputs = ["y0", "y1"]
+
+    model_ir.tensors["base_nhwc"] = TensorIR(
+        name="base_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 10, 8],
+        shape_signature=[1, 6, 10, 8],
+    )
+    model_ir.tensors["skip_ndhwc"] = TensorIR(
+        name="skip_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 10, 8],
+        shape_signature=[1, 6, 6, 10, 8],
+    )
+    model_ir.tensors["gate_ndhwc"] = TensorIR(
+        name="gate_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 10, 8],
+        shape_signature=[1, 6, 6, 10, 8],
+    )
+    model_ir.tensors["perm4_pre"] = TensorIR(
+        name="perm4_pre",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["perm5_pre"] = TensorIR(
+        name="perm5_pre",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 4, 1, 2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["perm5_post"] = TensorIR(
+        name="perm5_post",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 2, 3, 4, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["base_reshape_shape"] = TensorIR(
+        name="base_reshape_shape",
+        dtype="INT64",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([1, 8, 1, 6, 10], dtype=np.int64),
+        is_variable=False,
+    )
+    model_ir.tensors["base_nchw"] = TensorIR(
+        name="base_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 10],
+        shape_signature=[1, 8, 6, 10],
+    )
+    model_ir.tensors["base_ncdhw"] = TensorIR(
+        name="base_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 6, 10],
+        shape_signature=[1, 8, 1, 6, 10],
+    )
+    model_ir.tensors["skip_ncdhw"] = TensorIR(
+        name="skip_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["skip_leaky_ncdhw"] = TensorIR(
+        name="skip_leaky_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["add0_ncdhw"] = TensorIR(
+        name="add0_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["add0_ndhwc"] = TensorIR(
+        name="add0_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 10, 8],
+        shape_signature=[1, 6, 6, 10, 8],
+    )
+    model_ir.tensors["gate_ncdhw"] = TensorIR(
+        name="gate_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["gate_sig_ncdhw"] = TensorIR(
+        name="gate_sig_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["mul1_ncdhw"] = TensorIR(
+        name="mul1_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["add1_ncdhw"] = TensorIR(
+        name="add1_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 6, 6, 10],
+        shape_signature=[1, 8, 6, 6, 10],
+    )
+    model_ir.tensors["add1_ndhwc"] = TensorIR(
+        name="add1_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 10, 8],
+        shape_signature=[1, 6, 6, 10, 8],
+    )
+    model_ir.tensors["y0"] = TensorIR(
+        name="y0",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 10, 8],
+        shape_signature=[1, 6, 6, 10, 8],
+    )
+    model_ir.tensors["y1"] = TensorIR(
+        name="y1",
+        dtype="FLOAT32",
+        shape=[1, 6, 6, 10, 8],
+        shape_signature=[1, 6, 6, 10, 8],
+    )
+
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["base_nhwc", "perm4_pre"], outputs=["base_nchw"]),
+        OperatorIR(op_type="RESHAPE", inputs=["base_nchw", "base_reshape_shape"], outputs=["base_ncdhw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["skip_ndhwc", "perm5_pre"], outputs=["skip_ncdhw"]),
+        OperatorIR(op_type="LEAKY_RELU", inputs=["skip_ncdhw"], outputs=["skip_leaky_ncdhw"], options={"alpha": 0.1}),
+        OperatorIR(op_type="ADD", inputs=["skip_leaky_ncdhw", "base_ncdhw"], outputs=["add0_ncdhw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["add0_ncdhw", "perm5_post"], outputs=["add0_ndhwc"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["gate_ndhwc", "perm5_pre"], outputs=["gate_ncdhw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["gate_ncdhw"], outputs=["gate_sig_ncdhw"]),
+        OperatorIR(op_type="MUL", inputs=["gate_sig_ncdhw", "base_ncdhw"], outputs=["mul1_ncdhw"]),
+        OperatorIR(op_type="ADD", inputs=["mul1_ncdhw", "skip_leaky_ncdhw"], outputs=["add1_ncdhw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["add1_ncdhw", "perm5_post"], outputs=["add1_ndhwc"]),
+        OperatorIR(op_type="RELU", inputs=["add0_ndhwc"], outputs=["y0"]),
+        OperatorIR(op_type="RELU", inputs=["add1_ndhwc"], outputs=["y1"]),
+    ]
+
+    stats = _optimize_transpose_3d_leaky_logistic_muladd_ndhwc_chains(model_ir)
+    assert stats["optimized_transpose_3d_leaky_logistic_muladd_ndhwc_chains"] == 1
+
+    assert not any(str(op.op_type) == "TRANSPOSE" for op in model_ir.operators)
+
+    reshape_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE")
+    assert [str(v) for v in list(reshape_op.inputs)] == ["base_nhwc", "base_reshape_shape"]
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["base_reshape_shape"].data, dtype=np.int64),
+        np.asarray([1, 1, 6, 10, 8], dtype=np.int64),
+    )
+
+    skip_leaky_op = next(op for op in model_ir.operators if str(op.op_type) == "LEAKY_RELU")
+    assert [str(v) for v in list(skip_leaky_op.inputs)] == ["skip_ndhwc"]
+
+    logistic_op = next(op for op in model_ir.operators if str(op.op_type) == "LOGISTIC")
+    assert [str(v) for v in list(logistic_op.inputs)] == ["gate_ndhwc"]
+
+    add_ops = [op for op in model_ir.operators if str(op.op_type) == "ADD"]
+    assert [str(v) for v in list(add_ops[0].outputs)] == ["add0_ndhwc"]
+    assert [str(v) for v in list(add_ops[1].outputs)] == ["add1_ndhwc"]
+
+    assert list(model_ir.tensors["base_ncdhw"].shape) == [1, 1, 6, 10, 8]
+    assert list(model_ir.tensors["skip_leaky_ncdhw"].shape) == [1, 6, 6, 10, 8]
+
+
 def test_flatbuffer_direct_transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_optimized() -> None:
     model_ir = ModelIR(name="transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
@@ -6447,6 +7460,278 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_relu_and_swish_inputs_optim
     assert list(model_ir.tensors["swish_out"].shape) == [1, 6, 6, 384]
 
 
+def test_flatbuffer_direct_transpose_pre_concat_ndhwc_unary_inputs_optimized() -> None:
+    model_ir = ModelIR(name="transpose_pre_concat_ndhwc_unary_opt_test")
+    model_ir.inputs = ["x0_ndhwc", "x1_ndhwc"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x0_ndhwc"] = TensorIR(
+        name="x0_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4, 5],
+        shape_signature=[1, 2, 3, 4, 5],
+    )
+    model_ir.tensors["x1_ndhwc"] = TensorIR(
+        name="x1_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4, 6],
+        shape_signature=[1, 2, 3, 4, 6],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 4, 1, 2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 2, 3, 4, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["x0_ncdhw"] = TensorIR(
+        name="x0_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 5, 2, 3, 4],
+        shape_signature=[1, 5, 2, 3, 4],
+    )
+    model_ir.tensors["x1_ncdhw"] = TensorIR(
+        name="x1_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 6, 2, 3, 4],
+        shape_signature=[1, 6, 2, 3, 4],
+    )
+    model_ir.tensors["x1_leaky_ncdhw"] = TensorIR(
+        name="x1_leaky_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 6, 2, 3, 4],
+        shape_signature=[1, 6, 2, 3, 4],
+    )
+    model_ir.tensors["concat_ncdhw"] = TensorIR(
+        name="concat_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 11, 2, 3, 4],
+        shape_signature=[1, 11, 2, 3, 4],
+    )
+    model_ir.tensors["concat_ndhwc"] = TensorIR(
+        name="concat_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4, 11],
+        shape_signature=[1, 2, 3, 4, 11],
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4, 11],
+        shape_signature=[1, 2, 3, 4, 11],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x0_ndhwc", "pre_perm"], outputs=["x0_ncdhw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["x1_ndhwc", "pre_perm"], outputs=["x1_ncdhw"]),
+        OperatorIR(op_type="LEAKY_RELU", inputs=["x1_ncdhw"], outputs=["x1_leaky_ncdhw"]),
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=["x0_ncdhw", "x1_leaky_ncdhw"],
+            outputs=["concat_ncdhw"],
+            options={"axis": 1, "fusedActivationFunction": "NONE"},
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["concat_ncdhw", "post_perm"], outputs=["concat_ndhwc"]),
+        OperatorIR(op_type="RELU", inputs=["concat_ndhwc"], outputs=["y"]),
+    ]
+
+    stats = _optimize_transpose_pre_concat_ndhwc_chains(model_ir)
+    assert stats["optimized_transpose_pre_concat_ndhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+    concat_op = next(op for op in model_ir.operators if str(op.op_type) == "CONCATENATION")
+    assert list(concat_op.inputs) == ["x0_ndhwc", "x1_leaky_ncdhw"]
+    assert list(concat_op.outputs) == ["concat_ndhwc"]
+    assert int(concat_op.options.get("axis", -1)) == 4
+    assert list(model_ir.tensors["x1_leaky_ncdhw"].shape) == [1, 2, 3, 4, 6]
+    assert list(model_ir.tensors["concat_ndhwc"].shape) == [1, 2, 3, 4, 11]
+    relu_op = next(op for op in model_ir.operators if str(op.op_type) == "RELU")
+    assert list(relu_op.inputs) == ["concat_ndhwc"]
+
+
+def test_flatbuffer_direct_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_conv3d_leaky_mul_unsqueeze_ndhwc_opt_test")
+    model_ir.inputs = ["sem_ndhwc", "conv_ndhwc"]
+    model_ir.outputs = ["y"]
+
+    model_ir.tensors["sem_ndhwc"] = TensorIR(
+        name="sem_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 48, 80, 8],
+        shape_signature=[1, 48, 80, 8],
+    )
+    model_ir.tensors["conv_ndhwc"] = TensorIR(
+        name="conv_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 48, 48, 80, 8],
+        shape_signature=[1, 48, 48, 80, 8],
+    )
+    model_ir.tensors["perm_ndhwc_to_ncdhw"] = TensorIR(
+        name="perm_ndhwc_to_ncdhw",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 4, 1, 2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["perm_nhwc_to_nchw"] = TensorIR(
+        name="perm_nhwc_to_nchw",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["perm_ncdhw_to_ndhwc"] = TensorIR(
+        name="perm_ncdhw_to_ndhwc",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([0, 2, 3, 4, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["sem_ncdhw"] = TensorIR(
+        name="sem_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 48, 80],
+        shape_signature=[1, 8, 48, 80],
+    )
+    model_ir.tensors["unsqueeze_shape"] = TensorIR(
+        name="unsqueeze_shape",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([1, 8, 1, 48, 80], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["gate_ncdhw"] = TensorIR(
+        name="gate_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 48, 80],
+        shape_signature=[1, 8, 1, 48, 80],
+    )
+    model_ir.tensors["conv_ncdhw"] = TensorIR(
+        name="conv_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 48, 48, 80],
+        shape_signature=[1, 8, 48, 48, 80],
+    )
+    model_ir.tensors["act_ncdhw"] = TensorIR(
+        name="act_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 48, 48, 80],
+        shape_signature=[1, 8, 48, 48, 80],
+    )
+    model_ir.tensors["mul_ncdhw"] = TensorIR(
+        name="mul_ncdhw",
+        dtype="FLOAT32",
+        shape=[1, 8, 48, 48, 80],
+        shape_signature=[1, 8, 48, 48, 80],
+    )
+    model_ir.tensors["mul_ndhwc"] = TensorIR(
+        name="mul_ndhwc",
+        dtype="FLOAT32",
+        shape=[1, 48, 48, 80, 8],
+        shape_signature=[1, 48, 48, 80, 8],
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 48, 48, 80, 4],
+        shape_signature=[1, 48, 48, 80, 4],
+    )
+
+    model_ir.operators = [
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["sem_ndhwc", "perm_nhwc_to_nchw"],
+            outputs=["sem_ncdhw"],
+        ),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["sem_ncdhw", "unsqueeze_shape"],
+            outputs=["gate_ncdhw"],
+            options={"newShape": [1, 8, 1, 48, 80]},
+        ),
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["conv_ndhwc", "perm_ndhwc_to_ncdhw"],
+            outputs=["conv_ncdhw"],
+        ),
+        OperatorIR(
+            op_type="LEAKY_RELU",
+            inputs=["conv_ncdhw"],
+            outputs=["act_ncdhw"],
+            options={"alpha": 0.1},
+        ),
+        OperatorIR(
+            op_type="MUL",
+            inputs=["act_ncdhw", "gate_ncdhw"],
+            outputs=["mul_ncdhw"],
+        ),
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["mul_ncdhw", "perm_ncdhw_to_ndhwc"],
+            outputs=["mul_ndhwc"],
+        ),
+        OperatorIR(
+            op_type="CONV_3D",
+            inputs=["mul_ndhwc", "dummy_w", "dummy_b"],
+            outputs=["y"],
+            options={},
+        ),
+    ]
+
+    model_ir.tensors["dummy_w"] = TensorIR(
+        name="dummy_w",
+        dtype="FLOAT32",
+        shape=[4, 1, 1, 1, 8],
+        shape_signature=[4, 1, 1, 1, 8],
+        data=np.ones((4, 1, 1, 1, 8), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["dummy_b"] = TensorIR(
+        name="dummy_b",
+        dtype="FLOAT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.zeros((4,), dtype=np.float32),
+        is_variable=False,
+    )
+
+    stats = _optimize_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains(model_ir)
+    assert stats["optimized_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+
+    reshape_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE")
+    assert list(reshape_op.inputs) == ["sem_ndhwc", "unsqueeze_shape"]
+    assert model_ir.tensors["unsqueeze_shape"].data is not None
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["unsqueeze_shape"].data, dtype=np.int32),
+        np.asarray([1, 1, 48, 80, 8], dtype=np.int32),
+    )
+    assert list(model_ir.tensors["gate_ncdhw"].shape) == [1, 1, 48, 80, 8]
+
+    leaky_op = next(op for op in model_ir.operators if str(op.op_type) == "LEAKY_RELU")
+    assert list(leaky_op.inputs) == ["conv_ndhwc"]
+    assert list(model_ir.tensors["act_ncdhw"].shape) == [1, 48, 48, 80, 8]
+
+    mul_op = next(op for op in model_ir.operators if str(op.op_type) == "MUL")
+    assert list(mul_op.outputs) == ["mul_ndhwc"]
+    conv3d_op = next(op for op in model_ir.operators if str(op.op_type) == "CONV_3D")
+    assert list(conv3d_op.inputs)[0] == "mul_ndhwc"
+
+
 def test_flatbuffer_direct_transpose_pre_concat_single_post_adapter_supports_relu_inputs() -> None:
     model_ir = ModelIR(name="transpose_pre_concat_single_post_adapter_relu_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
@@ -7245,6 +8530,184 @@ def test_flatbuffer_direct_transpose_slice_logistic_concat_reshape_tail_nhwc_cha
         split1_size_vals = np.asarray(model_ir.tensors[f"{branch_name}_split1_size"].data, dtype=np.int32).reshape(-1).tolist()
         assert split1_begin_vals == [0, 0, 0, 5]
         assert split1_size_vals == [1, int(height), int(width), 32]
+
+
+def test_flatbuffer_direct_transpose_cost_volume_scatter_ndhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_cost_volume_scatter_ndhwc_opt_test")
+    model_ir.inputs = ["desc0_nhwc", "desc1_nhwc"]
+    model_ir.outputs = ["conv_out"]
+
+    def _add_tensor(name: str, dtype: str, shape: list[int], data: np.ndarray | None = None) -> None:
+        model_ir.tensors[name] = TensorIR(
+            name=name,
+            dtype=dtype,
+            shape=[int(v) for v in list(shape)],
+            shape_signature=[int(v) for v in list(shape)],
+            data=(None if data is None else np.asarray(data)),
+            is_variable=False,
+        )
+
+    _add_tensor("desc0_nhwc", "FLOAT32", [1, 3, 6, 4])
+    _add_tensor("desc1_nhwc", "FLOAT32", [1, 3, 6, 4])
+    _add_tensor("desc0_nchw", "FLOAT32", [1, 4, 3, 6])
+    _add_tensor("desc1_nchw", "FLOAT32", [1, 4, 3, 6])
+    _add_tensor("slice_begin", "INT32", [4], np.asarray([0, 0, 0, 1], dtype=np.int32))
+    _add_tensor("slice_size", "INT32", [4], np.asarray([1, 4, 3, 5], dtype=np.int32))
+    _add_tensor("slice0", "FLOAT32", [1, 4, 3, 5])
+    _add_tensor("slice1", "FLOAT32", [1, 4, 3, 5])
+    _add_tensor("mul_out", "FLOAT32", [1, 4, 3, 5])
+    _add_tensor("mean_axes", "INT32", [1], np.asarray([1], dtype=np.int32))
+    _add_tensor("mean_out", "FLOAT32", [1, 1, 3, 5])
+    _add_tensor("reshape_shape", "INT32", [5], np.asarray([1, 1, 1, 3, 5], dtype=np.int32))
+    _add_tensor("reshape_out", "FLOAT32", [1, 1, 1, 3, 5])
+    _add_tensor(
+        "scatter_shape",
+        "INT32",
+        [5],
+        np.asarray([1, 1, 3, 4, 6], dtype=np.int32),
+    )
+    index_data = np.zeros((1, 1, 1, 3, 5, 5), dtype=np.float32)
+    for h in range(3):
+        for w in range(5):
+            index_data[0, 0, 0, h, w] = np.asarray([0, 0, 0, h, w + 1], dtype=np.float32)
+    _add_tensor("indices_f32", "FLOAT32", [1, 1, 1, 3, 5, 5], index_data)
+    _add_tensor("indices_i32", "INT32", [1, 1, 1, 3, 5, 5])
+    _add_tensor("scatter_ncdhw", "FLOAT32", [1, 1, 3, 4, 6])
+    _add_tensor("scatter_ndhwc", "FLOAT32", [1, 3, 4, 6, 1])
+    _add_tensor("conv_w", "FLOAT32", [1, 1, 1, 1, 2])
+    _add_tensor("conv_b", "FLOAT32", [2])
+    _add_tensor("conv_out", "FLOAT32", [1, 3, 4, 6, 2])
+    _add_tensor(
+        "perm_nhwc_to_nchw",
+        "INT32",
+        [4],
+        np.asarray([0, 3, 1, 2], dtype=np.int32),
+    )
+    _add_tensor(
+        "perm_ncdhw_to_ndhwc",
+        "INT32",
+        [5],
+        np.asarray([0, 2, 3, 4, 1], dtype=np.int32),
+    )
+
+    model_ir.operators = [
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["desc0_nhwc", "perm_nhwc_to_nchw"],
+            outputs=["desc0_nchw"],
+        ),
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["desc1_nhwc", "perm_nhwc_to_nchw"],
+            outputs=["desc1_nchw"],
+        ),
+        OperatorIR(
+            op_type="SLICE",
+            inputs=["desc0_nchw", "slice_begin", "slice_size"],
+            outputs=["slice0"],
+        ),
+        OperatorIR(
+            op_type="SLICE",
+            inputs=["desc1_nchw", "slice_begin", "slice_size"],
+            outputs=["slice1"],
+        ),
+        OperatorIR(
+            op_type="MUL",
+            inputs=["slice0", "slice1"],
+            outputs=["mul_out"],
+        ),
+        OperatorIR(
+            op_type="MEAN",
+            inputs=["mul_out", "mean_axes"],
+            outputs=["mean_out"],
+            options={"keepDims": True},
+        ),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["mean_out", "reshape_shape"],
+            outputs=["reshape_out"],
+            options={"newShape": [1, 1, 1, 3, 5], "onnxRawNewShape": [1, 1, 1, 3, 5]},
+        ),
+        OperatorIR(
+            op_type="CAST",
+            inputs=["indices_f32"],
+            outputs=["indices_i32"],
+            options={"inDataType": "FLOAT32", "outDataType": "INT32"},
+        ),
+        OperatorIR(
+            op_type="SCATTER_ND",
+            inputs=["indices_i32", "reshape_out", "scatter_shape"],
+            outputs=["scatter_ncdhw"],
+        ),
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["scatter_ncdhw", "perm_ncdhw_to_ndhwc"],
+            outputs=["scatter_ndhwc"],
+        ),
+        OperatorIR(
+            op_type="CONV_3D",
+            inputs=["scatter_ndhwc", "conv_w", "conv_b"],
+            outputs=["conv_out"],
+            options={
+                "padding": "SAME",
+                "strideD": 1,
+                "strideH": 1,
+                "strideW": 1,
+                "dilationDFactor": 1,
+                "dilationHFactor": 1,
+                "dilationWFactor": 1,
+                "fusedActivationFunction": "NONE",
+            },
+        ),
+    ]
+
+    stats = _optimize_transpose_cost_volume_scatter_ndhwc_chains(model_ir)
+    assert stats["optimized_transpose_cost_volume_scatter_ndhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+
+    slice_ops = [op for op in model_ir.operators if str(op.op_type) == "SLICE"]
+    assert len(slice_ops) == 2
+    for slice_op in slice_ops:
+        assert str(slice_op.inputs[0]) in {"desc0_nhwc", "desc1_nhwc"}
+        slice_begin_vals = np.asarray(
+            model_ir.tensors[str(slice_op.inputs[1])].data,
+            dtype=np.int32,
+        ).reshape(-1).tolist()
+        slice_size_vals = np.asarray(
+            model_ir.tensors[str(slice_op.inputs[2])].data,
+            dtype=np.int32,
+        ).reshape(-1).tolist()
+        assert slice_begin_vals == [0, 0, 1, 0]
+        assert slice_size_vals == [1, 3, 5, 4]
+
+    mean_op = next(op for op in model_ir.operators if str(op.op_type) == "MEAN")
+    mean_axes_vals = np.asarray(
+        model_ir.tensors[str(mean_op.inputs[1])].data,
+        dtype=np.int32,
+    ).reshape(-1).tolist()
+    assert mean_axes_vals == [3]
+
+    scatter_op = next(op for op in model_ir.operators if str(op.op_type) == "SCATTER_ND")
+    scatter_shape_vals = np.asarray(
+        model_ir.tensors[str(scatter_op.inputs[2])].data,
+        dtype=np.int32,
+    ).reshape(-1).tolist()
+    assert scatter_shape_vals == [1, 3, 4, 6, 1]
+
+    cast_op = next(op for op in model_ir.operators if str(op.op_type) == "CAST")
+    remapped_indices = np.asarray(
+        model_ir.tensors[str(cast_op.inputs[0])].data,
+        dtype=np.float32,
+    )
+    assert remapped_indices.shape == (1, 1, 1, 3, 5, 5)
+    assert remapped_indices[0, 0, 0, 0, 0].tolist() == [0.0, 0.0, 0.0, 1.0, 0.0]
+
+    conv_op = next(op for op in model_ir.operators if str(op.op_type) == "CONV_3D")
+    assert str(conv_op.inputs[0]) == "scatter_ncdhw"
+    assert model_ir.tensors["scatter_ncdhw"].shape == [1, 3, 4, 6, 1]
+    assert model_ir.tensors["slice0"].shape == [1, 3, 5, 4]
 
 
 def test_flatbuffer_direct_shufflenet_reshape_transpose_shuffle_nhwc_chain_optimized() -> None:
@@ -8813,6 +10276,498 @@ def test_flatbuffer_direct_transpose_conv_attention_hardswish_activation_nhwc_pr
     final_mul_op = next(op for op in model_ir.operators if list(op.outputs) == ["y_nhwc"])
     assert list(final_mul_op.inputs)[0] == "a_nchw"
     assert list(model_ir.tensors["a_nchw"].shape) == [1, 8, 8, 16]
+
+
+def test_flatbuffer_direct_transpose_csp_attention_nhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_csp_attention_nhwc_chain_opt_test")
+    model_ir.inputs = ["short_nhwc", "main_nhwc", "point_nhwc"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["short_nhwc"] = TensorIR(
+        name="short_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 16, 16, 24],
+        shape_signature=[1, 16, 16, 24],
+    )
+    model_ir.tensors["main_nhwc"] = TensorIR(
+        name="main_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 16, 16, 24],
+        shape_signature=[1, 16, 16, 24],
+    )
+    model_ir.tensors["point_nhwc"] = TensorIR(
+        name="point_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 16, 16, 24],
+        shape_signature=[1, 16, 16, 24],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["mean_axes"] = TensorIR(
+        name="mean_axes",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["hs_alpha"] = TensorIR(
+        name="hs_alpha",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1.0 / 6.0], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["hs_beta"] = TensorIR(
+        name="hs_beta",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([0.5], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["gate_w"] = TensorIR(
+        name="gate_w",
+        dtype="FLOAT32",
+        shape=[48, 1, 1, 48],
+        shape_signature=[48, 1, 1, 48],
+        data=np.ones((48, 1, 1, 48), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["gate_b"] = TensorIR(
+        name="gate_b",
+        dtype="FLOAT32",
+        shape=[48],
+        shape_signature=[48],
+        data=np.zeros((48,), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["short_nchw"] = TensorIR(
+        name="short_nchw",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["short_sig"] = TensorIR(
+        name="short_sig",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["short_branch"] = TensorIR(
+        name="short_branch",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["main_nchw"] = TensorIR(
+        name="main_nchw",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["point_nchw"] = TensorIR(
+        name="point_nchw",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["point_sig"] = TensorIR(
+        name="point_sig",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["point_branch"] = TensorIR(
+        name="point_branch",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["add_nchw"] = TensorIR(
+        name="add_nchw",
+        dtype="FLOAT32",
+        shape=[1, 24, 16, 16],
+        shape_signature=[1, 24, 16, 16],
+    )
+    model_ir.tensors["concat_nchw"] = TensorIR(
+        name="concat_nchw",
+        dtype="FLOAT32",
+        shape=[1, 48, 16, 16],
+        shape_signature=[1, 48, 16, 16],
+    )
+    model_ir.tensors["mean_nchw"] = TensorIR(
+        name="mean_nchw",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["mean_nhwc"] = TensorIR(
+        name="mean_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 48],
+        shape_signature=[1, 1, 1, 48],
+    )
+    model_ir.tensors["gate_conv_out_nhwc"] = TensorIR(
+        name="gate_conv_out_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 48],
+        shape_signature=[1, 1, 1, 48],
+    )
+    model_ir.tensors["gate_in_nchw"] = TensorIR(
+        name="gate_in_nchw",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["gate_mul"] = TensorIR(
+        name="gate_mul",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["gate_add"] = TensorIR(
+        name="gate_add",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["gate_nchw"] = TensorIR(
+        name="gate_nchw",
+        dtype="FLOAT32",
+        shape=[1, 48, 1, 1],
+        shape_signature=[1, 48, 1, 1],
+    )
+    model_ir.tensors["attn_mul_nchw"] = TensorIR(
+        name="attn_mul_nchw",
+        dtype="FLOAT32",
+        shape=[1, 48, 16, 16],
+        shape_signature=[1, 48, 16, 16],
+    )
+    model_ir.tensors["y_nhwc"] = TensorIR(
+        name="y_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 16, 16, 48],
+        shape_signature=[1, 16, 16, 48],
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 16, 16, 48],
+        shape_signature=[1, 16, 16, 48],
+    )
+    conv_options = {
+        "padding": "SAME",
+        "strideH": 1,
+        "strideW": 1,
+        "dilationHFactor": 1,
+        "dilationWFactor": 1,
+        "fusedActivationFunction": "NONE",
+    }
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["short_nhwc", "pre_perm"], outputs=["short_nchw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["short_nchw"], outputs=["short_sig"]),
+        OperatorIR(op_type="MUL", inputs=["short_nchw", "short_sig"], outputs=["short_branch"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["main_nhwc", "pre_perm"], outputs=["main_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["point_nhwc", "pre_perm"], outputs=["point_nchw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["point_nchw"], outputs=["point_sig"]),
+        OperatorIR(op_type="MUL", inputs=["point_nchw", "point_sig"], outputs=["point_branch"]),
+        OperatorIR(op_type="ADD", inputs=["main_nchw", "point_branch"], outputs=["add_nchw"]),
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=["add_nchw", "short_branch"],
+            outputs=["concat_nchw"],
+            options={"axis": 1, "fusedActivationFunction": "NONE"},
+        ),
+        OperatorIR(
+            op_type="MEAN",
+            inputs=["concat_nchw", "mean_axes"],
+            outputs=["mean_nchw"],
+            options={"keepDims": True},
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["mean_nchw", "post_perm"], outputs=["mean_nhwc"]),
+        OperatorIR(
+            op_type="CONV_2D",
+            inputs=["mean_nhwc", "gate_w", "gate_b"],
+            outputs=["gate_conv_out_nhwc"],
+            options=conv_options,
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["gate_conv_out_nhwc", "pre_perm"], outputs=["gate_in_nchw"]),
+        OperatorIR(op_type="MUL", inputs=["gate_in_nchw", "hs_alpha"], outputs=["gate_mul"]),
+        OperatorIR(op_type="ADD", inputs=["gate_mul", "hs_beta"], outputs=["gate_add"]),
+        OperatorIR(op_type="RELU_0_TO_1", inputs=["gate_add"], outputs=["gate_nchw"]),
+        OperatorIR(op_type="MUL", inputs=["concat_nchw", "gate_nchw"], outputs=["attn_mul_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["attn_mul_nchw", "post_perm"], outputs=["y_nhwc"]),
+        OperatorIR(op_type="RELU", inputs=["y_nhwc"], outputs=["z"]),
+    ]
+
+    stats = _optimize_transpose_csp_attention_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_csp_attention_nhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+    concat_op = next(op for op in model_ir.operators if str(op.op_type) == "CONCATENATION")
+    assert int(concat_op.options.get("axis", -1)) == 3
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["mean_axes"].data, dtype=np.int32),
+        np.asarray([1, 2], dtype=np.int32),
+    )
+    conv_op = next(op for op in model_ir.operators if str(op.op_type) == "CONV_2D")
+    assert list(conv_op.inputs)[0] == "mean_nchw"
+    gate_mul_op = next(op for op in model_ir.operators if list(op.outputs) == ["gate_mul"])
+    assert list(gate_mul_op.inputs)[0] == "gate_conv_out_nhwc"
+    final_mul_op = next(op for op in model_ir.operators if str(op.op_type) == "MUL" and list(op.outputs) == ["y_nhwc"])
+    assert set(list(final_mul_op.inputs)) == {"concat_nchw", "gate_nchw"}
+    assert list(model_ir.tensors["concat_nchw"].shape) == [1, 16, 16, 48]
+
+
+def test_flatbuffer_direct_transpose_csp_attention_nhwc_chain_without_main_add_optimized() -> None:
+    model_ir = ModelIR(name="transpose_csp_attention_nhwc_chain_no_add_opt_test")
+    model_ir.inputs = ["short_nhwc", "point_nhwc"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["short_nhwc"] = TensorIR(
+        name="short_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 20, 20, 192],
+        shape_signature=[1, 20, 20, 192],
+    )
+    model_ir.tensors["point_nhwc"] = TensorIR(
+        name="point_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 20, 20, 192],
+        shape_signature=[1, 20, 20, 192],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["mean_axes"] = TensorIR(
+        name="mean_axes",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["hs_alpha"] = TensorIR(
+        name="hs_alpha",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1.0 / 6.0], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["hs_beta"] = TensorIR(
+        name="hs_beta",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([0.5], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["gate_w"] = TensorIR(
+        name="gate_w",
+        dtype="FLOAT32",
+        shape=[384, 1, 1, 384],
+        shape_signature=[384, 1, 1, 384],
+        data=np.ones((384, 1, 1, 384), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["gate_b"] = TensorIR(
+        name="gate_b",
+        dtype="FLOAT32",
+        shape=[384],
+        shape_signature=[384],
+        data=np.zeros((384,), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["short_nchw"] = TensorIR(
+        name="short_nchw",
+        dtype="FLOAT32",
+        shape=[1, 192, 20, 20],
+        shape_signature=[1, 192, 20, 20],
+    )
+    model_ir.tensors["short_sig"] = TensorIR(
+        name="short_sig",
+        dtype="FLOAT32",
+        shape=[1, 192, 20, 20],
+        shape_signature=[1, 192, 20, 20],
+    )
+    model_ir.tensors["short_branch"] = TensorIR(
+        name="short_branch",
+        dtype="FLOAT32",
+        shape=[1, 192, 20, 20],
+        shape_signature=[1, 192, 20, 20],
+    )
+    model_ir.tensors["point_nchw"] = TensorIR(
+        name="point_nchw",
+        dtype="FLOAT32",
+        shape=[1, 192, 20, 20],
+        shape_signature=[1, 192, 20, 20],
+    )
+    model_ir.tensors["point_sig"] = TensorIR(
+        name="point_sig",
+        dtype="FLOAT32",
+        shape=[1, 192, 20, 20],
+        shape_signature=[1, 192, 20, 20],
+    )
+    model_ir.tensors["point_branch"] = TensorIR(
+        name="point_branch",
+        dtype="FLOAT32",
+        shape=[1, 192, 20, 20],
+        shape_signature=[1, 192, 20, 20],
+    )
+    model_ir.tensors["concat_nchw"] = TensorIR(
+        name="concat_nchw",
+        dtype="FLOAT32",
+        shape=[1, 384, 20, 20],
+        shape_signature=[1, 384, 20, 20],
+    )
+    model_ir.tensors["mean_nchw"] = TensorIR(
+        name="mean_nchw",
+        dtype="FLOAT32",
+        shape=[1, 384, 1, 1],
+        shape_signature=[1, 384, 1, 1],
+    )
+    model_ir.tensors["mean_nhwc"] = TensorIR(
+        name="mean_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 384],
+        shape_signature=[1, 1, 1, 384],
+    )
+    model_ir.tensors["gate_conv_out_nhwc"] = TensorIR(
+        name="gate_conv_out_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 384],
+        shape_signature=[1, 1, 1, 384],
+    )
+    model_ir.tensors["gate_in_nchw"] = TensorIR(
+        name="gate_in_nchw",
+        dtype="FLOAT32",
+        shape=[1, 384, 1, 1],
+        shape_signature=[1, 384, 1, 1],
+    )
+    model_ir.tensors["gate_mul"] = TensorIR(
+        name="gate_mul",
+        dtype="FLOAT32",
+        shape=[1, 384, 1, 1],
+        shape_signature=[1, 384, 1, 1],
+    )
+    model_ir.tensors["gate_add"] = TensorIR(
+        name="gate_add",
+        dtype="FLOAT32",
+        shape=[1, 384, 1, 1],
+        shape_signature=[1, 384, 1, 1],
+    )
+    model_ir.tensors["gate_nchw"] = TensorIR(
+        name="gate_nchw",
+        dtype="FLOAT32",
+        shape=[1, 384, 1, 1],
+        shape_signature=[1, 384, 1, 1],
+    )
+    model_ir.tensors["attn_mul_nchw"] = TensorIR(
+        name="attn_mul_nchw",
+        dtype="FLOAT32",
+        shape=[1, 384, 20, 20],
+        shape_signature=[1, 384, 20, 20],
+    )
+    model_ir.tensors["y_nhwc"] = TensorIR(
+        name="y_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 20, 20, 384],
+        shape_signature=[1, 20, 20, 384],
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 20, 20, 384],
+        shape_signature=[1, 20, 20, 384],
+    )
+    conv_options = {
+        "padding": "SAME",
+        "strideH": 1,
+        "strideW": 1,
+        "dilationHFactor": 1,
+        "dilationWFactor": 1,
+        "fusedActivationFunction": "NONE",
+    }
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["short_nhwc", "pre_perm"], outputs=["short_nchw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["short_nchw"], outputs=["short_sig"]),
+        OperatorIR(op_type="MUL", inputs=["short_nchw", "short_sig"], outputs=["short_branch"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["point_nhwc", "pre_perm"], outputs=["point_nchw"]),
+        OperatorIR(op_type="LOGISTIC", inputs=["point_nchw"], outputs=["point_sig"]),
+        OperatorIR(op_type="MUL", inputs=["point_nchw", "point_sig"], outputs=["point_branch"]),
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=["point_branch", "short_branch"],
+            outputs=["concat_nchw"],
+            options={"axis": 1, "fusedActivationFunction": "NONE"},
+        ),
+        OperatorIR(
+            op_type="MEAN",
+            inputs=["concat_nchw", "mean_axes"],
+            outputs=["mean_nchw"],
+            options={"keepDims": True},
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["mean_nchw", "post_perm"], outputs=["mean_nhwc"]),
+        OperatorIR(
+            op_type="CONV_2D",
+            inputs=["mean_nhwc", "gate_w", "gate_b"],
+            outputs=["gate_conv_out_nhwc"],
+            options=conv_options,
+        ),
+        OperatorIR(op_type="TRANSPOSE", inputs=["gate_conv_out_nhwc", "pre_perm"], outputs=["gate_in_nchw"]),
+        OperatorIR(op_type="MUL", inputs=["gate_in_nchw", "hs_alpha"], outputs=["gate_mul"]),
+        OperatorIR(op_type="ADD", inputs=["gate_mul", "hs_beta"], outputs=["gate_add"]),
+        OperatorIR(op_type="RELU_0_TO_1", inputs=["gate_add"], outputs=["gate_nchw"]),
+        OperatorIR(op_type="MUL", inputs=["concat_nchw", "gate_nchw"], outputs=["attn_mul_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["attn_mul_nchw", "post_perm"], outputs=["y_nhwc"]),
+        OperatorIR(op_type="RELU", inputs=["y_nhwc"], outputs=["z"]),
+    ]
+
+    stats = _optimize_transpose_csp_attention_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_csp_attention_nhwc_chains"] == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("TRANSPOSE") == 0
+    concat_op = next(op for op in model_ir.operators if str(op.op_type) == "CONCATENATION")
+    assert int(concat_op.options.get("axis", -1)) == 3
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["mean_axes"].data, dtype=np.int32),
+        np.asarray([1, 2], dtype=np.int32),
+    )
+    gate_mul_op = next(op for op in model_ir.operators if list(op.outputs) == ["gate_mul"])
+    assert list(gate_mul_op.inputs)[0] == "gate_conv_out_nhwc"
+    final_mul_op = next(op for op in model_ir.operators if str(op.op_type) == "MUL" and list(op.outputs) == ["y_nhwc"])
+    assert set(list(final_mul_op.inputs)) == {"concat_nchw", "gate_nchw"}
+    assert list(model_ir.tensors["concat_nchw"].shape) == [1, 20, 20, 384]
 
 
 def test_flatbuffer_direct_hardsigmoid_mul_transpose_passthrough_with_legacy_fanout_keeps_adapter() -> None:
@@ -10519,6 +12474,40 @@ def test_flatbuffer_direct_serialize_model_supports_leaky_relu() -> None:
         assert int(op_code.BuiltinCode()) == int(schema_tflite["BuiltinOperator"].LEAKY_RELU)
 
 
+def test_flatbuffer_direct_serialize_model_supports_mirror_pad() -> None:
+    model_ir = ModelIR(name="serialize_mirror_pad_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4])
+    model_ir.tensors["pads"] = TensorIR(
+        name="pads",
+        dtype="INT32",
+        shape=[2, 2],
+        data=np.asarray([[0, 0], [1, 1]], dtype=np.int32),
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 6])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="MIRROR_PAD",
+            inputs=["x", "pads"],
+            outputs=["y"],
+            options={"mode": "REFLECT"},
+        ),
+    ]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema_tflite = load_schema_module(tmpdir)
+        model_bytes = serialize_model(schema_tflite=schema_tflite, model_ir=model_ir)
+        model_obj = schema_tflite["ModelT"].InitFromObj(schema_tflite["Model"].GetRootAs(model_bytes, 0))
+        subgraph = model_obj.subgraphs[0]
+        assert len(subgraph.operators) == 1
+        op = subgraph.operators[0]
+        op_code = model_obj.operatorCodes[int(op.opcodeIndex)]
+        assert int(op_code.builtinCode) == int(schema_tflite["BuiltinOperator"].MIRROR_PAD)
+        assert int(op.builtinOptionsType) == int(schema_tflite["BuiltinOptions"].MirrorPadOptions)
+        assert int(op.builtinOptions.mode) == int(schema_tflite["MirrorPadMode"].REFLECT)
+
+
 def test_flatbuffer_direct_serialize_model_supports_fill() -> None:
     model_ir = ModelIR(name="serialize_fill_test")
     model_ir.outputs = ["y"]
@@ -11064,7 +13053,6 @@ def test_flatbuffer_direct_fuse_add_relu_after_transpose_pre_add_rewrite() -> No
     [
         ("Relu", "RELU", "RELU"),
         ("Relu6", "RELU6", "RELU6"),
-        ("Tanh", "TANH", "TANH"),
     ],
 )
 def test_flatbuffer_direct_fuse_binary_activation_chain(
@@ -11092,34 +13080,40 @@ def test_flatbuffer_direct_fuse_binary_activation_chain(
 
 
 @pytest.mark.parametrize(
-    ("binary_onnx_op", "binary_tflite_op"),
+    ("binary_onnx_op", "binary_tflite_op", "activation_onnx_op", "activation_tflite_op"),
     [
-        ("Add", "ADD"),
-        ("Sub", "SUB"),
-        ("Mul", "MUL"),
-        ("Div", "DIV"),
+        ("Add", "ADD", "Sigmoid", "LOGISTIC"),
+        ("Sub", "SUB", "Sigmoid", "LOGISTIC"),
+        ("Mul", "MUL", "Sigmoid", "LOGISTIC"),
+        ("Div", "DIV", "Sigmoid", "LOGISTIC"),
+        ("Add", "ADD", "Tanh", "TANH"),
+        ("Sub", "SUB", "Tanh", "TANH"),
+        ("Mul", "MUL", "Tanh", "TANH"),
+        ("Div", "DIV", "Tanh", "TANH"),
     ],
 )
-def test_flatbuffer_direct_no_fuse_binary_sigmoid_chain(
+def test_flatbuffer_direct_no_fuse_binary_activation_chain(
     binary_onnx_op: str,
     binary_tflite_op: str,
+    activation_onnx_op: str,
+    activation_tflite_op: str,
 ) -> None:
-    model = _make_binary_activation_model(binary_onnx_op, "Sigmoid")
+    model = _make_binary_activation_model(binary_onnx_op, activation_onnx_op)
     register_default_preprocess_rules()
     preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
     model_ir = lower_onnx_to_ir(
         onnx_graph=preprocessed_model,
-        output_file_name=f"no_fuse_{binary_onnx_op.lower()}_sigmoid_chain_test",
+        output_file_name=f"no_fuse_{binary_onnx_op.lower()}_{activation_onnx_op.lower()}_chain_test",
     )
 
     binary_ops = [op for op in model_ir.operators if str(op.op_type) == binary_tflite_op]
-    logistic_ops = [op for op in model_ir.operators if str(op.op_type) == "LOGISTIC"]
+    activation_ops = [op for op in model_ir.operators if str(op.op_type) == activation_tflite_op]
 
     assert len(binary_ops) == 1
-    assert len(logistic_ops) == 1
+    assert len(activation_ops) == 1
     assert str(binary_ops[0].options.get("fusedActivationFunction", "NONE")).upper() == "NONE"
     assert list(binary_ops[0].outputs) == ["a0"]
-    assert list(logistic_ops[0].outputs) == ["z"]
+    assert list(activation_ops[0].outputs) == ["z"]
 
 
 def test_flatbuffer_direct_lstm_forward_builtin_lowering() -> None:
@@ -11143,6 +13137,107 @@ def test_flatbuffer_direct_lstm_forward_builtin_lowering() -> None:
     assert y_tensor is not None
     assert list(y_tensor.shape) == [3, 1, 1, 2]
     assert list(y_tensor.shape_signature) == [3, 1, 1, 2]
+
+
+def test_flatbuffer_direct_lstm_reverse_builtin_lowering() -> None:
+    model = _make_reverse_lstm_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="lstm_reverse_builtin_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("UNIDIRECTIONAL_SEQUENCE_LSTM") == 1
+    assert op_types.count("BIDIRECTIONAL_SEQUENCE_LSTM") == 0
+    assert op_types.count("REVERSE_V2") == 2
+    assert op_types.count("CUSTOM") == 0
+
+    y_tensor = model_ir.tensors.get("y")
+    assert y_tensor is not None
+    assert list(y_tensor.shape) == [3, 1, 1, 2]
+    assert list(y_tensor.shape_signature) == [3, 1, 1, 2]
+
+
+def test_flatbuffer_direct_lstm_forward_state_io_builtin_lowering() -> None:
+    model = _make_forward_lstm_with_state_io_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="lstm_forward_state_io_builtin_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("UNIDIRECTIONAL_SEQUENCE_LSTM") == 1
+    assert op_types.count("CUSTOM") == 0
+    assert op_types.count("RESHAPE") >= 3
+
+    y_tensor = model_ir.tensors.get("y")
+    h_out_tensor = model_ir.tensors.get("h_out")
+    c_out_tensor = model_ir.tensors.get("c_out")
+    assert y_tensor is not None
+    assert h_out_tensor is not None
+    assert c_out_tensor is not None
+    assert list(y_tensor.shape) == [4, 1, 1, 2]
+    assert list(h_out_tensor.shape) == [1, 1, 2]
+    assert list(c_out_tensor.shape) == [1, 1, 2]
+
+
+def test_flatbuffer_direct_rnn_reverse_builtin_lowering() -> None:
+    model = _make_reverse_rnn_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="rnn_reverse_builtin_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("UNIDIRECTIONAL_SEQUENCE_RNN") == 1
+    assert op_types.count("REVERSE_V2") == 2
+    assert op_types.count("CUSTOM") == 0
+    rnn_ops = [op for op in model_ir.operators if str(op.op_type) == "UNIDIRECTIONAL_SEQUENCE_RNN"]
+    assert str(rnn_ops[0].options.get("fusedActivationFunction", "NONE")).upper() == "RELU"
+
+    y_tensor = model_ir.tensors.get("y")
+    y_h_tensor = model_ir.tensors.get("y_h")
+    assert y_tensor is not None
+    assert y_h_tensor is not None
+    assert list(y_tensor.shape) == [4, 1, 1, 3]
+    assert list(y_h_tensor.shape) == [1, 1, 3]
+
+
+def test_flatbuffer_direct_rnn_bidirectional_builtin_lowering() -> None:
+    model = _make_bidirectional_rnn_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="rnn_bidirectional_builtin_lowering_test",
+        allow_custom_ops=False,
+    )
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("UNIDIRECTIONAL_SEQUENCE_RNN") == 2
+    assert op_types.count("REVERSE_V2") == 2
+    assert op_types.count("CONCATENATION") >= 2
+    assert op_types.count("CUSTOM") == 0
+    rnn_ops = [op for op in model_ir.operators if str(op.op_type) == "UNIDIRECTIONAL_SEQUENCE_RNN"]
+    fused = [str(op.options.get("fusedActivationFunction", "NONE")).upper() for op in rnn_ops]
+    assert fused.count("TANH") == 1
+    assert fused.count("RELU") == 1
+
+    y_tensor = model_ir.tensors.get("y")
+    y_h_tensor = model_ir.tensors.get("y_h")
+    assert y_tensor is not None
+    assert y_h_tensor is not None
+    assert list(y_tensor.shape) == [4, 2, 1, 3]
+    assert list(y_h_tensor.shape) == [2, 1, 3]
 
 
 def test_flatbuffer_direct_transpose_mul_const_add_transpose_optimization() -> None:
@@ -11439,6 +13534,76 @@ def test_flatbuffer_direct_maximum_minimum_chain_rewrites_to_relu_0_to_1() -> No
     assert [str(v) for v in list(model_ir.operators[0].outputs)] == ["y"]
 
 
+def test_flatbuffer_direct_maximum_with_zero_input2_rewrites_to_relu() -> None:
+    model_ir = ModelIR(name="maximum_input2_zero_relu_opt_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4],
+        shape_signature=[1, 2, 3, 4],
+    )
+    model_ir.tensors["zero"] = TensorIR(
+        name="zero",
+        dtype="FLOAT32",
+        shape=[],
+        shape_signature=[],
+        data=np.asarray(0.0, dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4],
+        shape_signature=[1, 2, 3, 4],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="MAXIMUM", inputs=["x", "zero"], outputs=["y"]),
+    ]
+
+    stats = _optimize_maximum_with_zero_input2_to_relu(model_ir)
+    assert stats["rewritten_maximum_with_zero_input2_to_relu"] == 1
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types == ["RELU"]
+    assert [str(v) for v in list(model_ir.operators[0].inputs)] == ["x"]
+    assert [str(v) for v in list(model_ir.operators[0].outputs)] == ["y"]
+
+
+def test_flatbuffer_direct_maximum_with_zero_input1_is_not_rewritten() -> None:
+    model_ir = ModelIR(name="maximum_input1_zero_no_relu_opt_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4],
+        shape_signature=[1, 2, 3, 4],
+    )
+    model_ir.tensors["zero"] = TensorIR(
+        name="zero",
+        dtype="FLOAT32",
+        shape=[],
+        shape_signature=[],
+        data=np.asarray(0.0, dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 2, 3, 4],
+        shape_signature=[1, 2, 3, 4],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="MAXIMUM", inputs=["zero", "x"], outputs=["y"]),
+    ]
+
+    stats = _optimize_maximum_with_zero_input2_to_relu(model_ir)
+    assert stats["rewritten_maximum_with_zero_input2_to_relu"] == 0
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types == ["MAXIMUM"]
+
+
 def test_flatbuffer_direct_transpose_hardsigmoid_transpose_optimization() -> None:
     model = _make_transpose_hardsigmoid_transpose_model()
     register_default_preprocess_rules()
@@ -11521,7 +13686,7 @@ def test_flatbuffer_direct_transpose_gelu_tanh_transpose_optimization() -> None:
     )
     op_types = [str(op.op_type) for op in model_ir.operators]
     assert op_types.count("TRANSPOSE") == 0
-    assert op_types.count("TANH") == 0
+    assert op_types.count("TANH") == 1
     assert op_types.count("MUL") == 6
     assert op_types.count("ADD") == 2
     assert op_types.count("RELU") == 0

--- a/uv.lock
+++ b/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "onnx2tf"
-version = "2.0.22"
+version = "2.0.23"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
## Summary
This PR brings the latest `fix-var` branch improvements into `main` and focuses on making the `flatbuffer_direct` path more practical for real ONNX models.

## Key improvements
- Expanded builtin lowering coverage for multiple previously custom/failing paths, including additional pooling/reduction and recurrent/convolution-related cases.
- Added and refined operator builders/validators in the direct TFLite builder pipeline (`op_registry`, `op_builders`, and lowering passes).
- Improved transpose/layout optimization passes to remove redundant adapter chains and reduce graph bloat.
- Improved numerical consistency in several edge cases (including Softmax axis handling and shape/broadcast-sensitive paths).
- Added GlobalMaxPool builtin lowering (`REDUCE_MAX`) for `flatbuffer_direct`.
- Updated accuracy/coverage-related handling and added regression tests.
- Updated README documentation to reflect newly builtin-covered ops and behavioral changes.

## Validation
- `pytest -q tests/test_tflite_builder_direct.py` (full suite): **307 passed**
- Additional targeted conversion checks were performed during development for `flatbuffer_direct` models using `--report_op_coverage`.

## Notes
- This PR is intentionally broad because `fix-var` accumulated tightly related direct-backend changes that were validated together.
- The changes are centered on `flatbuffer_direct` behavior and test/documentation alignment.
