### PR TITLE
Improve flatbuffer_direct coverage and DAMO conversion robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.2.1
+  ghcr.io/pinto0309/onnx2tf:2.2.2
 
   or
 
@@ -685,7 +685,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.2.1
+  docker.io/pinto0309/onnx2tf:2.2.2
 
   or
 
@@ -695,7 +695,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.2.1 \
+  docker.io/pinto0309/onnx2tf:2.2.2 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, List
 
-from onnx2tf.tflite_builder.ir import clone_model_ir_with_float16
+from onnx2tf.tflite_builder.ir import (
+    clone_model_ir_with_float16,
+    clone_model_ir_with_float32,
+    optimize_redundant_transpose_operators,
+    prune_identity_cast_operators,
+)
 from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     build_op_coverage_report,
     build_tensor_correspondence_report,
@@ -577,11 +582,24 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
             _advance_export_progress()
 
         _set_export_progress_desc("write float32 tflite")
+        model_ir_fp32 = clone_model_ir_with_float32(model_ir)
+        prune_identity_cast_operators(
+            model_ir_fp32,
+            preserve_model_outputs=True,
+        )
+        optimize_redundant_transpose_operators(
+            model_ir_fp32,
+            preserve_model_outputs=True,
+        )
+        _set_reduced_precision_support_metadata(
+            model_ir=model_ir_fp32,
+            enable_accumulation_type_float16=enable_accumulation_type_float16,
+        )
         float32_path = os.path.join(output_folder_path, f"{output_file_name}_float32.tflite")
         float32_write_timing: Dict[str, Any] = {}
         write_model_file(
             schema_tflite=schema_tflite,
-            model_ir=model_ir,
+            model_ir=model_ir_fp32,
             output_tflite_path=float32_path,
             timing=float32_write_timing,
         )
@@ -597,6 +615,10 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
 
         _set_export_progress_desc("write float16 tflite")
         model_ir_fp16 = clone_model_ir_with_float16(model_ir)
+        optimize_redundant_transpose_operators(
+            model_ir_fp16,
+            preserve_model_outputs=True,
+        )
         _set_reduced_precision_support_metadata(
             model_ir=model_ir_fp16,
             enable_accumulation_type_float16=enable_accumulation_type_float16,

--- a/onnx2tf/tflite_builder/ir.py
+++ b/onnx2tf/tflite_builder/ir.py
@@ -120,3 +120,366 @@ def clone_model_ir_with_float16(model_ir: ModelIR) -> ModelIR:
             ),
         )
     return clone
