### PR TITLE
flatbuffer_direct: add built-in Loop/If lowering and runtime-check hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,12 +369,13 @@ Notes:
 |HardSigmoid|MUL + ADD + MAXIMUM + MINIMUM|Input/output dtype must be FLOAT16 or FLOAT32|
 |HardSwish|HARD_SWISH|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |Identity|RESHAPE|-|
-|If|CONCATENATION + REDUCE_MAX + CAST + ADD + MUL + RESHAPE + NON_MAX_SUPPRESSION_V4/V5 + SLICE + GATHER + SHAPE + SUB|Built-in lowering supports constrained patterns: NMS-guard pattern (empty then-branch + NMS else-branch), axis0 Add-branch pattern (single `Add` per branch, same trailing dims, different static first dim), SequenceConstruct Add-branch pattern (branch-local `Constant`/`Add` with terminal `SequenceConstruct`), and nested ReduceMin/Add pattern (else-branch `ReduceMin/Greater` with nested Add/Add `If`)|
+|If|CONCATENATION + REDUCE_MAX + CAST + ADD + MUL + RESHAPE + NON_MAX_SUPPRESSION_V4/V5 + SLICE + GATHER + SHAPE + SUB|Built-in lowering supports constrained patterns: NMS-guard pattern (empty then-branch + NMS else-branch), axis0 Add-branch pattern (single `Add` per branch, same trailing dims, different static first dim), SequenceConstruct Add-branch pattern (branch-local `Constant`/`Add` with terminal `SequenceConstruct`), and nested ReduceMin/Add pattern (else-branch `ReduceMin/Greater` with nested Add/Add `If`). In control-flow branch lowering, dynamic-condition `If` is additionally supported when both branches are single-output initializer-only constants (lowered via `Where`)|
 |InstanceNormalization|MEAN + SUB + MUL + MEAN + ADD + SQRT + DIV + MUL + ADD|Input/output dtype must be `FLOAT16` or `FLOAT32`; input rank must be `>=3`; `scale` and `bias` inputs must be constant|
 |Less|LESS|-|
 |LessOrEqual|LESS_EQUAL|-|
 |Log|LOG|Input/output dtype must be `FLOAT16` or `FLOAT32`|
 |LogSoftmax|SOFTMAX + LOG (+ transpose in/out for non-last axis)|`axis` must be in range (negative axis normalized)|
+|Loop|WHILE (+ subgraph-local ADD/LESS/LOGICAL_AND/RESHAPE and lowered body ops)|Built-in lowering supports either static-unroll patterns (constant `trip_count`/`cond`, loop-carried outputs only) or WHILE patterns with loop-carried outputs only (no scan outputs). `max_trip_count` input dtype must be `INT32` or `INT64`|
 |LpNormalization|L2_NORMALIZATION|`p=2`, `axis=last` only|
 |LRN|LOCAL_RESPONSE_NORMALIZATION (+ transpose in/out)|Input rank must be 4, `size` must be a positive odd integer|
 |LSTM|UNIDIRECTIONAL_SEQUENCE_LSTM / BIDIRECTIONAL_SEQUENCE_LSTM + REVERSE_V2 + SPLIT + SQUEEZE + SLICE + RESHAPE/EXPAND_DIMS + CONCATENATION|`direction` in `{forward,reverse,bidirectional}`, `layout=0`, `input_forget=0`; `W/R` must be constant rank-3 with `num_directions` matching `direction`; optional `B` must be constant shape `[num_directions, 8*hidden_size]`; `initial_h/initial_c` are optional (when provided, shape must be `[num_directions, batch, hidden]`; runtime tensor inputs are supported); `sequence_lens` and peephole input `P` unsupported; projection (`R.shape[2] != hidden_size`) unsupported|
@@ -459,7 +460,7 @@ Notes:
 |DeformConv|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |GridSample|builtin_supported on constrained 2D pattern; otherwise explicit_error (`custom_op_candidate_disabled`)|Unsupported GridSample patterns can be lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |If|builtin_supported on constrained patterns (NMS-guard, axis0 Add-branch, SequenceConstruct Add-branch, and nested ReduceMin/Add); otherwise explicit_error (`custom_op_candidate_disabled`)|Unsupported If patterns can be lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
-|Loop|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
+|Loop|builtin_supported on constrained patterns (static-unroll / WHILE loop-carried forms); otherwise explicit_error (`custom_op_candidate_disabled`)|Unsupported Loop patterns can be lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |RoiAlign|builtin_supported on constrained pattern; otherwise explicit_error (`custom_op_candidate_disabled`)|Unsupported RoiAlign patterns can be lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |Scan|explicit_error (`custom_op_candidate_disabled`)|Lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
 |ScatterElements|builtin_supported on constrained pattern; otherwise explicit_error (`custom_op_candidate_disabled`)|Unsupported ScatterElements patterns can be lowered to TFLite `CUSTOM` when `--flatbuffer_direct_allow_custom_ops` is enabled and allowlist passes|
@@ -480,6 +481,7 @@ Notes:
 - `NonMaxSuppression` is now treated as `builtin_supported` when builtin constraints pass; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `DynamicQuantizeLinear` is now treated as `builtin_supported` for constrained float-input/uint8-output patterns; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `If` is now treated as `builtin_supported` for constrained patterns (NMS-guard, axis0 Add-branch, SequenceConstruct Add-branch, and nested ReduceMin/Add); unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
+- `Loop` is now treated as `builtin_supported` for constrained static-unroll/WHILE loop-carried patterns; unsupported patterns may still fallback to `CUSTOM` if custom-op mode is enabled.
 - `OneHot`, `MatMulInteger`, `Pow`, and `Reciprocal` are now treated as `builtin_supported` when builtin constraints pass.
 - `ReduceMin` is now treated as `builtin_supported` under builtin constraints.
 - `Min` and `TopK` are now treated as `builtin_supported` under builtin constraints, reducing `ONNX_MIN` / `ONNX_TOPK` custom-op fallbacks.
@@ -635,7 +637,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.0.24
+  ghcr.io/pinto0309/onnx2tf:2.0.25
 
   or
 
@@ -644,7 +646,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.0.24
+  docker.io/pinto0309/onnx2tf:2.0.25
 
   or
 
@@ -654,7 +656,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.0.24 \
+  docker.io/pinto0309/onnx2tf:2.0.25 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or
@@ -2005,7 +2007,7 @@ optional arguments:
        `SOFTMAX`, `L2_NORMALIZATION`, `LOCAL_RESPONSE_NORMALIZATION`,
        `CONV_2D`, `DEPTHWISE_CONV_2D`, `CONV_3D`, `TRANSPOSE_CONV`, `CONV_3D_TRANSPOSE`, `AVERAGE_POOL_2D`, `MAX_POOL_2D`, `FULLY_CONNECTED`, `BATCH_MATMUL`,
        `RESIZE_NEAREST_NEIGHBOR`, `RESIZE_BILINEAR`,
-       `BIDIRECTIONAL_SEQUENCE_LSTM`, `SPLIT`, `EXPAND_DIMS`,
+       `BIDIRECTIONAL_SEQUENCE_LSTM`, `SPLIT`, `EXPAND_DIMS`, `WHILE`,
        `DEQUANTIZE`, `QUANTIZE`.
     6. Unsupported OPs fail explicitly with `NotImplementedError`.
     7. Custom OP policy (opt-in):

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.0.24'
+__version__ = '2.0.25'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -191,6 +191,26 @@ def _prepare_onnx_graph_for_runtime_checks(
         prepared,
         prune_orphan_value_info=True,
     )
+    try:
+        # Some exporter/simplifier pipelines may leave nodes out-of-order for ORT.
+        # Rebuild runtime-check graph with a stable topological order.
+        preserved_domain = str(prepared.domain)
+        preserved_ir_version = int(prepared.ir_version)
+        preserved_metadata_props = None
+        if hasattr(prepared, 'metadata_props'):
+            preserved_metadata_props = list(prepared.metadata_props)
+        graph = gs.import_onnx(prepared)
+        graph.cleanup().toposort()
+        prepared = gs.export_onnx(
+            graph=graph,
+            do_type_check=False,
+            domain=preserved_domain,
+            ir_version=preserved_ir_version,
+        )
+        if preserved_metadata_props:
+            prepared.metadata_props.extend(preserved_metadata_props)
+    except Exception:
+        pass
     return prepared
 
 
@@ -1699,8 +1719,18 @@ def convert(
             output_folder_path,
             f'{output_file_name}_accuracy_report.json',
         )
+        eval_in_process = str(
+            os.environ.get('ONNX2TF_EVAL_IN_PROCESS', '0')
+        ).strip().lower() in {'1', 'true', 'yes', 'on'}
         try:
-            from onnx2tf.tflite_builder.accuracy_evaluator import evaluate_onnx_tflite_outputs
+            if eval_in_process:
+                from onnx2tf.tflite_builder.accuracy_evaluator import (
+                    evaluate_onnx_tflite_outputs as evaluate_onnx_tflite_outputs_impl,
+                )
+            else:
+                from onnx2tf.tflite_builder.accuracy_evaluator import (
+                    evaluate_onnx_tflite_outputs_isolated as evaluate_onnx_tflite_outputs_impl,
+                )
         except Exception as ex:
             msg = (
                 'ONNX/TFLite output check was skipped because evaluator dependencies are unavailable. '
@@ -1739,7 +1769,7 @@ def convert(
             )
             if onnx_graph_for_eval is None:
                 raise RuntimeError('ONNX graph is unavailable for evaluation.')
-            report = evaluate_onnx_tflite_outputs(
+            report = evaluate_onnx_tflite_outputs_impl(
                 onnx_graph=onnx_graph_for_eval,
                 tflite_path=tflite_path,
                 output_report_path=report_path,
@@ -1752,6 +1782,35 @@ def convert(
                 fail_on_threshold=eval_fail_on_threshold_local,
             )
         except Exception as ex:
+            ex_str = str(ex)
+            if (
+                not required
+                and 'INVALID_GRAPH' in ex_str
+                and 'topologically sorted' in ex_str
+            ):
+                info(
+                    Color.YELLOW(
+                        'ONNX/TFLite output check was skipped because ONNX graph validation '
+                        'failed in ONNX Runtime (topological order issue). '
+                        f'source={source_label} target={target_key}'
+                    )
+                )
+                return
+            if (
+                not required
+                and 'Worker exited abnormally' in ex_str
+                and 'worker=_tflite_inference_worker' in ex_str
+                and (
+                    'exit_code=-11' in ex_str
+                    or 'exit_code=139' in ex_str
+                )
+            ):
+                warn(
+                    'ONNX/TFLite output check was skipped because LiteRT crashed while invoking '
+                    f'the generated model (likely runtime-side issue). source={source_label} target={target_key} '
+                    f'reason={ex}'
+                )
+                return
             msg = (
                 'ONNX/TFLite output check failed. '
                 f'source={source_label} target={target_key} reason={ex}'
@@ -1888,6 +1947,16 @@ def convert(
                 )
             )
         except Exception as ex:
+            ex_str = str(ex)
+            if 'failed to prepare' in ex_str:
+                info(
+                    Color.YELLOW(
+                        'OP error report generation was skipped because the generated '
+                        'TFLite model could not be prepared by LiteRT for intermediate '
+                        f'tensor capture. reason={ex}'
+                    )
+                )
+                return
             warn(
                 'OP error report generation failed. '
                 f'reason={ex}'
@@ -3310,13 +3379,18 @@ def convert(
                     warn(
                         f'Conversion failed and automatic JSON generation could not find a solution after {attempt} attempts.'
                     )
-            elif not param_replacement_file and input_onnx_file_path and not auto_generate_json_on_error:
+            elif (
+                tflite_backend != 'flatbuffer_direct'
+                and not param_replacement_file
+                and input_onnx_file_path
+                and not auto_generate_json_on_error
+            ):
                 warn(
                     'Conversion failed. Automatic JSON generation on error is disabled by default.\n' +
                     'Re-run with --auto_generate_json_on_error or provide a parameter replacement JSON file.'
                 )
             if tflite_backend == 'flatbuffer_direct':
-                warn(
+                info(
                     Color.YELLOW(
                         'TF conversion path failed. '
                         'Attempting flatbuffer_direct-only conversion. '
@@ -3360,14 +3434,14 @@ def convert(
                                     tflite_split_target_bytes=tflite_split_target_bytes,
                                 )
                                 if direct_output_nms_with_argmax and not output_nms_with_argmax:
-                                    warn(
+                                    info(
                                         Color.YELLOW(
                                             'Retrying flatbuffer_direct with output_nms_with_argmax enabled '
                                             'for builtin NonMaxSuppression lowering.'
                                         )
                                     )
                                 if direct_allow_custom_ops and not flatbuffer_direct_allow_custom_ops:
-                                    warn(
+                                    info(
                                         Color.YELLOW(
                                             'Retrying flatbuffer_direct with custom-op lowering enabled '
                                             'after TF conversion failure.'
@@ -3776,14 +3850,14 @@ def convert(
                                 tflite_split_target_bytes=tflite_split_target_bytes,
                             )
                             if direct_output_nms_with_argmax and not output_nms_with_argmax:
-                                warn(
+                                info(
                                     Color.YELLOW(
                                         'Retrying flatbuffer_direct with output_nms_with_argmax enabled '
                                         'for builtin NonMaxSuppression lowering.'
                                     )
                                 )
                             if direct_allow_custom_ops and not flatbuffer_direct_allow_custom_ops:
-                                warn(
+                                info(
                                     Color.YELLOW(
                                         'Retrying flatbuffer_direct with custom-op lowering enabled.'
                                     )

--- a/onnx2tf/ops/Concat.py
+++ b/onnx2tf/ops/Concat.py
@@ -372,7 +372,13 @@ def make_node(
             return True
 
         def _perm_shape(shape, perm):
-            return [shape[i] for i in perm] if shape is not None else None
+            if shape is None:
+                return None
+            if any(int(i) < 0 or int(i) >= len(shape) for i in perm):
+                # Rank mismatch between candidate permutation and actual tensor rank.
+                # Let caller skip this permutation safely.
+                return None
+            return [shape[i] for i in perm]
 
         def _limited_perms(rank):
             identity = list(range(rank))

--- a/onnx2tf/ops/RandomNormalLike.py
+++ b/onnx2tf/ops/RandomNormalLike.py
@@ -53,9 +53,22 @@ def make_node(
     rseed = graph_node.attrs.get('seed', 0)
     rshape = graph_node_input.shape \
         if input_tensor is None else input_tensor.shape
-    rshape = [
-        s if not isinstance(s, str) else None for s in rshape
-    ]
+    if isinstance(rshape, tf.TensorShape):
+        try:
+            rshape = rshape.as_list()
+        except ValueError:
+            rshape = None
+    if isinstance(rshape, tuple):
+        rshape = list(rshape)
+    if rshape is None:
+        rshape = tf.shape(input_tensor) if input_tensor is not None else graph_node_output.shape
+    if isinstance(rshape, list):
+        rshape = [
+            s if not isinstance(s, str) else None for s in rshape
+        ]
+        if input_tensor is not None and any(s is None for s in rshape):
+            # Stateful random ops do not accept None in shape lists.
+            rshape = tf.shape(input_tensor)
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -65,13 +78,13 @@ def make_node(
     }
 
     # Generation of TF OP
-    generator = tf.random.Generator.from_seed(rseed)
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        generator.normal(
+        tf.random.normal(
             shape=rshape,
             mean=rmean,
             stddev=rscale,
             dtype=ONNX_DTYPES_TO_TF_DTYPES[rdtype],
+            seed=rseed,
             name=graph_node.name,
         )
 

--- a/onnx2tf/ops/RandomUniformLike.py
+++ b/onnx2tf/ops/RandomUniformLike.py
@@ -53,9 +53,22 @@ def make_node(
     rseed = graph_node.attrs.get('seed', 0)
     rshape = graph_node_input.shape \
         if input_tensor is None else input_tensor.shape
-    rshape = [
-        s if not isinstance(s, str) else None for s in rshape
-    ]
+    if isinstance(rshape, tf.TensorShape):
+        try:
+            rshape = rshape.as_list()
+        except ValueError:
+            rshape = None
+    if isinstance(rshape, tuple):
+        rshape = list(rshape)
+    if rshape is None:
+        rshape = tf.shape(input_tensor) if input_tensor is not None else graph_node_output.shape
+    if isinstance(rshape, list):
+        rshape = [
+            s if not isinstance(s, str) else None for s in rshape
+        ]
+        if input_tensor is not None and any(s is None for s in rshape):
+            # Stateful random ops do not accept None in shape lists.
+            rshape = tf.shape(input_tensor)
 
     # Preserving Graph Structure (Dict)
     tf_layers_dict[graph_node_output.name] = {
@@ -65,13 +78,13 @@ def make_node(
     }
 
     # Generation of TF OP
-    generator = tf.random.Generator.from_seed(rseed)
     tf_layers_dict[graph_node_output.name]['tf_node'] = \
-        generator.uniform(
+        tf.random.uniform(
             shape=rshape,
             minval=rlow,
             maxval=rhigh,
             dtype=ONNX_DTYPES_TO_TF_DTYPES[rdtype],
+            seed=rseed,
             name=graph_node.name,
         )
 

--- a/onnx2tf/tflite_builder/accuracy_evaluator.py
+++ b/onnx2tf/tflite_builder/accuracy_evaluator.py
@@ -269,6 +269,14 @@ def _adapt_input_layout_for_tflite_input(data: np.ndarray, detail: Dict[str, Any
     if target_shape is None:
         return value
     target_shape = [int(v) for v in np.asarray(target_shape).reshape(-1).tolist()]
+
+    # ONNX scalar ([] rank) is commonly represented as [1] in TFLite runtime tensors.
+    if value.ndim == 0 and len(target_shape) == 1 and _dim_matches(target_shape[0], 1):
+        return value.reshape((1,))
+    # Conversely, some runtime tensors can stay scalar while ONNX sample is [1].
+    if value.ndim == 1 and int(value.size) == 1 and len(target_shape) == 0:
+        return np.asarray(value).reshape(())
+
     if len(target_shape) != value.ndim:
         return value
 

--- a/onnx2tf/tflite_builder/ir.py
+++ b/onnx2tf/tflite_builder/ir.py
@@ -43,6 +43,7 @@ class ModelIR:
     operators: List[OperatorIR] = field(default_factory=list)
     inputs: List[str] = field(default_factory=list)
     outputs: List[str] = field(default_factory=list)
+    subgraphs: List["ModelIR"] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
 
 
@@ -76,6 +77,7 @@ def clone_model_ir_with_float16(model_ir: ModelIR) -> ModelIR:
     )
     clone.inputs = list(model_ir.inputs)
     clone.outputs = list(model_ir.outputs)
+    clone.subgraphs = [clone_model_ir_with_float16(subgraph) for subgraph in model_ir.subgraphs]
     clone.operators = [
         OperatorIR(
             op_type=op.op_type,

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -924,7 +924,49 @@ def _resolve_reshape_new_shape_from_static_input(
             candidate[idx] = int(in_dim)
 
     if all(int(dim) >= 0 for dim in candidate):
-        return list(candidate)
+        if input_signature is None or len(input_signature) == 0:
+            return list(candidate)
+        if any(int(dim) <= 0 for dim in input_signature):
+            return list(candidate)
+
+        input_product = int(np.prod(np.asarray(input_signature, dtype=np.int64)))
+        if input_product <= 0:
+            return list(candidate)
+        target_product = int(np.prod(np.asarray(candidate, dtype=np.int64)))
+        if target_product == input_product:
+            return list(candidate)
+
+        # Stale reshape constants can appear after late layout rewrites.
+        # If exactly one dimension can be re-inferred from static input size,
+        # repair that dimension instead of keeping an invalid constant.
+        inferable_dims: List[Tuple[int, int]] = []
+        for idx in range(len(candidate)):
+            other_product = 1
+            valid = True
+            for j, dim in enumerate(candidate):
+                if j == idx:
+                    continue
+                d = int(dim)
+                if d <= 0:
+                    valid = False
+                    break
+                other_product *= d
+            if not valid or other_product <= 0:
+                continue
+            if input_product % other_product != 0:
+                continue
+            inferred_dim = int(input_product // other_product)
+            if inferred_dim <= 0:
+                continue
+            inferable_dims.append((int(idx), int(inferred_dim)))
+
+        if len(inferable_dims) == 1:
+            dim_idx, inferred_dim = inferable_dims[0]
+            repaired = [int(v) for v in candidate]
+            repaired[dim_idx] = int(inferred_dim)
+            return repaired
+
+        return None
 
     minus_one_indices = [idx for idx, dim in enumerate(candidate) if int(dim) == -1]
     if len(minus_one_indices) != 1:
@@ -1025,6 +1067,110 @@ def _resolve_dynamic_reshape_shapes(model_ir: ModelIR) -> Dict[str, int]:
             resolved_count += 1
 
     return {"resolved_dynamic_reshape_shapes": int(resolved_count)}
+
+
+def _sanitize_hardswish_tensor_shapes(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    HARD_SWISH must preserve input shape exactly.
+    Late transpose/layout rewrites can occasionally leave stale output metadata.
+    """
+    fixed = 0
+    for op in model_ir.operators:
+        if str(op.op_type) != "HARD_SWISH":
+            continue
+        if len(op.inputs) < 1 or len(op.outputs) != 1:
+            continue
+
+        input_name = str(op.inputs[0])
+        output_name = str(op.outputs[0])
+        input_tensor = model_ir.tensors.get(input_name, None)
+        output_tensor = model_ir.tensors.get(output_name, None)
+        if input_tensor is None or output_tensor is None:
+            continue
+        if input_tensor.shape is None or len(list(input_tensor.shape)) == 0:
+            continue
+
+        input_shape = [int(v) for v in list(input_tensor.shape)]
+        input_signature_current = (
+            [int(v) for v in list(input_tensor.shape_signature)]
+            if input_tensor.shape_signature is not None
+            else []
+        )
+        if _is_fully_known_positive_shape(input_shape):
+            input_signature = [int(v) for v in list(input_shape)]
+        else:
+            input_signature = (
+                [int(v) for v in list(input_signature_current)]
+                if len(input_signature_current) > 0
+                else [int(v) for v in list(input_shape)]
+            )
+        output_shape = (
+            [int(v) for v in list(output_tensor.shape)]
+            if output_tensor.shape is not None
+            else []
+        )
+        output_signature = (
+            [int(v) for v in list(output_tensor.shape_signature)]
+            if output_tensor.shape_signature is not None
+            else [int(v) for v in list(output_shape)]
+        )
+
+        if (
+            input_signature_current == input_signature
+            and output_shape == input_shape
+            and output_signature == input_signature
+        ):
+            continue
+
+        input_tensor.shape_signature = [int(v) for v in list(input_signature)]
+        output_tensor.shape = [int(v) for v in list(input_shape)]
+        output_tensor.shape_signature = [int(v) for v in list(input_signature)]
+        fixed += 1
+
+    return {"sanitized_hardswish_tensor_shapes": int(fixed)}
+
+
+def _sanitize_static_shape_signature_consistency(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    For fully static tensors, keep shape_signature consistent with runtime shape.
+
+    Notes:
+    - Do not touch dynamic signatures that contain negative dimensions.
+    - This is metadata-only sanitation for tooling consistency (e.g. Netron).
+    """
+    fixed = 0
+    for tensor in model_ir.tensors.values():
+        if tensor.shape is None:
+            continue
+        shape = [int(v) for v in list(tensor.shape)]
+        if len(shape) == 0:
+            if tensor.shape_signature is None:
+                tensor.shape_signature = []
+                fixed += 1
+            continue
+        if not _is_fully_known_positive_shape(shape):
+            continue
+
+        signature = (
+            [int(v) for v in list(tensor.shape_signature)]
+            if tensor.shape_signature is not None
+            else None
+        )
+        if signature is None:
+            tensor.shape_signature = [int(v) for v in list(shape)]
+            fixed += 1
+            continue
+        if len(signature) != len(shape):
+            tensor.shape_signature = [int(v) for v in list(shape)]
+            fixed += 1
+            continue
+        if any(int(v) < 0 for v in signature):
+            continue
+        if signature != shape:
+            tensor.shape_signature = [int(v) for v in list(shape)]
+            fixed += 1
+
+    return {"sanitized_static_shape_signature_consistency": int(fixed)}
 
 
 def _is_fully_known_positive_shape(shape: Optional[List[int]]) -> bool:
@@ -6272,21 +6418,26 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
       x_t --MUL(alpha)--> m1 --ADD(beta)--> a1 --(MAXIMUM(0)->MINIMUM(1) | RELU_0_TO_1)--> h1
       MUL(x_t, h1) --> y_t
       y_t --TRANSPOSE(inv(P))--> Y
+      (optional branch)
+      y_t --MEAN(axes_nchw, keepDims=True)--> m_t --TRANSPOSE(inv(P))--> M
 
     Rewrite:
       X --MUL(alpha)--> m1 --ADD(beta)--> a1 --(MAXIMUM(0)->MINIMUM(1) | RELU_0_TO_1)--> h1
       MUL(X, h1) --> Y
+      MEAN(Y, axes_nhwc, keepDims=True) --> M
 
     Safety:
     - Strict HardSigmoid decomposition topology on one branch.
     - HardSigmoid branch constants must be singleton constants.
     - Chain on the HardSigmoid branch must be linear.
+    - Optional MEAN branch must be rank-4 constant-axes and only feed inverse post-transpose adapters.
     """
     rewritten = 0
 
     while True:
         changed = False
         consumers = _build_tensor_consumer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
 
         for pre_idx, pre_op in enumerate(model_ir.operators):
             if str(pre_op.op_type) != "TRANSPOSE":
@@ -6308,86 +6459,139 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
             if len(pre_users) != 2:
                 continue
 
-            def _try_match_pair(hs_mul_idx: int, residual_mul_idx: int) -> Optional[Dict[str, Any]]:
-                hs_mul_op = model_ir.operators[int(hs_mul_idx)]
-                if str(hs_mul_op.op_type) != "MUL" or len(hs_mul_op.inputs) != 2 or len(hs_mul_op.outputs) != 1:
-                    return None
-                hs_mul_inputs = [str(v) for v in list(hs_mul_op.inputs)]
-                if pre_output_name == hs_mul_inputs[0]:
-                    hs_mul_data_input_index = 0
-                    hs_mul_side_name = hs_mul_inputs[1]
-                elif pre_output_name == hs_mul_inputs[1]:
-                    hs_mul_data_input_index = 1
-                    hs_mul_side_name = hs_mul_inputs[0]
-                else:
-                    return None
-                if not _is_singleton_constant_tensor(model_ir, hs_mul_side_name):
-                    return None
-                hs_mul_out_name = str(hs_mul_op.outputs[0])
+            def _try_match_pair(hs_entry_idx: int, residual_mul_idx: int) -> Optional[Dict[str, Any]]:
+                hs_entry_op = model_ir.operators[int(hs_entry_idx)]
+                hs_entry_type = str(hs_entry_op.op_type)
+                hs_data_idx: Optional[int] = None
+                hs_data_input_index: Optional[int] = None
+                hs_out_name: Optional[str] = None
+                hs_intermediate_names: List[str] = []
 
-                hs_mul_users = [int(v) for v in consumers.get(hs_mul_out_name, [])]
-                if len(hs_mul_users) != 1:
-                    return None
-                hs_add_idx = int(hs_mul_users[0])
-                hs_add_op = model_ir.operators[int(hs_add_idx)]
-                if str(hs_add_op.op_type) != "ADD" or len(hs_add_op.inputs) != 2 or len(hs_add_op.outputs) != 1:
-                    return None
-                hs_add_inputs = [str(v) for v in list(hs_add_op.inputs)]
-                if hs_mul_out_name == hs_add_inputs[0]:
-                    hs_add_side_name = hs_add_inputs[1]
-                elif hs_mul_out_name == hs_add_inputs[1]:
-                    hs_add_side_name = hs_add_inputs[0]
-                else:
-                    return None
-                if not _is_singleton_constant_tensor(model_ir, hs_add_side_name):
-                    return None
-                hs_add_out_name = str(hs_add_op.outputs[0])
-
-                hs_add_users = [int(v) for v in consumers.get(hs_add_out_name, [])]
-                if len(hs_add_users) != 1:
-                    return None
-                hs_clamp_idx = int(hs_add_users[0])
-                hs_clamp_op = model_ir.operators[int(hs_clamp_idx)]
-                hs_intermediate_names: List[str] = [str(hs_mul_out_name), str(hs_add_out_name)]
-                if (
-                    str(hs_clamp_op.op_type) == "RELU_0_TO_1"
-                    and len(hs_clamp_op.inputs) == 1
-                    and len(hs_clamp_op.outputs) == 1
-                    and str(hs_clamp_op.inputs[0]) == hs_add_out_name
-                ):
-                    hs_out_name = str(hs_clamp_op.outputs[0])
-                else:
-                    if str(hs_clamp_op.op_type) != "MAXIMUM" or len(hs_clamp_op.inputs) != 2 or len(hs_clamp_op.outputs) != 1:
-                        return None
-                    hs_max_inputs = [str(v) for v in list(hs_clamp_op.inputs)]
-                    if hs_add_out_name == hs_max_inputs[0]:
-                        hs_max_side_name = hs_max_inputs[1]
-                    elif hs_add_out_name == hs_max_inputs[1]:
-                        hs_max_side_name = hs_max_inputs[0]
+                if hs_entry_type == "MUL" and len(hs_entry_op.inputs) == 2 and len(hs_entry_op.outputs) == 1:
+                    hs_mul_inputs = [str(v) for v in list(hs_entry_op.inputs)]
+                    if pre_output_name == hs_mul_inputs[0]:
+                        hs_data_input_index = 0
+                        hs_mul_side_name = hs_mul_inputs[1]
+                    elif pre_output_name == hs_mul_inputs[1]:
+                        hs_data_input_index = 1
+                        hs_mul_side_name = hs_mul_inputs[0]
                     else:
                         return None
-                    if not _is_singleton_constant_tensor(model_ir, hs_max_side_name):
+                    if not _is_singleton_constant_tensor(model_ir, hs_mul_side_name):
                         return None
-                    hs_max_out_name = str(hs_clamp_op.outputs[0])
-                    hs_intermediate_names.append(str(hs_max_out_name))
+                    hs_data_idx = int(hs_entry_idx)
+                    hs_mul_out_name = str(hs_entry_op.outputs[0])
 
-                    hs_max_users = [int(v) for v in consumers.get(hs_max_out_name, [])]
-                    if len(hs_max_users) != 1:
+                    hs_mul_users = [int(v) for v in consumers.get(hs_mul_out_name, [])]
+                    if len(hs_mul_users) != 1:
                         return None
-                    hs_min_idx = int(hs_max_users[0])
-                    hs_min_op = model_ir.operators[int(hs_min_idx)]
-                    if str(hs_min_op.op_type) != "MINIMUM" or len(hs_min_op.inputs) != 2 or len(hs_min_op.outputs) != 1:
+                    hs_add_idx = int(hs_mul_users[0])
+                    hs_add_op = model_ir.operators[int(hs_add_idx)]
+                    if str(hs_add_op.op_type) != "ADD" or len(hs_add_op.inputs) != 2 or len(hs_add_op.outputs) != 1:
                         return None
-                    hs_min_inputs = [str(v) for v in list(hs_min_op.inputs)]
-                    if hs_max_out_name == hs_min_inputs[0]:
-                        hs_min_side_name = hs_min_inputs[1]
-                    elif hs_max_out_name == hs_min_inputs[1]:
-                        hs_min_side_name = hs_min_inputs[0]
+                    hs_add_inputs = [str(v) for v in list(hs_add_op.inputs)]
+                    if hs_mul_out_name == hs_add_inputs[0]:
+                        hs_add_side_name = hs_add_inputs[1]
+                    elif hs_mul_out_name == hs_add_inputs[1]:
+                        hs_add_side_name = hs_add_inputs[0]
                     else:
                         return None
-                    if not _is_singleton_constant_tensor(model_ir, hs_min_side_name):
+                    if not _is_singleton_constant_tensor(model_ir, hs_add_side_name):
                         return None
-                    hs_out_name = str(hs_min_op.outputs[0])
+                    hs_add_out_name = str(hs_add_op.outputs[0])
+
+                    hs_add_users = [int(v) for v in consumers.get(hs_add_out_name, [])]
+                    if len(hs_add_users) != 1:
+                        return None
+                    hs_clamp_idx = int(hs_add_users[0])
+                    hs_clamp_op = model_ir.operators[int(hs_clamp_idx)]
+                    hs_intermediate_names = [str(hs_mul_out_name), str(hs_add_out_name)]
+                    if (
+                        str(hs_clamp_op.op_type) == "RELU_0_TO_1"
+                        and len(hs_clamp_op.inputs) == 1
+                        and len(hs_clamp_op.outputs) == 1
+                        and str(hs_clamp_op.inputs[0]) == hs_add_out_name
+                    ):
+                        hs_out_name = str(hs_clamp_op.outputs[0])
+                    else:
+                        if (
+                            str(hs_clamp_op.op_type) != "MAXIMUM"
+                            or len(hs_clamp_op.inputs) != 2
+                            or len(hs_clamp_op.outputs) != 1
+                        ):
+                            return None
+                        hs_max_inputs = [str(v) for v in list(hs_clamp_op.inputs)]
+                        if hs_add_out_name == hs_max_inputs[0]:
+                            hs_max_side_name = hs_max_inputs[1]
+                        elif hs_add_out_name == hs_max_inputs[1]:
+                            hs_max_side_name = hs_max_inputs[0]
+                        else:
+                            return None
+                        if not _is_singleton_constant_tensor(model_ir, hs_max_side_name):
+                            return None
+                        hs_max_out_name = str(hs_clamp_op.outputs[0])
+                        hs_intermediate_names.append(str(hs_max_out_name))
+
+                        hs_max_users = [int(v) for v in consumers.get(hs_max_out_name, [])]
+                        if len(hs_max_users) != 1:
+                            return None
+                        hs_min_idx = int(hs_max_users[0])
+                        hs_min_op = model_ir.operators[int(hs_min_idx)]
+                        if (
+                            str(hs_min_op.op_type) != "MINIMUM"
+                            or len(hs_min_op.inputs) != 2
+                            or len(hs_min_op.outputs) != 1
+                        ):
+                            return None
+                        hs_min_inputs = [str(v) for v in list(hs_min_op.inputs)]
+                        if hs_max_out_name == hs_min_inputs[0]:
+                            hs_min_side_name = hs_min_inputs[1]
+                        elif hs_max_out_name == hs_min_inputs[1]:
+                            hs_min_side_name = hs_min_inputs[0]
+                        else:
+                            return None
+                        if not _is_singleton_constant_tensor(model_ir, hs_min_side_name):
+                            return None
+                        hs_out_name = str(hs_min_op.outputs[0])
+                elif hs_entry_type == "ADD" and len(hs_entry_op.inputs) == 2 and len(hs_entry_op.outputs) == 1:
+                    hs_add_inputs = [str(v) for v in list(hs_entry_op.inputs)]
+                    if pre_output_name == hs_add_inputs[0]:
+                        hs_data_input_index = 0
+                        hs_add_side_name = hs_add_inputs[1]
+                    elif pre_output_name == hs_add_inputs[1]:
+                        hs_data_input_index = 1
+                        hs_add_side_name = hs_add_inputs[0]
+                    else:
+                        return None
+                    if not _is_singleton_constant_tensor(model_ir, hs_add_side_name):
+                        return None
+                    hs_data_idx = int(hs_entry_idx)
+                    hs_add_out_name = str(hs_entry_op.outputs[0])
+                    hs_intermediate_names.append(str(hs_add_out_name))
+
+                    hs_add_users = [int(v) for v in consumers.get(hs_add_out_name, [])]
+                    if len(hs_add_users) != 1:
+                        return None
+                    hs_mul_idx = int(hs_add_users[0])
+                    hs_mul_op = model_ir.operators[int(hs_mul_idx)]
+                    if str(hs_mul_op.op_type) != "MUL" or len(hs_mul_op.inputs) != 2 or len(hs_mul_op.outputs) != 1:
+                        return None
+                    hs_mul_inputs = [str(v) for v in list(hs_mul_op.inputs)]
+                    if hs_add_out_name == hs_mul_inputs[0]:
+                        hs_mul_side_name = hs_mul_inputs[1]
+                    elif hs_add_out_name == hs_mul_inputs[1]:
+                        hs_mul_side_name = hs_mul_inputs[0]
+                    else:
+                        return None
+                    if not _is_singleton_constant_tensor(model_ir, hs_mul_side_name):
+                        return None
+                    hs_out_name = str(hs_mul_op.outputs[0])
+                    hs_intermediate_names.append(str(hs_out_name))
+                else:
+                    return None
+
+                if hs_data_idx is None or hs_data_input_index is None or hs_out_name is None:
+                    return None
 
                 residual_mul_op = model_ir.operators[int(residual_mul_idx)]
                 if (
@@ -6411,6 +6615,7 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
                 post_indices: List[int] = []
                 post_output_names: List[str] = []
                 legacy_users: List[int] = []
+                mean_branches: List[Dict[str, Any]] = []
                 valid_users = True
                 for user_idx in residual_mul_users:
                     user_op = model_ir.operators[int(user_idx)]
@@ -6426,14 +6631,82 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
                             break
                         post_indices.append(int(user_idx))
                         post_output_names.append(str(user_op.outputs[0]))
+                    elif (
+                        str(user_op.op_type) == "MEAN"
+                        and len(user_op.inputs) >= 2
+                        and len(user_op.outputs) == 1
+                        and str(user_op.inputs[0]) == residual_mul_out_name
+                        and bool(user_op.options.get("keepDims", False))
+                    ):
+                        mean_idx = int(user_idx)
+                        mean_axes_name = str(user_op.inputs[1])
+                        mean_axes_tensor = model_ir.tensors.get(mean_axes_name, None)
+                        mean_axes_vals = _read_const_ints_from_tensor(mean_axes_tensor)
+                        if mean_axes_vals is None or len(mean_axes_vals) == 0:
+                            valid_users = False
+                            break
+                        mean_out_name = str(user_op.outputs[0])
+                        if mean_out_name in model_outputs:
+                            valid_users = False
+                            break
+                        mean_users = [int(v) for v in consumers.get(mean_out_name, [])]
+                        if len(mean_users) == 0:
+                            valid_users = False
+                            break
+                        # Keep legacy NCHW adapter path when MEAN branch terminates
+                        # at graph output through a single inverse transpose.
+                        if len(mean_users) == 1:
+                            only_mean_user_op = model_ir.operators[int(mean_users[0])]
+                            if (
+                                str(only_mean_user_op.op_type) == "TRANSPOSE"
+                                and len(only_mean_user_op.inputs) >= 2
+                                and len(only_mean_user_op.outputs) == 1
+                                and str(only_mean_user_op.inputs[0]) == mean_out_name
+                                and _read_transpose_perm(model_ir, only_mean_user_op) == perm_post_expected
+                                and str(only_mean_user_op.outputs[0]) in model_outputs
+                            ):
+                                legacy_users.append(int(mean_idx))
+                                continue
+                        mean_post_indices: List[int] = []
+                        mean_post_output_names: List[str] = []
+                        for mean_user_idx in mean_users:
+                            mean_user_op = model_ir.operators[int(mean_user_idx)]
+                            if (
+                                str(mean_user_op.op_type) != "TRANSPOSE"
+                                or len(mean_user_op.inputs) < 2
+                                or len(mean_user_op.outputs) != 1
+                                or str(mean_user_op.inputs[0]) != mean_out_name
+                            ):
+                                valid_users = False
+                                break
+                            mean_perm_post = _read_transpose_perm(model_ir, mean_user_op)
+                            if mean_perm_post is None or mean_perm_post != perm_post_expected:
+                                valid_users = False
+                                break
+                            mean_post_output_name = str(mean_user_op.outputs[0])
+                            mean_post_indices.append(int(mean_user_idx))
+                            mean_post_output_names.append(mean_post_output_name)
+                        if not valid_users or len(mean_post_indices) == 0:
+                            valid_users = False
+                            break
+                        mean_branches.append(
+                            {
+                                "mean_idx": int(mean_idx),
+                                "mean_axes_name": str(mean_axes_name),
+                                "mean_axes_vals": [int(v) for v in mean_axes_vals],
+                                "mean_out_name": str(mean_out_name),
+                                "mean_post_indices": [int(v) for v in mean_post_indices],
+                                "mean_post_output_names": [str(v) for v in mean_post_output_names],
+                            }
+                        )
                     else:
                         legacy_users.append(int(user_idx))
                 if not valid_users or len(post_indices) == 0:
                     return None
 
                 return {
-                    "hs_mul_idx": int(hs_mul_idx),
-                    "hs_mul_data_input_index": int(hs_mul_data_input_index),
+                    "hs_data_idx": int(hs_data_idx),
+                    "hs_data_input_index": int(hs_data_input_index),
                     "hs_intermediate_names": [str(v) for v in hs_intermediate_names],
                     "residual_mul_idx": int(residual_mul_idx),
                     "residual_mul_data_input_index": int(residual_mul_data_input_index),
@@ -6441,6 +6714,7 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
                     "post_indices": [int(v) for v in post_indices],
                     "post_output_names": [str(v) for v in post_output_names],
                     "legacy_users": [int(v) for v in legacy_users],
+                    "mean_branches": list(mean_branches),
                 }
 
             matched = _try_match_pair(int(pre_users[0]), int(pre_users[1]))
@@ -6449,20 +6723,21 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
             if matched is None:
                 continue
 
-            hs_mul_op = model_ir.operators[int(matched["hs_mul_idx"])]
+            hs_data_op = model_ir.operators[int(matched["hs_data_idx"])]
             residual_mul_op = model_ir.operators[int(matched["residual_mul_idx"])]
             residual_mul_out_name = str(matched["residual_mul_out_name"])
             post_indices = [int(v) for v in list(matched.get("post_indices", []))]
             post_output_names = [str(v) for v in list(matched.get("post_output_names", []))]
             legacy_users = [int(v) for v in list(matched.get("legacy_users", []))]
+            mean_branches = list(matched.get("mean_branches", []))
             if len(post_indices) == 0 or len(post_output_names) == 0:
                 continue
             representative_output_name = str(post_output_names[0])
 
             _replace_operator_input_at(
                 model_ir=model_ir,
-                op=hs_mul_op,
-                input_index=int(matched["hs_mul_data_input_index"]),
+                op=hs_data_op,
+                input_index=int(matched["hs_data_input_index"]),
                 new_input_name=pre_input_name,
             )
             _replace_operator_input_at(
@@ -6495,6 +6770,78 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
                     perm_post_expected,
                 )
 
+            mean_post_remove_indices: List[int] = []
+            mean_rewrite_ok = True
+            for mean_branch in mean_branches:
+                mean_idx = int(mean_branch["mean_idx"])
+                mean_axes_name = str(mean_branch["mean_axes_name"])
+                mean_axes_vals = [int(v) for v in list(mean_branch["mean_axes_vals"])]
+                mean_out_name = str(mean_branch["mean_out_name"])
+                mean_post_indices = [int(v) for v in list(mean_branch["mean_post_indices"])]
+                mean_post_output_names = [str(v) for v in list(mean_branch["mean_post_output_names"])]
+                if len(mean_post_indices) == 0 or len(mean_post_output_names) == 0:
+                    mean_rewrite_ok = False
+                    break
+
+                mapped_axes: List[int] = []
+                valid_axes = True
+                for axis in mean_axes_vals:
+                    a = int(axis)
+                    if a < 0:
+                        a += 4
+                    if a < 0 or a >= 4:
+                        valid_axes = False
+                        break
+                    mapped_axes.append(int(perm_pre[int(a)]))
+                if not valid_axes:
+                    mean_rewrite_ok = False
+                    break
+
+                mean_op = model_ir.operators[int(mean_idx)]
+                mean_axes_tensor = model_ir.tensors.get(mean_axes_name, None)
+                if mean_axes_tensor is None or not _write_const_ints_to_tensor(mean_axes_tensor, mapped_axes):
+                    mean_rewrite_ok = False
+                    break
+
+                mean_inputs = [str(v) for v in list(mean_op.inputs)]
+                if len(mean_inputs) == 0:
+                    mean_rewrite_ok = False
+                    break
+                mean_inputs[0] = representative_output_name
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=mean_op,
+                    new_inputs=mean_inputs,
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(mean_out_name, None),
+                    perm_post_expected,
+                )
+
+                representative_mean_output_name = str(mean_post_output_names[0])
+                _set_operator_outputs(
+                    model_ir=model_ir,
+                    op=mean_op,
+                    new_outputs=[representative_mean_output_name],
+                )
+                for alias_mean_output_name in mean_post_output_names[1:]:
+                    _replace_tensor_inputs(model_ir, alias_mean_output_name, representative_mean_output_name)
+
+                old_mean_tensor = model_ir.tensors.get(mean_out_name, None)
+                representative_mean_tensor = model_ir.tensors.get(representative_mean_output_name, None)
+                if representative_mean_tensor is not None and old_mean_tensor is not None:
+                    representative_mean_tensor.dtype = str(old_mean_tensor.dtype)
+                    representative_mean_tensor.quantization = _clone_quantization(old_mean_tensor.quantization)
+                    _permute_tensor_metadata_if_rank_matches(
+                        representative_mean_tensor,
+                        perm_post_expected,
+                    )
+
+                mean_post_remove_indices.extend(int(v) for v in mean_post_indices)
+
+            if not mean_rewrite_ok:
+                continue
+
             preserve_nchw_adapter = len(legacy_users) > 0 or residual_mul_out_name in model_ir.outputs
             if preserve_nchw_adapter:
                 keep_post_idx = int(post_indices[0])
@@ -6517,7 +6864,10 @@ def _optimize_hardsigmoid_mul_transpose_passthrough_chains(model_ir: ModelIR) ->
             else:
                 post_remove_indices = [int(v) for v in post_indices]
 
-            remove_indices = sorted(list({int(pre_idx), *post_remove_indices}), reverse=True)
+            remove_indices = sorted(
+                list({int(pre_idx), *post_remove_indices, *[int(v) for v in mean_post_remove_indices]}),
+                reverse=True,
+            )
             for remove_idx in remove_indices:
                 del model_ir.operators[int(remove_idx)]
 
@@ -6716,6 +7066,323 @@ def _optimize_hardsigmoid_transpose_passthrough_chains(model_ir: ModelIR) -> Dic
 
     _prune_unused_tensors(model_ir)
     return {"rewritten_hardsigmoid_transpose_passthrough_chains": int(rewritten)}
+
+
+def _optimize_transpose_hardswish_se_conv_hardsigmoid_mul_prepost_nhwc_chains(
+    model_ir: ModelIR,
+) -> Dict[str, int]:
+    """
+    Remove NCHW bridge transposes in HARD_SWISH + SE-conv + HardSigmoid gating blocks.
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for pre_idx, pre_op in enumerate(model_ir.operators):
+            if str(pre_op.op_type) != "TRANSPOSE" or len(pre_op.inputs) < 2 or len(pre_op.outputs) != 1:
+                continue
+            if _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw:
+                continue
+
+            pre_input_name = str(pre_op.inputs[0])
+            pre_output_name = str(pre_op.outputs[0])
+            if pre_output_name in model_outputs:
+                continue
+
+            pre_users = [int(v) for v in consumers.get(pre_output_name, [])]
+            if len(pre_users) != 1:
+                continue
+            hsw_idx = int(pre_users[0])
+            hsw_op = model_ir.operators[int(hsw_idx)]
+            if (
+                str(hsw_op.op_type) != "HARD_SWISH"
+                or len(hsw_op.inputs) != 1
+                or len(hsw_op.outputs) != 1
+                or str(hsw_op.inputs[0]) != pre_output_name
+            ):
+                continue
+            hsw_out_name = str(hsw_op.outputs[0])
+            if hsw_out_name in model_outputs:
+                continue
+
+            hsw_users = [int(v) for v in consumers.get(hsw_out_name, [])]
+            if len(hsw_users) != 2:
+                continue
+
+            mean_idx: Optional[int] = None
+            residual_mul_idx: Optional[int] = None
+            for user_idx in hsw_users:
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) == "MEAN"
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == hsw_out_name
+                    and bool(user_op.options.get("keepDims", False))
+                ):
+                    mean_idx = int(user_idx)
+                elif (
+                    str(user_op.op_type) == "MUL"
+                    and len(user_op.inputs) == 2
+                    and len(user_op.outputs) == 1
+                    and hsw_out_name in {str(v) for v in list(user_op.inputs)}
+                ):
+                    residual_mul_idx = int(user_idx)
+            if mean_idx is None or residual_mul_idx is None:
+                continue
+
+            mean_op = model_ir.operators[int(mean_idx)]
+            mean_axes_name = str(mean_op.inputs[1])
+            mean_axes_tensor = model_ir.tensors.get(mean_axes_name, None)
+            mean_axes_vals = _read_const_ints_from_tensor(mean_axes_tensor)
+            if mean_axes_vals is None or len(mean_axes_vals) == 0:
+                continue
+            mean_out_name = str(mean_op.outputs[0])
+            if mean_out_name in model_outputs:
+                continue
+
+            mean_users = [int(v) for v in consumers.get(mean_out_name, [])]
+            if len(mean_users) != 1:
+                continue
+            post_mean_idx = int(mean_users[0])
+            post_mean_op = model_ir.operators[int(post_mean_idx)]
+            if (
+                str(post_mean_op.op_type) != "TRANSPOSE"
+                or len(post_mean_op.inputs) < 2
+                or len(post_mean_op.outputs) != 1
+                or str(post_mean_op.inputs[0]) != mean_out_name
+                or _read_transpose_perm(model_ir, post_mean_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            post_mean_out_name = str(post_mean_op.outputs[0])
+            if post_mean_out_name in model_outputs:
+                continue
+
+            post_mean_users = [int(v) for v in consumers.get(post_mean_out_name, [])]
+            if len(post_mean_users) != 1:
+                continue
+            conv1_idx = int(post_mean_users[0])
+            conv1_op = model_ir.operators[int(conv1_idx)]
+            if (
+                str(conv1_op.op_type) != "CONV_2D"
+                or len(conv1_op.inputs) < 1
+                or len(conv1_op.outputs) != 1
+                or str(conv1_op.inputs[0]) != post_mean_out_name
+            ):
+                continue
+            conv1_out_name = str(conv1_op.outputs[0])
+
+            conv1_users = [int(v) for v in consumers.get(conv1_out_name, [])]
+            if len(conv1_users) != 1:
+                continue
+            conv2_idx = int(conv1_users[0])
+            conv2_op = model_ir.operators[int(conv2_idx)]
+            if (
+                str(conv2_op.op_type) != "CONV_2D"
+                or len(conv2_op.inputs) < 1
+                or len(conv2_op.outputs) != 1
+                or str(conv2_op.inputs[0]) != conv1_out_name
+            ):
+                continue
+            conv2_out_name = str(conv2_op.outputs[0])
+
+            conv2_users = [int(v) for v in consumers.get(conv2_out_name, [])]
+            if len(conv2_users) != 1:
+                continue
+            pre_gate_idx = int(conv2_users[0])
+            pre_gate_op = model_ir.operators[int(pre_gate_idx)]
+            if (
+                str(pre_gate_op.op_type) != "TRANSPOSE"
+                or len(pre_gate_op.inputs) < 2
+                or len(pre_gate_op.outputs) != 1
+                or str(pre_gate_op.inputs[0]) != conv2_out_name
+                or _read_transpose_perm(model_ir, pre_gate_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            pre_gate_out_name = str(pre_gate_op.outputs[0])
+
+            pre_gate_users = [int(v) for v in consumers.get(pre_gate_out_name, [])]
+            if len(pre_gate_users) != 1:
+                continue
+            hs_mul_idx = int(pre_gate_users[0])
+            hs_mul_op = model_ir.operators[int(hs_mul_idx)]
+            if str(hs_mul_op.op_type) != "MUL" or len(hs_mul_op.inputs) != 2 or len(hs_mul_op.outputs) != 1:
+                continue
+            hs_mul_inputs = [str(v) for v in list(hs_mul_op.inputs)]
+            if pre_gate_out_name == hs_mul_inputs[0]:
+                hs_mul_data_input_index = 0
+                hs_mul_side_name = hs_mul_inputs[1]
+            elif pre_gate_out_name == hs_mul_inputs[1]:
+                hs_mul_data_input_index = 1
+                hs_mul_side_name = hs_mul_inputs[0]
+            else:
+                continue
+            if not _is_singleton_constant_tensor(model_ir, hs_mul_side_name):
+                continue
+            hs_mul_out_name = str(hs_mul_op.outputs[0])
+
+            hs_mul_users = [int(v) for v in consumers.get(hs_mul_out_name, [])]
+            if len(hs_mul_users) != 1:
+                continue
+            hs_add_idx = int(hs_mul_users[0])
+            hs_add_op = model_ir.operators[int(hs_add_idx)]
+            if str(hs_add_op.op_type) != "ADD" or len(hs_add_op.inputs) != 2 or len(hs_add_op.outputs) != 1:
+                continue
+            hs_add_inputs = [str(v) for v in list(hs_add_op.inputs)]
+            if hs_mul_out_name == hs_add_inputs[0]:
+                hs_add_side_name = hs_add_inputs[1]
+            elif hs_mul_out_name == hs_add_inputs[1]:
+                hs_add_side_name = hs_add_inputs[0]
+            else:
+                continue
+            if not _is_singleton_constant_tensor(model_ir, hs_add_side_name):
+                continue
+            hs_add_out_name = str(hs_add_op.outputs[0])
+
+            hs_add_users = [int(v) for v in consumers.get(hs_add_out_name, [])]
+            if len(hs_add_users) != 1:
+                continue
+            hs_relu_idx = int(hs_add_users[0])
+            hs_relu_op = model_ir.operators[int(hs_relu_idx)]
+            if (
+                str(hs_relu_op.op_type) != "RELU_0_TO_1"
+                or len(hs_relu_op.inputs) != 1
+                or len(hs_relu_op.outputs) != 1
+                or str(hs_relu_op.inputs[0]) != hs_add_out_name
+            ):
+                continue
+            hs_out_name = str(hs_relu_op.outputs[0])
+
+            residual_mul_op = model_ir.operators[int(residual_mul_idx)]
+            residual_inputs = [str(v) for v in list(residual_mul_op.inputs)]
+            if not (
+                (residual_inputs[0] == hsw_out_name and residual_inputs[1] == hs_out_name)
+                or (residual_inputs[1] == hsw_out_name and residual_inputs[0] == hs_out_name)
+            ):
+                continue
+            residual_out_name = str(residual_mul_op.outputs[0])
+            if residual_out_name in model_outputs:
+                continue
+
+            residual_users = [int(v) for v in consumers.get(residual_out_name, [])]
+            if len(residual_users) != 1:
+                continue
+            post_idx = int(residual_users[0])
+            post_op = model_ir.operators[int(post_idx)]
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or str(post_op.inputs[0]) != residual_out_name
+                or _read_transpose_perm(model_ir, post_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            post_output_name = str(post_op.outputs[0])
+
+            mapped_axes: List[int] = []
+            valid_axes = True
+            for axis in mean_axes_vals:
+                a = int(axis)
+                if a < 0:
+                    a += 4
+                if a < 0 or a >= 4:
+                    valid_axes = False
+                    break
+                mapped_axes.append(int(perm_nhwc_to_nchw[int(a)]))
+            if not valid_axes:
+                continue
+            if mean_axes_tensor is None or not _write_const_ints_to_tensor(mean_axes_tensor, mapped_axes):
+                continue
+
+            _set_operator_inputs(model_ir=model_ir, op=hsw_op, new_inputs=[pre_input_name])
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(hsw_out_name, None),
+                perm_nchw_to_nhwc,
+            )
+
+            mean_inputs = [str(v) for v in list(mean_op.inputs)]
+            mean_inputs[0] = hsw_out_name
+            _set_operator_inputs(model_ir=model_ir, op=mean_op, new_inputs=mean_inputs)
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(mean_out_name, None),
+                perm_nchw_to_nhwc,
+            )
+
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=mean_op,
+                new_outputs=[post_mean_out_name],
+            )
+            old_mean_tensor = model_ir.tensors.get(mean_out_name, None)
+            post_mean_tensor = model_ir.tensors.get(post_mean_out_name, None)
+            if post_mean_tensor is not None and old_mean_tensor is not None:
+                post_mean_tensor.dtype = str(old_mean_tensor.dtype)
+                post_mean_tensor.quantization = _clone_quantization(old_mean_tensor.quantization)
+                post_mean_tensor.shape = [int(v) for v in list(old_mean_tensor.shape)]
+                post_mean_tensor.shape_signature = (
+                    [int(v) for v in list(old_mean_tensor.shape_signature)]
+                    if old_mean_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_mean_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    post_mean_tensor,
+                    perm_nchw_to_nhwc,
+                )
+
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=hs_mul_op,
+                input_index=int(hs_mul_data_input_index),
+                new_input_name=conv2_out_name,
+            )
+            for name in [hs_mul_out_name, hs_add_out_name, hs_out_name]:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(name, None),
+                    perm_nchw_to_nhwc,
+                )
+
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=residual_mul_op,
+                new_outputs=[post_output_name],
+            )
+            old_residual_tensor = model_ir.tensors.get(residual_out_name, None)
+            post_output_tensor = model_ir.tensors.get(post_output_name, None)
+            if post_output_tensor is not None and old_residual_tensor is not None:
+                post_output_tensor.dtype = str(old_residual_tensor.dtype)
+                post_output_tensor.quantization = _clone_quantization(old_residual_tensor.quantization)
+                post_output_tensor.shape = [int(v) for v in list(old_residual_tensor.shape)]
+                post_output_tensor.shape_signature = (
+                    [int(v) for v in list(old_residual_tensor.shape_signature)]
+                    if old_residual_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_residual_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    post_output_tensor,
+                    perm_nchw_to_nhwc,
+                )
+
+            remove_indices = sorted(
+                list({int(pre_idx), int(post_mean_idx), int(pre_gate_idx), int(post_idx)}),
+                reverse=True,
+            )
+            for remove_idx in remove_indices:
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_hardswish_se_conv_hardsigmoid_mul_prepost_nhwc_chains": int(rewritten)}
 
 
 def _optimize_transpose_pad_prepost_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -14127,6 +14794,18 @@ def _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir:
     Rewrite:
       x_nhwc --UNARY(1-input)-> u_nhwc
       u_nhwc --RESHAPE([N,HW,C])--> z
+
+    Extended (pseudo-unary Swish):
+      x_nhwc --TRANSPOSE(0,3,1,2)--> x_nchw
+      s_nchw = LOGISTIC(x_nchw)
+      y_nchw = MUL(x_nchw, s_nchw)
+      y_nchw --RESHAPE([N,C,HW])--> r
+      r --TRANSPOSE([0,2,1])--> z
+
+    Rewrite:
+      s_nhwc = LOGISTIC(x_nhwc)
+      y_nhwc = MUL(x_nhwc, s_nhwc)
+      y_nhwc --RESHAPE([N,HW,C])--> z
     """
     rewritten = 0
     perm_nhwc_to_nchw = [0, 3, 1, 2]
@@ -14212,15 +14891,59 @@ def _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir:
             if unary_idx is None:
                 continue
             unary_op = model_ir.operators[int(unary_idx)]
+            rewrite_kind = ""
+            swish_log_idx: Optional[int] = None
+            swish_log_op: Optional[OperatorIR] = None
+            swish_log_out_name = ""
+            swish_mul_data_input_index: Optional[int] = None
+
             if (
-                str(unary_op.op_type) not in unary_ops
-                or len(unary_op.inputs) != 1
-                or len(unary_op.outputs) != 1
-                or str(unary_op.outputs[0]) != reshape_in_name
+                str(unary_op.op_type) in unary_ops
+                and len(unary_op.inputs) == 1
+                and len(unary_op.outputs) == 1
+                and str(unary_op.outputs[0]) == reshape_in_name
             ):
+                rewrite_kind = "unary"
+                pre_out_name = str(unary_op.inputs[0])
+            elif (
+                str(unary_op.op_type) == "MUL"
+                and len(unary_op.inputs) == 2
+                and len(unary_op.outputs) == 1
+                and str(unary_op.outputs[0]) == reshape_in_name
+            ):
+                mul_inputs = [str(v) for v in unary_op.inputs]
+                for log_input_index in [0, 1]:
+                    data_input_index = 1 - int(log_input_index)
+                    candidate_log_out_name = str(mul_inputs[log_input_index])
+                    candidate_pre_out_name = str(mul_inputs[data_input_index])
+                    candidate_log_idx = producers.get(candidate_log_out_name, None)
+                    if candidate_log_idx is None:
+                        continue
+                    candidate_log_op = model_ir.operators[int(candidate_log_idx)]
+                    if (
+                        str(candidate_log_op.op_type) != "LOGISTIC"
+                        or len(candidate_log_op.inputs) != 1
+                        or len(candidate_log_op.outputs) != 1
+                        or str(candidate_log_op.outputs[0]) != candidate_log_out_name
+                        or str(candidate_log_op.inputs[0]) != candidate_pre_out_name
+                    ):
+                        continue
+                    candidate_log_users = [int(v) for v in consumers.get(candidate_log_out_name, [])]
+                    if set(candidate_log_users) != {int(unary_idx)}:
+                        continue
+                    rewrite_kind = "swish"
+                    pre_out_name = candidate_pre_out_name
+                    swish_log_idx = int(candidate_log_idx)
+                    swish_log_op = candidate_log_op
+                    swish_log_out_name = candidate_log_out_name
+                    swish_mul_data_input_index = int(data_input_index)
+                    break
+            else:
                 continue
 
-            pre_out_name = str(unary_op.inputs[0])
+            if rewrite_kind == "":
+                continue
+
             pre_idx = producers.get(pre_out_name, None)
             if pre_idx is None:
                 continue
@@ -14242,7 +14965,18 @@ def _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir:
             ):
                 continue
 
-            if set(int(v) for v in consumers.get(pre_out_name, [])) != {int(unary_idx)}:
+            if rewrite_kind == "unary":
+                if set(int(v) for v in consumers.get(pre_out_name, [])) != {int(unary_idx)}:
+                    continue
+            elif rewrite_kind == "swish":
+                expected_pre_users = {int(unary_idx), int(swish_log_idx)} if swish_log_idx is not None else {int(unary_idx)}
+                if set(int(v) for v in consumers.get(pre_out_name, [])) != expected_pre_users:
+                    continue
+                if swish_log_out_name == "":
+                    continue
+                if set(int(v) for v in consumers.get(swish_log_out_name, [])) != {int(unary_idx)}:
+                    continue
+            else:
                 continue
             if set(int(v) for v in consumers.get(reshape_in_name, [])) != {int(reshape_idx)}:
                 continue
@@ -14252,11 +14986,31 @@ def _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir:
             if not shape_changed and not opts_changed:
                 continue
 
-            _set_operator_inputs(
-                model_ir=model_ir,
-                op=unary_op,
-                new_inputs=[pre_in_name],
-            )
+            if rewrite_kind == "unary":
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=unary_op,
+                    new_inputs=[pre_in_name],
+                )
+            else:
+                if swish_log_op is None or swish_mul_data_input_index is None:
+                    continue
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=swish_log_op,
+                    new_inputs=[pre_in_name],
+                )
+                _replace_operator_input_at(
+                    model_ir=model_ir,
+                    op=unary_op,
+                    input_index=int(swish_mul_data_input_index),
+                    new_input_name=pre_in_name,
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(swish_log_out_name, None),
+                    perm_nchw_to_nhwc,
+                )
+
             _permute_tensor_metadata_if_rank_matches(
                 model_ir.tensors.get(reshape_in_name, None),
                 perm_nchw_to_nhwc,
@@ -14296,6 +15050,272 @@ def _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir:
 
     _prune_unused_tensors(model_ir)
     return {"optimized_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains": int(rewritten)}
+
+
+def _optimize_transpose_pre_unary_squeeze_transpose_suffix_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate NHWC->NCHW unary/Swish wrappers that feed SQUEEZE + [0,2,1] transpose suffix.
+
+    Target:
+      x_nhwc --TRANSPOSE(0,3,1,2)--> x_nchw
+      x_nchw --(UNARY | Swish(LOGISTIC+MUL))-> y_nchw
+      y_nchw --SQUEEZE(axis in {2,3})--> s
+      s --TRANSPOSE([0,2,1])--> z
+
+    Rewrite:
+      x_nhwc --(same UNARY/Swish)-> y_nhwc
+      y_nhwc --SQUEEZE(mapped axis)-> z
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    perm_3d_nchw_to_nhwc = [0, 2, 1]
+    unary_ops = {
+        "RELU",
+        "RELU6",
+        "LEAKY_RELU",
+        "LOGISTIC",
+        "TANH",
+        "ABS",
+        "NEG",
+        "SQRT",
+        "EXP",
+        "CAST",
+        "FLOOR",
+        "CEIL",
+        "ROUND",
+    }
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        producers = _build_tensor_producer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for squeeze_idx, squeeze_op in enumerate(model_ir.operators):
+            if str(squeeze_op.op_type) != "SQUEEZE" or len(squeeze_op.inputs) != 1 or len(squeeze_op.outputs) != 1:
+                continue
+
+            squeeze_in_name = str(squeeze_op.inputs[0])
+            squeeze_out_name = str(squeeze_op.outputs[0])
+            if squeeze_in_name in model_outputs or squeeze_out_name in model_outputs:
+                continue
+
+            squeeze_users = [int(v) for v in consumers.get(squeeze_out_name, [])]
+            if len(squeeze_users) != 1:
+                continue
+            post_idx = int(squeeze_users[0])
+            post_op = model_ir.operators[int(post_idx)]
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or str(post_op.inputs[0]) != squeeze_out_name
+                or _read_transpose_perm(model_ir, post_op) != perm_3d_nchw_to_nhwc
+            ):
+                continue
+            post_out_name = str(post_op.outputs[0])
+
+            unary_idx = producers.get(squeeze_in_name, None)
+            if unary_idx is None:
+                continue
+            unary_op = model_ir.operators[int(unary_idx)]
+
+            rewrite_kind = ""
+            swish_log_idx: Optional[int] = None
+            swish_log_op: Optional[OperatorIR] = None
+            swish_log_out_name = ""
+            swish_mul_data_input_index: Optional[int] = None
+
+            if (
+                str(unary_op.op_type) in unary_ops
+                and len(unary_op.inputs) == 1
+                and len(unary_op.outputs) == 1
+                and str(unary_op.outputs[0]) == squeeze_in_name
+            ):
+                rewrite_kind = "unary"
+                pre_out_name = str(unary_op.inputs[0])
+            elif (
+                str(unary_op.op_type) == "MUL"
+                and len(unary_op.inputs) == 2
+                and len(unary_op.outputs) == 1
+                and str(unary_op.outputs[0]) == squeeze_in_name
+            ):
+                mul_inputs = [str(v) for v in unary_op.inputs]
+                for log_input_index in [0, 1]:
+                    data_input_index = 1 - int(log_input_index)
+                    candidate_log_out_name = str(mul_inputs[log_input_index])
+                    candidate_pre_out_name = str(mul_inputs[data_input_index])
+                    candidate_log_idx = producers.get(candidate_log_out_name, None)
+                    if candidate_log_idx is None:
+                        continue
+                    candidate_log_op = model_ir.operators[int(candidate_log_idx)]
+                    if (
+                        str(candidate_log_op.op_type) != "LOGISTIC"
+                        or len(candidate_log_op.inputs) != 1
+                        or len(candidate_log_op.outputs) != 1
+                        or str(candidate_log_op.outputs[0]) != candidate_log_out_name
+                        or str(candidate_log_op.inputs[0]) != candidate_pre_out_name
+                    ):
+                        continue
+                    if set(int(v) for v in consumers.get(candidate_log_out_name, [])) != {int(unary_idx)}:
+                        continue
+                    rewrite_kind = "swish"
+                    pre_out_name = candidate_pre_out_name
+                    swish_log_idx = int(candidate_log_idx)
+                    swish_log_op = candidate_log_op
+                    swish_log_out_name = candidate_log_out_name
+                    swish_mul_data_input_index = int(data_input_index)
+                    break
+            else:
+                continue
+
+            if rewrite_kind == "":
+                continue
+
+            pre_idx = producers.get(pre_out_name, None)
+            if pre_idx is None:
+                continue
+            pre_op = model_ir.operators[int(pre_idx)]
+            if (
+                str(pre_op.op_type) != "TRANSPOSE"
+                or len(pre_op.inputs) < 2
+                or len(pre_op.outputs) != 1
+                or str(pre_op.outputs[0]) != pre_out_name
+                or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            pre_in_name = str(pre_op.inputs[0])
+            if pre_in_name in model_outputs or pre_out_name in model_outputs:
+                continue
+
+            if rewrite_kind == "unary":
+                if set(int(v) for v in consumers.get(pre_out_name, [])) != {int(unary_idx)}:
+                    continue
+            elif rewrite_kind == "swish":
+                expected_pre_users = {int(unary_idx), int(swish_log_idx)} if swish_log_idx is not None else {int(unary_idx)}
+                if set(int(v) for v in consumers.get(pre_out_name, [])) != expected_pre_users:
+                    continue
+                if swish_log_out_name == "":
+                    continue
+                if set(int(v) for v in consumers.get(swish_log_out_name, [])) != {int(unary_idx)}:
+                    continue
+            else:
+                continue
+
+            if set(int(v) for v in consumers.get(squeeze_in_name, [])) != {int(squeeze_idx)}:
+                continue
+            if set(int(v) for v in consumers.get(squeeze_out_name, [])) != {int(post_idx)}:
+                continue
+
+            squeeze_in_tensor = model_ir.tensors.get(squeeze_in_name, None)
+            squeeze_out_tensor = model_ir.tensors.get(squeeze_out_name, None)
+            if (
+                squeeze_in_tensor is None
+                or squeeze_out_tensor is None
+                or not _is_fully_known_positive_shape(squeeze_in_tensor.shape)
+                or not _is_fully_known_positive_shape(squeeze_out_tensor.shape)
+            ):
+                continue
+            squeeze_in_shape = [int(v) for v in list(squeeze_in_tensor.shape)]
+            squeeze_out_shape = [int(v) for v in list(squeeze_out_tensor.shape)]
+            if len(squeeze_in_shape) != 4 or len(squeeze_out_shape) != 3:
+                continue
+
+            squeeze_axis_candidates: List[int] = []
+            for axis in range(4):
+                if int(squeeze_in_shape[axis]) != 1:
+                    continue
+                candidate_out_shape = [int(v) for i, v in enumerate(squeeze_in_shape) if int(i) != int(axis)]
+                if candidate_out_shape == squeeze_out_shape:
+                    squeeze_axis_candidates.append(int(axis))
+            if len(squeeze_axis_candidates) != 1:
+                continue
+
+            squeeze_axis_nchw = int(squeeze_axis_candidates[0])
+            if squeeze_axis_nchw == 2:
+                squeeze_axis_nhwc = 1
+            elif squeeze_axis_nchw == 3:
+                squeeze_axis_nhwc = 2
+            else:
+                continue
+
+            squeeze_in_shape_nhwc = _permute_shape(squeeze_in_shape, perm_nchw_to_nhwc)
+            if (
+                squeeze_in_shape_nhwc is None
+                or len(squeeze_in_shape_nhwc) != 4
+                or int(squeeze_in_shape_nhwc[squeeze_axis_nhwc]) != 1
+            ):
+                continue
+
+            if rewrite_kind == "unary":
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=unary_op,
+                    new_inputs=[pre_in_name],
+                )
+            else:
+                if swish_log_op is None or swish_mul_data_input_index is None:
+                    continue
+                _set_operator_inputs(
+                    model_ir=model_ir,
+                    op=swish_log_op,
+                    new_inputs=[pre_in_name],
+                )
+                _replace_operator_input_at(
+                    model_ir=model_ir,
+                    op=unary_op,
+                    input_index=int(swish_mul_data_input_index),
+                    new_input_name=pre_in_name,
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(swish_log_out_name, None),
+                    perm_nchw_to_nhwc,
+                )
+
+            _permute_tensor_metadata_if_rank_matches(
+                model_ir.tensors.get(squeeze_in_name, None),
+                perm_nchw_to_nhwc,
+            )
+
+            squeeze_options = dict(squeeze_op.options) if isinstance(squeeze_op.options, dict) else {}
+            squeeze_options["squeezeDims"] = [int(squeeze_axis_nhwc)]
+            squeeze_op.options = squeeze_options
+
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=squeeze_op,
+                new_outputs=[post_out_name],
+            )
+
+            old_squeeze_out_tensor = model_ir.tensors.get(squeeze_out_name, None)
+            canonical_tensor = model_ir.tensors.get(post_out_name, None)
+            if old_squeeze_out_tensor is not None and canonical_tensor is not None:
+                canonical_tensor.dtype = str(old_squeeze_out_tensor.dtype)
+                canonical_tensor.quantization = _clone_quantization(old_squeeze_out_tensor.quantization)
+                canonical_tensor.shape = [int(v) for v in list(old_squeeze_out_tensor.shape)]
+                canonical_tensor.shape_signature = (
+                    [int(v) for v in list(old_squeeze_out_tensor.shape_signature)]
+                    if old_squeeze_out_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_squeeze_out_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    canonical_tensor,
+                    perm_3d_nchw_to_nhwc,
+                )
+
+            for remove_idx in sorted([int(pre_idx), int(post_idx)], reverse=True):
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_pre_unary_squeeze_transpose_suffix_nhwc_chains": int(rewritten)}
 
 
 def _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -18247,6 +19267,227 @@ def _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir: ModelIR) 
 
     _prune_unused_tensors(model_ir)
     return {"optimized_transpose_mean_prepost_nhwc_passthrough_chains": int(rewritten)}
+
+
+def _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Eliminate terminal NHWC->NCHW adapters before unary/MEAN suffixes.
+
+    Target (strict chain):
+      x_nhwc --TRANSPOSE(0,3,1,2)--> x_nchw
+      x_nchw --(UNARY)*--> u_nchw
+      u_nchw --MEAN(axes_nchw, keepDims=True)--> m_nchw
+      m_nchw --RESHAPE--> y
+
+    Rewrite:
+      x_nhwc --(same UNARY)*--> u_nhwc
+      u_nhwc --MEAN(axes_nhwc, keepDims=True)--> m_nhwc
+      m_nhwc --(same RESHAPE)--> y
+
+    Safety:
+    - Pre-transpose direction is canonical NHWC->NCHW.
+    - Unary chain is linear and layout-agnostic.
+    - MEAN rank is 4 with constant axes.
+    - Skip chains already handled by pre/post MEAN transpose elimination.
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    unary_passthrough_ops = {
+        "RELU",
+        "RELU6",
+        "RELU_0_TO_1",
+        "HARD_SWISH",
+        "LEAKY_RELU",
+        "LOGISTIC",
+        "TANH",
+        "GELU",
+        "ABS",
+        "NEG",
+        "SQRT",
+        "EXP",
+        "FLOOR",
+        "CEIL",
+    }
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for pre_idx, pre_op in enumerate(model_ir.operators):
+            if str(pre_op.op_type) != "TRANSPOSE" or len(pre_op.inputs) < 2 or len(pre_op.outputs) != 1:
+                continue
+            if _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw:
+                continue
+
+            pre_input_name = str(pre_op.inputs[0])
+            pre_output_name = str(pre_op.outputs[0])
+            if pre_output_name in model_outputs:
+                continue
+
+            pre_users = [int(v) for v in consumers.get(pre_output_name, [])]
+            if len(pre_users) == 0:
+                continue
+
+            for first_user_idx in pre_users:
+                first_user_op = model_ir.operators[int(first_user_idx)]
+                first_user_type = str(first_user_op.op_type)
+                if (
+                    first_user_type != "MEAN"
+                    and first_user_type not in unary_passthrough_ops
+                ):
+                    continue
+
+                unary_chain_indices: List[int] = []
+                unary_chain_ops: List[OperatorIR] = []
+                current_tensor_name = pre_output_name
+                current_op_idx = int(first_user_idx)
+                mean_idx: Optional[int] = None
+                valid_path = True
+
+                while True:
+                    current_op = model_ir.operators[int(current_op_idx)]
+                    current_type = str(current_op.op_type)
+                    if current_type in unary_passthrough_ops:
+                        if len(current_op.inputs) != 1 or len(current_op.outputs) != 1:
+                            valid_path = False
+                            break
+                        if str(current_op.inputs[0]) != current_tensor_name:
+                            valid_path = False
+                            break
+                        unary_out_name = str(current_op.outputs[0])
+                        if unary_out_name in model_outputs:
+                            valid_path = False
+                            break
+                        unary_users = [int(v) for v in consumers.get(unary_out_name, [])]
+                        if len(unary_users) != 1:
+                            valid_path = False
+                            break
+                        unary_chain_indices.append(int(current_op_idx))
+                        unary_chain_ops.append(current_op)
+                        current_tensor_name = unary_out_name
+                        current_op_idx = int(unary_users[0])
+                        continue
+                    if current_type == "MEAN":
+                        mean_idx = int(current_op_idx)
+                        break
+                    valid_path = False
+                    break
+                if not valid_path or mean_idx is None:
+                    continue
+
+                mean_op = model_ir.operators[int(mean_idx)]
+                if len(mean_op.inputs) < 2 or len(mean_op.outputs) != 1:
+                    continue
+                if str(mean_op.inputs[0]) != current_tensor_name:
+                    continue
+                if not bool(mean_op.options.get("keepDims", False)):
+                    continue
+
+                rank = 4
+                pre_input_tensor = model_ir.tensors.get(pre_input_name, None)
+                if (
+                    pre_input_tensor is not None
+                    and pre_input_tensor.shape is not None
+                    and len(pre_input_tensor.shape) > 0
+                ):
+                    rank = int(len(list(pre_input_tensor.shape)))
+                if rank != 4:
+                    continue
+
+                mean_axes_name = str(mean_op.inputs[1])
+                mean_axes_tensor = model_ir.tensors.get(mean_axes_name, None)
+                mean_axes = _read_const_ints_from_tensor(mean_axes_tensor)
+                if mean_axes is None or len(mean_axes) == 0:
+                    continue
+
+                normalized_axes: List[int] = []
+                valid_axes = True
+                for axis in mean_axes:
+                    a = int(axis)
+                    if a < 0:
+                        a += int(rank)
+                    if a < 0 or a >= int(rank):
+                        valid_axes = False
+                        break
+                    normalized_axes.append(int(a))
+                if not valid_axes:
+                    continue
+                mapped_axes = [int(perm_nhwc_to_nchw[int(axis)]) for axis in normalized_axes]
+
+                mean_out_name = str(mean_op.outputs[0])
+                mean_users = [int(v) for v in consumers.get(mean_out_name, [])]
+                if len(mean_users) != 1:
+                    continue
+
+                tail_idx = int(mean_users[0])
+                tail_op = model_ir.operators[int(tail_idx)]
+                tail_type = str(tail_op.op_type)
+                if (
+                    tail_type == "TRANSPOSE"
+                    and len(tail_op.inputs) >= 2
+                    and len(tail_op.outputs) == 1
+                    and str(tail_op.inputs[0]) == mean_out_name
+                    and _read_transpose_perm(model_ir, tail_op) == perm_nchw_to_nhwc
+                ):
+                    # Leave paired pre/post transpose chains to dedicated rewrite.
+                    continue
+                if tail_type != "RESHAPE":
+                    continue
+                if len(tail_op.inputs) < 2 or len(tail_op.outputs) != 1:
+                    continue
+                if str(tail_op.inputs[0]) != mean_out_name:
+                    continue
+                if _read_const_ints_from_tensor(model_ir.tensors.get(str(tail_op.inputs[1]), None)) is None:
+                    continue
+
+                _write_const_ints_to_tensor(mean_axes_tensor, [int(v) for v in mapped_axes])
+
+                if len(unary_chain_ops) > 0:
+                    _set_operator_inputs(
+                        model_ir=model_ir,
+                        op=unary_chain_ops[0],
+                        new_inputs=[pre_input_name],
+                    )
+                    for unary_op in unary_chain_ops:
+                        _permute_tensor_metadata_if_rank_matches(
+                            model_ir.tensors.get(str(unary_op.outputs[0]), None),
+                            perm_nchw_to_nhwc,
+                        )
+                else:
+                    mean_inputs = [str(v) for v in list(mean_op.inputs)]
+                    mean_inputs[0] = pre_input_name
+                    _set_operator_inputs(
+                        model_ir=model_ir,
+                        op=mean_op,
+                        new_inputs=mean_inputs,
+                    )
+
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(mean_out_name, None),
+                    perm_nchw_to_nhwc,
+                )
+
+                pre_remaining_users = [int(v) for v in pre_users if int(v) != int(first_user_idx)]
+                remove_indices: List[int] = []
+                if len(pre_remaining_users) == 0:
+                    remove_indices.append(int(pre_idx))
+                for remove_idx in sorted(remove_indices, reverse=True):
+                    del model_ir.operators[int(remove_idx)]
+
+                rewritten += 1
+                changed = True
+                break
+
+            if changed:
+                break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_pre_unary_mean_terminal_nhwc_chains": int(rewritten)}
 
 
 def _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir: ModelIR) -> Dict[str, int]:
@@ -27557,6 +28798,7 @@ def _optimize_transpose_unary_passthrough_chains(model_ir: ModelIR) -> Dict[str,
     - Only layout-agnostic unary ops are allowed.
     """
     rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
     unary_passthrough_ops = {
         "RELU",
         "RELU6",
@@ -27591,6 +28833,10 @@ def _optimize_transpose_unary_passthrough_chains(model_ir: ModelIR) -> Dict[str,
 
             perm_pre = _read_transpose_perm(model_ir, pre_op)
             if perm_pre is None:
+                continue
+            # Only fold the canonical NHWC->NCHW->NHWC bridge direction.
+            # Reverse-direction folds can corrupt downstream layout contracts.
+            if [int(v) for v in list(perm_pre)] != perm_nhwc_to_nchw:
                 continue
             perm_post_expected = _invert_perm(perm_pre)
             if perm_post_expected is None:
@@ -34439,9 +35685,11 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
+        _optimize_transpose_pre_unary_squeeze_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
+        _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
         _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
@@ -34510,9 +35758,11 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
+        _optimize_transpose_pre_unary_squeeze_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
+        _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
         _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
@@ -34584,9 +35834,11 @@ def lower_onnx_to_ir(
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains(model_ir)
+        _optimize_transpose_pre_unary_squeeze_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
+        _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
         _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
@@ -34676,6 +35928,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
+        _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
         _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
@@ -34726,6 +35979,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
+        _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
         _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_conv_attention_nhwc_propagation_chains(model_ir)
@@ -34762,6 +36016,7 @@ def lower_onnx_to_ir(
         # Boundary/layout recovery can still recreate NCHW wrappers around MEAN.
         # Run dedicated NHWC passthrough once more in the terminal stage.
         _optimize_transpose_mean_prepost_nhwc_passthrough_chains(model_ir)
+        _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
         _optimize_transpose_se_conv_mul_prepost_nhwc_chains(model_ir)
         _optimize_transpose_se_fc_mul_prepost_nhwc_chains(model_ir)
         _optimize_batchmatmul_affine_transpose_input_chains(model_ir)
@@ -34780,6 +36035,7 @@ def lower_onnx_to_ir(
     _optimize_sinet_concat_resize_affine_tail_concat_transpose_chains(model_ir)
     _optimize_sinet_softmax_mask_residual_nhwc_tail_chains(model_ir)
     _optimize_transpose_mul_add_const_prelu_prepost_nhwc_terminal_chains(model_ir)
+    _optimize_transpose_hardswish_se_conv_hardsigmoid_mul_prepost_nhwc_chains(model_ir)
     # Terminal MUL/ADD/PRELU rewriting can recreate NCHW bridge wrappers.
     _optimize_transpose_pre_add_mul_add_prelu_nhwc_chains(model_ir)
     _optimize_sinet_concat_resize_affine_transpose_chains(model_ir)
@@ -34832,5 +36088,20 @@ def lower_onnx_to_ir(
     _optimize_layout_transpose_chains(model_ir)
     _prune_dead_operators(model_ir)
     _reconcile_static_tensor_shapes(model_ir)
+    # Late transpose/layout rewrites can invalidate previously resolved
+    # RESHAPE constants. Re-resolve once at absolute end.
+    _resolve_dynamic_reshape_shapes(model_ir)
+    _reconcile_static_tensor_shapes(model_ir)
+    # Keep HARD_SWISH outputs shape-preserving at the final serialization boundary.
+    _sanitize_hardswish_tensor_shapes(model_ir)
+    _reconcile_static_tensor_shapes(model_ir)
+    # If HARD_SWISH metadata was corrected above, allow RESHAPE constants to
+    # converge one last time from the repaired input signatures.
+    _resolve_dynamic_reshape_shapes(model_ir)
+    _reconcile_static_tensor_shapes(model_ir)
+    # Keep final serialized metadata consistent for tools that render
+    # shape_signature (e.g. Netron): HARD_SWISH is shape-preserving.
+    _sanitize_hardswish_tensor_shapes(model_ir)
+    _sanitize_static_shape_signature_consistency(model_ir)
 
     return model_ir

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -480,6 +480,16 @@ def _build_strided_slice_options(
     return _enum(schema_tflite, "BuiltinOptions", "StridedSliceOptions"), options
 
 
+def _build_while_options(
+    schema_tflite: Dict[str, Any],
+    op: OperatorIR,
+) -> Tuple[int, object]:
+    options = schema_tflite["WhileOptionsT"]()
+    options.condSubgraphIndex = int(op.options.get("condSubgraphIndex", 0))
+    options.bodySubgraphIndex = int(op.options.get("bodySubgraphIndex", 0))
+    return _enum(schema_tflite, "BuiltinOptions", "WhileOptions"), options
+
+
 def _build_builtin_options(
     schema_tflite: Dict[str, Any],
     op: OperatorIR,
@@ -578,6 +588,8 @@ def _build_builtin_options(
         return _build_sequence_rnn_options(schema_tflite, op)
     if op.op_type == "STRIDED_SLICE":
         return _build_strided_slice_options(schema_tflite, op)
+    if op.op_type == "WHILE":
+        return _build_while_options(schema_tflite, op)
     if op.op_type in [
         "LOGISTIC",
         "LOGICAL_AND",
@@ -672,48 +684,91 @@ def _build_operator_table(
     return table
 
 
+def _build_subgraph_tensors_and_append_buffers(
+    *,
+    schema_tflite: Dict[str, Any],
+    model_ir: ModelIR,
+    global_buffer_table: List[object],
+) -> Tuple[List[object], Dict[str, int]]:
+    tensors, local_buffers, tensor_index_map = build_tensors_and_buffers(
+        schema_tflite=schema_tflite,
+        tensors=model_ir.tensors,
+    )
+    if len(global_buffer_table) == 0:
+        raise ValueError("Global buffer table must contain Buffer[0].")
+    buffer_offset = int(len(global_buffer_table) - 1)
+    for tensor in tensors:
+        current_buffer = int(getattr(tensor, "buffer", 0))
+        if current_buffer > 0:
+            tensor.buffer = int(current_buffer + buffer_offset)
+    global_buffer_table.extend(local_buffers[1:])
+    return tensors, tensor_index_map
+
+
 def build_model_object(
     *,
     schema_tflite: Dict[str, Any],
     model_ir: ModelIR,
     with_signature_defs: bool = True,
 ) -> object:
-    operator_codes, op_index_map = build_operator_codes(schema_tflite, model_ir.operators)
-    tensors, buffers, tensor_index_map = build_tensors_and_buffers(schema_tflite, model_ir.tensors)
-    operators = _build_operator_table(
-        schema_tflite=schema_tflite,
-        operators=model_ir.operators,
-        op_index_map=op_index_map,
-        tensor_index_map=tensor_index_map,
-    )
+    all_subgraphs: List[ModelIR] = [model_ir] + list(model_ir.subgraphs)
+    all_operators: List[OperatorIR] = []
+    for subgraph_ir in all_subgraphs:
+        all_operators.extend(list(subgraph_ir.operators))
+    operator_codes, op_index_map = build_operator_codes(schema_tflite, all_operators)
 
-    subgraph = schema_tflite["SubGraphT"]()
-    subgraph.name = model_ir.name
-    subgraph.tensors = tensors
-    subgraph.operators = operators
-    subgraph.inputs = _require_tensor_indices(
-        tensor_index_map=tensor_index_map,
-        tensor_names=model_ir.inputs,
-        op_type="MODEL",
-        tensor_role="graph input",
-    )
-    subgraph.outputs = _require_tensor_indices(
-        tensor_index_map=tensor_index_map,
-        tensor_names=model_ir.outputs,
-        op_type="MODEL",
-        tensor_role="graph output",
-    )
+    buffers: List[object] = []
+    empty_buffer = schema_tflite["BufferT"]()
+    empty_buffer.data = bytes()
+    buffers.append(empty_buffer)
+
+    serialized_subgraphs: List[object] = []
+    main_tensor_index_map: Optional[Dict[str, int]] = None
+    for subgraph_index, subgraph_ir in enumerate(all_subgraphs):
+        tensors, tensor_index_map = _build_subgraph_tensors_and_append_buffers(
+            schema_tflite=schema_tflite,
+            model_ir=subgraph_ir,
+            global_buffer_table=buffers,
+        )
+        operators = _build_operator_table(
+            schema_tflite=schema_tflite,
+            operators=subgraph_ir.operators,
+            op_index_map=op_index_map,
+            tensor_index_map=tensor_index_map,
+        )
+        subgraph = schema_tflite["SubGraphT"]()
+        subgraph.name = subgraph_ir.name
+        subgraph.tensors = tensors
+        subgraph.operators = operators
+        subgraph.inputs = _require_tensor_indices(
+            tensor_index_map=tensor_index_map,
+            tensor_names=subgraph_ir.inputs,
+            op_type="MODEL",
+            tensor_role="graph input",
+        )
+        subgraph.outputs = _require_tensor_indices(
+            tensor_index_map=tensor_index_map,
+            tensor_names=subgraph_ir.outputs,
+            op_type="MODEL",
+            tensor_role="graph output",
+        )
+        serialized_subgraphs.append(subgraph)
+        if int(subgraph_index) == 0:
+            main_tensor_index_map = dict(tensor_index_map)
+
+    if main_tensor_index_map is None:
+        raise ValueError("Main subgraph tensor index map is missing.")
 
     model = schema_tflite["ModelT"]()
     model.version = 3
     model.description = model_ir.description
     model.operatorCodes = operator_codes
-    model.subgraphs = [subgraph]
+    model.subgraphs = serialized_subgraphs
     model.buffers = buffers
     if with_signature_defs:
         model.signatureDefs = build_signature_defs(
             schema_tflite=schema_tflite,
-            tensor_index_map=tensor_index_map,
+            tensor_index_map=main_tensor_index_map,
             input_names=model_ir.inputs,
             output_names=model_ir.outputs,
         )

--- a/onnx2tf/tflite_builder/op_builders/__init__.py
+++ b/onnx2tf/tflite_builder/op_builders/__init__.py
@@ -114,10 +114,13 @@ from onnx2tf.tflite_builder.op_builders.custom import (
 )
 from onnx2tf.tflite_builder.op_builders.control import (
     build_if_op,
+    build_loop_op,
     is_supported_if_axis0_add_branch_pattern,
     is_supported_if_nms_guard_pattern,
     is_supported_if_nested_reducemin_add_branch_pattern,
     is_supported_if_sequenceconstruct_add_branch_pattern,
+    is_supported_loop_static_unroll_pattern,
+    is_supported_loop_while_pattern,
 )
 from onnx2tf.tflite_builder.op_builders.quantized import (
     build_dequantize_linear_op,
@@ -232,10 +235,13 @@ __all__ = [
     "build_lrn_op",
     "build_custom_passthrough_op",
     "build_if_op",
+    "build_loop_op",
     "is_supported_if_axis0_add_branch_pattern",
     "is_supported_if_nms_guard_pattern",
     "is_supported_if_nested_reducemin_add_branch_pattern",
     "is_supported_if_sequenceconstruct_add_branch_pattern",
+    "is_supported_loop_static_unroll_pattern",
+    "is_supported_loop_while_pattern",
     "build_dequantize_linear_op",
     "build_dynamic_quantize_linear_op",
     "build_qgemm_op",

--- a/onnx2tf/tflite_builder/op_builders/control.py
+++ b/onnx2tf/tflite_builder/op_builders/control.py
@@ -6,7 +6,7 @@ import numpy as np
 import onnx
 from onnx import numpy_helper
 
-from onnx2tf.tflite_builder.ir import OperatorIR
+from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR
 
 
 def is_supported_if_nms_guard_pattern(node: Any) -> bool:
@@ -545,12 +545,89 @@ def _lower_graph_nodes(
                 )
             cond_name = remap_in.get(str(graph_node.input[0]), str(graph_node.input[0]))
             cond_value = ctx.get_constant_array(cond_name)
+            attrs = {a.name: a for a in graph_node.attribute}
             if cond_value is None:
+                then_attr = attrs.get("then_branch", None)
+                else_attr = attrs.get("else_branch", None)
+                then_graph = then_attr.g if then_attr is not None else None
+                else_graph = else_attr.g if else_attr is not None else None
+                if (
+                    then_graph is not None
+                    and else_graph is not None
+                    and len(then_graph.input) == 0
+                    and len(else_graph.input) == 0
+                    and len(then_graph.output) == 1
+                    and len(else_graph.output) == 1
+                    and len(then_graph.node) == 0
+                    and len(else_graph.node) == 0
+                ):
+                    _ensure_graph_initializers(then_graph, ctx)
+                    _ensure_graph_initializers(else_graph, ctx)
+
+                    then_output_name = remap_in.get(
+                        str(then_graph.output[0].name),
+                        str(then_graph.output[0].name),
+                    )
+                    else_output_name = remap_in.get(
+                        str(else_graph.output[0].name),
+                        str(else_graph.output[0].name),
+                    )
+                    nested_out_name = remap_out.get(
+                        str(graph_node.output[0]),
+                        str(graph_node.output[0]),
+                    )
+                    ctx.ensure_tensor(then_output_name)
+                    ctx.ensure_tensor(else_output_name)
+
+                    then_shape = [int(v) for v in ctx.get_tensor_shape(then_output_name)]
+                    else_shape = [int(v) for v in ctx.get_tensor_shape(else_output_name)]
+                    if then_shape != else_shape:
+                        raise NotImplementedError(
+                            "If in branch with dynamic condition requires same-shape then/else "
+                            f"constant outputs. node={graph_node.name} "
+                            f"then_shape={then_shape} else_shape={else_shape}"
+                        )
+
+                    expected_output_dtype = str(ctx.get_tensor_dtype(then_output_name)).upper()
+                    if nested_out_name in ctx.model_ir.tensors:
+                        expected_output_dtype = str(ctx.get_tensor_dtype(nested_out_name)).upper()
+                        expected_output_shape = [int(v) for v in ctx.get_tensor_shape(nested_out_name)]
+                    else:
+                        expected_output_shape = [int(v) for v in then_shape]
+                        ctx.ensure_tensor(
+                            nested_out_name,
+                            dtype=expected_output_dtype,
+                            shape=expected_output_shape,
+                        )
+                    then_output_name = _cast_to_dtype_for_if(
+                        tensor_name=then_output_name,
+                        target_dtype=expected_output_dtype,
+                        output_name=nested_out_name,
+                        suffix="then",
+                        ctx=ctx,
+                    )
+                    else_output_name = _cast_to_dtype_for_if(
+                        tensor_name=else_output_name,
+                        target_dtype=expected_output_dtype,
+                        output_name=nested_out_name,
+                        suffix="else",
+                        ctx=ctx,
+                    )
+                    _emit_where_mux(
+                        cond_name=cond_name,
+                        then_name=then_output_name,
+                        else_name=else_output_name,
+                        output_name=nested_out_name,
+                        output_shape=expected_output_shape,
+                        output_dtype=expected_output_dtype,
+                        node_name=f"{graph_node.name}_where",
+                        ctx=ctx,
+                    )
+                    continue
                 raise NotImplementedError(
                     f"If in branch requires constant condition in flatbuffer_direct. node={graph_node.name}"
                 )
             cond_bool = bool(np.asarray(cond_value).reshape(-1)[0])
-            attrs = {a.name: a for a in graph_node.attribute}
             selected_attr = "then_branch" if cond_bool else "else_branch"
             if selected_attr not in attrs:
                 raise NotImplementedError(
@@ -1345,4 +1422,575 @@ def build_if_op(node: Any, ctx: Any) -> None:
         candidate_name=candidate_output_name,
         output_name=output_name,
         ctx=ctx,
+    )
+
+
+def _loop_const_trip_count(node: Any, ctx: Any) -> Optional[int]:
+    if len(node.inputs) < 1:
+        return None
+    trip_count_name = node.inputs[0].name
+    if str(trip_count_name) == "":
+        return None
+    trip_count_arr = ctx.get_constant_array(trip_count_name)
+    if trip_count_arr is None:
+        return None
+    flat = np.asarray(trip_count_arr).reshape(-1)
+    if int(flat.size) == 0:
+        return None
+    return int(flat[0])
+
+
+def _loop_const_cond(node: Any, ctx: Any) -> Optional[bool]:
+    if len(node.inputs) < 2:
+        return None
+    cond_name = node.inputs[1].name
+    if str(cond_name) == "":
+        return None
+    cond_arr = ctx.get_constant_array(cond_name)
+    if cond_arr is None:
+        return None
+    flat = np.asarray(cond_arr).reshape(-1)
+    if int(flat.size) == 0:
+        return None
+    return bool(flat[0])
+
+
+def is_supported_loop_static_unroll_pattern(node: Any, ctx: Any) -> bool:
+    body = node.attrs.get("body", None)
+    if body is None or not hasattr(body, "input") or not hasattr(body, "output"):
+        return False
+    if len(node.inputs) < 3:
+        return False
+    trip_count = _loop_const_trip_count(node, ctx)
+    if trip_count is None or int(trip_count) < 0:
+        return False
+    if int(trip_count) > 1024:
+        return False
+    if _loop_const_cond(node, ctx) is None:
+        return False
+
+    state_count = int(len(node.inputs) - 2)
+    if state_count <= 0:
+        return False
+    # Static unroll path supports loop-carried outputs only (no scan outputs).
+    if len(node.outputs) != state_count:
+        return False
+    if len(body.input) != int(2 + state_count):
+        return False
+    if len(body.output) != int(1 + state_count):
+        return False
+    return True
+
+
+def is_supported_loop_while_pattern(node: Any, ctx: Any) -> bool:
+    body = node.attrs.get("body", None)
+    if body is None or not hasattr(body, "input") or not hasattr(body, "output"):
+        return False
+    if len(node.inputs) < 3:
+        return False
+    state_count = int(len(node.inputs) - 2)
+    if state_count <= 0:
+        return False
+    # WHILE lowering currently supports loop-carried outputs only (no scan outputs).
+    if len(node.outputs) != state_count:
+        return False
+    if len(body.input) != int(2 + state_count):
+        return False
+    if len(body.output) != int(1 + state_count):
+        return False
+    return True
+
+
+def _make_unique_tensor_name(*, base_name: str, ctx: Any) -> str:
+    name = str(base_name) if str(base_name) != "" else "loop_tensor"
+    if name not in ctx.model_ir.tensors and name not in ctx.shape_map:
+        return name
+    suffix = 1
+    while True:
+        candidate = f"{name}_{suffix}"
+        if candidate not in ctx.model_ir.tensors and candidate not in ctx.shape_map:
+            return candidate
+        suffix += 1
+
+
+def _register_tensor_remap_metadata(*, old_name: str, new_name: str, ctx: Any) -> None:
+    if str(old_name) in ctx.shape_map and str(new_name) not in ctx.shape_map:
+        ctx.shape_map[str(new_name)] = [int(v) for v in list(ctx.shape_map[str(old_name)])]
+    if str(old_name) in ctx.dtype_map and str(new_name) not in ctx.dtype_map:
+        ctx.dtype_map[str(new_name)] = str(ctx.dtype_map[str(old_name)])
+
+
+def _copy_tensor_metadata_for_alias(*, src_name: str, dst_name: str, ctx: Any) -> None:
+    src_tensor = ctx.model_ir.tensors.get(str(src_name), None)
+    dst_tensor = ctx.model_ir.tensors.get(str(dst_name), None)
+    if src_tensor is None or dst_tensor is None:
+        return
+    dst_tensor.dtype = str(src_tensor.dtype)
+    dst_tensor.shape = [int(v) for v in list(src_tensor.shape)]
+    if src_tensor.shape_signature is not None:
+        dst_tensor.shape_signature = [int(v) for v in list(src_tensor.shape_signature)]
+    else:
+        dst_tensor.shape_signature = [int(v) for v in list(src_tensor.shape)]
+    dst_tensor.quantization = src_tensor.quantization
+
+
+def _emit_tensor_alias_via_reshape(
+    *,
+    src_name: str,
+    dst_name: str,
+    alias_base_name: str,
+    ctx: Any,
+) -> None:
+    if str(src_name) == str(dst_name):
+        return
+    ctx.ensure_tensor(str(src_name))
+    src_shape = [int(v) for v in ctx.get_tensor_shape(str(src_name))]
+    src_dtype = str(ctx.get_tensor_dtype(str(src_name))).upper()
+    ctx.ensure_tensor(str(dst_name), dtype=src_dtype, shape=src_shape)
+    _copy_tensor_metadata_for_alias(
+        src_name=str(src_name),
+        dst_name=str(dst_name),
+        ctx=ctx,
+    )
+    alias_shape_name = ctx.add_const_tensor(
+        _make_unique_tensor_name(base_name=f"{alias_base_name}_shape", ctx=ctx),
+        np.asarray(src_shape, dtype=np.int32),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=[str(src_name), str(alias_shape_name)],
+            outputs=[str(dst_name)],
+            options={"newShape": [int(v) for v in src_shape]},
+        )
+        )
+
+
+def _build_loop_static_unroll(node: Any, ctx: Any) -> None:
+    body_graph = node.attrs["body"]
+    _ensure_graph_initializers(body_graph, ctx)
+
+    trip_count = int(_loop_const_trip_count(node, ctx))
+    cond_initial = bool(_loop_const_cond(node, ctx))
+    state_input_names = [str(v.name) for v in node.inputs[2:]]
+    state_output_names = [str(v.name) for v in node.outputs]
+    state_count = int(len(state_input_names))
+
+    for state_input_name in state_input_names:
+        ctx.ensure_tensor(state_input_name)
+
+    current_states = [str(v) for v in state_input_names]
+    if cond_initial and trip_count > 0:
+        body_input_iter_name = str(body_graph.input[0].name)
+        body_input_cond_name = str(body_graph.input[1].name)
+        body_state_input_names = [str(v.name) for v in body_graph.input[2:2 + state_count]]
+        body_cond_output_name = str(body_graph.output[0].name)
+        body_state_output_names = [str(v.name) for v in body_graph.output[1:1 + state_count]]
+
+        for iter_idx in range(int(trip_count)):
+            iter_const_name = ctx.add_const_tensor(
+                _make_unique_tensor_name(base_name=f"{node.name}_loop_iter_{iter_idx}", ctx=ctx),
+                np.asarray(iter_idx, dtype=np.int64),
+            )
+            cond_const_name = ctx.add_const_tensor(
+                _make_unique_tensor_name(base_name=f"{node.name}_loop_cond_{iter_idx}", ctx=ctx),
+                np.asarray(True, dtype=np.bool_),
+            )
+
+            iteration_internal_remap: Dict[str, str] = {}
+            for body_node in body_graph.node:
+                for output_name in body_node.output:
+                    out_name = str(output_name)
+                    if out_name == "":
+                        continue
+                    if out_name in iteration_internal_remap:
+                        continue
+                    scoped_name = _make_unique_tensor_name(
+                        base_name=f"{out_name}_loop_{iter_idx}",
+                        ctx=ctx,
+                    )
+                    iteration_internal_remap[out_name] = scoped_name
+                    _register_tensor_remap_metadata(
+                        old_name=out_name,
+                        new_name=scoped_name,
+                        ctx=ctx,
+                    )
+
+            input_remap = dict(iteration_internal_remap)
+            input_remap[body_input_iter_name] = str(iter_const_name)
+            input_remap[body_input_cond_name] = str(cond_const_name)
+            for state_idx, body_state_input_name in enumerate(body_state_input_names):
+                input_remap[str(body_state_input_name)] = str(current_states[state_idx])
+
+            output_remap = dict(iteration_internal_remap)
+            cond_output_scoped = _make_unique_tensor_name(
+                base_name=f"{node.name}_loop_cond_out_{iter_idx}",
+                ctx=ctx,
+            )
+            output_remap[str(body_cond_output_name)] = str(cond_output_scoped)
+            _register_tensor_remap_metadata(
+                old_name=str(body_cond_output_name),
+                new_name=str(cond_output_scoped),
+                ctx=ctx,
+            )
+
+            next_states: List[str] = []
+            for state_idx, body_state_output_name in enumerate(body_state_output_names):
+                next_state_name = _make_unique_tensor_name(
+                    base_name=f"{node.name}_loop_state_{state_idx}_iter_{iter_idx}",
+                    ctx=ctx,
+                )
+                output_remap[str(body_state_output_name)] = str(next_state_name)
+                _register_tensor_remap_metadata(
+                    old_name=str(body_state_output_name),
+                    new_name=str(next_state_name),
+                    ctx=ctx,
+                )
+                next_states.append(str(next_state_name))
+
+            _lower_graph_nodes(
+                graph=body_graph,
+                ctx=ctx,
+                input_name_remap=input_remap,
+                output_name_remap=output_remap,
+            )
+
+            for state_idx, next_state_name in enumerate(next_states):
+                if next_state_name in ctx.model_ir.tensors:
+                    continue
+                body_state_output_name = str(body_state_output_names[state_idx])
+                source_name = input_remap.get(body_state_output_name, None)
+                if source_name is None:
+                    source_name = str(current_states[state_idx])
+                if str(source_name) not in ctx.model_ir.tensors:
+                    raise NotImplementedError(
+                        (
+                            "Loop static unroll could not resolve loop-carried state output. "
+                            f"node={node.name} iter={iter_idx} output={body_state_output_name}"
+                        )
+                    )
+                _emit_tensor_alias_via_reshape(
+                    src_name=str(source_name),
+                    dst_name=str(next_state_name),
+                    alias_base_name=f"{node.name}_loop_state_alias_{state_idx}_iter_{iter_idx}",
+                    ctx=ctx,
+                )
+
+            current_states = [str(v) for v in next_states]
+
+    for state_idx, output_name in enumerate(state_output_names):
+        src_name = str(current_states[state_idx])
+        _emit_tensor_alias_via_reshape(
+            src_name=src_name,
+            dst_name=str(output_name),
+            alias_base_name=f"{node.name}_loop_final_state_{state_idx}",
+            ctx=ctx,
+        )
+
+
+def _build_loop_while(node: Any, ctx: Any) -> None:
+    body_graph = node.attrs["body"]
+    _ensure_graph_initializers(body_graph, ctx)
+
+    state_input_names = [str(v.name) for v in node.inputs[2:]]
+    state_output_names = [str(v.name) for v in node.outputs]
+    state_count = int(len(state_input_names))
+
+    max_trip_input_name = str(node.inputs[0].name)
+    cond_input_name = str(node.inputs[1].name)
+    if max_trip_input_name == "" or cond_input_name == "":
+        raise NotImplementedError(
+            (
+                "Loop WHILE lowering currently requires explicit max_trip_count and condition inputs. "
+                f"node={node.name}"
+            )
+        )
+
+    ctx.ensure_tensor(max_trip_input_name)
+    ctx.ensure_tensor(cond_input_name)
+    for state_input_name in state_input_names:
+        ctx.ensure_tensor(state_input_name)
+
+    iter_dtype = str(ctx.get_tensor_dtype(max_trip_input_name)).upper()
+    if iter_dtype not in {"INT32", "INT64"}:
+        raise NotImplementedError(
+            f"Loop WHILE lowering requires INT32/INT64 max_trip_count. node={node.name} dtype={iter_dtype}"
+        )
+
+    cond_dtype = str(ctx.get_tensor_dtype(cond_input_name)).upper()
+    while_cond_input_name = cond_input_name
+    if cond_dtype != "BOOL":
+        cast_cond_name = ctx.add_intermediate_tensor(
+            _make_unique_tensor_name(base_name=f"{node.name}_loop_cond_cast", ctx=ctx),
+            dtype="BOOL",
+            shape=[],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[cond_input_name],
+                outputs=[cast_cond_name],
+                options={"inDataType": cond_dtype, "outDataType": "BOOL"},
+            )
+        )
+        while_cond_input_name = cast_cond_name
+
+    iter_init_name = ctx.add_const_tensor(
+        _make_unique_tensor_name(base_name=f"{node.name}_loop_iter_init", ctx=ctx),
+        np.asarray(0, dtype=np.int64 if iter_dtype == "INT64" else np.int32),
+    )
+
+    while_input_names = [iter_init_name, max_trip_input_name, while_cond_input_name] + state_input_names
+    while_output_names: List[str] = [
+        _make_unique_tensor_name(base_name=f"{node.name}_loop_iter_out", ctx=ctx),
+        _make_unique_tensor_name(base_name=f"{node.name}_loop_trip_out", ctx=ctx),
+        _make_unique_tensor_name(base_name=f"{node.name}_loop_cond_out", ctx=ctx),
+    ] + state_output_names
+
+    ctx.ensure_tensor(while_output_names[0], dtype=iter_dtype, shape=[])
+    ctx.ensure_tensor(while_output_names[1], dtype=iter_dtype, shape=[])
+    ctx.ensure_tensor(while_output_names[2], dtype="BOOL", shape=[])
+    for idx, state_output_name in enumerate(state_output_names):
+        state_shape = [int(v) for v in ctx.get_tensor_shape(state_input_names[idx])]
+        state_dtype = str(ctx.get_tensor_dtype(state_input_names[idx])).upper()
+        ctx.ensure_tensor(state_output_name, dtype=state_dtype, shape=state_shape)
+
+    cond_subgraph = ModelIR(name=f"{node.name}_while_cond")
+    body_subgraph = ModelIR(name=f"{node.name}_while_body")
+
+    # Build subgraph-local contexts with copied shape/dtype knowledge.
+    from onnx2tf.tflite_builder.lower_from_onnx2tf import LoweringContext
+
+    cond_ctx = LoweringContext(
+        model_ir=cond_subgraph,
+        shape_map=dict(ctx.shape_map),
+        dtype_map=dict(ctx.dtype_map),
+        constants={},
+        onnx_model=getattr(ctx, "onnx_model", None),
+        allow_custom_ops=bool(getattr(ctx, "allow_custom_ops", False)),
+        custom_op_allowlist=list(getattr(ctx, "custom_op_allowlist", []) or []),
+        disable_group_convolution=bool(getattr(ctx, "disable_group_convolution", False)),
+        tensor_consumer_count={},
+        graph_output_names=None,
+        output_nms_with_argmax=bool(getattr(ctx, "output_nms_with_argmax", False)),
+        switch_nms_version=str(getattr(ctx, "switch_nms_version", "v4")),
+    )
+    body_ctx = LoweringContext(
+        model_ir=body_subgraph,
+        shape_map=dict(ctx.shape_map),
+        dtype_map=dict(ctx.dtype_map),
+        constants={},
+        onnx_model=getattr(ctx, "onnx_model", None),
+        allow_custom_ops=bool(getattr(ctx, "allow_custom_ops", False)),
+        custom_op_allowlist=list(getattr(ctx, "custom_op_allowlist", []) or []),
+        disable_group_convolution=bool(getattr(ctx, "disable_group_convolution", False)),
+        tensor_consumer_count={},
+        graph_output_names=None,
+        output_nms_with_argmax=bool(getattr(ctx, "output_nms_with_argmax", False)),
+        switch_nms_version=str(getattr(ctx, "switch_nms_version", "v4")),
+    )
+    _ensure_graph_initializers(body_graph, body_ctx)
+
+    cond_iter_in = f"{node.name}_while_iter_in"
+    cond_trip_in = f"{node.name}_while_trip_in"
+    cond_cond_in = f"{node.name}_while_cond_in"
+    cond_state_in_names = [f"{node.name}_while_state_{idx}_in" for idx in range(state_count)]
+    cond_out_name = f"{node.name}_while_cond_out"
+
+    for tensor_name, dtype_name, shape in [
+        (cond_iter_in, iter_dtype, []),
+        (cond_trip_in, iter_dtype, []),
+        (cond_cond_in, "BOOL", []),
+    ]:
+        cond_ctx.ensure_tensor(tensor_name, dtype=dtype_name, shape=shape)
+    for idx, state_name in enumerate(cond_state_in_names):
+        cond_ctx.ensure_tensor(
+            state_name,
+            dtype=str(ctx.get_tensor_dtype(state_input_names[idx])).upper(),
+            shape=[int(v) for v in ctx.get_tensor_shape(state_input_names[idx])],
+        )
+    cond_ctx.ensure_tensor(cond_out_name, dtype="BOOL", shape=[])
+
+    cond_iter_lt_name = cond_ctx.add_intermediate_tensor(
+        f"{node.name}_while_iter_lt_trip",
+        dtype="BOOL",
+        shape=[],
+    )
+    cond_ctx.add_operator(
+        OperatorIR(
+            op_type="LESS",
+            inputs=[cond_iter_in, cond_trip_in],
+            outputs=[cond_iter_lt_name],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+    cond_ctx.add_operator(
+        OperatorIR(
+            op_type="LOGICAL_AND",
+            inputs=[cond_cond_in, cond_iter_lt_name],
+            outputs=[cond_out_name],
+            options={},
+        )
+    )
+    cond_subgraph.inputs = [cond_iter_in, cond_trip_in, cond_cond_in] + cond_state_in_names
+    cond_subgraph.outputs = [cond_out_name]
+
+    body_iter_in = f"{node.name}_while_iter_in"
+    body_trip_in = f"{node.name}_while_trip_in"
+    body_cond_in = f"{node.name}_while_cond_in"
+    body_state_in_names = [f"{node.name}_while_state_{idx}_in" for idx in range(state_count)]
+    body_iter_out = f"{node.name}_while_iter_out"
+    body_trip_out = f"{node.name}_while_trip_out"
+    body_cond_out = f"{node.name}_while_cond_out"
+    body_state_out_names = [f"{node.name}_while_state_{idx}_out" for idx in range(state_count)]
+
+    for tensor_name, dtype_name, shape in [
+        (body_iter_in, iter_dtype, []),
+        (body_trip_in, iter_dtype, []),
+        (body_cond_in, "BOOL", []),
+    ]:
+        body_ctx.ensure_tensor(tensor_name, dtype=dtype_name, shape=shape)
+    for idx, state_name in enumerate(body_state_in_names):
+        body_ctx.ensure_tensor(
+            state_name,
+            dtype=str(ctx.get_tensor_dtype(state_input_names[idx])).upper(),
+            shape=[int(v) for v in ctx.get_tensor_shape(state_input_names[idx])],
+        )
+
+    iter_plus_one_const_name = body_ctx.add_const_tensor(
+        f"{node.name}_while_iter_plus_one_const",
+        np.asarray(1, dtype=np.int64 if iter_dtype == "INT64" else np.int32),
+    )
+    body_ctx.ensure_tensor(body_iter_out, dtype=iter_dtype, shape=[])
+    body_ctx.add_operator(
+        OperatorIR(
+            op_type="ADD",
+            inputs=[body_iter_in, iter_plus_one_const_name],
+            outputs=[body_iter_out],
+            options={"fusedActivationFunction": "NONE"},
+        )
+    )
+    _emit_tensor_alias_via_reshape(
+        src_name=body_trip_in,
+        dst_name=body_trip_out,
+        alias_base_name=f"{node.name}_while_trip_passthrough",
+        ctx=body_ctx,
+    )
+
+    onnx_body_input_iter_name = str(body_graph.input[0].name)
+    onnx_body_input_cond_name = str(body_graph.input[1].name)
+    onnx_body_state_input_names = [str(v.name) for v in body_graph.input[2:2 + state_count]]
+    onnx_body_cond_output_name = str(body_graph.output[0].name)
+    onnx_body_state_output_names = [str(v.name) for v in body_graph.output[1:1 + state_count]]
+
+    body_input_remap: Dict[str, str] = {
+        onnx_body_input_iter_name: body_iter_in,
+        onnx_body_input_cond_name: body_cond_in,
+    }
+    for idx, state_input_name in enumerate(onnx_body_state_input_names):
+        body_input_remap[state_input_name] = body_state_in_names[idx]
+
+    body_output_remap: Dict[str, str] = {}
+    for graph_node in body_graph.node:
+        for output_name in graph_node.output:
+            out_name = str(output_name)
+            if out_name == "":
+                continue
+            if out_name == onnx_body_cond_output_name:
+                mapped_name = str(body_cond_out)
+            elif out_name in onnx_body_state_output_names:
+                mapped_name = str(body_state_out_names[onnx_body_state_output_names.index(out_name)])
+            else:
+                mapped_name = _make_unique_tensor_name(
+                    base_name=f"{node.name}_while_body_{out_name}",
+                    ctx=body_ctx,
+                )
+                _register_tensor_remap_metadata(
+                    old_name=out_name,
+                    new_name=mapped_name,
+                    ctx=body_ctx,
+                )
+            body_output_remap[out_name] = mapped_name
+            body_input_remap[out_name] = mapped_name
+
+    for idx, state_output_name in enumerate(onnx_body_state_output_names):
+        body_output_remap[state_output_name] = body_state_out_names[idx]
+
+    body_ctx.ensure_tensor(body_cond_out, dtype="BOOL", shape=[])
+    for idx, state_out_name in enumerate(body_state_out_names):
+        body_ctx.ensure_tensor(
+            state_out_name,
+            dtype=str(ctx.get_tensor_dtype(state_input_names[idx])).upper(),
+            shape=[int(v) for v in ctx.get_tensor_shape(state_input_names[idx])],
+        )
+
+    _lower_graph_nodes(
+        graph=body_graph,
+        ctx=body_ctx,
+        input_name_remap=body_input_remap,
+        output_name_remap=body_output_remap,
+    )
+
+    produced_tensor_names = {
+        str(out_name)
+        for op in body_ctx.model_ir.operators
+        for out_name in op.outputs
+    }
+    produced_tensor_names.update(str(name) for name in body_ctx.constants.keys())
+
+    if body_cond_out not in produced_tensor_names:
+        fallback_cond_src = body_input_remap.get(onnx_body_cond_output_name, body_cond_in)
+        _emit_tensor_alias_via_reshape(
+            src_name=str(fallback_cond_src),
+            dst_name=body_cond_out,
+            alias_base_name=f"{node.name}_while_cond_passthrough",
+            ctx=body_ctx,
+        )
+        produced_tensor_names.add(str(body_cond_out))
+    for idx, state_out_name in enumerate(body_state_out_names):
+        if str(state_out_name) in produced_tensor_names:
+            continue
+        fallback_state_src = body_input_remap.get(onnx_body_state_output_names[idx], body_state_in_names[idx])
+        _emit_tensor_alias_via_reshape(
+            src_name=str(fallback_state_src),
+            dst_name=state_out_name,
+            alias_base_name=f"{node.name}_while_state_passthrough_{idx}",
+            ctx=body_ctx,
+        )
+        produced_tensor_names.add(str(state_out_name))
+
+    body_subgraph.inputs = [body_iter_in, body_trip_in, body_cond_in] + body_state_in_names
+    body_subgraph.outputs = [body_iter_out, body_trip_out, body_cond_out] + body_state_out_names
+
+    cond_subgraph_index = int(len(ctx.model_ir.subgraphs) + 1)
+    ctx.model_ir.subgraphs.append(cond_subgraph)
+    body_subgraph_index = int(len(ctx.model_ir.subgraphs) + 1)
+    ctx.model_ir.subgraphs.append(body_subgraph)
+
+    ctx.add_operator(
+        OperatorIR(
+            op_type="WHILE",
+            inputs=while_input_names,
+            outputs=while_output_names,
+            options={
+                "condSubgraphIndex": int(cond_subgraph_index),
+                "bodySubgraphIndex": int(body_subgraph_index),
+            },
+        )
+    )
+
+
+def build_loop_op(node: Any, ctx: Any) -> None:
+    if is_supported_loop_while_pattern(node, ctx):
+        _build_loop_while(node, ctx)
+        return
+    if is_supported_loop_static_unroll_pattern(node, ctx):
+        _build_loop_static_unroll(node, ctx)
+        return
+    raise NotImplementedError(
+        (
+            "Loop built-in lowering supports either static-unroll patterns with constant trip_count/cond "
+            "or WHILE patterns with loop-carried outputs only (no scan outputs). "
+            f"node={node.name}"
+        )
     )

--- a/onnx2tf/tflite_builder/op_builders/conv.py
+++ b/onnx2tf/tflite_builder/op_builders/conv.py
@@ -386,6 +386,14 @@ def _build_conv1d_via_conv2d(node: Any, ctx: Any) -> None:
 
     input_sig = _tensor_signature(ctx, input_name)
     output_sig = _tensor_signature(ctx, output_name)
+    if len(input_sig) != 3:
+        input_sig = [int(v) for v in list(input_shape)]
+    if len(output_sig) != 3:
+        output_sig = [int(v) for v in list(output_shape)]
+    if len(input_sig) != 3:
+        input_sig = [int(v) for v in list(input_shape)]
+    if len(output_sig) != 3:
+        output_sig = [int(v) for v in list(output_shape)]
 
     axis_name = ctx.add_const_tensor(
         f"{node.name}_conv1d_expand_axis",
@@ -1177,7 +1185,63 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
     original_input_signature = [int(v) for v in list(input_signature)]
     original_output_signature = [int(v) for v in list(output_signature)]
 
+    def _shape_from_rank3_signature(signature: list[int]) -> list[int] | None:
+        if len(signature) != 3:
+            return None
+        return [int(v) if int(v) > 0 else 1 for v in list(signature)]
+
     weights_1d = ctx.get_constant_array(weight_name)
+    rank3_input_from_signature = _shape_from_rank3_signature(input_signature)
+    if len(input_shape) != 3 and rank3_input_from_signature is not None:
+        input_shape = [int(v) for v in list(rank3_input_from_signature)]
+        input_tensor.shape = [int(v) for v in list(input_shape)]
+    rank3_output_from_signature = _shape_from_rank3_signature(output_signature)
+    if len(output_shape) != 3 and rank3_output_from_signature is not None:
+        output_shape = [int(v) for v in list(rank3_output_from_signature)]
+        output_tensor.shape = [int(v) for v in list(output_shape)]
+    if (
+        weights_1d is not None
+        and np.asarray(weights_1d).ndim == 3
+        and (len(input_shape) != 3 or len(output_shape) != 3)
+    ):
+        inferred_input_shape, inferred_output_shape = _infer_convtranspose_io_shapes_with_onnxruntime(
+            ctx=ctx,
+            input_name=input_name,
+            output_name=output_name,
+        )
+        if inferred_input_shape is not None and len(inferred_input_shape) == 3:
+            input_shape = [int(v) for v in list(inferred_input_shape)]
+            input_tensor.shape = [int(v) for v in list(input_shape)]
+            if len(input_signature) == 3:
+                input_tensor.shape_signature = [int(v) for v in list(input_signature)]
+            else:
+                input_tensor.shape_signature = [int(v) for v in list(inferred_input_shape)]
+        if inferred_output_shape is not None and len(inferred_output_shape) == 3:
+            output_shape = [int(v) for v in list(inferred_output_shape)]
+            output_tensor.shape = [int(v) for v in list(output_shape)]
+            if len(output_signature) == 3:
+                output_tensor.shape_signature = [int(v) for v in list(output_signature)]
+            else:
+                output_tensor.shape_signature = [int(v) for v in list(inferred_output_shape)]
+    if (
+        weights_1d is not None
+        and np.asarray(weights_1d).ndim == 3
+        and (len(input_shape) != 3 or len(output_shape) != 3)
+    ):
+        weights_1d_arr = np.asarray(weights_1d)
+        group = int(node.attrs.get("group", 1))
+        in_channels = int(weights_1d_arr.shape[0])
+        out_channels = int(weights_1d_arr.shape[1]) * int(group)
+        if len(input_shape) != 3:
+            input_shape = [1, int(in_channels), 1]
+            input_tensor.shape = [int(v) for v in list(input_shape)]
+            if len(input_signature) != 3:
+                input_tensor.shape_signature = [-1, int(in_channels), -1]
+        if len(output_shape) != 3:
+            output_shape = [1, int(out_channels), 1]
+            output_tensor.shape = [int(v) for v in list(output_shape)]
+            if len(output_signature) != 3:
+                output_tensor.shape_signature = [-1, int(out_channels), -1]
     if (
         len(input_shape) == 3
         and len(output_shape) == 3
@@ -1373,10 +1437,21 @@ def build_conv_transpose_op(node: Any, ctx: Any) -> None:
         or any(int(v) <= 0 for v in list(original_output_signature))
     )
     if use_dynamic_output_shape and needs_spatial_crop:
-        raise NotImplementedError(
-            "ConvTranspose with explicit pads requires static output shape in flatbuffer_direct. "
-            f"op={node.name} output_signature={original_output_signature} pads={raw_pads}"
+        pads_are_symmetric = (
+            int(pad_top) == int(pad_bottom)
+            and int(pad_left) == int(pad_right)
         )
+        if (not pads_are_symmetric) or any(int(v) != 0 for v in output_padding):
+            raise NotImplementedError(
+                "ConvTranspose with explicit pads requires static output shape in flatbuffer_direct "
+                "unless pads are symmetric and output_padding is zero. "
+                f"op={node.name} output_signature={original_output_signature} "
+                f"pads={raw_pads} output_padding={output_padding}"
+            )
+        # For symmetric explicit pads, dynamic output-shape math below already
+        # accounts for pads. Skip explicit crop to keep the shape dynamic.
+        needs_spatial_crop = False
+        nhwc_transpose_conv_output_shape = [int(v) for v in list(nhwc_output_shape)]
     if use_dynamic_output_shape:
         kernel_shape_attr = node.attrs.get("kernel_shape", None)
         if kernel_shape_attr is None:

--- a/onnx2tf/tflite_builder/op_builders/shape.py
+++ b/onnx2tf/tflite_builder/op_builders/shape.py
@@ -350,6 +350,8 @@ def build_slice_op(node: Any, ctx: Any) -> None:
     strides_for_strided = [1 for _ in range(rank)]
     size = [int(input_shape[axis]) if known_dim_flags[axis] else -1 for axis in range(rank)]
     large_int = int(np.iinfo(np.int64).max // 2)
+    int32_min = int(np.iinfo(np.int32).min)
+    int32_max = int(np.iinfo(np.int32).max)
     use_strided_slice = any(not flag for flag in known_dim_flags)
 
     for idx, axis in enumerate(normalized_axes):
@@ -383,23 +385,19 @@ def build_slice_op(node: Any, ctx: Any) -> None:
             else:
                 size[axis] = -1
         else:
-            if start < 0:
-                raise NotImplementedError(
-                    f"Slice with negative start on unknown dimension is not supported. "
-                    f"op={node.name} axis={axis} start={start}"
-                )
-            begin[axis] = int(start)
+            if start < 0 or end < 0:
+                # Keep negative indices and defer resolution to runtime via STRIDED_SLICE.
+                use_strided_slice = True
+            begin[axis] = int(max(min(start, int32_max), int32_min))
             if end >= large_int:
-                end_for_strided[axis] = int(np.iinfo(np.int32).max)
+                end_for_strided[axis] = int32_max
                 size[axis] = -1
-            elif end < 0:
-                raise NotImplementedError(
-                    f"Slice with negative end on unknown dimension is not supported. "
-                    f"op={node.name} axis={axis} end={end}"
-                )
+            elif end <= -large_int:
+                end_for_strided[axis] = int32_min
+                size[axis] = -1
             else:
-                end_for_strided[axis] = int(end)
-                if step == 1:
+                end_for_strided[axis] = int(max(min(end, int32_max), int32_min))
+                if step == 1 and start >= 0 and end >= 0:
                     size[axis] = int(max(end - start, 0))
                 else:
                     size[axis] = -1

--- a/onnx2tf/tflite_builder/op_registry.py
+++ b/onnx2tf/tflite_builder/op_registry.py
@@ -60,6 +60,7 @@ from onnx2tf.tflite_builder.op_builders import (
     build_max_op,
     build_min_op,
     build_if_op,
+    build_loop_op,
     build_mish_op,
     build_nonzero_op,
     build_qgemm_op,
@@ -119,6 +120,8 @@ from onnx2tf.tflite_builder.op_builders import (
     is_supported_if_nested_reducemin_add_branch_pattern,
     is_supported_if_nms_guard_pattern,
     is_supported_if_sequenceconstruct_add_branch_pattern,
+    is_supported_loop_static_unroll_pattern,
+    is_supported_loop_while_pattern,
 )
 
 
@@ -4654,6 +4657,22 @@ def _validate_if(node: Any, ctx: Any) -> None:
         )
 
 
+def _validate_loop(node: Any, ctx: Any) -> None:
+    if not (
+        is_supported_loop_static_unroll_pattern(node, ctx)
+        or is_supported_loop_while_pattern(node, ctx)
+    ):
+        raise NodeValidationError(
+            reason_code="unsupported_control_flow_pattern",
+            message=(
+                "Loop built-in lowering supports either static-unroll patterns with constant trip_count/cond "
+                "or WHILE patterns with loop-carried outputs only (no scan outputs)."
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+
+
 def _normalize_axis_for_rank(*, axis: int, rank: int, node: Any) -> int:
     a = int(axis)
     if a < 0:
@@ -5518,6 +5537,13 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
         builder=build_if_op,
         validation=ValidationSpec(min_inputs=1, max_inputs=1, min_outputs=1, max_outputs=1),
         extra_validator=_validate_if,
+    ),
+    "Loop": DispatchEntry(
+        onnx_op="Loop",
+        tflite_ops=["RESHAPE"],
+        builder=build_loop_op,
+        validation=ValidationSpec(min_inputs=3, max_inputs=None, min_outputs=1, max_outputs=None),
+        extra_validator=_validate_loop,
     ),
     "Transpose": DispatchEntry(
         onnx_op="Transpose",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.0.24"
+version = "2.0.25"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -53,6 +53,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_transpose_pre_unary_reshape_transpose_suffix_nhwc_chains,
     _optimize_transpose_pre_concat_ndhwc_chains,
     _optimize_transpose_pre_concat_nhwc_chains,
+    _optimize_transpose_pre_unary_mean_terminal_nhwc_chains,
     _optimize_transpose_mul_add_const_prepost_nhwc_chains,
     _optimize_transpose_mul_add_const_prelu_prepost_nhwc_terminal_chains,
     _reconcile_static_tensor_shapes,
@@ -12695,6 +12696,86 @@ def test_flatbuffer_direct_transpose_mean_prepost_nhwc_passthrough_keeps_pre_on_
     assert list(relu_op.inputs) == ["x_nchw"]
 
 
+def test_flatbuffer_direct_transpose_pre_unary_mean_terminal_nhwc_chain() -> None:
+    model_ir = ModelIR(name="transpose_pre_unary_mean_terminal_nhwc_test")
+    model_ir.inputs = ["x_nhwc"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 4, 4, 8],
+        shape_signature=[1, 4, 4, 8],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["mean_axes_nchw"] = TensorIR(
+        name="mean_axes_nchw",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([2, 3], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["reshape_shape"] = TensorIR(
+        name="reshape_shape",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([1, 8], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["x_nchw"] = TensorIR(
+        name="x_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 4, 4],
+        shape_signature=[1, 8, 4, 4],
+    )
+    model_ir.tensors["u_nchw"] = TensorIR(
+        name="u_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 4, 4],
+        shape_signature=[1, 8, 4, 4],
+    )
+    model_ir.tensors["m_nchw"] = TensorIR(
+        name="m_nchw",
+        dtype="FLOAT32",
+        shape=[1, 8, 1, 1],
+        shape_signature=[1, 8, 1, 1],
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 8],
+        shape_signature=[1, 8],
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "pre_perm"], outputs=["x_nchw"]),
+        OperatorIR(op_type="RELU6", inputs=["x_nchw"], outputs=["u_nchw"]),
+        OperatorIR(op_type="MEAN", inputs=["u_nchw", "mean_axes_nchw"], outputs=["m_nchw"], options={"keepDims": True}),
+        OperatorIR(op_type="RESHAPE", inputs=["m_nchw", "reshape_shape"], outputs=["y"], options={"newShape": [1, 8]}),
+    ]
+
+    stats = _optimize_transpose_pre_unary_mean_terminal_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_pre_unary_mean_terminal_nhwc_chains"] == 1
+    assert [str(op.op_type) for op in model_ir.operators] == ["RELU6", "MEAN", "RESHAPE"]
+    relu_op = model_ir.operators[0]
+    assert list(relu_op.inputs) == ["x_nhwc"]
+    assert list(model_ir.tensors["u_nchw"].shape) == [1, 4, 4, 8]
+    mean_op = model_ir.operators[1]
+    assert list(mean_op.inputs) == ["u_nchw", "mean_axes_nchw"]
+    assert np.array_equal(
+        np.asarray(model_ir.tensors["mean_axes_nchw"].data, dtype=np.int32),
+        np.asarray([1, 2], dtype=np.int32),
+    )
+    assert list(model_ir.tensors["m_nchw"].shape) == [1, 1, 1, 8]
+
+
 def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain() -> None:
     model_ir = ModelIR(name="transpose_se_conv_mul_prepost_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
@@ -16712,6 +16793,177 @@ def test_flatbuffer_direct_flatten_preserves_dynamic_dim_in_reshape_shape() -> N
         np.asarray(shape_tensor.data, dtype=np.int32).reshape(-1),
         np.asarray([-1, 4], dtype=np.int32),
     )
+
+
+def _make_loop_static_unroll_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("loop_x", TensorProto.FLOAT, [3])
+    y = helper.make_tensor_value_info("loop_y", TensorProto.FLOAT, [3])
+
+    trip_count = numpy_helper.from_array(np.asarray(8, dtype=np.int64), name="loop_trip_count")
+    cond_init = numpy_helper.from_array(np.asarray(True, dtype=np.bool_), name="loop_cond_init")
+
+    body_iter = helper.make_tensor_value_info("i", TensorProto.INT64, [])
+    body_cond = helper.make_tensor_value_info("cond", TensorProto.BOOL, [])
+    body_state = helper.make_tensor_value_info("state_in", TensorProto.FLOAT, [3])
+    body_cond_out = helper.make_tensor_value_info("cond_out", TensorProto.BOOL, [])
+    body_state_out = helper.make_tensor_value_info("state_out", TensorProto.FLOAT, [3])
+    body_nodes = [
+        helper.make_node("Identity", ["cond"], ["cond_out"], name="LoopBodyCondIdentity"),
+        helper.make_node("Sigmoid", ["state_in"], ["state_out"], name="LoopBodySigmoid"),
+    ]
+    body_graph = helper.make_graph(
+        body_nodes,
+        "loop_body",
+        [body_iter, body_cond, body_state],
+        [body_cond_out, body_state_out],
+    )
+
+    loop_node = helper.make_node(
+        "Loop",
+        ["loop_trip_count", "loop_cond_init", "loop_x"],
+        ["loop_y"],
+        name="LoopStaticUnroll",
+        body=body_graph,
+    )
+    graph = helper.make_graph(
+        [loop_node],
+        "loop_static_unroll_graph",
+        [x],
+        [y],
+        initializer=[trip_count, cond_init],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 16)])
+
+
+def _make_loop_while_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("loop_x", TensorProto.FLOAT, [3])
+    counter = helper.make_tensor_value_info("loop_counter", TensorProto.INT64, [])
+    y = helper.make_tensor_value_info("loop_y", TensorProto.FLOAT, [3])
+
+    max_trip = numpy_helper.from_array(np.asarray(9223372036854775807, dtype=np.int64), name="loop_max_trip")
+    cond_limit = numpy_helper.from_array(np.asarray(64, dtype=np.int64), name="loop_cond_limit")
+
+    cond_node = helper.make_node("Less", ["loop_counter", "loop_cond_limit"], ["loop_cond"], name="LoopTopCond")
+
+    body_iter = helper.make_tensor_value_info("iter", TensorProto.INT64, [])
+    body_cond = helper.make_tensor_value_info("cond", TensorProto.BOOL, [])
+    body_state = helper.make_tensor_value_info("state_in", TensorProto.FLOAT, [3])
+    body_counter = helper.make_tensor_value_info("counter_in", TensorProto.INT64, [])
+    body_cond_out = helper.make_tensor_value_info("cond_out", TensorProto.BOOL, [])
+    body_state_out = helper.make_tensor_value_info("state_out", TensorProto.FLOAT, [3])
+    body_counter_out = helper.make_tensor_value_info("counter_out", TensorProto.INT64, [])
+    body_counter_one = numpy_helper.from_array(np.asarray(1, dtype=np.int64), name="body_counter_one")
+    body_counter_limit = numpy_helper.from_array(np.asarray(64, dtype=np.int64), name="body_counter_limit")
+    body_nodes = [
+        helper.make_node("Sigmoid", ["state_in"], ["state_out"], name="LoopBodySigmoid"),
+        helper.make_node("Add", ["counter_in", "body_counter_one"], ["counter_out"], name="LoopBodyCounterAdd"),
+        helper.make_node("Less", ["counter_out", "body_counter_limit"], ["cond_out"], name="LoopBodyLess"),
+    ]
+    body_graph = helper.make_graph(
+        body_nodes,
+        "loop_while_body",
+        [body_iter, body_cond, body_state, body_counter],
+        [body_cond_out, body_state_out, body_counter_out],
+        initializer=[body_counter_one, body_counter_limit],
+    )
+
+    loop_node = helper.make_node(
+        "Loop",
+        ["loop_max_trip", "loop_cond", "loop_x", "loop_counter"],
+        ["loop_y", "loop_counter_out"],
+        name="LoopWhileNode",
+        body=body_graph,
+    )
+    graph = helper.make_graph(
+        [cond_node, loop_node],
+        "loop_while_graph",
+        [x, counter],
+        [y],
+        initializer=[max_trip, cond_limit],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 16)])
+
+
+def test_flatbuffer_direct_loop_static_unroll_lowers_to_builtin_ops_without_custom() -> None:
+    model_ir = lower_onnx_to_ir(
+        _make_loop_static_unroll_model(),
+        output_file_name="loop_static_unroll_builtin",
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert "CUSTOM" not in op_types
+    assert "WHILE" in op_types
+    assert len(model_ir.subgraphs) == 2
+    out_tensor = model_ir.tensors["loop_y"]
+    assert list(out_tensor.shape) == [3]
+
+
+def test_flatbuffer_direct_loop_while_lowers_to_builtin_ops_without_custom() -> None:
+    model_ir = lower_onnx_to_ir(
+        _make_loop_while_model(),
+        output_file_name="loop_while_builtin",
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert "CUSTOM" not in op_types
+    assert "WHILE" in op_types
+    assert len(model_ir.subgraphs) == 2
+    assert len(model_ir.subgraphs[0].operators) > 0
+    assert len(model_ir.subgraphs[1].operators) > 0
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires flatc and curl")
+def test_flatbuffer_direct_loop_static_unroll_op_coverage_reports_builtin_loop() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_loop_static_unroll_model()
+        model_path = _save_model(tmpdir, "loop_static_unroll", model)
+        out_dir = os.path.join(tmpdir, "out")
+        tflite_path = _convert(
+            model_path=model_path,
+            output_dir=out_dir,
+            backend="flatbuffer_direct",
+            report_op_coverage=True,
+        )
+        assert os.path.isfile(tflite_path)
+
+        report_path = os.path.join(out_dir, "loop_static_unroll_op_coverage_report.json")
+        assert os.path.isfile(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["graph_custom_ops"] == []
+        loop_reports = [
+            node
+            for node in report["graph_node_reports"]
+            if str(node.get("onnx_op", "")) == "Loop"
+        ]
+        assert len(loop_reports) == 1
+        assert loop_reports[0]["dispatch_mode"] == "builtin"
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires flatc and curl")
+def test_flatbuffer_direct_loop_while_op_coverage_reports_builtin_loop() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_loop_while_model()
+        model_path = _save_model(tmpdir, "loop_while", model)
+        out_dir = os.path.join(tmpdir, "out")
+        tflite_path = _convert(
+            model_path=model_path,
+            output_dir=out_dir,
+            backend="flatbuffer_direct",
+            report_op_coverage=True,
+        )
+        assert os.path.isfile(tflite_path)
+
+        report_path = os.path.join(out_dir, "loop_while_op_coverage_report.json")
+        assert os.path.isfile(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["graph_custom_ops"] == []
+        loop_reports = [
+            node
+            for node in report["graph_node_reports"]
+            if str(node.get("onnx_op", "")) == "Loop"
+        ]
+        assert len(loop_reports) == 1
+        assert loop_reports[0]["dispatch_mode"] == "builtin"
 
 
 def _make_if_nms_guard_direct_model() -> onnx.ModelProto:

--- a/uv.lock
+++ b/uv.lock
@@ -467,7 +467,7 @@ wheels = [
 
 [[package]]
 name = "onnx2tf"
-version = "2.0.24"
+version = "2.0.25"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
## Summary
This PR improves `flatbuffer_direct` conversion reliability and coverage, with a focus on control-flow lowering and shape/runtime correctness.

### What changed
- Added built-in control-flow lowering for ONNX `Loop` and improved branch handling for `If` in `flatbuffer_direct`.
- Registered and wired new control-flow builders across IR/model-writer/registry paths.
- Hardened runtime-check graph preparation in `onnx2tf.py` (preserving graph metadata such as domain/IR version) and improved eval fallback behavior.
- Fixed TF path random-like ops (`RandomNormalLike`, `RandomUniformLike`) to avoid `None` shape conversion failures.
- Added shape/permutation robustness fixes in several builders (`Concat`, `ConvTranspose`, `Slice`, control-flow related lowering paths).
- Added/updated direct-lowering tests, including loop-focused cases and transpose-optimization-related assertions.
- Updated README and version metadata (`2.0.25`).

## Why
Recent conversion failures and regressions were observed around:
- unresolved `ONNX_LOOP` custom-op fallback,
- control-flow lowering edge cases,
- runtime-check invalid-graph handling,
- shape mismatch/transpose redundancy around direct-lowered graphs.

This PR addresses those issues by expanding built-in lowering coverage and tightening shape/runtime validation paths.

## Validation
- `pytest -q tests/test_tflite_builder_direct.py -k "loop_"`
  - Result: `4 passed`.

## Notes
- This change is intentionally focused on `flatbuffer_direct` behavior and diagnostics, and keeps compatibility with existing conversion paths.