+
+
+def _rewrite_float16_token_to_float32(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _rewrite_float16_token_to_float32(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_rewrite_float16_token_to_float32(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_rewrite_float16_token_to_float32(item) for item in value)
+    if isinstance(value, str) and str(value).upper() == "FLOAT16":
+        return "FLOAT32"
+    return value
+
+
+def clone_model_ir_with_float32(model_ir: ModelIR) -> ModelIR:
+    clone = ModelIR(
+        name=model_ir.name,
+        description=model_ir.description,
+        metadata=dict(model_ir.metadata),
+    )
+    clone.inputs = list(model_ir.inputs)
+    clone.outputs = list(model_ir.outputs)
+    clone.subgraphs = [clone_model_ir_with_float32(subgraph) for subgraph in model_ir.subgraphs]
+    clone.operators = [
+        OperatorIR(
+            op_type=op.op_type,
+            inputs=list(op.inputs),
+            outputs=list(op.outputs),
+            options=_rewrite_float16_token_to_float32(dict(op.options)),
+            version=op.version,
+        ) for op in model_ir.operators
+    ]
+    for name, tensor in model_ir.tensors.items():
+        new_data = tensor.data
+        new_dtype = str(tensor.dtype).upper()
+        if new_dtype == "FLOAT16":
+            new_dtype = "FLOAT32"
+            if tensor.data is not None:
+                new_data = tensor.data.astype(np.float32)
+        clone.tensors[name] = TensorIR(
+            name=tensor.name,
+            dtype=new_dtype,
+            shape=list(tensor.shape),
+            shape_signature=list(tensor.shape_signature) if tensor.shape_signature is not None else None,
+            data=new_data.copy() if isinstance(new_data, np.ndarray) else new_data,
+            is_variable=tensor.is_variable,
+            quantization=(
+                dict(tensor.quantization)
+                if isinstance(tensor.quantization, dict)
+                else QuantParamIR(
+                    scale=list(tensor.quantization.scale),
+                    zero_point=list(tensor.quantization.zero_point),
+                    quantized_dimension=int(tensor.quantization.quantized_dimension),
+                    min=list(tensor.quantization.min)
+                    if tensor.quantization.min is not None
+                    else None,
+                    max=list(tensor.quantization.max)
+                    if tensor.quantization.max is not None
+                    else None,
+                )
+                if isinstance(tensor.quantization, QuantParamIR)
+                else tensor.quantization
+            ),
+        )
+    return clone
+
+
+def prune_identity_cast_operators(
+    model_ir: ModelIR,
+    *,
+    preserve_model_outputs: bool = True,
+) -> int:
+    """
+    Remove redundant CAST operators where in/out dtypes are identical.
+
+    Example:
+      CAST(inDataType=FLOAT32, outDataType=FLOAT32): a -> b
+    can be removed by rewiring consumers of `b` to `a`.
+
+    By default, casts whose output tensor is a model output are preserved to
+    avoid changing boundary tensor names/contracts.
+    """
+    rewritten = 0
+
+    while True:
+        changed = False
+        for cast_idx, cast_op in enumerate(model_ir.operators):
+            if str(cast_op.op_type) != "CAST" or len(cast_op.inputs) != 1 or len(cast_op.outputs) != 1:
+                continue
+
+            in_name = str(cast_op.inputs[0])
+            out_name = str(cast_op.outputs[0])
+            if in_name == "" or out_name == "" or in_name == out_name:
+                continue
+            if bool(preserve_model_outputs) and out_name in set(str(v) for v in model_ir.outputs):
+                continue
+
+            in_tensor = model_ir.tensors.get(in_name, None)
+            out_tensor = model_ir.tensors.get(out_name, None)
+            in_dtype = str(cast_op.options.get("inDataType", "")).upper()
+            out_dtype = str(cast_op.options.get("outDataType", "")).upper()
+            if in_dtype == "" and in_tensor is not None:
+                in_dtype = str(in_tensor.dtype).upper()
+            if out_dtype == "" and out_tensor is not None:
+                out_dtype = str(out_tensor.dtype).upper()
+            if in_dtype == "" or out_dtype == "" or in_dtype != out_dtype:
+                continue
+
+            for op in model_ir.operators:
+                if len(op.inputs) > 0:
+                    op.inputs = [
+                        in_name if str(input_name) == out_name else input_name
+                        for input_name in op.inputs
+                    ]
+            if not bool(preserve_model_outputs):
+                model_ir.outputs = [
+                    in_name if str(output_name) == out_name else output_name
+                    for output_name in model_ir.outputs
+                ]
+
+            del model_ir.operators[int(cast_idx)]
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    if rewritten > 0:
+        _prune_unused_tensors(model_ir)
+
+    return int(rewritten)
+
+
+def _prune_unused_tensors(model_ir: ModelIR) -> None:
+    used_tensor_names = set(str(v) for v in list(model_ir.inputs) + list(model_ir.outputs))
+    for op in model_ir.operators:
+        used_tensor_names.update(str(v) for v in op.inputs)
+        used_tensor_names.update(str(v) for v in op.outputs)
+    for tensor_name in [name for name in list(model_ir.tensors.keys()) if str(name) not in used_tensor_names]:
+        del model_ir.tensors[tensor_name]
+
+
+def _build_tensor_consumer_map(model_ir: ModelIR) -> Dict[str, List[int]]:
+    consumers: Dict[str, List[int]] = {}
+    for op_idx, op in enumerate(model_ir.operators):
+        for input_name in op.inputs:
+            key = str(input_name)
+            if key == "":
+                continue
+            consumers.setdefault(key, []).append(int(op_idx))
+    return consumers
+
+
+def _is_identity_perm(perm: List[int]) -> bool:
+    return list(int(v) for v in perm) == list(range(len(perm)))
+
+
+def _is_inverse_perm(perm_a: List[int], perm_b: List[int]) -> bool:
+    if len(perm_a) != len(perm_b):
+        return False
+    rank = len(perm_a)
+    if sorted(int(v) for v in perm_a) != list(range(rank)):
+        return False
+    if sorted(int(v) for v in perm_b) != list(range(rank)):
+        return False
+    return all(int(perm_b[int(perm_a[i])]) == int(i) for i in range(rank))
+
+
+def _compose_permutations(perm_pre: List[int], perm_post: List[int]) -> Optional[List[int]]:
+    if len(perm_pre) != len(perm_post) or len(perm_pre) == 0:
+        return None
+    rank = len(perm_pre)
+    if sorted(int(v) for v in perm_pre) != list(range(rank)):
+        return None
+    if sorted(int(v) for v in perm_post) != list(range(rank)):
+        return None
+    try:
+        return [int(perm_pre[int(v)]) for v in perm_post]
+    except Exception:
+        return None
+
+
+def _replace_tensor_inputs(model_ir: ModelIR, old_name: str, new_name: str) -> None:
+    for op in model_ir.operators:
+        if len(op.inputs) == 0:
+            continue
+        op.inputs = [
+            new_name if str(input_name) == str(old_name) else input_name
+            for input_name in op.inputs
+        ]
+
+
+def _read_transpose_perm(model_ir: ModelIR, op: OperatorIR) -> Optional[List[int]]:
+    if str(op.op_type) != "TRANSPOSE":
+        return None
+    if len(op.inputs) >= 2:
+        perm_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+        if perm_tensor is not None and perm_tensor.data is not None:
+            try:
+                perm = [int(v) for v in np.asarray(perm_tensor.data).reshape(-1).tolist()]
+                if len(perm) > 0 and sorted(perm) == list(range(len(perm))):
+                    return perm
+            except Exception:
+                pass
+    opt_perm = op.options.get("perm", None)
+    if isinstance(opt_perm, (list, tuple)) and len(opt_perm) > 0:
+        try:
+            perm = [int(v) for v in list(opt_perm)]
+            if sorted(perm) == list(range(len(perm))):
+                return perm
+        except Exception:
+            return None
+    return None
+
+
+def _write_transpose_perm(
+    model_ir: ModelIR,
+    op: OperatorIR,
+    perm: List[int],
+) -> None:
+    perm_values = [int(v) for v in list(perm)]
+    op.options["perm"] = list(perm_values)
+    if len(op.inputs) >= 2:
+        perm_name = str(op.inputs[1])
+        perm_tensor = model_ir.tensors.get(perm_name, None)
+        if perm_tensor is not None:
+            perm_arr = np.asarray(perm_values, dtype=np.int32)
+            perm_tensor.data = perm_arr
+            perm_tensor.dtype = "INT32"
+            perm_tensor.shape = [int(perm_arr.size)]
+            perm_tensor.shape_signature = [int(perm_arr.size)]
+            return
+    base_name = str(op.outputs[0]) if len(op.outputs) == 1 else f"transpose_perm_{len(model_ir.tensors)}"
+    new_perm_name = f"{base_name}_perm"
+    suffix = 1
+    while new_perm_name in model_ir.tensors:
+        new_perm_name = f"{base_name}_perm_{suffix}"
+        suffix += 1
+    perm_arr = np.asarray(perm_values, dtype=np.int32)
+    model_ir.tensors[new_perm_name] = TensorIR(
+        name=new_perm_name,
+        dtype="INT32",
+        shape=[int(perm_arr.size)],
+        shape_signature=[int(perm_arr.size)],
+        data=perm_arr,
+    )
+    if len(op.inputs) >= 2:
+        op.inputs[1] = new_perm_name
+    else:
+        op.inputs.append(new_perm_name)
+
+
+def optimize_redundant_transpose_operators(
+    model_ir: ModelIR,
+    *,
+    preserve_model_outputs: bool = True,
+) -> Dict[str, int]:
+    """
+    Reduce redundant TRANSPOSE chains:
+    - remove identity TRANSPOSE
+    - remove inverse consecutive TRANSPOSE pairs
+    - compose consecutive TRANSPOSE pairs into one TRANSPOSE
+    """
+    removed_identity = 0
+    removed_inverse_pairs = 0
+    composed_pairs = 0
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+
+        # 1) Remove identity transpose.
+        for op_idx, op in enumerate(model_ir.operators):
+            if str(op.op_type) != "TRANSPOSE" or len(op.outputs) != 1:
+                continue
+            perm = _read_transpose_perm(model_ir, op)
+            if perm is None or not _is_identity_perm(perm):
+                continue
+            in_name = str(op.inputs[0]) if len(op.inputs) >= 1 else ""
+            out_name = str(op.outputs[0])
+            if in_name == "" or out_name == "":
+                continue
+            if bool(preserve_model_outputs) and out_name in set(str(v) for v in model_ir.outputs):
+                continue
+            _replace_tensor_inputs(model_ir, out_name, in_name)
+            del model_ir.operators[int(op_idx)]
+            removed_identity += 1
+            changed = True
+            break
+        if changed:
+            continue
+
+        # 2) Simplify consecutive transpose pair.
+        for op_idx, pre_op in enumerate(model_ir.operators):
+            if str(pre_op.op_type) != "TRANSPOSE" or len(pre_op.outputs) != 1 or len(pre_op.inputs) < 1:
+                continue
+            bridge_name = str(pre_op.outputs[0])
+            bridge_users = [int(v) for v in consumers.get(bridge_name, [])]
+            if len(bridge_users) != 1:
+                continue
+            post_idx = int(bridge_users[0])
+            if post_idx == int(op_idx):
+                continue
+            post_op = model_ir.operators[int(post_idx)]
+            if str(post_op.op_type) != "TRANSPOSE" or len(post_op.outputs) != 1 or len(post_op.inputs) < 1:
+                continue
+            if str(post_op.inputs[0]) != bridge_name:
+                continue
+            pre_perm = _read_transpose_perm(model_ir, pre_op)
+            post_perm = _read_transpose_perm(model_ir, post_op)
+            if pre_perm is None or post_perm is None:
+                continue
+
+            composed_perm = _compose_permutations(pre_perm, post_perm)
+            if composed_perm is None:
+                continue
+
+            pre_input = str(pre_op.inputs[0])
+            post_output = str(post_op.outputs[0])
+            post_op.inputs[0] = pre_input
+
+            if _is_identity_perm(composed_perm):
+                if bool(preserve_model_outputs) and post_output in set(str(v) for v in model_ir.outputs):
+                    _write_transpose_perm(
+                        model_ir=model_ir,
+                        op=post_op,
+                        perm=[int(v) for v in range(len(composed_perm))],
+                    )
+                    del model_ir.operators[int(op_idx)]
+                    changed = True
+                    break
+                _replace_tensor_inputs(model_ir, post_output, pre_input)
+                for remove_idx in sorted([int(op_idx), int(post_idx)], reverse=True):
+                    del model_ir.operators[remove_idx]
+                removed_inverse_pairs += 1
+                changed = True
+                break
+
+            _write_transpose_perm(
+                model_ir=model_ir,
+                op=post_op,
+                perm=composed_perm,
+            )
+            del model_ir.operators[int(op_idx)]
+            composed_pairs += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    if removed_identity > 0 or removed_inverse_pairs > 0 or composed_pairs > 0:
+        _prune_unused_tensors(model_ir)
+
+    return {
+        "removed_identity_transpose": int(removed_identity),
+        "removed_inverse_transpose_pairs": int(removed_inverse_pairs),
+        "composed_consecutive_transpose_pairs": int(composed_pairs),
+    }

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -1555,7 +1555,10 @@ def _resolve_reshape_new_shape_from_static_input(
     return candidate
 
 
-def _resolve_dynamic_reshape_shapes(model_ir: ModelIR) -> Dict[str, int]:
+def _resolve_dynamic_reshape_shapes(
+    model_ir: ModelIR,
+    prefer_runtime_inferable_from_onnx_raw: bool = False,
+) -> Dict[str, int]:
     def _sanitize_reshape_template(
         *,
         template: List[int],
@@ -1666,7 +1669,21 @@ def _resolve_dynamic_reshape_shapes(model_ir: ModelIR) -> Dict[str, int]:
             # ONNX-exported raw reshape constants are semantically authoritative.
             # Do not re-infer them from possibly stale intermediate static metadata.
             # If a concrete newShape already exists, keep it as the most stable form.
+            raw_has_minus_one = any(int(dim) == -1 for dim in new_shape)
+            raw_has_zero_dim = any(int(dim) == 0 for dim in new_shape)
             if (
+                bool(prefer_runtime_inferable_from_onnx_raw)
+                and raw_has_minus_one
+                and not raw_has_zero_dim
+                and len(new_shape) >= 5
+            ):
+                # Final-stage safety mode:
+                # keep ONNX's runtime-inferable `-1` instead of stale concretized values.
+                resolved_shape = _sanitize_reshape_template(
+                    template=new_shape,
+                    input_dims=signature_for_resolve,
+                )
+            elif (
                 len(existing_new_shape_list) > 0
                 and all(int(dim) > 0 for dim in existing_new_shape_list)
             ):
@@ -2465,6 +2482,12 @@ def _sanitize_static_shape_signature_consistency(model_ir: ModelIR) -> Dict[str,
         if producer_op_type == "WHERE" and len(signature) >= 1 and int(signature[0]) < 0:
             dynamic_lineage_root_names.add(str(tensor_name))
             continue
+        if producer_op_type == "RANGE" and any(int(v) < 0 for v in signature):
+            # RANGE output length is runtime-dependent when `limit` is non-const.
+            # Keep this tensor as a dynamic-lineage root so downstream GATHER /
+            # RESHAPE chains preserve leading -1 signatures.
+            dynamic_lineage_root_names.add(str(tensor_name))
+            continue
         if producer_op_type == "RESHAPE":
             reshape_target: List[int] = []
             try:
@@ -2677,6 +2700,194 @@ def _write_const_ints_to_tensor(tensor: Optional[TensorIR], values: List[int]) -
     tensor.shape = [int(len(normalized))]
     tensor.shape_signature = [int(len(normalized))]
     return True
+
+
+def _replace_unsupported_split_with_slice(model_ir: ModelIR) -> Dict[str, int]:
+    """
+    Replace SPLIT ops whose input dtype is unsupported by LiteRT with SLICE chains.
+
+    LiteRT SPLIT currently accepts only:
+      FLOAT32, UINT8, INT8, INT16, INT32, INT64
+
+    For unsupported input dtypes (e.g. FLOAT16), rewrite:
+      SPLIT(axis, src) -> out_i
+    to:
+      [optional CAST(src -> target_dtype)]
+      SLICE(src_or_cast, begin_i, size_i) -> out_i
+    """
+    split_supported_input_dtypes = {
+        "FLOAT32",
+        "UINT8",
+        "INT8",
+        "INT16",
+        "INT32",
+        "INT64",
+    }
+
+    def _unique_tensor_name(base: str) -> str:
+        candidate = str(base)
+        serial = 1
+        while candidate in model_ir.tensors:
+            candidate = f"{base}_{serial}"
+            serial += 1
+        return candidate
+
+    rewritten = 0
+    new_operators: List[OperatorIR] = []
+
+    for op in model_ir.operators:
+        if str(op.op_type) != "SPLIT" or len(op.inputs) < 2 or len(op.outputs) <= 0:
+            new_operators.append(op)
+            continue
+
+        axis_tensor = model_ir.tensors.get(str(op.inputs[0]), None)
+        source_name = str(op.inputs[1])
+        source_tensor = model_ir.tensors.get(source_name, None)
+        if source_tensor is None:
+            new_operators.append(op)
+            continue
+
+        source_dtype = str(source_tensor.dtype).upper()
+        if source_dtype in split_supported_input_dtypes:
+            new_operators.append(op)
+            continue
+
+        axis_values = _read_const_ints_from_tensor(axis_tensor)
+        if axis_values is None or len(axis_values) == 0:
+            new_operators.append(op)
+            continue
+
+        source_shape = (
+            [int(v) for v in list(source_tensor.shape)]
+            if source_tensor.shape is not None
+            else []
+        )
+        rank = int(len(source_shape))
+        if rank <= 0:
+            new_operators.append(op)
+            continue
+
+        axis = int(axis_values[0])
+        if axis < 0:
+            axis += int(rank)
+        if axis < 0 or axis >= int(rank):
+            new_operators.append(op)
+            continue
+
+        outputs = [str(v) for v in list(op.outputs)]
+        num_splits = int(op.options.get("numSplits", len(outputs)))
+        if num_splits <= 0 or len(outputs) != int(num_splits):
+            new_operators.append(op)
+            continue
+
+        # Prefer explicit output tensor metadata for chunk sizes.
+        split_sizes: List[int] = []
+        can_derive_from_outputs = True
+        output_dtypes: List[str] = []
+        for output_name in outputs:
+            output_tensor = model_ir.tensors.get(output_name, None)
+            if output_tensor is None or output_tensor.shape is None:
+                can_derive_from_outputs = False
+                break
+            output_shape = [int(v) for v in list(output_tensor.shape)]
+            if len(output_shape) != int(rank):
+                can_derive_from_outputs = False
+                break
+            split_dim = int(output_shape[int(axis)])
+            if split_dim <= 0:
+                can_derive_from_outputs = False
+                break
+            split_sizes.append(int(split_dim))
+            output_dtypes.append(str(output_tensor.dtype).upper())
+
+        if not can_derive_from_outputs:
+            axis_dim = int(source_shape[int(axis)]) if int(axis) < len(source_shape) else -1
+            if axis_dim <= 0 or axis_dim % int(num_splits) != 0:
+                new_operators.append(op)
+                continue
+            each = int(axis_dim // int(num_splits))
+            split_sizes = [int(each) for _ in range(int(num_splits))]
+            output_dtypes = [
+                str(model_ir.tensors.get(output_name, source_tensor).dtype).upper()
+                for output_name in outputs
+            ]
+
+        slice_source_name = str(source_name)
+        unique_output_dtypes = sorted(set(output_dtypes))
+        if len(unique_output_dtypes) == 1:
+            target_dtype = str(unique_output_dtypes[0]).upper()
+            if target_dtype != "" and target_dtype != str(source_dtype).upper():
+                cast_output_name = _unique_tensor_name(f"{source_name}_split_cast")
+                source_signature = (
+                    [int(v) for v in list(source_tensor.shape_signature)]
+                    if source_tensor.shape_signature is not None
+                    else [int(v) for v in list(source_shape)]
+                )
+                model_ir.tensors[cast_output_name] = TensorIR(
+                    name=cast_output_name,
+                    dtype=target_dtype,
+                    shape=[int(v) for v in list(source_shape)],
+                    shape_signature=[int(v) for v in list(source_signature)],
+                    data=None,
+                    is_variable=False,
+                    quantization=None,
+                )
+                new_operators.append(
+                    OperatorIR(
+                        op_type="CAST",
+                        inputs=[str(source_name)],
+                        outputs=[cast_output_name],
+                        options={"outDataType": target_dtype},
+                    )
+                )
+                slice_source_name = str(cast_output_name)
+
+        offset = 0
+        for output_index, output_name in enumerate(outputs):
+            begin = [0 for _ in range(int(rank))]
+            begin[int(axis)] = int(offset)
+            size = [-1 for _ in range(int(rank))]
+            size[int(axis)] = int(split_sizes[int(output_index)])
+            offset += int(split_sizes[int(output_index)])
+
+            begin_name = _unique_tensor_name(f"{output_name}_split_fallback_begin")
+            size_name = _unique_tensor_name(f"{output_name}_split_fallback_size")
+
+            model_ir.tensors[begin_name] = TensorIR(
+                name=begin_name,
+                dtype="INT32",
+                shape=[int(rank)],
+                shape_signature=[int(rank)],
+                data=np.asarray(begin, dtype=np.int32),
+                is_variable=False,
+                quantization=None,
+            )
+            model_ir.tensors[size_name] = TensorIR(
+                name=size_name,
+                dtype="INT32",
+                shape=[int(rank)],
+                shape_signature=[int(rank)],
+                data=np.asarray(size, dtype=np.int32),
+                is_variable=False,
+                quantization=None,
+            )
+
+            new_operators.append(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[str(slice_source_name), begin_name, size_name],
+                    outputs=[output_name],
+                    options={},
+                )
+            )
+
+        rewritten += 1
+
+    if rewritten > 0:
+        model_ir.operators = new_operators
+        _prune_unused_tensors(model_ir)
+
+    return {"replaced_unsupported_split_with_slice": int(rewritten)}
 
 
 def _infer_slice_output_shape_and_resolved_params(
@@ -32724,6 +32935,529 @@ def _optimize_transpose_instancenorm_pad_prepost_nhwc_chains(model_ir: ModelIR) 
     return {"optimized_transpose_instancenorm_pad_prepost_nhwc_chains": int(rewritten)}
 
 
+def _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains(
+    model_ir: ModelIR,
+) -> Dict[str, int]:
+    """
+    Remove NHWC<->NCHW transpose bridges around flattened global-normalization blocks.
+
+    Target:
+      x_nhwc --T(0,3,1,2)--> x_nchw
+      x_nchw --RESHAPE([N,1,-1])--> r
+      r --(global norm decomposition)--> r_out
+      r_out --RESHAPE([N,C,H,W])--> y_nchw
+      y_nchw --(layout-agnostic tail)*--> t_nchw
+      t_nchw --PAD|MIRROR_PAD(pads_nchw)--> p_nchw
+      p_nchw --T(0,2,3,1)--> z_nhwc
+
+    Rewrite:
+      x_nhwc --RESHAPE([N,1,-1])--> r
+      r --(same global norm decomposition)--> r_out
+      r_out --RESHAPE([N,H,W,C])--> y_nhwc
+      y_nhwc --(same layout-agnostic tail)*--> t_nhwc
+      t_nhwc --PAD|MIRROR_PAD(pads_nhwc)--> z_nhwc
+    """
+    rewritten = 0
+    perm_nhwc_to_nchw = [0, 3, 1, 2]
+    perm_nchw_to_nhwc = [0, 2, 3, 1]
+    unary_tail_ops = {
+        "LEAKY_RELU",
+        "RELU",
+        "RELU6",
+        "TANH",
+        "LOGISTIC",
+        "HARD_SWISH",
+        "NEG",
+        "ABS",
+        "FLOOR",
+    }
+    binary_tail_ops = {"ADD", "SUB", "MUL", "DIV"}
+
+    def _is_const_broadcast_layout_agnostic(name: str) -> bool:
+        tensor = model_ir.tensors.get(str(name), None)
+        if tensor is None or tensor.data is None:
+            return False
+        array = np.asarray(tensor.data)
+        if int(array.size) == 1:
+            return True
+        shape = [int(v) for v in list(array.shape)]
+        return len(shape) > 0 and all(int(dim) == 1 for dim in shape)
+
+    def _can_rewrite_tail_const_to_nhwc(name: str) -> bool:
+        tensor = model_ir.tensors.get(str(name), None)
+        if tensor is None or tensor.data is None:
+            return False
+        array = np.asarray(tensor.data)
+        if int(array.size) == 1:
+            return True
+        shape = [int(v) for v in list(array.shape)]
+        if len(shape) > 0 and all(int(dim) == 1 for dim in shape):
+            return True
+        if len(shape) == 3 and int(shape[1]) == 1 and int(shape[2]) == 1:
+            return True
+        if (
+            len(shape) == 4
+            and int(shape[0]) == 1
+            and int(shape[2]) == 1
+            and int(shape[3]) == 1
+        ):
+            return True
+        return False
+
+    def _rewrite_tail_const_to_nhwc(name: str) -> bool:
+        tensor = model_ir.tensors.get(str(name), None)
+        if tensor is None or tensor.data is None:
+            return False
+        array = np.asarray(tensor.data)
+        if int(array.size) == 1:
+            return True
+        shape = [int(v) for v in list(array.shape)]
+        if len(shape) > 0 and all(int(dim) == 1 for dim in shape):
+            return True
+        if len(shape) == 3 and int(shape[1]) == 1 and int(shape[2]) == 1:
+            nhwc = np.reshape(array, newshape=[1, 1, int(shape[0])]).astype(array.dtype, copy=False)
+            tensor.data = np.asarray(nhwc)
+            tensor.shape = [int(v) for v in list(nhwc.shape)]
+            tensor.shape_signature = [int(v) for v in list(nhwc.shape)]
+            return True
+        if (
+            len(shape) == 4
+            and int(shape[0]) == 1
+            and int(shape[2]) == 1
+            and int(shape[3]) == 1
+        ):
+            nhwc = np.transpose(array, perm_nchw_to_nhwc).astype(array.dtype, copy=False)
+            tensor.data = np.asarray(nhwc)
+            tensor.shape = [int(v) for v in list(nhwc.shape)]
+            tensor.shape_signature = [int(v) for v in list(nhwc.shape)]
+            return True
+        return False
+
+    def _read_reshape_target(op: OperatorIR) -> Optional[List[int]]:
+        target: List[int] = []
+        if len(op.inputs) >= 2:
+            shape_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+            shape_vals = _read_const_ints_from_tensor(shape_tensor)
+            if shape_vals is not None:
+                target = [int(v) for v in list(shape_vals)]
+        if len(target) == 0:
+            raw_target = op.options.get("newShape", [])
+            try:
+                target = [int(v) for v in np.asarray(raw_target).reshape(-1).tolist()]
+            except Exception:
+                target = []
+        return [int(v) for v in list(target)] if len(target) > 0 else None
+
+    def _set_reshape_target(op: OperatorIR, target: List[int]) -> bool:
+        updated = False
+        shape_values = [int(v) for v in list(target)]
+        if len(op.inputs) >= 2:
+            shape_tensor = model_ir.tensors.get(str(op.inputs[1]), None)
+            if shape_tensor is not None:
+                if not _write_const_ints_to_tensor(shape_tensor, shape_values):
+                    return False
+                updated = True
+        if "newShape" in op.options:
+            op.options["newShape"] = [int(v) for v in list(shape_values)]
+            updated = True
+        if "onnxRawNewShape" in op.options and isinstance(op.options["onnxRawNewShape"], list):
+            raw_shape = [int(v) for v in list(op.options["onnxRawNewShape"])]
+            if (
+                len(raw_shape) == len(shape_values)
+                and all(int(v) >= 0 for v in raw_shape)
+            ):
+                op.options["onnxRawNewShape"] = [int(v) for v in list(shape_values)]
+                updated = True
+        return updated
+
+    while True:
+        changed = False
+        consumers = _build_tensor_consumer_map(model_ir)
+        model_outputs = set(str(v) for v in model_ir.outputs)
+
+        for pre_idx, pre_op in enumerate(model_ir.operators):
+            if (
+                str(pre_op.op_type) != "TRANSPOSE"
+                or len(pre_op.inputs) < 2
+                or len(pre_op.outputs) != 1
+                or _read_transpose_perm(model_ir, pre_op) != perm_nhwc_to_nchw
+            ):
+                continue
+            pre_in_name = str(pre_op.inputs[0])
+            pre_out_name = str(pre_op.outputs[0])
+            if pre_in_name in model_outputs or pre_out_name in model_outputs:
+                continue
+
+            pre_users = [int(v) for v in consumers.get(pre_out_name, [])]
+            if len(pre_users) != 1:
+                continue
+            reshape1_idx = int(pre_users[0])
+            reshape1_op = model_ir.operators[int(reshape1_idx)]
+            if (
+                str(reshape1_op.op_type) != "RESHAPE"
+                or len(reshape1_op.inputs) < 1
+                or len(reshape1_op.outputs) != 1
+                or str(reshape1_op.inputs[0]) != pre_out_name
+            ):
+                continue
+            reshape1_out_name = str(reshape1_op.outputs[0])
+            reshape1_target = _read_reshape_target(reshape1_op)
+            if (
+                reshape1_target is None
+                or len(reshape1_target) != 3
+                or int(reshape1_target[1]) != 1
+                or int(reshape1_target[2]) != -1
+            ):
+                continue
+
+            flat_users = set(int(v) for v in consumers.get(reshape1_out_name, []))
+            if len(flat_users) != 2:
+                continue
+            mean1_idx: Optional[int] = None
+            sub_idx: Optional[int] = None
+            for user_idx in sorted(list(flat_users)):
+                user_op = model_ir.operators[int(user_idx)]
+                if (
+                    str(user_op.op_type) == "MEAN"
+                    and len(user_op.inputs) == 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == reshape1_out_name
+                ):
+                    axes_vals = _read_const_ints_from_tensor(
+                        model_ir.tensors.get(str(user_op.inputs[1]), None)
+                    )
+                    if axes_vals is None or [int(v) for v in list(axes_vals)] != [2]:
+                        break
+                    mean1_idx = int(user_idx)
+                elif (
+                    str(user_op.op_type) == "SUB"
+                    and len(user_op.inputs) == 2
+                    and len(user_op.outputs) == 1
+                    and reshape1_out_name in {str(user_op.inputs[0]), str(user_op.inputs[1])}
+                ):
+                    sub_idx = int(user_idx)
+            if mean1_idx is None or sub_idx is None:
+                continue
+
+            mean1_op = model_ir.operators[int(mean1_idx)]
+            sub_op = model_ir.operators[int(sub_idx)]
+            mean1_out_name = str(mean1_op.outputs[0])
+            if mean1_out_name not in {str(sub_op.inputs[0]), str(sub_op.inputs[1])}:
+                continue
+            if set(int(v) for v in consumers.get(mean1_out_name, [])) != {int(sub_idx)}:
+                continue
+
+            centered_name = str(sub_op.outputs[0])
+            centered_users = set(int(v) for v in consumers.get(centered_name, []))
+            if len(centered_users) != 2:
+                continue
+            mul_square_idx: Optional[int] = None
+            mul_norm_idx: Optional[int] = None
+            for user_idx in sorted(list(centered_users)):
+                user_op = model_ir.operators[int(user_idx)]
+                if str(user_op.op_type) != "MUL" or len(user_op.inputs) != 2 or len(user_op.outputs) != 1:
+                    continue
+                in0 = str(user_op.inputs[0])
+                in1 = str(user_op.inputs[1])
+                if in0 == centered_name and in1 == centered_name:
+                    mul_square_idx = int(user_idx)
+                elif centered_name in {in0, in1}:
+                    mul_norm_idx = int(user_idx)
+            if mul_square_idx is None or mul_norm_idx is None:
+                continue
+
+            mul_square_op = model_ir.operators[int(mul_square_idx)]
+            squared_name = str(mul_square_op.outputs[0])
+            mean2_users = set(int(v) for v in consumers.get(squared_name, []))
+            if len(mean2_users) != 1:
+                continue
+            mean2_idx = int(list(mean2_users)[0])
+            mean2_op = model_ir.operators[int(mean2_idx)]
+            if (
+                str(mean2_op.op_type) != "MEAN"
+                or len(mean2_op.inputs) != 2
+                or len(mean2_op.outputs) != 1
+                or str(mean2_op.inputs[0]) != squared_name
+            ):
+                continue
+            axes2_vals = _read_const_ints_from_tensor(model_ir.tensors.get(str(mean2_op.inputs[1]), None))
+            if axes2_vals is None or [int(v) for v in list(axes2_vals)] != [2]:
+                continue
+
+            mean2_out_name = str(mean2_op.outputs[0])
+            add_eps_users = set(int(v) for v in consumers.get(mean2_out_name, []))
+            if len(add_eps_users) != 1:
+                continue
+            add_eps_idx = int(list(add_eps_users)[0])
+            add_eps_op = model_ir.operators[int(add_eps_idx)]
+            if (
+                str(add_eps_op.op_type) != "ADD"
+                or len(add_eps_op.inputs) != 2
+                or len(add_eps_op.outputs) != 1
+                or mean2_out_name not in {str(add_eps_op.inputs[0]), str(add_eps_op.inputs[1])}
+            ):
+                continue
+            add_eps_out_name = str(add_eps_op.outputs[0])
+
+            sqrt_users = set(int(v) for v in consumers.get(add_eps_out_name, []))
+            if len(sqrt_users) != 1:
+                continue
+            sqrt_idx = int(list(sqrt_users)[0])
+            sqrt_op = model_ir.operators[int(sqrt_idx)]
+            if (
+                str(sqrt_op.op_type) != "SQRT"
+                or len(sqrt_op.inputs) != 1
+                or len(sqrt_op.outputs) != 1
+                or str(sqrt_op.inputs[0]) != add_eps_out_name
+            ):
+                continue
+            sqrt_out_name = str(sqrt_op.outputs[0])
+
+            div_users = set(int(v) for v in consumers.get(sqrt_out_name, []))
+            if len(div_users) != 1:
+                continue
+            div_idx = int(list(div_users)[0])
+            div_op = model_ir.operators[int(div_idx)]
+            if (
+                str(div_op.op_type) != "DIV"
+                or len(div_op.inputs) != 2
+                or len(div_op.outputs) != 1
+                or str(div_op.inputs[1]) != sqrt_out_name
+            ):
+                continue
+            div_out_name = str(div_op.outputs[0])
+
+            mul_norm_op = model_ir.operators[int(mul_norm_idx)]
+            if div_out_name not in {str(mul_norm_op.inputs[0]), str(mul_norm_op.inputs[1])}:
+                continue
+            normalized_name = str(mul_norm_op.outputs[0])
+
+            mul_scale_users = set(int(v) for v in consumers.get(normalized_name, []))
+            if len(mul_scale_users) != 1:
+                continue
+            mul_scale_idx = int(list(mul_scale_users)[0])
+            mul_scale_op = model_ir.operators[int(mul_scale_idx)]
+            if (
+                str(mul_scale_op.op_type) != "MUL"
+                or len(mul_scale_op.inputs) != 2
+                or len(mul_scale_op.outputs) != 1
+                or normalized_name not in {str(mul_scale_op.inputs[0]), str(mul_scale_op.inputs[1])}
+            ):
+                continue
+            scale_const_name = (
+                str(mul_scale_op.inputs[0])
+                if str(mul_scale_op.inputs[1]) == normalized_name
+                else str(mul_scale_op.inputs[1])
+            )
+            if not _is_const_broadcast_layout_agnostic(scale_const_name):
+                continue
+            scaled_name = str(mul_scale_op.outputs[0])
+
+            add_bias_users = set(int(v) for v in consumers.get(scaled_name, []))
+            if len(add_bias_users) != 1:
+                continue
+            add_bias_idx = int(list(add_bias_users)[0])
+            add_bias_op = model_ir.operators[int(add_bias_idx)]
+            if (
+                str(add_bias_op.op_type) != "ADD"
+                or len(add_bias_op.inputs) != 2
+                or len(add_bias_op.outputs) != 1
+                or scaled_name not in {str(add_bias_op.inputs[0]), str(add_bias_op.inputs[1])}
+            ):
+                continue
+            bias_const_name = (
+                str(add_bias_op.inputs[0])
+                if str(add_bias_op.inputs[1]) == scaled_name
+                else str(add_bias_op.inputs[1])
+            )
+            if not _is_const_broadcast_layout_agnostic(bias_const_name):
+                continue
+            inst_flat_name = str(add_bias_op.outputs[0])
+
+            reshape2_users = [int(v) for v in consumers.get(inst_flat_name, [])]
+            if len(reshape2_users) != 1:
+                continue
+            reshape2_idx = int(reshape2_users[0])
+            reshape2_op = model_ir.operators[int(reshape2_idx)]
+            if (
+                str(reshape2_op.op_type) != "RESHAPE"
+                or len(reshape2_op.inputs) < 1
+                or len(reshape2_op.outputs) != 1
+                or str(reshape2_op.inputs[0]) != inst_flat_name
+            ):
+                continue
+            reshape2_target = _read_reshape_target(reshape2_op)
+            if (
+                reshape2_target is None
+                or len(reshape2_target) != 4
+                or any(int(v) <= 0 for v in reshape2_target)
+            ):
+                continue
+
+            tail_rank4_names: List[str] = [str(reshape2_op.outputs[0])]
+            tail_const_names: List[str] = []
+            cursor_name = str(reshape2_op.outputs[0])
+            pad_idx: Optional[int] = None
+            pad_op: Optional[OperatorIR] = None
+            visited_names: set[str] = {cursor_name}
+            while True:
+                cursor_users = [int(v) for v in consumers.get(cursor_name, [])]
+                if len(cursor_users) != 1:
+                    break
+                user_idx = int(cursor_users[0])
+                user_op = model_ir.operators[int(user_idx)]
+                user_type = str(user_op.op_type)
+                if (
+                    user_type in {"PAD", "MIRROR_PAD"}
+                    and len(user_op.inputs) >= 2
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == cursor_name
+                ):
+                    pad_idx = int(user_idx)
+                    pad_op = user_op
+                    tail_rank4_names.append(str(user_op.outputs[0]))
+                    break
+                if (
+                    user_type in unary_tail_ops
+                    and len(user_op.inputs) == 1
+                    and len(user_op.outputs) == 1
+                    and str(user_op.inputs[0]) == cursor_name
+                ):
+                    cursor_name = str(user_op.outputs[0])
+                    if cursor_name in visited_names:
+                        break
+                    visited_names.add(cursor_name)
+                    tail_rank4_names.append(cursor_name)
+                    continue
+                if (
+                    user_type in binary_tail_ops
+                    and len(user_op.inputs) == 2
+                    and len(user_op.outputs) == 1
+                    and cursor_name in {str(user_op.inputs[0]), str(user_op.inputs[1])}
+                ):
+                    other_name = (
+                        str(user_op.inputs[0])
+                        if str(user_op.inputs[1]) == cursor_name
+                        else str(user_op.inputs[1])
+                    )
+                    if not _can_rewrite_tail_const_to_nhwc(other_name):
+                        break
+                    tail_const_names.append(str(other_name))
+                    cursor_name = str(user_op.outputs[0])
+                    if cursor_name in visited_names:
+                        break
+                    visited_names.add(cursor_name)
+                    tail_rank4_names.append(cursor_name)
+                    continue
+                break
+            if pad_idx is None or pad_op is None:
+                continue
+
+            pad_out_name = str(pad_op.outputs[0])
+            post_users = [int(v) for v in consumers.get(pad_out_name, [])]
+            if len(post_users) != 1:
+                continue
+            post_idx = int(post_users[0])
+            post_op = model_ir.operators[int(post_idx)]
+            if (
+                str(post_op.op_type) != "TRANSPOSE"
+                or len(post_op.inputs) < 2
+                or len(post_op.outputs) != 1
+                or str(post_op.inputs[0]) != pad_out_name
+                or _read_transpose_perm(model_ir, post_op) != perm_nchw_to_nhwc
+            ):
+                continue
+            post_out_name = str(post_op.outputs[0])
+
+            pads_name = str(pad_op.inputs[1])
+            pads_tensor = model_ir.tensors.get(pads_name, None)
+            if pads_tensor is None or pads_tensor.data is None:
+                continue
+            try:
+                pads_pairs = np.asarray(pads_tensor.data).reshape(4, 2)
+            except Exception:
+                continue
+            if int(pads_pairs.size) != 8:
+                continue
+
+            _replace_operator_input_at(
+                model_ir=model_ir,
+                op=reshape1_op,
+                input_index=0,
+                new_input_name=pre_in_name,
+            )
+
+            nchw_shape = [int(v) for v in list(reshape2_target)]
+            nhwc_shape = [
+                int(nchw_shape[0]),
+                int(nchw_shape[2]),
+                int(nchw_shape[3]),
+                int(nchw_shape[1]),
+            ]
+            if not _set_reshape_target(reshape2_op, nhwc_shape):
+                continue
+
+            unique_tail_const_names = []
+            seen_const_names: set[str] = set()
+            for const_name in tail_const_names:
+                key = str(const_name)
+                if key in seen_const_names:
+                    continue
+                seen_const_names.add(key)
+                unique_tail_const_names.append(key)
+            if any(not _rewrite_tail_const_to_nhwc(const_name) for const_name in unique_tail_const_names):
+                continue
+
+            pads_nhwc = np.asarray(
+                [pads_pairs[0], pads_pairs[2], pads_pairs[3], pads_pairs[1]],
+                dtype=pads_pairs.dtype,
+            )
+            pads_tensor.data = np.asarray(pads_nhwc)
+            pads_tensor.shape = [4, 2]
+            pads_tensor.shape_signature = [4, 2]
+
+            _set_operator_outputs(
+                model_ir=model_ir,
+                op=pad_op,
+                new_outputs=[post_out_name],
+            )
+
+            for tensor_name in tail_rank4_names:
+                _permute_tensor_metadata_if_rank_matches(
+                    model_ir.tensors.get(str(tensor_name), None),
+                    perm_nchw_to_nhwc,
+                )
+
+            old_pad_tensor = model_ir.tensors.get(str(pad_out_name), None)
+            post_out_tensor = model_ir.tensors.get(str(post_out_name), None)
+            if old_pad_tensor is not None and post_out_tensor is not None:
+                post_out_tensor.dtype = str(old_pad_tensor.dtype)
+                post_out_tensor.quantization = _clone_quantization(old_pad_tensor.quantization)
+                post_out_tensor.shape = [int(v) for v in list(old_pad_tensor.shape)]
+                post_out_tensor.shape_signature = (
+                    [int(v) for v in list(old_pad_tensor.shape_signature)]
+                    if old_pad_tensor.shape_signature is not None
+                    else [int(v) for v in list(old_pad_tensor.shape)]
+                )
+                _permute_tensor_metadata_if_rank_matches(
+                    post_out_tensor,
+                    perm_nchw_to_nhwc,
+                )
+
+            for remove_idx in sorted([int(pre_idx), int(post_idx)], reverse=True):
+                del model_ir.operators[int(remove_idx)]
+
+            rewritten += 1
+            changed = True
+            break
+
+        if not changed:
+            break
+
+    _prune_unused_tensors(model_ir)
+    return {"optimized_transpose_flatten_globalnorm_pad_prepost_nhwc_chains": int(rewritten)}
+
+
 def _optimize_transpose_instancenorm_residual_add_to_single_post_adapter_nhwc_chains(
     model_ir: ModelIR,
 ) -> Dict[str, int]:
@@ -54126,6 +54860,8 @@ def _optimize_consecutive_reshape_passthrough_chains(model_ir: ModelIR) -> Dict[
         for reshape_idx, reshape_op in enumerate(model_ir.operators):
             if str(reshape_op.op_type) != "RESHAPE" or len(reshape_op.inputs) < 1 or len(reshape_op.outputs) != 1:
                 continue
+            if bool(reshape_op.options.get("preserveDynamicShape", False)):
+                continue
 
             src_name = str(reshape_op.inputs[0])
             dst_name = str(reshape_op.outputs[0])
@@ -68737,6 +69473,11 @@ def lower_onnx_to_ir(
                     "optimized_transpose_instancenorm_pad_prepost_nhwc_chains", 0
                 )
             )
+            rewritten_flat_globalnorm_pad = int(
+                _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains(model_ir).get(
+                    "optimized_transpose_flatten_globalnorm_pad_prepost_nhwc_chains", 0
+                )
+            )
             rewritten_instnorm_residual = int(
                 _optimize_transpose_instancenorm_residual_add_to_single_post_adapter_nhwc_chains(model_ir).get(
                     "optimized_transpose_instancenorm_residual_add_to_single_post_adapter_nhwc_chains", 0
@@ -68756,6 +69497,7 @@ def lower_onnx_to_ir(
                 rewritten_instnorm
                 + rewritten_instnorm_posttranspose_bias
                 + rewritten_instnorm_pad
+                + rewritten_flat_globalnorm_pad
                 + rewritten_instnorm_residual
                 + rewritten_instnorm_residual_tail
                 + rewritten_instnorm_dualstats_residual
@@ -68803,6 +69545,7 @@ def lower_onnx_to_ir(
     # Late recovery passes can recreate Conv->InstNorm(NCHW)->Pad wrappers.
     _optimize_transpose_instancenorm_posttranspose_bias_add_nhwc_chains(model_ir)
     _optimize_transpose_instancenorm_pad_prepost_nhwc_chains(model_ir)
+    _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains(model_ir)
     _optimize_transpose_instancenorm_residual_add_to_single_post_adapter_nhwc_chains(model_ir)
     _optimize_transpose_instancenorm_residual_mul_concat_conv_nhwc_chains(model_ir)
     _optimize_transpose_instancenorm_dualstats_residual_add_resize_nhwc_chains(model_ir)
@@ -69170,10 +69913,17 @@ def lower_onnx_to_ir(
     _optimize_transpose_gather_transpose_axis_remap_nhwc_chains(model_ir)
     _optimize_constant_input_cast_chains(model_ir)
     _optimize_redundant_int64_to_int32_cast_chains(model_ir)
+    _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains(model_ir)
     # Very late terminal bridge/transpose rewrites above can still stale out
     # RESHAPE constant inputs. Re-resolve once immediately before final sort.
-    _resolve_dynamic_reshape_shapes(model_ir)
+    _resolve_dynamic_reshape_shapes(
+        model_ir,
+        prefer_runtime_inferable_from_onnx_raw=True,
+    )
     _reconcile_static_tensor_shapes(model_ir)
+    split_fallback_stats = _replace_unsupported_split_with_slice(model_ir)
+    if int(split_fallback_stats.get("replaced_unsupported_split_with_slice", 0)) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
 
     # Safety fallback:
     # Some aggressive transpose/layout rewrites can leave dangling dynamic inputs
@@ -69237,6 +69987,7 @@ def lower_onnx_to_ir(
     # one more strict TRANSPOSE->MUL(const)->TRANSPOSE->ADD(const) fragment.
     _optimize_transpose_mul_posttranspose_add_nhwc_chains(model_ir)
     _optimize_transpose_instancenorm_posttranspose_bias_add_nhwc_chains(model_ir)
+    _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains(model_ir)
     _topologically_sort_operators(model_ir)
     _advance_post_progress()
     if post_progress_bar is not None:

--- a/onnx2tf/tflite_builder/op_builders/elementwise.py
+++ b/onnx2tf/tflite_builder/op_builders/elementwise.py
@@ -1274,9 +1274,14 @@ def build_inverse_op(node: Any, ctx: Any) -> None:
         cols = int(rows)
     elif col_known and not row_known:
         rows = int(cols)
-    if rows != cols or rows not in {2, 3}:
+    if rows != cols or rows < 1:
         raise NotImplementedError(
-            "Inverse currently supports only square matrix last dims [2,2] or [3,3] in "
+            "Inverse currently supports only square matrix last dims [N,N] with N >= 1 in "
+            f"flatbuffer_direct. op={node.name} input_shape={input_shape} input_signature={input_signature}"
+        )
+    if rows > 16:
+        raise NotImplementedError(
+            "Inverse currently supports matrix last dims up to [16,16] in "
             f"flatbuffer_direct. op={node.name} input_shape={input_shape} input_signature={input_signature}"
         )
 
@@ -1373,6 +1378,301 @@ def build_inverse_op(node: Any, ctx: Any) -> None:
             )
         )
         return out_name
+
+    if cols > 3:
+        np_dtype = np.float16 if compute_dtype == "FLOAT16" else np.float32
+        prefix_ones = [1 for _ in prefix_shape]
+        matrix_rank_shape = prefix_ones + [rows, cols]
+        row_selector_shape = prefix_ones + [rows, 1]
+
+        identity = np.eye(rows, dtype=np_dtype).reshape(matrix_rank_shape)
+        if len(prefix_shape) > 0:
+            identity = np.tile(identity, prefix_shape + [1, 1])
+        identity_name = ctx.add_const_tensor(
+            f"{compute_output_name}_inverse_identity",
+            identity.astype(np_dtype),
+        )
+
+        eps_name = _add_scalar_const(
+            ctx,
+            f"{compute_output_name}_inverse_eps",
+            float(1e-6),
+            compute_dtype,
+        )
+
+        def _slice_matrix_row(src_name: str, row: int, suffix: str) -> str:
+            begin = [0 for _ in range(rank)]
+            size = [-1 for _ in range(rank)]
+            begin[-2] = int(row)
+            size[-2] = 1
+            begin_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_{suffix}_begin",
+                np.asarray(begin, dtype=np.int32),
+            )
+            size_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_{suffix}_size",
+                np.asarray(size, dtype=np.int32),
+            )
+            out_name = ctx.add_intermediate_tensor(
+                f"{compute_output_name}_inverse_{suffix}",
+                dtype=compute_dtype,
+                shape=row_shape,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[src_name, begin_name, size_name],
+                    outputs=[out_name],
+                )
+            )
+            return out_name
+
+        def _slice_matrix_col(src_name: str, col: int, suffix: str) -> str:
+            begin = [0 for _ in range(rank)]
+            size = [-1 for _ in range(rank)]
+            begin[-1] = int(col)
+            size[-1] = 1
+            begin_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_{suffix}_begin",
+                np.asarray(begin, dtype=np.int32),
+            )
+            size_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_{suffix}_size",
+                np.asarray(size, dtype=np.int32),
+            )
+            out_name = ctx.add_intermediate_tensor(
+                f"{compute_output_name}_inverse_{suffix}",
+                dtype=compute_dtype,
+                shape=prefix_shape + [rows, 1],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[src_name, begin_name, size_name],
+                    outputs=[out_name],
+                )
+            )
+            return out_name
+
+        def _slice_matrix_scalar(src_name: str, row: int, col: int, suffix: str) -> str:
+            begin = [0 for _ in range(rank)]
+            size = [-1 for _ in range(rank)]
+            begin[-2] = int(row)
+            begin[-1] = int(col)
+            size[-2] = 1
+            size[-1] = 1
+            begin_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_{suffix}_begin",
+                np.asarray(begin, dtype=np.int32),
+            )
+            size_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_{suffix}_size",
+                np.asarray(size, dtype=np.int32),
+            )
+            out_name = ctx.add_intermediate_tensor(
+                f"{compute_output_name}_inverse_{suffix}",
+                dtype=compute_dtype,
+                shape=scalar_shape,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SLICE",
+                    inputs=[src_name, begin_name, size_name],
+                    outputs=[out_name],
+                )
+            )
+            return out_name
+
+        def _binary_tensor(
+            op_type: str,
+            lhs: str,
+            rhs: str,
+            shape: list[int],
+            suffix: str,
+        ) -> str:
+            out_name = ctx.add_intermediate_tensor(
+                f"{compute_output_name}_inverse_{suffix}",
+                dtype=compute_dtype,
+                shape=shape,
+            )
+            options = (
+                {"fusedActivationFunction": "NONE"}
+                if str(op_type) in {"ADD", "SUB", "MUL", "DIV"}
+                else {}
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type=op_type,
+                    inputs=[lhs, rhs],
+                    outputs=[out_name],
+                    options=options,
+                )
+            )
+            return out_name
+
+        def _batch_matmul(lhs: str, rhs: str, suffix: str) -> str:
+            out_name = ctx.add_intermediate_tensor(
+                f"{compute_output_name}_inverse_{suffix}",
+                dtype=compute_dtype,
+                shape=matrix_shape,
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="BATCH_MATMUL",
+                    inputs=[lhs, rhs],
+                    outputs=[out_name],
+                    options={
+                        "adjX": False,
+                        "adjY": False,
+                        "asymmetricQuantizeInputs": False,
+                    },
+                )
+            )
+            return out_name
+
+        matrix_state = str(compute_input_name)
+        inverse_state = str(identity_name)
+        for row_idx in range(rows):
+            row_mask_arr = np.zeros(row_selector_shape, dtype=np_dtype)
+            row_mask_arr[..., int(row_idx), 0] = np_dtype(1.0)
+            row_mask_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_rowmask_{row_idx}",
+                row_mask_arr,
+            )
+
+            elim_mask_arr = np.ones(row_selector_shape, dtype=np_dtype)
+            elim_mask_arr[..., int(row_idx), 0] = np_dtype(0.0)
+            elim_mask_name = ctx.add_const_tensor(
+                f"{compute_output_name}_inverse_elimmask_{row_idx}",
+                elim_mask_arr,
+            )
+
+            row_a = _slice_matrix_row(matrix_state, row_idx, f"iter{row_idx}_row_a")
+            row_inv = _slice_matrix_row(inverse_state, row_idx, f"iter{row_idx}_row_inv")
+            pivot = _slice_matrix_scalar(matrix_state, row_idx, row_idx, f"iter{row_idx}_pivot")
+            pivot_safe = _binary_tensor(
+                "ADD",
+                pivot,
+                eps_name,
+                scalar_shape,
+                f"iter{row_idx}_pivot_safe",
+            )
+
+            row_a_norm = _binary_tensor(
+                "DIV",
+                row_a,
+                pivot_safe,
+                row_shape,
+                f"iter{row_idx}_row_a_norm",
+            )
+            row_inv_norm = _binary_tensor(
+                "DIV",
+                row_inv,
+                pivot_safe,
+                row_shape,
+                f"iter{row_idx}_row_inv_norm",
+            )
+
+            delta_row_a = _binary_tensor(
+                "SUB",
+                row_a_norm,
+                row_a,
+                row_shape,
+                f"iter{row_idx}_delta_row_a",
+            )
+            delta_row_inv = _binary_tensor(
+                "SUB",
+                row_inv_norm,
+                row_inv,
+                row_shape,
+                f"iter{row_idx}_delta_row_inv",
+            )
+
+            row_update_a = _batch_matmul(
+                row_mask_name,
+                delta_row_a,
+                f"iter{row_idx}_row_update_a",
+            )
+            row_update_inv = _batch_matmul(
+                row_mask_name,
+                delta_row_inv,
+                f"iter{row_idx}_row_update_inv",
+            )
+
+            matrix_norm = _binary_tensor(
+                "ADD",
+                matrix_state,
+                row_update_a,
+                matrix_shape,
+                f"iter{row_idx}_matrix_norm",
+            )
+            inverse_norm = _binary_tensor(
+                "ADD",
+                inverse_state,
+                row_update_inv,
+                matrix_shape,
+                f"iter{row_idx}_inverse_norm",
+            )
+
+            factor_col = _slice_matrix_col(
+                matrix_norm,
+                row_idx,
+                f"iter{row_idx}_factor_col",
+            )
+            factor_col_masked = _binary_tensor(
+                "MUL",
+                factor_col,
+                elim_mask_name,
+                prefix_shape + [rows, 1],
+                f"iter{row_idx}_factor_col_masked",
+            )
+
+            elim_matrix = _batch_matmul(
+                factor_col_masked,
+                row_a_norm,
+                f"iter{row_idx}_elim_matrix",
+            )
+            elim_inverse = _batch_matmul(
+                factor_col_masked,
+                row_inv_norm,
+                f"iter{row_idx}_elim_inverse",
+            )
+
+            matrix_state = _binary_tensor(
+                "SUB",
+                matrix_norm,
+                elim_matrix,
+                matrix_shape,
+                f"iter{row_idx}_matrix_state",
+            )
+            inverse_state = _binary_tensor(
+                "SUB",
+                inverse_norm,
+                elim_inverse,
+                matrix_shape,
+                f"iter{row_idx}_inverse_state",
+            )
+
+        final_shape_name = ctx.add_const_tensor(
+            f"{compute_output_name}_inverse_final_shape",
+            np.asarray(matrix_shape, dtype=np.int32),
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="RESHAPE",
+                inputs=[inverse_state, final_shape_name],
+                outputs=[compute_output_name],
+                options={"newShape": [int(v) for v in matrix_shape]},
+            )
+        )
+        _finalize_float_compute_output(
+            ctx=ctx,
+            compute_output_name=compute_output_name,
+            output_name=output_name,
+            compute_dtype=compute_dtype,
+            output_dtype=output_dtype,
+        )
+        return
 
     if cols == 2:
         a00 = _slice_matrix_entry(0, 0)

--- a/onnx2tf/tflite_builder/op_builders/fc.py
+++ b/onnx2tf/tflite_builder/op_builders/fc.py
@@ -423,11 +423,24 @@ def build_fully_connected_from_gemm_or_matmul(node: Any, ctx: Any) -> None:
             np.asarray(bias_values, dtype=np.float32),
         )
 
+        fc_input_name = _add_cast_if_needed(
+            tensor_name=input_name,
+            suffix="fc_in",
+            target_dtype=compute_dtype,
+        )
+        fc_output_name = output_name
+        if output_dtype != compute_dtype:
+            fc_output_name = ctx.add_intermediate_tensor(
+                f"{output_name}_fc_{str(compute_dtype).lower()}",
+                dtype=compute_dtype,
+                shape=[int(v) for v in list(output_shape)],
+            )
+
         ctx.add_operator(
             OperatorIR(
                 op_type="FULLY_CONNECTED",
-                inputs=[input_name, w_name, b_name],
-                outputs=[output_name],
+                inputs=[fc_input_name, w_name, b_name],
+                outputs=[fc_output_name],
                 options={
                     "fusedActivationFunction": "NONE",
                     "weightsFormat": "DEFAULT",
@@ -436,6 +449,15 @@ def build_fully_connected_from_gemm_or_matmul(node: Any, ctx: Any) -> None:
                 },
             )
         )
+        if fc_output_name != output_name:
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="CAST",
+                    inputs=[fc_output_name],
+                    outputs=[output_name],
+                    options={"inDataType": compute_dtype, "outDataType": output_dtype},
+                )
+            )
         return
 
     # Dynamic GEMM fallback: BATCH_MATMUL (+ alpha/beta/C) so Gemm can remain builtin.

--- a/onnx2tf/tflite_builder/op_builders/index.py
+++ b/onnx2tf/tflite_builder/op_builders/index.py
@@ -703,9 +703,9 @@ def build_gather_nd_op(node: Any, ctx: Any) -> None:
     ctx.ensure_tensor(output_name)
 
     batch_dims = int(node.attrs.get("batch_dims", 0))
-    if batch_dims != 0:
+    if batch_dims < 0:
         raise NotImplementedError(
-            f"GatherND batch_dims != 0 is not supported in flatbuffer_direct. "
+            f"GatherND batch_dims must be >= 0 in flatbuffer_direct. "
             f"op={node.name} batch_dims={batch_dims}"
         )
 
@@ -806,10 +806,11 @@ def build_gather_nd_op(node: Any, ctx: Any) -> None:
         gather_dims = int(indices_shape[-1]) if len(indices_shape) > 0 else -1
         if len(indices_runtime_signature) > 0 and int(indices_runtime_signature[-1]) > 0:
             gather_dims = int(indices_runtime_signature[-1])
-        if gather_dims > 0 and gather_dims <= len(params_signature):
+        max_gather_dims = int(len(params_signature) - int(batch_dims))
+        if gather_dims > 0 and gather_dims <= max_gather_dims:
             inferred_output_signature = (
                 [int(v) for v in indices_runtime_signature[:-1]]
-                + [int(v) for v in params_signature[gather_dims:]]
+                + [int(v) for v in params_signature[int(batch_dims) + gather_dims:]]
             )
     if inferred_output_signature is None:
         inferred_output_signature = (
@@ -841,11 +842,255 @@ def build_gather_nd_op(node: Any, ctx: Any) -> None:
         int(v) if int(v) >= 0 else 1 for v in final_output_signature
     ]
 
+    if int(batch_dims) == 0:
+        ctx.add_operator(
+            OperatorIR(
+                op_type="GATHER_ND",
+                inputs=[params_name, indices_for_gather_nd],
+                outputs=[output_name],
+            )
+        )
+        return
+
+    # Lower GatherND(batch_dims>0) into builtin GatherND(batch_dims=0):
+    # 1) flatten batch prefix into one axis
+    # 2) prepend generated batch-id to each index vector
+    # 3) gather_nd on reshaped params/indices
+    # 4) reshape gathered result back to ONNX output shape
+    if len(params_shape) <= int(batch_dims) or len(indices_shape) <= int(batch_dims):
+        raise NotImplementedError(
+            f"GatherND batch_dims is out of range for input ranks in flatbuffer_direct. "
+            f"op={node.name} batch_dims={batch_dims} params_shape={params_shape} indices_shape={indices_shape}"
+        )
+
+    params_batch_shape = [int(v) for v in params_shape[: int(batch_dims)]]
+    indices_batch_shape = [int(v) for v in indices_shape[: int(batch_dims)]]
+    if params_batch_shape != indices_batch_shape:
+        raise NotImplementedError(
+            "GatherND requires params/indices batch prefix match for batch_dims>0 in flatbuffer_direct. "
+            f"op={node.name} batch_dims={batch_dims} "
+            f"params_batch_shape={params_batch_shape} indices_batch_shape={indices_batch_shape}"
+        )
+    if any(int(v) <= 0 for v in params_batch_shape):
+        raise NotImplementedError(
+            "GatherND batch_dims>0 currently requires static positive batch prefix dimensions "
+            "in flatbuffer_direct. "
+            f"op={node.name} params_batch_shape={params_batch_shape}"
+        )
+    if any(int(v) < 0 for v in indices_shape[int(batch_dims) : -1]):
+        raise NotImplementedError(
+            "GatherND batch_dims>0 currently requires static non-negative non-batch index dimensions "
+            "in flatbuffer_direct. "
+            f"op={node.name} indices_shape={indices_shape}"
+        )
+
+    gather_dims = int(indices_shape[-1]) if len(indices_shape) > 0 else -1
+    if gather_dims <= 0:
+        raise NotImplementedError(
+            "GatherND requires static positive indices last dimension in flatbuffer_direct. "
+            f"op={node.name} indices_shape={indices_shape}"
+        )
+    if int(gather_dims) > int(len(params_shape) - int(batch_dims)):
+        raise NotImplementedError(
+            "GatherND indices last dimension exceeds params rank after batch_dims in flatbuffer_direct. "
+            f"op={node.name} batch_dims={batch_dims} indices_last_dim={gather_dims} params_rank={len(params_shape)}"
+        )
+
+    batch_count = int(np.prod(np.asarray(params_batch_shape, dtype=np.int64), dtype=np.int64))
+    if batch_count < 0 or batch_count > int(np.iinfo(np.int32).max):
+        raise NotImplementedError(
+            "GatherND flattened batch size is out of supported range in flatbuffer_direct. "
+            f"op={node.name} flattened_batch={batch_count}"
+        )
+
+    params_tail_shape = [int(v) for v in params_shape[int(batch_dims) :]]
+    indices_inner_shape = [int(v) for v in indices_shape[int(batch_dims) : -1]]
+
+    params_flat_shape = [int(batch_count)] + [int(v) for v in params_tail_shape]
+    params_flat_shape_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_params_flat_shape",
+        np.asarray(params_flat_shape, dtype=np.int32),
+    )
+    params_flat_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_params_flat",
+        dtype=params_dtype,
+        shape=[int(v) if int(v) > 0 else 1 for v in params_flat_shape],
+    )
+    params_flat_tensor = ctx.model_ir.tensors.get(params_flat_name, None)
+    if params_flat_tensor is not None:
+        params_flat_tensor.shape_signature = [int(v) for v in params_flat_shape]
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=[params_name, params_flat_shape_name],
+            outputs=[params_flat_name],
+            options={"newShape": [int(v) for v in params_flat_shape]},
+        )
+    )
+
+    indices_flat_shape = [int(batch_count)] + [int(v) for v in indices_inner_shape] + [int(gather_dims)]
+    indices_flat_shape_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_indices_flat_shape",
+        np.asarray(indices_flat_shape, dtype=np.int32),
+    )
+    indices_flat_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_indices_flat",
+        dtype="INT32",
+        shape=[int(v) if int(v) > 0 else 1 for v in indices_flat_shape],
+    )
+    indices_flat_tensor = ctx.model_ir.tensors.get(indices_flat_name, None)
+    if indices_flat_tensor is not None:
+        indices_flat_tensor.shape_signature = (
+            [int(v) for v in indices_runtime_signature]
+            if len(indices_runtime_signature) == len(indices_flat_shape)
+            else [int(v) for v in indices_flat_shape]
+        )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=[indices_for_gather_nd, indices_flat_shape_name],
+            outputs=[indices_flat_name],
+            options={"newShape": [int(v) for v in indices_flat_shape]},
+        )
+    )
+
+    batch_range_start_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_batch_range_start",
+        np.asarray(0, dtype=np.int32),
+    )
+    batch_range_limit_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_batch_range_limit",
+        np.asarray(int(batch_count), dtype=np.int32),
+    )
+    batch_range_delta_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_batch_range_delta",
+        np.asarray(1, dtype=np.int32),
+    )
+    for scalar_name in [
+        batch_range_start_name,
+        batch_range_limit_name,
+        batch_range_delta_name,
+    ]:
+        scalar_tensor = ctx.model_ir.tensors.get(scalar_name, None)
+        if scalar_tensor is not None:
+            scalar_tensor.shape = []
+            scalar_tensor.shape_signature = []
+
+    batch_ids_1d_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_batch_ids_1d",
+        dtype="INT32",
+        shape=[int(batch_count) if int(batch_count) > 0 else 1],
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RANGE",
+            inputs=[
+                batch_range_start_name,
+                batch_range_limit_name,
+                batch_range_delta_name,
+            ],
+            outputs=[batch_ids_1d_name],
+        )
+    )
+
+    batch_ids_base_shape = [int(batch_count)] + [1 for _ in indices_inner_shape] + [1]
+    batch_ids_base_shape_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_batch_ids_base_shape",
+        np.asarray(batch_ids_base_shape, dtype=np.int32),
+    )
+    batch_ids_base_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_batch_ids_base",
+        dtype="INT32",
+        shape=[int(v) if int(v) > 0 else 1 for v in batch_ids_base_shape],
+    )
+    batch_ids_base_tensor = ctx.model_ir.tensors.get(batch_ids_base_name, None)
+    if batch_ids_base_tensor is not None:
+        batch_ids_base_tensor.shape_signature = [int(v) for v in batch_ids_base_shape]
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=[batch_ids_1d_name, batch_ids_base_shape_name],
+            outputs=[batch_ids_base_name],
+            options={"newShape": [int(v) for v in batch_ids_base_shape]},
+        )
+    )
+
+    batch_ids_tile_multiples = [1] + [int(v) for v in indices_inner_shape] + [1]
+    batch_ids_tile_multiples_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_batch_ids_tile_multiples",
+        np.asarray(batch_ids_tile_multiples, dtype=np.int32),
+    )
+    batch_ids_tiled_shape = [int(batch_count)] + [int(v) for v in indices_inner_shape] + [1]
+    batch_ids_tiled_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_batch_ids_tiled",
+        dtype="INT32",
+        shape=[int(v) if int(v) > 0 else 1 for v in batch_ids_tiled_shape],
+    )
+    batch_ids_tiled_tensor = ctx.model_ir.tensors.get(batch_ids_tiled_name, None)
+    if batch_ids_tiled_tensor is not None:
+        batch_ids_tiled_tensor.shape_signature = [int(v) for v in batch_ids_tiled_shape]
+    ctx.add_operator(
+        OperatorIR(
+            op_type="TILE",
+            inputs=[batch_ids_base_name, batch_ids_tile_multiples_name],
+            outputs=[batch_ids_tiled_name],
+        )
+    )
+
+    indices_with_batch_shape = [int(batch_count)] + [int(v) for v in indices_inner_shape] + [int(gather_dims) + 1]
+    indices_with_batch_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_indices_with_batch",
+        dtype="INT32",
+        shape=[int(v) if int(v) > 0 else 1 for v in indices_with_batch_shape],
+    )
+    indices_with_batch_tensor = ctx.model_ir.tensors.get(indices_with_batch_name, None)
+    if indices_with_batch_tensor is not None:
+        indices_with_batch_tensor.shape_signature = [int(v) for v in indices_with_batch_shape]
+    ctx.add_operator(
+        OperatorIR(
+            op_type="CONCATENATION",
+            inputs=[batch_ids_tiled_name, indices_flat_name],
+            outputs=[indices_with_batch_name],
+            options={
+                "axis": int(len(indices_flat_shape) - 1),
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    )
+
+    gather_flat_shape = (
+        [int(batch_count)]
+        + [int(v) for v in indices_inner_shape]
+        + [int(v) for v in params_tail_shape[int(gather_dims) :]]
+    )
+    gather_flat_name = ctx.add_intermediate_tensor(
+        f"{output_name}_gather_nd_flat_out",
+        dtype=params_dtype,
+        shape=[int(v) if int(v) > 0 else 1 for v in gather_flat_shape],
+    )
+    gather_flat_tensor = ctx.model_ir.tensors.get(gather_flat_name, None)
+    if gather_flat_tensor is not None:
+        gather_flat_tensor.shape_signature = [int(v) for v in gather_flat_shape]
+        gather_flat_tensor.quantization = _clone_quantization(output_tensor.quantization)
     ctx.add_operator(
         OperatorIR(
             op_type="GATHER_ND",
-            inputs=[params_name, indices_for_gather_nd],
+            inputs=[params_flat_name, indices_with_batch_name],
+            outputs=[gather_flat_name],
+        )
+    )
+
+    output_shape_static = [int(v) for v in params_batch_shape + indices_inner_shape + params_tail_shape[int(gather_dims) :]]
+    output_shape_name = ctx.add_const_tensor(
+        f"{output_name}_gather_nd_output_shape",
+        np.asarray(output_shape_static, dtype=np.int32),
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=[gather_flat_name, output_shape_name],
             outputs=[output_name],
+            options={"newShape": [int(v) for v in output_shape_static]},
         )
     )
 
@@ -4723,36 +4968,77 @@ def build_non_max_suppression_op(node: Any, ctx: Any) -> None:
             dtype="INT32",
             shape=[-1],
         )
-        valid_count_vec_name = ctx.add_intermediate_tensor(
-            f"{output_name}_nms_valid_count_vec{suffix}",
+        valid_indices_range_start_name = ctx.add_const_tensor(
+            f"{output_name}_nms_valid_indices_range_start{suffix}",
+            np.asarray(0, dtype=np.int32),
+        )
+        valid_indices_range_start_tensor = ctx.model_ir.tensors.get(
+            valid_indices_range_start_name,
+            None,
+        )
+        if valid_indices_range_start_tensor is not None:
+            valid_indices_range_start_tensor.shape = []
+            valid_indices_range_start_tensor.shape_signature = []
+        valid_indices_range_delta_name = ctx.add_const_tensor(
+            f"{output_name}_nms_valid_indices_range_delta{suffix}",
+            np.asarray(1, dtype=np.int32),
+        )
+        valid_indices_range_delta_tensor = ctx.model_ir.tensors.get(
+            valid_indices_range_delta_name,
+            None,
+        )
+        if valid_indices_range_delta_tensor is not None:
+            valid_indices_range_delta_tensor.shape = []
+            valid_indices_range_delta_tensor.shape_signature = []
+        valid_indices_name = ctx.add_intermediate_tensor(
+            f"{output_name}_nms_valid_indices{suffix}",
             dtype="INT32",
-            shape=[1],
+            shape=[-1],
         )
-        valid_count_vec_shape_name = ctx.add_const_tensor(
-            f"{output_name}_nms_valid_count_vec_shape{suffix}",
-            np.asarray([1], dtype=np.int32),
+        nms_valid_count_scalar_shape_name = ctx.add_const_tensor(
+            f"{output_name}_nms_valid_count_scalar_shape{suffix}",
+            np.asarray([], dtype=np.int32),
         )
+        nms_valid_count_scalar_name = ctx.add_intermediate_tensor(
+            f"{output_name}_nms_valid_count_scalar{suffix}",
+            dtype="INT32",
+            shape=[],
+        )
+        nms_valid_count_scalar_tensor = ctx.model_ir.tensors.get(nms_valid_count_scalar_name, None)
+        if nms_valid_count_scalar_tensor is not None:
+            nms_valid_count_scalar_tensor.shape = []
+            nms_valid_count_scalar_tensor.shape_signature = []
         ctx.add_operator(
             OperatorIR(
                 op_type="RESHAPE",
-                inputs=[nms_valid_count_name, valid_count_vec_shape_name],
-                outputs=[valid_count_vec_name],
-                options={"newShape": [1]},
+                inputs=[nms_valid_count_name, nms_valid_count_scalar_shape_name],
+                outputs=[nms_valid_count_scalar_name],
+                options={
+                    "newShape": [],
+                    "preserveDynamicShape": True,
+                },
             )
-        )
-        selected_indices_valid_begin_name = ctx.add_const_tensor(
-            f"{output_name}_nms_selected_indices_valid_begin{suffix}",
-            np.asarray([0], dtype=np.int32),
         )
         ctx.add_operator(
             OperatorIR(
-                op_type="SLICE",
+                op_type="RANGE",
                 inputs=[
-                    nms_selected_indices_name,
-                    selected_indices_valid_begin_name,
-                    valid_count_vec_name,
+                    valid_indices_range_start_name,
+                    nms_valid_count_scalar_name,
+                    valid_indices_range_delta_name,
                 ],
+                outputs=[valid_indices_name],
+            )
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="GATHER",
+                inputs=[nms_selected_indices_name, valid_indices_name],
                 outputs=[selected_indices_valid_name],
+                options={
+                    "axis": 0,
+                    "batchDims": 0,
+                },
             )
         )
 
@@ -4761,16 +5047,45 @@ def build_non_max_suppression_op(node: Any, ctx: Any) -> None:
             dtype="INT32",
             shape=[-1, 1],
         )
-        selected_indices_col_shape_name = ctx.add_const_tensor(
+        selected_indices_valid_shape_name = ctx.add_intermediate_tensor(
+            f"{output_name}_nms_selected_indices_valid_shape{suffix}",
+            dtype="INT32",
+            shape=[1],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="SHAPE",
+                inputs=[selected_indices_valid_name],
+                outputs=[selected_indices_valid_shape_name],
+                options={"outType": "INT32"},
+            )
+        )
+        selected_indices_col_tail_dim_name = ctx.add_const_tensor(
+            f"{output_name}_nms_selected_indices_col_tail_dim{suffix}",
+            np.asarray([1], dtype=np.int32),
+        )
+        selected_indices_col_shape_name = ctx.add_intermediate_tensor(
             f"{output_name}_nms_selected_indices_col_shape{suffix}",
-            np.asarray([-1, 1], dtype=np.int32),
+            dtype="INT32",
+            shape=[2],
+        )
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CONCATENATION",
+                inputs=[selected_indices_valid_shape_name, selected_indices_col_tail_dim_name],
+                outputs=[selected_indices_col_shape_name],
+                options={
+                    "axis": 0,
+                    "fusedActivationFunction": "NONE",
+                },
+            )
         )
         ctx.add_operator(
             OperatorIR(
                 op_type="RESHAPE",
                 inputs=[selected_indices_valid_name, selected_indices_col_shape_name],
                 outputs=[selected_indices_col_name],
-                options={"newShape": [-1, 1]},
+                options={},
             )
         )
 
@@ -4811,16 +5126,45 @@ def build_non_max_suppression_op(node: Any, ctx: Any) -> None:
                 dtype="INT32",
                 shape=[-1, 1],
             )
-            class_ids_col_shape_name = ctx.add_const_tensor(
+            selected_class_ids_valid_shape_name = ctx.add_intermediate_tensor(
+                f"{output_name}_nms_selected_class_ids_shape{suffix}",
+                dtype="INT32",
+                shape=[1],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="SHAPE",
+                    inputs=[selected_class_ids_valid_name],
+                    outputs=[selected_class_ids_valid_shape_name],
+                    options={"outType": "INT32"},
+                )
+            )
+            class_ids_col_tail_dim_name = ctx.add_const_tensor(
+                f"{output_name}_nms_selected_class_ids_col_tail_dim{suffix}",
+                np.asarray([1], dtype=np.int32),
+            )
+            class_ids_col_shape_name = ctx.add_intermediate_tensor(
                 f"{output_name}_nms_selected_class_ids_col_shape{suffix}",
-                np.asarray([-1, 1], dtype=np.int32),
+                dtype="INT32",
+                shape=[2],
+            )
+            ctx.add_operator(
+                OperatorIR(
+                    op_type="CONCATENATION",
+                    inputs=[selected_class_ids_valid_shape_name, class_ids_col_tail_dim_name],
+                    outputs=[class_ids_col_shape_name],
+                    options={
+                        "axis": 0,
+                        "fusedActivationFunction": "NONE",
+                    },
+                )
             )
             ctx.add_operator(
                 OperatorIR(
                     op_type="RESHAPE",
                     inputs=[selected_class_ids_valid_name, class_ids_col_shape_name],
                     outputs=[class_ids_col_name],
-                    options={"newShape": [-1, 1]},
+                    options={},
                 )
             )
         elif class_id_value is not None and int(class_id_value) != 0:

--- a/onnx2tf/tflite_builder/op_builders/recurrent.py
+++ b/onnx2tf/tflite_builder/op_builders/recurrent.py
@@ -428,6 +428,7 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
     y_h_name = node.outputs[1].name if len(node.outputs) > 1 else ""
     y_c_name = node.outputs[2].name if len(node.outputs) > 2 else ""
     y_dtype = str(ctx.get_tensor_dtype(y_name))
+    y_dtype_upper = str(y_dtype).upper()
     ctx.ensure_tensor(x_name)
     ctx.ensure_tensor(y_name)
     if y_h_name != "":
@@ -883,34 +884,72 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
         state_tag="c0_bw",
     )
 
+    bilstm_input_name = x_name
+    x_dtype_upper = str(ctx.get_tensor_dtype(x_name)).upper()
+    if x_dtype_upper != "FLOAT32":
+        x_shape = [int(v) for v in ctx.get_tensor_shape(x_name)]
+        bilstm_input_name = ctx.add_intermediate_tensor(
+            f"{node.name}_bilstm_input_f32",
+            dtype="FLOAT32",
+            shape=[int(v) for v in list(x_shape)],
+        )
+        x_tensor = ctx.model_ir.tensors.get(x_name, None)
+        if (
+            x_tensor is not None
+            and x_tensor.shape_signature is not None
+            and len(x_tensor.shape_signature) == len(x_shape)
+        ):
+            ctx.model_ir.tensors[bilstm_input_name].shape_signature = [
+                int(v) for v in list(x_tensor.shape_signature)
+            ]
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[x_name],
+                outputs=[bilstm_input_name],
+                options={
+                    "inDataType": x_dtype_upper,
+                    "outDataType": "FLOAT32",
+                },
+            )
+        )
+
     merged_output_name = ctx.add_intermediate_tensor(
         f"{y_name}_bilstm_merged",
-        dtype=y_dtype,
+        dtype="FLOAT32",
         shape=[int(seq_dim), int(batch_dim), int(hidden_size * 2)],
     )
     fw_output_name = ctx.add_intermediate_tensor(
         f"{y_name}_fw",
-        dtype=y_dtype,
+        dtype="FLOAT32",
         shape=[int(seq_dim), int(batch_dim), int(hidden_size)],
     )
     bw_output_name = ctx.add_intermediate_tensor(
         f"{y_name}_bw",
-        dtype=y_dtype,
+        dtype="FLOAT32",
         shape=[int(seq_dim), int(batch_dim), int(hidden_size)],
     )
     fw_expanded_name = ctx.add_intermediate_tensor(
         f"{y_name}_fw_expanded",
-        dtype=y_dtype,
+        dtype="FLOAT32",
         shape=[int(seq_dim), 1, int(batch_dim), int(hidden_size)],
     )
     bw_expanded_name = ctx.add_intermediate_tensor(
         f"{y_name}_bw_expanded",
-        dtype=y_dtype,
+        dtype="FLOAT32",
         shape=[int(seq_dim), 1, int(batch_dim), int(hidden_size)],
     )
 
+    y_concat_output_name = y_name
+    if y_dtype_upper != "FLOAT32":
+        y_concat_output_name = ctx.add_intermediate_tensor(
+            f"{y_name}_bilstm_f32",
+            dtype="FLOAT32",
+            shape=[int(seq_dim), int(expected_num_directions), int(batch_dim), int(hidden_size)],
+        )
+
     bidirectional_inputs = [
-        x_name,
+        bilstm_input_name,
         _add_const("fw_w_i", fw_w_i),
         _add_const("fw_w_f", fw_w_f),
         _add_const("fw_w_c", fw_w_c),
@@ -1039,13 +1078,25 @@ def build_lstm_op(node: Any, ctx: Any) -> None:
         OperatorIR(
             op_type="CONCATENATION",
             inputs=[fw_expanded_name, bw_expanded_name],
-            outputs=[y_name],
+            outputs=[y_concat_output_name],
             options={
                 "axis": 1,
                 "fusedActivationFunction": "NONE",
             },
         )
     )
+    if y_concat_output_name != y_name:
+        ctx.add_operator(
+            OperatorIR(
+                op_type="CAST",
+                inputs=[y_concat_output_name],
+                outputs=[y_name],
+                options={
+                    "inDataType": "FLOAT32",
+                    "outDataType": y_dtype_upper,
+                },
+            )
+        )
     if y_h_name != "":
         fw_h_3d_name = ctx.add_intermediate_tensor(
             f"{y_h_name}_fw_3d",

--- a/onnx2tf/tflite_builder/op_builders/shape.py
+++ b/onnx2tf/tflite_builder/op_builders/shape.py
@@ -1066,7 +1066,9 @@ def build_slice_op(node: Any, ctx: Any) -> None:
             if step == 1:
                 size[axis] = int(max(end - start, 0))
             else:
-                size[axis] = -1
+                # Keep STRIDED_SLICE lowering for step != 1, but preserve static
+                # output shape metadata when slice bounds are statically known.
+                size[axis] = int(max((max(end - start, 0) + step - 1) // step, 0))
         else:
             if start < 0 or end < 0:
                 # Keep negative indices and defer resolution to runtime via STRIDED_SLICE.
@@ -1080,10 +1082,11 @@ def build_slice_op(node: Any, ctx: Any) -> None:
                 size[axis] = -1
             else:
                 end_for_strided[axis] = int(max(min(end, int32_max), int32_min))
-                if step == 1 and start >= 0 and end >= 0:
-                    size[axis] = int(max(end - start, 0))
-                else:
-                    size[axis] = -1
+                # Unknown input extent means runtime clipping can change the
+                # actual slice length even when start/end are non-negative.
+                # Keep this dimension dynamic instead of materializing an
+                # oversized static size from sentinel ends (e.g. INT32_MAX).
+                size[axis] = -1
             strides_for_strided[axis] = int(step)
 
     output_tensor = ctx.model_ir.tensors.get(output_name, None)
@@ -4950,8 +4953,40 @@ def build_grid_sample_op(node: Any, ctx: Any) -> None:
     grid_shape = [int(v) for v in ctx.get_tensor_shape(grid_name)]
     output_shape = [int(v) for v in ctx.get_tensor_shape(output_name)]
 
+    def _merge_with_raw_shape(tensor_name: str, resolved_shape: list[int]) -> list[int]:
+        raw = None
+        if hasattr(ctx, "shape_map") and isinstance(ctx.shape_map, dict):
+            raw = ctx.shape_map.get(str(tensor_name), None)
+        if raw is None:
+            return [int(v) for v in list(resolved_shape)]
+        try:
+            raw_shape = [int(v) for v in list(raw)]
+        except Exception:
+            return [int(v) for v in list(resolved_shape)]
+        if len(raw_shape) != len(resolved_shape):
+            return [int(v) for v in list(resolved_shape)]
+        merged: list[int] = []
+        for resolved_dim, raw_dim in zip(resolved_shape, raw_shape):
+            if int(raw_dim) > 0:
+                merged.append(int(raw_dim))
+            elif int(raw_dim) <= 0 and int(resolved_dim) == 1:
+                merged.append(-1)
+            else:
+                merged.append(int(resolved_dim))
+        return merged
+
+    image_shape = _merge_with_raw_shape(image_name, image_shape)
+    grid_shape = _merge_with_raw_shape(grid_name, grid_shape)
+    output_shape = _merge_with_raw_shape(output_name, output_shape)
+
+    image_tensor = ctx.model_ir.tensors.get(image_name, None)
     grid_tensor = ctx.model_ir.tensors.get(grid_name, None)
     output_tensor = ctx.model_ir.tensors.get(output_name, None)
+    image_signature = (
+        [int(v) for v in list(image_tensor.shape_signature)]
+        if image_tensor is not None and image_tensor.shape_signature is not None
+        else list(image_shape)
+    )
     grid_signature = (
         [int(v) for v in list(grid_tensor.shape_signature)]
         if grid_tensor is not None and grid_tensor.shape_signature is not None
@@ -4983,6 +5018,61 @@ def build_grid_sample_op(node: Any, ctx: Any) -> None:
     ]
 
     image_rank = int(len(image_shape))
+    expected_grid_last_dim = 2 if image_rank == 4 else 3 if image_rank == 5 else 0
+    if image_rank in {4, 5} and len(grid_shape) == image_rank and int(grid_shape[-1]) <= 0:
+        grid_shape[-1] = int(expected_grid_last_dim)
+        if grid_tensor is not None:
+            grid_tensor.shape = [int(v) if int(v) > 0 else 1 for v in list(grid_shape)]
+            grid_tensor.shape_signature = [int(v) for v in list(grid_shape)]
+        if len(grid_signature) == image_rank and int(grid_signature[-1]) <= 0:
+            grid_signature[-1] = int(expected_grid_last_dim)
+
+    if image_rank in {4, 5} and len(grid_shape) == image_rank:
+        expected_output_shape = (
+            [int(image_shape[0]), int(image_shape[1]), int(grid_shape[1]), int(grid_shape[2])]
+            if image_rank == 4
+            else [
+                int(image_shape[0]),
+                int(image_shape[1]),
+                int(grid_shape[1]),
+                int(grid_shape[2]),
+                int(grid_shape[3]),
+            ]
+        )
+        expected_output_signature = (
+            [
+                _shape_dim_from_signature(image_signature, 0, int(image_shape[0])),
+                _shape_dim_from_signature(image_signature, 1, int(image_shape[1])),
+                _shape_dim_from_signature(grid_signature, 1, int(grid_shape[1])),
+                _shape_dim_from_signature(grid_signature, 2, int(grid_shape[2])),
+            ]
+            if image_rank == 4
+            else [
+                _shape_dim_from_signature(image_signature, 0, int(image_shape[0])),
+                _shape_dim_from_signature(image_signature, 1, int(image_shape[1])),
+                _shape_dim_from_signature(grid_signature, 1, int(grid_shape[1])),
+                _shape_dim_from_signature(grid_signature, 2, int(grid_shape[2])),
+                _shape_dim_from_signature(grid_signature, 3, int(grid_shape[3])),
+            ]
+        )
+        if len(output_shape) != image_rank:
+            output_shape = [int(v) for v in list(expected_output_shape)]
+        else:
+            output_shape = [
+                int(expected_output_shape[idx]) if int(dim) <= 0 else int(dim)
+                for idx, dim in enumerate(output_shape)
+            ]
+        if len(output_signature) != image_rank:
+            output_signature = [int(v) for v in list(expected_output_signature)]
+        else:
+            output_signature = [
+                int(expected_output_signature[idx]) if int(dim) <= 0 else int(dim)
+                for idx, dim in enumerate(output_signature)
+            ]
+        if output_tensor is not None:
+            output_tensor.shape = [int(v) for v in list(output_shape)]
+            output_tensor.shape_signature = [int(v) for v in list(output_signature)]
+
     out_d = 1
     d = 1
     if image_rank == 4:

--- a/onnx2tf/tflite_builder/op_registry.py
+++ b/onnx2tf/tflite_builder/op_registry.py
@@ -2863,11 +2863,21 @@ def _validate_inverse(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    if row_dim not in {2, 3}:
+    if row_dim < 1:
         raise NodeValidationError(
             reason_code="unsupported_input_shape",
             message=(
-                "Inverse builtin lowering currently supports only last dims [2,2] or [3,3] "
+                "Inverse builtin lowering requires matrix dims >= 1 in flatbuffer_direct. "
+                f"input_shape={input_shape} raw_input_shape={raw_shape}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if row_dim > 16:
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "Inverse builtin lowering currently supports square matrix dims up to 16x16 "
                 f"in flatbuffer_direct. input_shape={input_shape} raw_input_shape={raw_shape}"
             ),
             node_name=node.name,
@@ -3250,13 +3260,70 @@ def _validate_gather_nd(node: Any, ctx: Any) -> None:
         )
 
     batch_dims = int(node.attrs.get("batch_dims", 0))
-    if batch_dims != 0:
+    if batch_dims < 0:
         raise NodeValidationError(
             reason_code="unsupported_attribute_value",
-            message=f"GatherND batch_dims must be 0. batch_dims={batch_dims}",
+            message=f"GatherND batch_dims must be >= 0. batch_dims={batch_dims}",
             node_name=node.name,
             node_op=node.op,
         )
+    if batch_dims >= len(indices_shape):
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=(
+                "GatherND batch_dims must be < indices rank. "
+                f"batch_dims={batch_dims} indices_rank={len(indices_shape)}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if batch_dims > len(params_shape):
+        raise NodeValidationError(
+            reason_code="unsupported_attribute_value",
+            message=(
+                "GatherND batch_dims must be <= params rank. "
+                f"batch_dims={batch_dims} params_rank={len(params_shape)}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
+    if batch_dims > 0:
+        params_batch_shape = [int(v) for v in params_shape[:batch_dims]]
+        indices_batch_shape = [int(v) for v in indices_shape[:batch_dims]]
+        if params_batch_shape != indices_batch_shape:
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "GatherND batch_dims requires params/indices batch prefix match. "
+                    f"params_batch_shape={params_batch_shape} "
+                    f"indices_batch_shape={indices_batch_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+        if any(int(v) <= 0 for v in params_batch_shape):
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "GatherND batch_dims>0 requires static positive batch prefix dimensions "
+                    "in flatbuffer_direct. "
+                    f"params_batch_shape={params_batch_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
+        non_batch_indices_shape = [int(v) for v in indices_shape[batch_dims:-1]]
+        if any(int(v) < 0 for v in non_batch_indices_shape):
+            raise NodeValidationError(
+                reason_code="unsupported_input_shape",
+                message=(
+                    "GatherND batch_dims>0 requires static non-negative non-batch index dimensions "
+                    "in flatbuffer_direct. "
+                    f"indices_shape={indices_shape}"
+                ),
+                node_name=node.name,
+                node_op=node.op,
+            )
 
     indices_dtype = str(ctx.get_tensor_dtype(node.inputs[1].name)).upper()
     supported_indices_dtypes = {
@@ -3291,12 +3358,12 @@ def _validate_gather_nd(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    if k_dim > len(params_shape):
+    if k_dim > int(len(params_shape) - int(batch_dims)):
         raise NodeValidationError(
             reason_code="unsupported_input_shape",
             message=(
-                "GatherND indices last dimension must be <= params rank. "
-                f"indices_last_dim={k_dim} params_rank={len(params_shape)}"
+                "GatherND indices last dimension must be <= params rank after batch_dims. "
+                f"indices_last_dim={k_dim} params_rank={len(params_shape)} batch_dims={batch_dims}"
             ),
             node_name=node.name,
             node_op=node.op,
@@ -6160,8 +6227,35 @@ def _validate_grid_sample(node: Any, ctx: Any) -> None:
     image_shape = [int(v) for v in ctx.get_tensor_shape(node.inputs[0].name)]
     grid_shape = [int(v) for v in ctx.get_tensor_shape(node.inputs[1].name)]
     output_shape = [int(v) for v in ctx.get_tensor_shape(node.outputs[0].name)]
+
+    def _merge_with_raw_shape(tensor_name: str, resolved_shape: List[int]) -> List[int]:
+        raw = None
+        if hasattr(ctx, "shape_map") and isinstance(ctx.shape_map, dict):
+            raw = ctx.shape_map.get(str(tensor_name), None)
+        if raw is None:
+            return [int(v) for v in list(resolved_shape)]
+        try:
+            raw_shape = [int(v) for v in list(raw)]
+        except Exception:
+            return [int(v) for v in list(resolved_shape)]
+        if len(raw_shape) != len(resolved_shape):
+            return [int(v) for v in list(resolved_shape)]
+        merged: List[int] = []
+        for resolved_dim, raw_dim in zip(resolved_shape, raw_shape):
+            if int(raw_dim) > 0:
+                merged.append(int(raw_dim))
+            elif int(raw_dim) <= 0 and int(resolved_dim) == 1:
+                # Preserve unknown-dimension intent from ONNX shape map.
+                merged.append(-1)
+            else:
+                merged.append(int(resolved_dim))
+        return merged
+
+    image_shape = _merge_with_raw_shape(node.inputs[0].name, image_shape)
+    grid_shape = _merge_with_raw_shape(node.inputs[1].name, grid_shape)
+    output_shape = _merge_with_raw_shape(node.outputs[0].name, output_shape)
     rank = int(len(image_shape))
-    if rank not in {4, 5} or len(grid_shape) != rank or len(output_shape) != rank:
+    if rank not in {4, 5} or len(grid_shape) != rank:
         raise NodeValidationError(
             reason_code="unsupported_input_rank",
             message=(
@@ -6171,19 +6265,9 @@ def _validate_grid_sample(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
-    if any(int(v) <= 0 for v in image_shape + grid_shape + output_shape):
-        raise NodeValidationError(
-            reason_code="unsupported_input_shape",
-            message=(
-                "GridSample requires static positive dimensions in flatbuffer_direct. "
-                f"image_shape={image_shape} grid_shape={grid_shape} output_shape={output_shape}"
-            ),
-            node_name=node.name,
-            node_op=node.op,
-        )
 
     expected_grid_last_dim = 2 if rank == 4 else 3
-    if int(grid_shape[-1]) != int(expected_grid_last_dim):
+    if int(grid_shape[-1]) > 0 and int(grid_shape[-1]) != int(expected_grid_last_dim):
         raise NodeValidationError(
             reason_code="unsupported_input_shape",
             message=(
@@ -6196,10 +6280,38 @@ def _validate_grid_sample(node: Any, ctx: Any) -> None:
             node_name=node.name,
             node_op=node.op,
         )
+    if int(grid_shape[-1]) <= 0:
+        grid_shape[-1] = int(expected_grid_last_dim)
+
+    expected_output_shape = (
+        [int(image_shape[0]), int(image_shape[1]), int(grid_shape[1]), int(grid_shape[2])]
+        if rank == 4
+        else [int(image_shape[0]), int(image_shape[1]), int(grid_shape[1]), int(grid_shape[2]), int(grid_shape[3])]
+    )
+    resolved_output_shape = [int(v) for v in list(output_shape)]
+    if len(resolved_output_shape) != rank:
+        resolved_output_shape = [int(v) for v in list(expected_output_shape)]
+    else:
+        resolved_output_shape = [
+            int(expected_output_shape[idx]) if int(dim) <= 0 else int(dim)
+            for idx, dim in enumerate(resolved_output_shape)
+        ]
+
+    if any(int(v) <= 0 for v in image_shape + grid_shape + resolved_output_shape):
+        raise NodeValidationError(
+            reason_code="unsupported_input_shape",
+            message=(
+                "GridSample requires static positive dimensions in flatbuffer_direct. "
+                f"image_shape={image_shape} grid_shape={grid_shape} "
+                f"output_shape={output_shape} resolved_output_shape={resolved_output_shape}"
+            ),
+            node_name=node.name,
+            node_op=node.op,
+        )
 
     if rank == 4:
         n, c, h, w = [int(v) for v in image_shape]
-        out_n, out_c, out_h, out_w = [int(v) for v in output_shape]
+        out_n, out_c, out_h, out_w = [int(v) for v in resolved_output_shape]
         grid_n, grid_h, grid_w, _ = [int(v) for v in grid_shape]
         if not (
             n == out_n == grid_n
@@ -6213,14 +6325,15 @@ def _validate_grid_sample(node: Any, ctx: Any) -> None:
                 reason_code="unsupported_input_shape",
                 message=(
                     "GridSample input/grid/output shapes are inconsistent for built-in lowering. "
-                    f"image_shape={image_shape} grid_shape={grid_shape} output_shape={output_shape}"
+                    f"image_shape={image_shape} grid_shape={grid_shape} "
+                    f"output_shape={output_shape} resolved_output_shape={resolved_output_shape}"
                 ),
                 node_name=node.name,
                 node_op=node.op,
             )
     else:
         n, c, d, h, w = [int(v) for v in image_shape]
-        out_n, out_c, out_d, out_h, out_w = [int(v) for v in output_shape]
+        out_n, out_c, out_d, out_h, out_w = [int(v) for v in resolved_output_shape]
         grid_n, grid_d, grid_h, grid_w, _ = [int(v) for v in grid_shape]
         if not (
             n == out_n == grid_n
@@ -6236,7 +6349,8 @@ def _validate_grid_sample(node: Any, ctx: Any) -> None:
                 reason_code="unsupported_input_shape",
                 message=(
                     "GridSample input/grid/output shapes are inconsistent for built-in lowering. "
-                    f"image_shape={image_shape} grid_shape={grid_shape} output_shape={output_shape}"
+                    f"image_shape={image_shape} grid_shape={grid_shape} "
+                    f"output_shape={output_shape} resolved_output_shape={resolved_output_shape}"
                 ),
                 node_name=node.name,
                 node_op=node.op,
@@ -7632,7 +7746,7 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
     ),
     "GatherND": DispatchEntry(
         onnx_op="GatherND",
-        tflite_ops=["CAST", "GATHER_ND"],
+        tflite_ops=["CAST", "RESHAPE", "RANGE", "TILE", "CONCATENATION", "GATHER_ND"],
         builder=build_gather_nd_op,
         validation=ValidationSpec(min_inputs=2, max_inputs=2, min_outputs=1, max_outputs=1),
         extra_validator=_validate_gather_nd,
@@ -7702,6 +7816,8 @@ _DISPATCH_REGISTRY: Dict[str, DispatchEntry] = {
             "NON_MAX_SUPPRESSION_V4",
             "NON_MAX_SUPPRESSION_V5",
             "SLICE",
+            "RANGE",
+            "SHAPE",
             "GATHER",
             "SUB",
             "CAST",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.2.1"
+version = "2.2.2"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -12,7 +12,14 @@ import onnx
 import onnx2tf
 import pytest
 from onnx import TensorProto, helper, numpy_helper
-from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
+from onnx2tf.tflite_builder.ir import (
+    ModelIR,
+    OperatorIR,
+    TensorIR,
+    clone_model_ir_with_float32,
+    optimize_redundant_transpose_operators,
+    prune_identity_cast_operators,
+)
 from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _align_boundary_signature_to_current_shape,
     _apply_safe_transpose_reduction_lite,
@@ -91,6 +98,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_transpose_nested_weighted_add_swish_prepost_nhwc_chains,
     _optimize_transpose_instancenorm_posttranspose_bias_add_nhwc_chains,
     _optimize_transpose_instancenorm_pad_prepost_nhwc_chains,
+    _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains,
     _optimize_transpose_instancenorm_residual_add_to_single_post_adapter_nhwc_chains,
     _optimize_transpose_instancenorm_residual_mul_concat_conv_nhwc_chains,
     _optimize_transpose_dual_mul_concat_prepost_nhwc_chains,
@@ -121,6 +129,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _find_unbound_nonconstant_operator_inputs,
     _repair_unbound_nonconstant_operator_inputs_with_layout_transpose,
     _resolve_dynamic_reshape_shapes,
+    _replace_unsupported_split_with_slice,
     _replace_expand_dims_and_squeeze_with_reshape,
     _sanitize_squeeze_axes_with_static_input_shapes,
     _sanitize_static_shape_signature_consistency,
@@ -1627,6 +1636,277 @@ def _make_gemm_dynamic_weight_model() -> onnx.ModelProto:
     )
     graph = helper.make_graph([node], "gemm_dynamic_weight_graph", [x, w], [y])
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_gemm_fp16_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT16, [2, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT16, [2, 3])
+    w = numpy_helper.from_array(np.ones((3, 4), dtype=np.float16), name="W")
+    b = numpy_helper.from_array(np.zeros((3,), dtype=np.float16), name="B")
+    node = helper.make_node("Gemm", ["x", "W", "B"], ["y"], name="GemmFP16Node", transB=1)
+    graph = helper.make_graph([node], "gemm_fp16_graph", [x], [y], initializer=[w, b])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_inverse_8x8_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 10, 8, 8])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 10, 8, 8])
+    node = helper.make_node("Inverse", ["x"], ["y"], name="Inverse8x8Node")
+    graph = helper.make_graph([node], "inverse_8x8_graph", [x], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_gridsample_unknown_shape_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [11, 3, 64, 64])
+    grid = helper.make_tensor_value_info("grid", TensorProto.FLOAT, [11, 64, 64, "unk__0"])
+    # Deliberately keep output shape metadata unresolved to emulate converter fallback paths.
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])
+    node = helper.make_node(
+        "GridSample",
+        ["x", "grid"],
+        ["y"],
+        name="GridSampleUnknownShapeNode",
+        mode="bilinear",
+        padding_mode="zeros",
+        align_corners=1,
+    )
+    graph = helper.make_graph([node], "gridsample_unknown_shape_graph", [x, grid], [y])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 16)])
+
+
+def test_clone_model_ir_with_float32_promotes_float16_tensors_and_cast_options() -> None:
+    model_ir = ModelIR(name="clone_fp16_to_fp32_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT16",
+        shape=[1, 4],
+        shape_signature=[1, 4],
+    )
+    model_ir.tensors["x_cast"] = TensorIR(
+        name="x_cast",
+        dtype="FLOAT16",
+        shape=[1, 4],
+        shape_signature=[1, 4],
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT16",
+        shape=[1, 4],
+        shape_signature=[1, 4],
+    )
+    model_ir.operators = [
+        OperatorIR(
+            op_type="CAST",
+            inputs=["x"],
+            outputs=["x_cast"],
+            options={"inDataType": "FLOAT16", "outDataType": "FLOAT16"},
+        ),
+        OperatorIR(op_type="RELU", inputs=["x_cast"], outputs=["y"]),
+    ]
+
+    promoted = clone_model_ir_with_float32(model_ir)
+    assert str(promoted.tensors["x"].dtype).upper() == "FLOAT32"
+    assert str(promoted.tensors["x_cast"].dtype).upper() == "FLOAT32"
+    assert str(promoted.tensors["y"].dtype).upper() == "FLOAT32"
+    cast_op = promoted.operators[0]
+    assert str(cast_op.options.get("inDataType", "")).upper() == "FLOAT32"
+    assert str(cast_op.options.get("outDataType", "")).upper() == "FLOAT32"
+
+
+def test_prune_identity_cast_operators_rewires_consumers() -> None:
+    model_ir = ModelIR(name="prune_identity_cast_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["x_cast"] = TensorIR(name="x_cast", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="CAST",
+            inputs=["x"],
+            outputs=["x_cast"],
+            options={"inDataType": "FLOAT32", "outDataType": "FLOAT32"},
+        ),
+        OperatorIR(
+            op_type="RELU",
+            inputs=["x_cast"],
+            outputs=["y"],
+        ),
+    ]
+
+    rewritten = prune_identity_cast_operators(model_ir)
+    assert int(rewritten) == 1
+    assert [str(op.op_type) for op in model_ir.operators] == ["RELU"]
+    assert [str(v) for v in list(model_ir.operators[0].inputs)] == ["x"]
+    assert "x_cast" not in model_ir.tensors
+
+
+def test_prune_identity_cast_operators_preserves_model_output_boundary() -> None:
+    model_ir = ModelIR(name="prune_identity_cast_keep_output_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="CAST",
+            inputs=["x"],
+            outputs=["y"],
+            options={"inDataType": "FLOAT32", "outDataType": "FLOAT32"},
+        ),
+    ]
+
+    rewritten = prune_identity_cast_operators(model_ir, preserve_model_outputs=True)
+    assert int(rewritten) == 0
+    assert [str(op.op_type) for op in model_ir.operators] == ["CAST"]
+
+
+def test_optimize_redundant_transpose_operators_removes_inverse_pair() -> None:
+    model_ir = ModelIR(name="optimize_inverse_transpose_pair_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 3],
+        shape_signature=[1, 4, 5, 3],
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
+    model_ir.tensors["z"] = TensorIR(name="z", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
+    model_ir.tensors["perm_1"] = TensorIR(
+        name="perm_1",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+    )
+    model_ir.tensors["perm_2"] = TensorIR(
+        name="perm_2",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x", "perm_1"], outputs=["x_nhwc"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "perm_2"], outputs=["y"]),
+        OperatorIR(op_type="RELU", inputs=["y"], outputs=["z"]),
+    ]
+
+    stats = optimize_redundant_transpose_operators(model_ir, preserve_model_outputs=True)
+    assert int(stats.get("removed_inverse_transpose_pairs", 0)) == 1
+    assert [str(op.op_type) for op in model_ir.operators] == ["RELU"]
+    assert [str(v) for v in list(model_ir.operators[0].inputs)] == ["x"]
+    assert "x_nhwc" not in model_ir.tensors
+
+
+def test_optimize_redundant_transpose_operators_keeps_output_name_boundary() -> None:
+    model_ir = ModelIR(name="optimize_transpose_output_boundary_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 3],
+        shape_signature=[1, 4, 5, 3],
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
+    model_ir.tensors["perm_1"] = TensorIR(
+        name="perm_1",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+    )
+    model_ir.tensors["perm_2"] = TensorIR(
+        name="perm_2",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x", "perm_1"], outputs=["x_nhwc"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "perm_2"], outputs=["y"]),
+    ]
+
+    stats = optimize_redundant_transpose_operators(model_ir, preserve_model_outputs=True)
+    assert int(stats.get("removed_inverse_transpose_pairs", 0)) == 0
+    assert [str(op.op_type) for op in model_ir.operators] == ["TRANSPOSE"]
+    assert [str(v) for v in list(model_ir.operators[0].inputs)] == ["x", "perm_2"]
+    assert [str(v) for v in list(model_ir.operators[0].outputs)] == ["y"]
+    perm_2 = model_ir.tensors["perm_2"]
+    assert np.asarray(perm_2.data).tolist() == [0, 1, 2, 3]
+
+
+def test_optimize_redundant_transpose_operators_composes_consecutive_pair() -> None:
+    model_ir = ModelIR(name="optimize_transpose_compose_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[2, 3, 5], shape_signature=[2, 3, 5])
+    model_ir.tensors["x_t0"] = TensorIR(name="x_t0", dtype="FLOAT32", shape=[3, 2, 5], shape_signature=[3, 2, 5])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[3, 5, 2], shape_signature=[3, 5, 2])
+    model_ir.tensors["perm_1"] = TensorIR(
+        name="perm_1",
+        dtype="INT32",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([1, 0, 2], dtype=np.int32),
+    )
+    model_ir.tensors["perm_2"] = TensorIR(
+        name="perm_2",
+        dtype="INT32",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([0, 2, 1], dtype=np.int32),
+    )
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x", "perm_1"], outputs=["x_t0"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_t0", "perm_2"], outputs=["y"]),
+    ]
+
+    stats = optimize_redundant_transpose_operators(model_ir, preserve_model_outputs=True)
+    assert int(stats.get("composed_consecutive_transpose_pairs", 0)) == 1
+    assert [str(op.op_type) for op in model_ir.operators] == ["TRANSPOSE"]
+    assert [str(v) for v in list(model_ir.operators[0].inputs)] == ["x", "perm_2"]
+    perm_2 = model_ir.tensors["perm_2"]
+    assert np.asarray(perm_2.data).tolist() == [1, 2, 0]
+
+
+def test_flatbuffer_direct_inverse_builtin_supports_static_8x8() -> None:
+    model = _make_inverse_8x8_model()
+    try:
+        register_default_preprocess_rules()
+        configure_pseudo_ops_wave1_targets(["inverse"])
+        preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+        model_ir = lower_onnx_to_ir(
+            onnx_graph=preprocessed_model,
+            output_file_name="inverse_8x8_builtin_test",
+        )
+    finally:
+        configure_pseudo_ops_wave1_targets(None)
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert "CUSTOM" not in op_types
+    assert op_types.count("BATCH_MATMUL") >= 1
+    assert [int(v) for v in model_ir.tensors["y"].shape] == [1, 10, 8, 8]
+
+
+def test_flatbuffer_direct_gridsample_unknown_last_dim_and_output_rank_is_inferred() -> None:
+    model = _make_gridsample_unknown_shape_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="gridsample_unknown_shape_builtin_test",
+    )
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert "CUSTOM" not in op_types
+    assert "GATHER" in op_types
+    assert [int(v) for v in model_ir.tensors["y"].shape] == [11, 3, 64, 64]
 
 
 def _make_maxpool1d_indices_kernel2_pad1_model() -> onnx.ModelProto:
@@ -5768,6 +6048,12 @@ def _collect_builtin_op_names(tflite_path: str) -> list[str]:
     return op_names
 
 
+def _collect_tensor_detail_dicts(tflite_path: str) -> list[dict[str, Any]]:
+    interpreter = Interpreter(model_path=tflite_path)
+    interpreter.allocate_tensors()
+    return [dict(v) for v in interpreter.get_tensor_details()]
+
+
 def test_tflite_backend_matrix_add() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         model = _make_add_model()
@@ -5927,6 +6213,53 @@ def test_flatbuffer_direct_gemm_dynamic_weight_lowering_uses_batch_matmul() -> N
     assert "CUSTOM" not in op_types
     assert "BATCH_MATMUL" in op_types
     assert "FULLY_CONNECTED" not in op_types
+
+
+def test_flatbuffer_direct_gemm_fp16_fully_connected_path_casts_io_to_float32() -> None:
+    model = _make_gemm_fp16_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="gemm_fp16_fc_cast_io_test",
+    )
+
+    fc_ops = [op for op in model_ir.operators if str(op.op_type) == "FULLY_CONNECTED"]
+    assert len(fc_ops) == 1
+    fc_op = fc_ops[0]
+
+    fc_input_name = str(fc_op.inputs[0])
+    fc_output_name = str(fc_op.outputs[0])
+    assert str(model_ir.tensors[fc_input_name].dtype).upper() == "FLOAT32"
+    assert str(model_ir.tensors[fc_output_name].dtype).upper() == "FLOAT32"
+
+    cast_ops = [op for op in model_ir.operators if str(op.op_type) == "CAST"]
+    assert len(cast_ops) >= 2
+    assert any(str(op.inputs[0]) == "x" and str(op.outputs[0]) == fc_input_name for op in cast_ops)
+    assert any(str(op.inputs[0]) == fc_output_name and str(op.outputs[0]) == "y" for op in cast_ops)
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_float32_export_promotes_fp16_graph_for_litert_invoke() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_gemm_fp16_model()
+        model_path = _save_model(tmpdir, "gemm_fp16_promote", model)
+        out_dir = os.path.join(tmpdir, "out")
+        tflite_path = _convert(model_path, out_dir, "flatbuffer_direct")
+        details = _collect_tensor_detail_dicts(tflite_path)
+        assert all(
+            np.dtype(detail["dtype"]) != np.dtype(np.float16)
+            for detail in details
+        )
+        interpreter = Interpreter(model_path=tflite_path)
+        interpreter.allocate_tensors()
+        input_detail = interpreter.get_input_details()[0]
+        output_detail = interpreter.get_output_details()[0]
+        x = np.ones(input_detail["shape"], dtype=input_detail["dtype"])
+        interpreter.set_tensor(input_detail["index"], x)
+        interpreter.invoke()
+        y = interpreter.get_tensor(output_detail["index"])
+        assert np.dtype(y.dtype) == np.dtype(np.float32)
 
 
 def test_flatbuffer_direct_maxpool1d_indices_kernel2_pad1_lowering_uses_builtin_ops() -> None:
@@ -9772,6 +10105,53 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_keeps_existing_concret
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, 1, 20, 2]
 
 
+def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_prefers_runtime_minus_one_from_onnx_raw() -> None:
+    model_ir = ModelIR(name="reshape_fixup_runtime_minus_one_preference_test")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 10, 4096, 2],
+        shape_signature=[1, 10, 4096, 2],
+    )
+    model_ir.tensors["reshape_shape"] = TensorIR(
+        name="reshape_shape",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray([1, 5, 64, 64, 2], dtype=np.int32),
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 5, 64, 64, 2],
+        shape_signature=[1, 5, 64, 64, 2],
+    )
+    model_ir.operators.append(
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["x", "reshape_shape"],
+            outputs=["y"],
+            options={
+                "newShape": [1, 5, 64, 64, 2],
+                "onnxRawNewShape": [1, -1, 64, 64, 2],
+                "allowZero": False,
+            },
+        )
+    )
+
+    stats = _resolve_dynamic_reshape_shapes(
+        model_ir,
+        prefer_runtime_inferable_from_onnx_raw=True,
+    )
+    assert stats["resolved_dynamic_reshape_shapes"] == 1
+    assert list(model_ir.operators[0].options["newShape"]) == [1, -1, 64, 64, 2]
+    assert list(model_ir.tensors["y"].shape) == [1, 1, 64, 64, 2]
+    assert list(model_ir.tensors["y"].shape_signature) == [1, -1, 64, 64, 2]
+    assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, -1, 64, 64, 2]
+
+
 def test_flatbuffer_direct_replace_squeeze_with_reshape_skips_all_ones_outputs() -> None:
     model_ir = ModelIR(name="squeeze_rewrite_all_ones_guard_test")
     model_ir.inputs = ["x"]
@@ -10030,6 +10410,113 @@ def test_flatbuffer_direct_repair_unbound_split_data_input_with_layout_transpose
 
     after_issues = _find_unbound_nonconstant_operator_inputs(model_ir)
     assert len(after_issues) == 0
+
+
+def test_flatbuffer_direct_replace_unsupported_split_with_slice_inserts_cast_on_dtype_mismatch() -> None:
+    model_ir = ModelIR(name="unsupported_split_cast_fallback_test")
+    model_ir.inputs = ["state_in"]
+    model_ir.outputs = ["state_fw", "state_bw"]
+    model_ir.tensors["state_in"] = TensorIR(
+        name="state_in",
+        dtype="FLOAT16",
+        shape=[2, 1, 256],
+        shape_signature=[2, 1, 256],
+    )
+    model_ir.tensors["split_axis"] = TensorIR(
+        name="split_axis",
+        dtype="INT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([0], dtype=np.int32),
+    )
+    model_ir.tensors["state_fw"] = TensorIR(
+        name="state_fw",
+        dtype="FLOAT32",
+        shape=[1, 1, 256],
+        shape_signature=[1, 1, 256],
+    )
+    model_ir.tensors["state_bw"] = TensorIR(
+        name="state_bw",
+        dtype="FLOAT32",
+        shape=[1, 1, 256],
+        shape_signature=[1, 1, 256],
+    )
+    model_ir.operators = [
+        OperatorIR(
+            op_type="SPLIT",
+            inputs=["split_axis", "state_in"],
+            outputs=["state_fw", "state_bw"],
+            options={"numSplits": 2},
+        )
+    ]
+
+    stats = _replace_unsupported_split_with_slice(model_ir)
+    assert int(stats["replaced_unsupported_split_with_slice"]) == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("SPLIT") == 0
+    assert op_types.count("CAST") == 1
+    assert op_types.count("SLICE") == 2
+
+    cast_op = next(op for op in model_ir.operators if str(op.op_type) == "CAST")
+    assert list(cast_op.inputs) == ["state_in"]
+    cast_output_name = str(cast_op.outputs[0])
+    assert str(model_ir.tensors[cast_output_name].dtype).upper() == "FLOAT32"
+
+    slice_ops = [op for op in model_ir.operators if str(op.op_type) == "SLICE"]
+    assert all(str(op.inputs[0]) == cast_output_name for op in slice_ops)
+
+
+def test_flatbuffer_direct_replace_unsupported_split_with_slice_without_cast_when_dtype_matches() -> None:
+    model_ir = ModelIR(name="unsupported_split_slice_fallback_test")
+    model_ir.inputs = ["split_in"]
+    model_ir.outputs = ["split0", "split1"]
+    model_ir.tensors["split_in"] = TensorIR(
+        name="split_in",
+        dtype="FLOAT16",
+        shape=[1, 4, 4, 8],
+        shape_signature=[1, 4, 4, 8],
+    )
+    model_ir.tensors["split_axis"] = TensorIR(
+        name="split_axis",
+        dtype="INT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([3], dtype=np.int32),
+    )
+    model_ir.tensors["split0"] = TensorIR(
+        name="split0",
+        dtype="FLOAT16",
+        shape=[1, 4, 4, 4],
+        shape_signature=[1, 4, 4, 4],
+    )
+    model_ir.tensors["split1"] = TensorIR(
+        name="split1",
+        dtype="FLOAT16",
+        shape=[1, 4, 4, 4],
+        shape_signature=[1, 4, 4, 4],
+    )
+    model_ir.operators = [
+        OperatorIR(
+            op_type="SPLIT",
+            inputs=["split_axis", "split_in"],
+            outputs=["split0", "split1"],
+            options={"numSplits": 2},
+        )
+    ]
+
+    stats = _replace_unsupported_split_with_slice(model_ir)
+    assert int(stats["replaced_unsupported_split_with_slice"]) == 1
+
+    op_types = [str(op.op_type) for op in model_ir.operators]
+    assert op_types.count("SPLIT") == 0
+    assert op_types.count("CAST") == 0
+    assert op_types.count("SLICE") == 2
+    assert all(
+        str(op.inputs[0]) == "split_in"
+        for op in model_ir.operators
+        if str(op.op_type) == "SLICE"
+    )
 
 
 def test_flatbuffer_direct_logsoftmax_lowering() -> None:
@@ -15018,6 +15505,276 @@ def test_flatbuffer_direct_transpose_instancenorm_posttranspose_bias_add_nhwc_ch
     assert list(model_ir.tensors["scale"].shape) == [1, 1, 1, 3]
     assert list(model_ir.tensors["scaled"].shape) == [1, 4, 5, 3]
     assert list(model_ir.tensors["inst_out"].shape) == [1, 4, 5, 3]
+
+
+def test_flatbuffer_direct_transpose_flatten_globalnorm_pad_prepost_nhwc_chain_optimized() -> None:
+    model_ir = ModelIR(name="transpose_flatten_globalnorm_pad_prepost_nhwc_chain_opt_test")
+    model_ir.inputs = ["x_nhwc"]
+    model_ir.outputs = ["z"]
+
+    model_ir.tensors["x_nhwc"] = TensorIR(
+        name="x_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 3],
+        shape_signature=[1, 4, 5, 3],
+    )
+    model_ir.tensors["pre_perm"] = TensorIR(
+        name="pre_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 3, 1, 2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["post_perm"] = TensorIR(
+        name="post_perm",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([0, 2, 3, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["reshape1_shape"] = TensorIR(
+        name="reshape1_shape",
+        dtype="INT32",
+        shape=[3],
+        shape_signature=[3],
+        data=np.asarray([1, 1, -1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["reshape2_shape"] = TensorIR(
+        name="reshape2_shape",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([1, 3, 4, 5], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["axes"] = TensorIR(
+        name="axes",
+        dtype="INT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([2], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["eps"] = TensorIR(
+        name="eps",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1e-5], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["one"] = TensorIR(
+        name="one",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1.0], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["scale"] = TensorIR(
+        name="scale",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+        data=np.asarray([[[0.75]]], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["bias"] = TensorIR(
+        name="bias",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+        data=np.asarray([[[0.2]]], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["tail_mul_c"] = TensorIR(
+        name="tail_mul_c",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1.25], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["tail_add_c"] = TensorIR(
+        name="tail_add_c",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([0.05], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["pads"] = TensorIR(
+        name="pads",
+        dtype="INT32",
+        shape=[4, 2],
+        shape_signature=[4, 2],
+        data=np.asarray([[0, 0], [0, 0], [1, 1], [2, 2]], dtype=np.int32),
+        is_variable=False,
+    )
+
+    model_ir.tensors["x_nchw"] = TensorIR(
+        name="x_nchw",
+        dtype="FLOAT32",
+        shape=[1, 3, 4, 5],
+        shape_signature=[1, 3, 4, 5],
+    )
+    model_ir.tensors["flat"] = TensorIR(
+        name="flat",
+        dtype="FLOAT32",
+        shape=[1, 1, 60],
+        shape_signature=[1, 1, 60],
+    )
+    model_ir.tensors["mean"] = TensorIR(
+        name="mean",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+    )
+    model_ir.tensors["centered"] = TensorIR(
+        name="centered",
+        dtype="FLOAT32",
+        shape=[1, 1, 60],
+        shape_signature=[1, 1, 60],
+    )
+    model_ir.tensors["squared"] = TensorIR(
+        name="squared",
+        dtype="FLOAT32",
+        shape=[1, 1, 60],
+        shape_signature=[1, 1, 60],
+    )
+    model_ir.tensors["var"] = TensorIR(
+        name="var",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+    )
+    model_ir.tensors["var_eps"] = TensorIR(
+        name="var_eps",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+    )
+    model_ir.tensors["std"] = TensorIR(
+        name="std",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+    )
+    model_ir.tensors["inv_std"] = TensorIR(
+        name="inv_std",
+        dtype="FLOAT32",
+        shape=[1, 1, 1],
+        shape_signature=[1, 1, 1],
+    )
+    model_ir.tensors["normalized"] = TensorIR(
+        name="normalized",
+        dtype="FLOAT32",
+        shape=[1, 1, 60],
+        shape_signature=[1, 1, 60],
+    )
+    model_ir.tensors["scaled"] = TensorIR(
+        name="scaled",
+        dtype="FLOAT32",
+        shape=[1, 1, 60],
+        shape_signature=[1, 1, 60],
+    )
+    model_ir.tensors["inst_flat"] = TensorIR(
+        name="inst_flat",
+        dtype="FLOAT32",
+        shape=[1, 1, 60],
+        shape_signature=[1, 1, 60],
+    )
+    model_ir.tensors["inst_nchw"] = TensorIR(
+        name="inst_nchw",
+        dtype="FLOAT32",
+        shape=[1, 3, 4, 5],
+        shape_signature=[1, 3, 4, 5],
+    )
+    model_ir.tensors["tail_mul"] = TensorIR(
+        name="tail_mul",
+        dtype="FLOAT32",
+        shape=[1, 3, 4, 5],
+        shape_signature=[1, 3, 4, 5],
+    )
+    model_ir.tensors["tail_add"] = TensorIR(
+        name="tail_add",
+        dtype="FLOAT32",
+        shape=[1, 3, 4, 5],
+        shape_signature=[1, 3, 4, 5],
+    )
+    model_ir.tensors["pad_nchw"] = TensorIR(
+        name="pad_nchw",
+        dtype="FLOAT32",
+        shape=[1, 3, 6, 9],
+        shape_signature=[1, 3, 6, 9],
+    )
+    model_ir.tensors["y_nhwc"] = TensorIR(
+        name="y_nhwc",
+        dtype="FLOAT32",
+        shape=[1, 6, 9, 3],
+        shape_signature=[1, 6, 9, 3],
+    )
+    model_ir.tensors["z"] = TensorIR(
+        name="z",
+        dtype="FLOAT32",
+        shape=[1, 6, 9, 3],
+        shape_signature=[1, 6, 9, 3],
+    )
+
+    model_ir.operators = [
+        OperatorIR(op_type="TRANSPOSE", inputs=["x_nhwc", "pre_perm"], outputs=["x_nchw"]),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["x_nchw", "reshape1_shape"],
+            outputs=["flat"],
+            options={"newShape": [1, 1, -1], "onnxRawNewShape": [1, 1, -1]},
+        ),
+        OperatorIR(op_type="MEAN", inputs=["flat", "axes"], outputs=["mean"], options={"keepDims": True}),
+        OperatorIR(op_type="SUB", inputs=["flat", "mean"], outputs=["centered"]),
+        OperatorIR(op_type="MUL", inputs=["centered", "centered"], outputs=["squared"]),
+        OperatorIR(op_type="MEAN", inputs=["squared", "axes"], outputs=["var"], options={"keepDims": True}),
+        OperatorIR(op_type="ADD", inputs=["var", "eps"], outputs=["var_eps"]),
+        OperatorIR(op_type="SQRT", inputs=["var_eps"], outputs=["std"]),
+        OperatorIR(op_type="DIV", inputs=["one", "std"], outputs=["inv_std"]),
+        OperatorIR(op_type="MUL", inputs=["centered", "inv_std"], outputs=["normalized"]),
+        OperatorIR(op_type="MUL", inputs=["normalized", "scale"], outputs=["scaled"]),
+        OperatorIR(op_type="ADD", inputs=["scaled", "bias"], outputs=["inst_flat"]),
+        OperatorIR(
+            op_type="RESHAPE",
+            inputs=["inst_flat", "reshape2_shape"],
+            outputs=["inst_nchw"],
+            options={"newShape": [1, 3, 4, 5], "onnxRawNewShape": [1, 3, 4, 5]},
+        ),
+        OperatorIR(op_type="MUL", inputs=["inst_nchw", "tail_mul_c"], outputs=["tail_mul"]),
+        OperatorIR(op_type="ADD", inputs=["tail_mul", "tail_add_c"], outputs=["tail_add"]),
+        OperatorIR(op_type="MIRROR_PAD", inputs=["tail_add", "pads"], outputs=["pad_nchw"]),
+        OperatorIR(op_type="TRANSPOSE", inputs=["pad_nchw", "post_perm"], outputs=["y_nhwc"]),
+        OperatorIR(op_type="RELU", inputs=["y_nhwc"], outputs=["z"]),
+    ]
+
+    stats = _optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains(model_ir)
+    assert stats["optimized_transpose_flatten_globalnorm_pad_prepost_nhwc_chains"] == 1
+    assert sum(1 for op in model_ir.operators if str(op.op_type) == "TRANSPOSE") == 0
+
+    reshape1_op = next(op for op in model_ir.operators if str(op.op_type) == "RESHAPE" and list(op.outputs) == ["flat"])
+    assert [str(v) for v in list(reshape1_op.inputs)] == ["x_nhwc", "reshape1_shape"]
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["reshape2_shape"].data, dtype=np.int32),
+        np.asarray([1, 4, 5, 3], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(model_ir.tensors["pads"].data, dtype=np.int32),
+        np.asarray([[0, 0], [1, 1], [2, 2], [0, 0]], dtype=np.int32),
+    )
+
+    pad_op = next(op for op in model_ir.operators if str(op.op_type) == "MIRROR_PAD")
+    assert [str(v) for v in list(pad_op.outputs)] == ["y_nhwc"]
+    relu_op = next(op for op in model_ir.operators if str(op.op_type) == "RELU")
+    assert [str(v) for v in list(relu_op.inputs)] == ["y_nhwc"]
+    assert list(model_ir.tensors["inst_nchw"].shape) == [1, 4, 5, 3]
 
 
 def test_flatbuffer_direct_transpose_instancenorm_mirror_pad_prepost_nhwc_with_side_consumer() -> None:


### PR DESCRIPTION
## Summary
This PR strengthens `flatbuffer_direct` conversion quality for DAMO-style graphs and broadens built-in operator coverage while keeping model contracts stable at graph boundaries.

## Functional Improvements
- Added robust Float32 export path from FP16-heavy IR:
  - Introduced `clone_model_ir_with_float32` to promote FP16 tensors/options into FP32.
  - Added `prune_identity_cast_operators` and `optimize_redundant_transpose_operators` to simplify generated graphs before writing TFLite.
  - Applied the same transpose cleanup to FP16 export and preserved reduced-precision metadata handling.
- Improved late-stage dynamic shape correctness:
  - `_resolve_dynamic_reshape_shapes` now supports `prefer_runtime_inferable_from_onnx_raw=True` to preserve ONNX runtime-inferable `-1` templates instead of stale concretized shapes.
  - Extended dynamic-lineage preservation for `RANGE` outputs with runtime-dependent lengths.
  - Prevented aggressive reshape passthrough folding when `preserveDynamicShape=True` is set.
- Added LiteRT compatibility fallback for unsupported `SPLIT` input dtypes:
  - Rewrites unsupported `SPLIT` into `SLICE` chains (with optional cast in/out) so conversion succeeds for dtype combinations not accepted by LiteRT `SPLIT`.
- Added a new graph optimizer for DAMO-like normalization/padding layouts:
  - `_optimize_transpose_flatten_globalnorm_pad_prepost_nhwc_chains` removes redundant pre/post transpose wrappers and rewrites affected shape/pad metadata into NHWC-consistent form.

## Operator Coverage Extensions
- `Inverse`:
  - Expanded built-in lowering from only 2x2/3x3 to generic square `NxN` (up to `16x16`) by Gauss-Jordan-style tensor-op decomposition.
- `GatherND`:
  - Added lowering support for `batch_dims > 0` by flattening batch prefix, synthesizing batch indices (`RANGE` + `TILE` + `CONCAT`), gathering, then reshaping back.
- `Gemm/MatMul -> FULLY_CONNECTED` path:
  - Added explicit I/O cast handling so FP16 interfaces can safely execute with internal FP32 compute.
- Bidirectional `LSTM` path:
  - Added FP16<->FP32 cast bridges to keep built-in kernel use while preserving external dtype contracts.
- `Slice` shape inference:
  - Improved static metadata resolution for strided slicing with known bounds; avoids incorrect oversized static lengths when runtime clipping may occur.
- `GridSample`:
  - Improved handling of partially-unknown shape metadata by merging with ONNX raw shape hints and inferring expected output dimensions when valid.

## Validation/Registry Alignment
- Updated validators (`Inverse`, `GatherND`, `GridSample`) to match new lowering capabilities and constraints.
- Expanded op registry declarations for `GatherND` and shape/index helper ops (`RANGE`, `SHAPE`) required by new lowerings.

## Tests
- Expanded `tests/test_tflite_builder_direct.py` with targeted regression tests covering:
  - FP16->FP32 IR promotion and cast/transpose cleanup
  - `Inverse` static `8x8` lowering
  - `GatherND(batch_dims>0)` and GridSample unknown-shape scenarios
  - FP16 FC cast bridges
  - unsupported-`SPLIT` fallback rewriting
  - reshape runtime `-1` preference behavior
  - transpose/flatten/globalnorm/pad chain optimization
- Local test result:
  - `pytest -q tests/test_tflite_builder_direct.py`
  - `568 passed, 1 warning`

## Release Metadata
- Bumped package version to `2.2.2` (`pyproject.toml`, `onnx2tf/__init__.py`).
- Updated Docker tag examples in README to `2.2.2`.
