### PR TITLE
feat: expand flatbuffer_direct split export and validation workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,6 @@ Actual speedup depends on model structure, enabled options, and runtime environm
 
 Fast path is intentionally disabled (falls back to the legacy TF-graph path) when TF-model dependent options are enabled:
 
-- `--enable_auto_split_model`
 - `--output_h5`
 - `--output_keras_v3`
 - `--output_tfv1_pb`
@@ -659,7 +658,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.3.0
+  ghcr.io/pinto0309/onnx2tf:2.3.1
 
   or
 
@@ -668,7 +667,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.3.0
+  docker.io/pinto0309/onnx2tf:2.3.1
 
   or
 
@@ -678,7 +677,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.3.0 \
+  docker.io/pinto0309/onnx2tf:2.3.1 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or
@@ -1954,7 +1953,7 @@ optional arguments:
     Input onnx file path.
 
   -it INPUT_TFLITE_FILE_PATH, --input_tflite_file_path INPUT_TFLITE_FILE_PATH
-    Input tflite file path for direct SavedModel export.
+    Input tflite file path for direct import mode.
 
   -V, --version
     Show version and exit.
@@ -2006,7 +2005,7 @@ optional arguments:
     1. `flatbuffer_direct` is experimental; always validate model-by-model before production rollout.
     2. onnx2tf first tries a direct fast path that skips TensorFlow per-node conversion (`op.make_node`) and directly exports from ONNX to TFLite FlatBuffer.
     3. Fast path is bypassed when TF-model dependent options are enabled:
-       `--enable_auto_split_model`, `--output_h5`, `--output_keras_v3`, `--output_tfv1_pb`, `--disable_model_save`.
+       `--output_h5`, `--output_keras_v3`, `--output_tfv1_pb`, `--disable_model_save`.
        In that case, conversion uses the legacy TF-graph path.
     4. Direct export supports FP32/FP16 `.tflite` generation.
     5. Dynamic range quantization (`-odrqt`) is supported in a limited form:
@@ -2050,12 +2049,28 @@ optional arguments:
        This option requires `--tflite_backend flatbuffer_direct`, cannot be combined with
        `--disable_model_save`,
        and fails explicitly if `CUSTOM` ops are present.
+       When split output is enabled, partition SavedModels are emitted instead of
+       a single root SavedModel.
+    14. Direct split planning in `flatbuffer_direct` is ModelIR-based and driven by
+       `--enable_auto_split_model`.
+       This always runs the split planner and emits split manifest output.
+       Outputs use the split manifest flow (`*_split_plan.json`, `*_split_manifest.json`,
+       `*_0001.tflite`, ...), not the legacy `part_0001/` recursive conversion flow.
+       Small models may still complete with a single-partition manifest when the planner
+       estimates that the model already fits within the target size.
+    15. Split accuracy evaluation is selected with a single option:
+       `--eval_split_models unsplit_tflite` or `--eval_split_models onnx`.
+       This is available only with `--tflite_backend flatbuffer_direct`
+       and requires `--enable_auto_split_model`.
+       This writes `*_split_accuracy_report.json`.
+       `*_accuracy_report.json` remains the unsplit base float32 TFLite vs ONNX report.
 
   -fdosm, --flatbuffer_direct_output_saved_model
     Output SavedModel directly from flatbuffer_direct ModelIR (float32).
     Available only with --tflite_backend flatbuffer_direct.
     Cannot be used with --disable_model_save.
     Fails explicitly if CUSTOM ops are present.
+    With split output, partition SavedModels are emitted instead of a single root SavedModel.
     When used with -cotof, also outputs `<model_name>_saved_model_validation_report.json`
     in the output directory (inference status + SavedModel/TFLite comparison metrics).
 
@@ -2276,13 +2291,24 @@ supports `--resume`, and generates `bulk_status.json` / `bulk_summary.json` / `b
   -easm, --enable_auto_split_model
     Force auto split regardless of the ONNX file size.
     Uses --auto_split_max_size as the target partition size.
+    In `flatbuffer_direct`, this forces the shared ModelIR split planner to run and
+    emit split manifest outputs even if the size estimate would otherwise fit in one partition.
 
   -asms AUTO_SPLIT_MAX_SIZE, --auto_split_max_size AUTO_SPLIT_MAX_SIZE
     Target maximum size per partition when auto-split is triggered or forced.
     Supported units: KB, MB, GB (e.g. 900MB, 1GB, 1536KB).
     Bare numbers are treated as MB.
-    When specified, this value is also used as the target size for --auto_split_tflite_by_size.
+    When specified, this value is also used as the target size for --enable_auto_split_model.
     Default: 1GB
+
+  --eval_split_models {unsplit_tflite,onnx}
+    Evaluate split partitions sequentially using split manifest output.
+    Specify `unsplit_tflite` to compare against the unsplit/base TFLite model,
+    or `onnx` to compare against ONNX Runtime output.
+    Available only with `--tflite_backend flatbuffer_direct`
+    and requires `--enable_auto_split_model`.
+    Writes `*_split_accuracy_report.json`.
+    `*_accuracy_report.json` remains the unsplit base float32 TFLite vs ONNX report.
 
   -dgc, --disable_group_convolution
     Disable GroupConvolution and replace it with SeparableConvolution for
@@ -2473,6 +2499,8 @@ supports `--resume`, and generates `bulk_status.json` / `bulk_summary.json` / `b
     When --input_tflite_file_path is specified, this runs SavedModel inference
     plus SavedModel vs input TFLite output comparison and emits
     `<model_name>_saved_model_validation_report.json`.
+    If split SavedModels are emitted, they are executed sequentially in
+    split-manifest order before comparison.
 
   -coton, --check_onnx_tf_outputs_sample_data_normalization
     norm: Validate using random data normalized to the range 0.0 to 1.0
@@ -2605,6 +2633,7 @@ convert(
   check_onnx_tf_outputs_sample_data_normalization: Optional[str] = 'norm',
   check_onnx_tf_outputs_elementwise_close_rtol: Optional[float] = 0.0,
   check_onnx_tf_outputs_elementwise_close_atol: Optional[float] = 1e-4,
+  eval_split_models: Optional[str] = None,
   test_data_nhwc_path: Union[str, NoneType] = None,
   disable_model_save: Union[bool, NoneType] = False,
   non_verbose: Union[bool, NoneType] = False,
@@ -2621,10 +2650,12 @@ convert(
 
     input_tflite_file_path: Optional[str]
       Input tflite file path.
-      If specified, runs tflite-direct SavedModel export mode.
-      In this mode, ONNX-dependent conversion options are rejected and
-      `check_onnx_tf_outputs_elementwise_close_full=True` runs
-      SavedModel vs input TFLite comparison.
+      If specified, runs tflite-direct import mode.
+      In this mode, ONNX-dependent conversion options are rejected.
+      By default it exports SavedModel from imported ModelIR, and
+      enable_auto_split_model=True can also emit split TFLite artifacts.
+      When used with flatbuffer_direct_output_saved_model=True and split,
+      partition SavedModels are emitted instead of a single root SavedModel.
 
     onnx_graph: Optional[onnx.ModelProto]
       onnx.ModelProto.
@@ -2681,6 +2712,8 @@ convert(
       Requires `tflite_backend="flatbuffer_direct"`.
       Cannot be combined with `disable_model_save=True`.
       Fails explicitly if `CUSTOM` ops are present.
+      When used together with split output, partition SavedModels are emitted
+      instead of a single root SavedModel.
       When used with `check_onnx_tf_outputs_elementwise_close_full=True`,
       `<model_name>_saved_model_validation_report.json` is generated.
 
@@ -2888,6 +2921,9 @@ convert(
     enable_auto_split_model: Optional[bool]
       Force auto split regardless of the ONNX file size.
       Uses auto_split_max_size as the target partition size.
+      In `flatbuffer_direct`, this runs the ModelIR split planner and forces
+      split manifest generation.
+      A small model may still result in a single-partition manifest.
       Short option: -easm
       Default: False
 
@@ -2896,8 +2932,17 @@ convert(
       Supports values such as "512KB", "900MB", and "1.5GB".
       Bare numeric values are treated as MB.
       Used when auto-split is triggered or forced.
-      When specified, also used as the split target when auto_split_tflite_by_size=True.
-      Default: "1GB"
+      When specified, also used as the split target when enable_auto_split_model=True.
+
+    eval_split_models: Optional[str]
+      Evaluate split partitions sequentially using split manifest output.
+      Specify "unsplit_tflite" to compare against the unsplit/base TFLite model,
+      or "onnx" to compare against ONNX Runtime output.
+      Available only with tflite_backend="flatbuffer_direct" and
+      requires enable_auto_split_model=True.
+      Writes `*_split_accuracy_report.json`.
+      `*_accuracy_report.json` remains the unsplit base float32 TFLite vs ONNX report.
+      Default: None
 
     auto_split_max_size_mb: Optional[int]
       [Deprecated] Legacy alias of auto_split_max_size in MB.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,3 @@
 from onnx2tf.onnx2tf import convert, main
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1153,10 +1153,8 @@ def convert(
     eval_fail_on_threshold: Optional[bool] = False,
     eval_target_tflite: Optional[str] = 'float32',
     eval_compare_mode: Optional[str] = 'auto',
-    eval_split_models: Optional[bool] = False,
-    eval_split_reference: Optional[str] = 'unsplit_tflite',
+    eval_split_models: Optional[str] = None,
     eval_split_fail_on_threshold: Optional[bool] = False,
-    auto_split_tflite_by_size: Optional[bool] = False,
     report_op_coverage: Optional[bool] = False,
     flatbuffer_direct_output_saved_model: Optional[bool] = False,
     flatbuffer_direct_allow_custom_ops: Optional[bool] = False,
@@ -1232,9 +1230,12 @@ def convert(
 
     input_tflite_file_path: Optional[str]
         Input tflite file path.\n
-        If specified, run tflite-direct SavedModel export mode.\n
-        In this mode, ONNX-dependent conversion options are rejected,\n
-        and -cotof performs SavedModel vs TFLite runtime comparison.
+        If specified, run tflite-direct import mode.\n
+        In this mode, ONNX-dependent conversion options are rejected.\n
+        By default it exports SavedModel from imported ModelIR,\n
+        and `--enable_auto_split_model` can also emit split TFLite artifacts.\n
+        When used with `--flatbuffer_direct_output_saved_model` and split,\n
+        partition SavedModels are emitted instead of a single root SavedModel.
 
     onnx_graph: Optional[onnx.ModelProto]
         onnx.ModelProto.\n
@@ -1318,20 +1319,19 @@ def convert(
         "raw": compare raw TFLite output tensors.\n
         Default: "auto"
 
-    eval_split_models: Optional[bool]
+    eval_split_models: Optional[str]
         Evaluate split tflite partitions (generated from split manifest)
-        by sequential execution.
-
-    eval_split_reference: Optional[str]
-        Reference for split evaluation.\n
-        "unsplit_tflite"(default) or "onnx"
+        by sequential execution.\n
+        "unsplit_tflite" compares against the unsplit/base TFLite model.\n
+        "onnx" compares against ONNX Runtime output.\n
+        Available only with `tflite_backend="flatbuffer_direct"` and
+        `enable_auto_split_model=True`.\n
+        This writes `*_split_accuracy_report.json`.\n
+        `*_accuracy_report.json` remains the unsplit base TFLite vs ONNX report.\n
+        Default: None
 
     eval_split_fail_on_threshold: Optional[bool]
         Fail conversion when split evaluation thresholds are not satisfied.
-
-    auto_split_tflite_by_size: Optional[bool]
-        Estimate flatbuffer size and generate split planning report
-        (`*_split_plan.json`) for flatbuffer_direct backend.
 
     report_op_coverage: Optional[bool]
         Generate ONNX OP coverage report (`*_op_coverage_report.json`) with
@@ -1339,7 +1339,11 @@ def convert(
 
     flatbuffer_direct_output_saved_model: Optional[bool]
         Export SavedModel directly from flatbuffer_direct ModelIR (float32 path)
-        without tf_converter fallback.
+        without tf_converter fallback.\n
+        When used together with split output, partition SavedModels are emitted
+        instead of a single root SavedModel.\n
+        With `check_onnx_tf_outputs_elementwise_close_full=True`, onnx2tf writes
+        `<model_name>_saved_model_validation_report.json`.
 
     flatbuffer_direct_allow_custom_ops: Optional[bool]
         Allow lowering selected unsupported ONNX ops as TFLite CUSTOM ops in
@@ -1684,6 +1688,8 @@ def convert(
     enable_auto_split_model: Optional[bool]
         Force auto split regardless of the ONNX file size.\n
         The target size is controlled by auto_split_max_size.\n
+        In flatbuffer_direct, this runs the ModelIR split planner and forces\n
+        split manifest generation.\n
         Default: False
 
     auto_split_max_size: Optional[Any]
@@ -1832,10 +1838,12 @@ def convert(
     eval_fail_on_threshold = bool(eval_fail_on_threshold)
     eval_target_tflite = str(eval_target_tflite).lower() if eval_target_tflite is not None else 'float32'
     eval_compare_mode = str(eval_compare_mode).lower() if eval_compare_mode is not None else 'auto'
-    eval_split_models = bool(eval_split_models)
-    eval_split_reference = str(eval_split_reference).lower() if eval_split_reference is not None else 'unsplit_tflite'
+    eval_split_models = (
+        str(eval_split_models).strip().lower()
+        if eval_split_models is not None
+        else None
+    )
     eval_split_fail_on_threshold = bool(eval_split_fail_on_threshold)
-    auto_split_tflite_by_size = bool(auto_split_tflite_by_size)
     report_op_coverage = bool(report_op_coverage)
     flatbuffer_direct_output_saved_model = bool(
         flatbuffer_direct_output_saved_model
@@ -1875,7 +1883,7 @@ def convert(
         sys.exit(1)
     tflite_split_max_bytes = int(tflite_split_max_bytes)
     tflite_split_target_bytes = int(tflite_split_target_bytes)
-    if auto_split_tflite_by_size and auto_split_max_size_specified:
+    if enable_auto_split_model:
         tflite_split_target_bytes = int(auto_split_max_size_bytes)
         if tflite_split_max_bytes < tflite_split_target_bytes:
             tflite_split_max_bytes = tflite_split_target_bytes
@@ -1915,10 +1923,10 @@ def convert(
             f'eval_compare_mode: {eval_compare_mode}'
         )
         sys.exit(1)
-    if eval_split_reference not in ['unsplit_tflite', 'onnx']:
+    if eval_split_models not in [None, 'unsplit_tflite', 'onnx']:
         error(
-            f'eval_split_reference must be one of ["unsplit_tflite", "onnx"]. ' +
-            f'eval_split_reference: {eval_split_reference}'
+            f'eval_split_models must be one of ["unsplit_tflite", "onnx"] or None. ' +
+            f'eval_split_models: {eval_split_models}'
         )
         sys.exit(1)
     if tflite_split_max_bytes <= 0:
@@ -1943,19 +1951,14 @@ def convert(
             'eval_with_onnx currently supports only tflite_backend="flatbuffer_direct".'
         )
         sys.exit(1)
-    if eval_split_models and tflite_backend != 'flatbuffer_direct':
+    if eval_split_models is not None and tflite_backend != 'flatbuffer_direct':
         error(
             'eval_split_models currently supports only tflite_backend="flatbuffer_direct".'
         )
         sys.exit(1)
-    if eval_split_models and not auto_split_tflite_by_size:
+    if eval_split_models is not None and not enable_auto_split_model:
         error(
-            'eval_split_models=True requires auto_split_tflite_by_size=True.'
-        )
-        sys.exit(1)
-    if auto_split_tflite_by_size and tflite_backend != 'flatbuffer_direct':
-        error(
-            'auto_split_tflite_by_size currently supports only tflite_backend="flatbuffer_direct".'
+            'eval_split_models requires enable_auto_split_model=True.'
         )
         sys.exit(1)
     if report_op_coverage and tflite_backend != 'flatbuffer_direct':
@@ -2000,17 +2003,14 @@ def convert(
             ('output_dynamic_range_quantized_tflite', bool(output_dynamic_range_quantized_tflite)),
             ('output_integer_quantized_tflite', bool(output_integer_quantized_tflite)),
             ('eval_with_onnx', bool(eval_with_onnx)),
-            ('eval_split_models', bool(eval_split_models)),
-            ('auto_split_tflite_by_size', bool(auto_split_tflite_by_size)),
+            ('eval_split_models', eval_split_models),
             ('report_op_coverage', bool(report_op_coverage)),
-            ('flatbuffer_direct_output_saved_model', bool(flatbuffer_direct_output_saved_model)),
             ('flatbuffer_direct_allow_custom_ops', bool(flatbuffer_direct_allow_custom_ops)),
             (
                 'flatbuffer_direct_custom_op_allowlist',
                 bool(flatbuffer_direct_custom_op_allowlist is not None and len(flatbuffer_direct_custom_op_allowlist) > 0),
             ),
             ('check_onnx_tf_outputs_elementwise_close', bool(check_onnx_tf_outputs_elementwise_close)),
-            ('enable_auto_split_model', bool(enable_auto_split_model)),
             ('check_gpu_delegate_compatibility', bool(check_gpu_delegate_compatibility)),
             ('auto_generate_json', bool(auto_generate_json)),
             ('auto_generate_json_on_error', bool(auto_generate_json_on_error)),
@@ -2064,6 +2064,7 @@ def convert(
         tflite_paths: Dict[str, str],
         source_label: str,
         contains_custom_ops: bool = False,
+        split_manifest_path: Optional[str] = None,
     ) -> None:
         if not run_onnx_tflite_output_check:
             return
@@ -2219,6 +2220,15 @@ def convert(
                 f'pass={report["evaluation_pass"]}'
             )
         )
+        if split_manifest_path is not None and str(split_manifest_path) != '':
+            info(
+                Color.YELLOW(
+                    'Note: *_accuracy_report.json compares the unsplit base float32 TFLite '
+                    'model against ONNX even when split output is enabled. '
+                    'Use --eval_split_models {unsplit_tflite|onnx} to evaluate split '
+                    'partitions sequentially.'
+                )
+            )
 
     def _run_saved_model_tflite_direct_check(
         *,
@@ -3163,6 +3173,76 @@ def convert(
                 f'source={source_label} path={saved_model_path} reason={inference_exception}'
             ) from inference_exception
 
+    def _maybe_run_saved_model_inference_check(
+        *,
+        saved_model_path: Optional[str],
+        float32_tflite_path: Optional[str] = None,
+        source_label: str,
+    ) -> None:
+        if not run_saved_model_inference_check:
+            return
+        normalized_saved_model_path = (
+            str(saved_model_path)
+            if saved_model_path is not None and str(saved_model_path) != ''
+            else None
+        )
+        if normalized_saved_model_path is None:
+            return
+        _run_saved_model_inference_check(
+            saved_model_path=normalized_saved_model_path,
+            float32_tflite_path=float32_tflite_path,
+            source_label=source_label,
+        )
+
+    def _maybe_run_split_saved_model_inference_check(
+        *,
+        split_manifest_path: Optional[str],
+        reference_tflite_path: Optional[str],
+        source_label: str,
+    ) -> None:
+        if not run_saved_model_inference_check:
+            return
+        normalized_manifest_path = (
+            str(split_manifest_path)
+            if split_manifest_path is not None and str(split_manifest_path) != ''
+            else None
+        )
+        normalized_reference_tflite_path = (
+            str(reference_tflite_path)
+            if reference_tflite_path is not None and str(reference_tflite_path) != ''
+            else None
+        )
+        if (
+            normalized_manifest_path is None
+            or normalized_reference_tflite_path is None
+        ):
+            return
+        from onnx2tf.tflite_builder.split_saved_model_evaluator import (
+            evaluate_split_saved_model_outputs,
+        )
+
+        report_path = os.path.join(
+            output_folder_path,
+            f'{output_file_name}_saved_model_validation_report.json',
+        )
+        report = evaluate_split_saved_model_outputs(
+            split_manifest_path=normalized_manifest_path,
+            reference_tflite_path=normalized_reference_tflite_path,
+            output_report_path=report_path,
+            source_label=source_label,
+            rtol=eval_rtol,
+            atol=eval_atol,
+        )
+        info(
+            Color.GREEN(
+                'Split SavedModel validation report output complete! '
+                f'({report_path}) '
+                f'pass={report["overall_pass"]} '
+                f'matched={report["comparison"]["matched"]}/{report["comparison"]["total"]} '
+                f'max_abs={report["comparison"]["max_abs"]:.6g}'
+            )
+        )
+
     def _run_flatbuffer_direct_op_error_report(
         *,
         tflite_path: Optional[str],
@@ -3508,17 +3588,120 @@ def convert(
                 optimize_redundant_transpose_operators,
                 prune_identity_cast_operators,
             )
+            from onnx2tf.tflite_builder.model_writer import (
+                write_model_file,
+            )
             from onnx2tf.tflite_builder.saved_model_exporter import (
                 export_saved_model_from_model_ir,
+            )
+            from onnx2tf.tflite_builder.schema_loader import (
+                load_schema_module,
+            )
+            from onnx2tf.tflite_builder.split_planner import (
+                plan_contiguous_partitions_by_size,
+                write_split_model_files_and_manifest,
+                write_split_plan_report,
+            )
+            from onnx2tf.tflite_builder.split_saved_model_exporter import (
+                export_split_saved_models,
             )
             from onnx2tf.tflite_builder.tflite_importer import (
                 import_model_ir_from_tflite,
             )
+            from ai_edge_litert.interpreter import Interpreter
 
             model_ir = import_model_ir_from_tflite(
                 tflite_file_path=input_tflite_file_path,
                 output_folder_path=output_folder_path,
             )
+            if enable_auto_split_model:
+                schema_tflite = load_schema_module(output_folder_path)
+                split_plan_report = plan_contiguous_partitions_by_size(
+                    model_ir=model_ir,
+                    target_max_bytes=tflite_split_target_bytes,
+                    hard_max_bytes=tflite_split_max_bytes,
+                    schema_tflite=schema_tflite,
+                )
+                split_plan_report_path = write_split_plan_report(
+                    report=split_plan_report,
+                    output_report_path=os.path.join(
+                        output_folder_path,
+                        f'{output_file_name}_split_plan.json',
+                    ),
+                )
+
+                def _validate_split_tflite_loadable(tflite_path: str) -> None:
+                    interpreter = Interpreter(model_path=tflite_path)
+                    interpreter.allocate_tensors()
+
+                split_outputs = write_split_model_files_and_manifest(
+                    schema_tflite=schema_tflite,
+                    model_ir=model_ir,
+                    plan_report=split_plan_report,
+                    output_folder_path=output_folder_path,
+                    output_file_name=output_file_name,
+                    tflite_loader_validator=_validate_split_tflite_loadable,
+                )
+                base_tflite_path = os.path.join(
+                    output_folder_path,
+                    f'{output_file_name}.tflite',
+                )
+                write_model_file(
+                    schema_tflite=schema_tflite,
+                    model_ir=model_ir,
+                    output_tflite_path=base_tflite_path,
+                )
+
+                info(Color.GREEN(f'TFLite output complete! ({base_tflite_path})'))
+                info(Color.GREEN(f'Split plan report output complete! ({split_plan_report_path})'))
+                info(
+                    Color.GREEN(
+                        f'Split manifest output complete! '
+                        f'({split_outputs["split_manifest_path"]}) '
+                        f'partitions={split_outputs["split_partition_count"]}'
+                    )
+                )
+
+                if flatbuffer_direct_output_saved_model:
+                    split_saved_model_outputs = export_split_saved_models(
+                        model_ir=model_ir,
+                        split_manifest_path=split_outputs['split_manifest_path'],
+                        output_folder_path=output_folder_path,
+                        output_file_name=output_file_name,
+                    )
+                    info(
+                        Color.GREEN(
+                            'Split SavedModel output complete! '
+                            f'partitions={split_saved_model_outputs["split_saved_model_count"]}'
+                        )
+                    )
+                    _maybe_run_split_saved_model_inference_check(
+                        split_manifest_path=split_outputs['split_manifest_path'],
+                        reference_tflite_path=base_tflite_path,
+                        source_label='tflite_direct_input',
+                    )
+                else:
+                    model_ir_fp32 = clone_model_ir_with_float32(model_ir)
+                    prune_identity_cast_operators(
+                        model_ir_fp32,
+                        preserve_model_outputs=True,
+                    )
+                    optimize_redundant_transpose_operators(
+                        model_ir_fp32,
+                        preserve_model_outputs=True,
+                    )
+                    saved_model_path = export_saved_model_from_model_ir(
+                        model_ir=model_ir_fp32,
+                        output_folder_path=output_folder_path,
+                    )
+                    info(Color.GREEN(f'SavedModel output complete! ({saved_model_path})'))
+                    _run_saved_model_tflite_direct_check(
+                        saved_model_path=saved_model_path,
+                        float32_tflite_path=base_tflite_path,
+                        source_label='tflite_direct_input',
+                    )
+                return None
+
             model_ir_fp32 = clone_model_ir_with_float32(model_ir)
             prune_identity_cast_operators(
                 model_ir_fp32,
@@ -3807,7 +3990,7 @@ def convert(
     fuse_expanded_qdq_to_qdq(graph=graph)
 
     # Auto split model by estimated weight size
-    if auto_split_model:
+    if auto_split_model and tflite_backend != 'flatbuffer_direct':
         if input_names_to_interrupt_model_conversion or output_names_to_interrupt_model_conversion:
             error(
                 'Auto split cannot be used together with input_names_to_interrupt_model_conversion '
@@ -4100,9 +4283,7 @@ def convert(
                     'eval_target_tflite': eval_target_tflite,
                     'eval_compare_mode': eval_compare_mode,
                     'eval_split_models': eval_split_models,
-                    'eval_split_reference': eval_split_reference,
                     'eval_split_fail_on_threshold': eval_split_fail_on_threshold,
-                    'auto_split_tflite_by_size': auto_split_tflite_by_size,
                     'report_op_coverage': report_op_coverage,
                     'flatbuffer_direct_output_saved_model': flatbuffer_direct_output_saved_model,
                     'flatbuffer_direct_allow_custom_ops': flatbuffer_direct_allow_custom_ops,
@@ -4525,12 +4706,15 @@ def convert(
     info('')
     info(Color.REVERSE(f'Model loaded'), '=' * 72)
 
+    split_plan_enabled = bool(auto_split_model)
+    force_split_manifest = bool(
+        tflite_backend == 'flatbuffer_direct' and auto_split_model
+    )
+
     # Create Output folder
     os.makedirs(output_folder_path, exist_ok=True)
 
     flatbuffer_direct_fast_path_blockers = []
-    if auto_split_model:
-        flatbuffer_direct_fast_path_blockers.append('auto_split_model')
     if output_h5:
         flatbuffer_direct_fast_path_blockers.append('output_h5')
     if output_keras_v3:
@@ -4539,6 +4723,86 @@ def convert(
         flatbuffer_direct_fast_path_blockers.append('output_tfv1_pb')
     if disable_model_save:
         flatbuffer_direct_fast_path_blockers.append('disable_model_save')
+
+    def _log_flatbuffer_direct_split_outputs(
+        direct_outputs: Dict[str, Any],
+        *,
+        split_plan_requested: bool,
+        force_split_manifest: bool,
+        target_bytes: int,
+    ) -> None:
+        if not split_plan_requested:
+            return
+        if 'split_plan_report_path' not in direct_outputs:
+            raise RuntimeError(
+                'flatbuffer_direct split plan was requested but no report was generated.'
+            )
+        info(
+            Color.GREEN(
+                f'Split plan report output complete! '
+                f'({direct_outputs["split_plan_report_path"]})'
+            )
+        )
+        if 'split_manifest_path' in direct_outputs:
+            partition_count = int(direct_outputs.get('split_partition_count', 0))
+            if bool(direct_outputs.get('split_required_by_estimate', False)):
+                info(
+                    Color.GREEN(
+                        f'Split manifest output complete! '
+                        f'({direct_outputs["split_manifest_path"]}) '
+                        f'partitions={partition_count} [required_by_estimate]'
+                    )
+                )
+            elif force_split_manifest:
+                info(
+                    Color.GREEN(
+                        f'Split manifest output complete! '
+                        f'({direct_outputs["split_manifest_path"]}) '
+                        f'partitions={partition_count} [forced_by_enable_auto_split_model]'
+                    )
+                )
+                if partition_count <= 1:
+                    info(
+                        Color.GREEN(
+                            'Split planner completed with a single partition '
+                            '(model fits within the target size).'
+                        )
+                    )
+                else:
+                    info(
+                        Color.GREEN(
+                            'Split planner produced partition outputs even though '
+                            'split was not required by estimate.'
+                        )
+                    )
+                estimated_bytes = direct_outputs.get('split_plan_total_estimated_bytes', None)
+                if estimated_bytes is not None:
+                    info(
+                        Color.GREEN(
+                            f'Split target summary: estimated={estimated_bytes} '
+                            f'target={target_bytes}'
+                        )
+                    )
+            else:
+                info(
+                    Color.GREEN(
+                        f'Split manifest output complete! '
+                        f'({direct_outputs["split_manifest_path"]}) '
+                        f'partitions={partition_count}'
+                    )
+                )
+        elif bool(direct_outputs.get('split_required_by_estimate', False)):
+            raise RuntimeError(
+                'flatbuffer_direct split was required by estimate, '
+                'but split manifest was not generated.'
+            )
+        else:
+            info(
+                Color.GREEN(
+                    'Split manifest output skipped '
+                    '(model fits target size estimate and no forced split was requested).'
+                )
+            )
 
     if tflite_backend == 'flatbuffer_direct' and not flatbuffer_direct_fast_path_blockers:
         info('')
@@ -4567,7 +4831,7 @@ def convert(
                             output_dynamic_range_quantized_tflite=output_dynamic_range_quantized_tflite,
                             output_integer_quantized_tflite=output_integer_quantized_tflite,
                             enable_accumulation_type_float16=enable_accumulation_type_float16,
-                            auto_split_tflite_by_size=auto_split_tflite_by_size,
+                            force_split_manifest=force_split_manifest,
                             report_op_coverage=report_op_coverage,
                             output_saved_model_from_model_ir=flatbuffer_direct_output_saved_model,
                             flatbuffer_direct_allow_custom_ops=direct_allow_custom_ops,
@@ -4650,36 +4914,12 @@ def convert(
                         f'SavedModel output complete! ({direct_outputs["saved_model_path"]})'
                     )
                 )
-            if auto_split_tflite_by_size:
-                if 'split_plan_report_path' not in direct_outputs:
-                    raise RuntimeError(
-                        'flatbuffer_direct split plan was requested but no report was generated.'
-                    )
-                info(
-                    Color.GREEN(
-                        f'Split plan report output complete! '
-                        f'({direct_outputs["split_plan_report_path"]})'
-                    )
-                )
-                if bool(direct_outputs.get('split_required_by_estimate', False)):
-                    if 'split_manifest_path' not in direct_outputs:
-                        raise RuntimeError(
-                            'flatbuffer_direct split was required by estimate, '
-                            'but split manifest was not generated.'
-                        )
-                    info(
-                        Color.GREEN(
-                            f'Split manifest output complete! '
-                            f'({direct_outputs["split_manifest_path"]}) '
-                            f'partitions={direct_outputs.get("split_partition_count", "0")}'
-                        )
-                    )
-                else:
-                    info(
-                        Color.GREEN(
-                            'Split manifest output skipped (model fits target size estimate).'
-                        )
-                    )
+            _log_flatbuffer_direct_split_outputs(
+                direct_outputs,
+                split_plan_requested=split_plan_enabled,
+                force_split_manifest=force_split_manifest,
+                target_bytes=tflite_split_target_bytes,
+            )
             if report_op_coverage:
                 if 'op_coverage_report_path' not in direct_outputs:
                     raise RuntimeError(
@@ -4779,17 +5019,25 @@ def convert(
                 tflite_paths=direct_eval_paths,
                 source_label='flatbuffer_direct',
                 contains_custom_ops=direct_contains_custom_ops,
+                split_manifest_path=direct_outputs.get('split_manifest_path', None),
             )
-            _run_saved_model_inference_check(
-                saved_model_path=direct_outputs.get('saved_model_path', None),
-                float32_tflite_path=direct_outputs.get('float32_tflite_path', None),
-                source_label='flatbuffer_direct',
-            )
-            if eval_split_models:
+            if 'split_saved_model_dirs' in direct_outputs:
+                _maybe_run_split_saved_model_inference_check(
+                    split_manifest_path=direct_outputs.get('split_manifest_path', None),
+                    reference_tflite_path=direct_outputs.get('float32_tflite_path', None),
+                    source_label='flatbuffer_direct',
+                )
+            else:
+                _maybe_run_saved_model_inference_check(
+                    saved_model_path=direct_outputs.get('saved_model_path', None),
+                    float32_tflite_path=direct_outputs.get('float32_tflite_path', None),
+                    source_label='flatbuffer_direct',
+                )
+            if eval_split_models is not None:
                 if 'split_manifest_path' not in direct_outputs:
                     raise RuntimeError(
-                        'eval_split_models=True but split manifest is not available. '
-                        'Ensure auto_split_tflite_by_size=True and split is required by estimate.'
+                        'eval_split_models is set but split manifest is not available. '
+                        'Ensure enable_auto_split_model=True so split manifest output is generated.'
                     )
                 from onnx2tf.tflite_builder.split_accuracy_evaluator import evaluate_split_manifest_outputs
                 split_accuracy_report_path = os.path.join(
@@ -4797,12 +5045,12 @@ def convert(
                     f'{output_file_name}_split_accuracy_report.json',
                 )
                 reference_tflite_path = None
-                if eval_split_reference == 'unsplit_tflite':
+                if eval_split_models == 'unsplit_tflite':
                     reference_tflite_path = direct_outputs['float32_tflite_path']
                 split_report = evaluate_split_manifest_outputs(
                     onnx_graph=onnx_graph,
                     split_manifest_path=direct_outputs['split_manifest_path'],
-                    reference_mode=eval_split_reference,
+                    reference_mode=eval_split_models,
                     reference_tflite_path=reference_tflite_path,
                     output_report_path=split_accuracy_report_path,
                     num_samples=eval_num_samples,
@@ -5287,7 +5535,7 @@ def convert(
                                     output_dynamic_range_quantized_tflite=output_dynamic_range_quantized_tflite,
                                     output_integer_quantized_tflite=output_integer_quantized_tflite,
                                     enable_accumulation_type_float16=enable_accumulation_type_float16,
-                                    auto_split_tflite_by_size=auto_split_tflite_by_size,
+                                    force_split_manifest=force_split_manifest,
                                     report_op_coverage=report_op_coverage,
                                     output_saved_model_from_model_ir=flatbuffer_direct_output_saved_model,
                                     flatbuffer_direct_allow_custom_ops=direct_allow_custom_ops,
@@ -5394,12 +5642,20 @@ def convert(
                             tflite_paths=direct_eval_paths,
                             source_label='flatbuffer_direct',
                             contains_custom_ops=direct_contains_custom_ops,
+                            split_manifest_path=direct_outputs.get('split_manifest_path', None),
                         )
-                        _run_saved_model_inference_check(
-                            saved_model_path=direct_outputs.get('saved_model_path', None),
-                            float32_tflite_path=direct_outputs.get('float32_tflite_path', None),
-                            source_label='flatbuffer_direct',
-                        )
+                        if 'split_saved_model_dirs' in direct_outputs:
+                            _maybe_run_split_saved_model_inference_check(
+                                split_manifest_path=direct_outputs.get('split_manifest_path', None),
+                                reference_tflite_path=direct_outputs.get('float32_tflite_path', None),
+                                source_label='flatbuffer_direct',
+                            )
+                        else:
+                            _maybe_run_saved_model_inference_check(
+                                saved_model_path=direct_outputs.get('saved_model_path', None),
+                                float32_tflite_path=direct_outputs.get('float32_tflite_path', None),
+                                source_label='flatbuffer_direct',
+                            )
                     return None
                 except Exception:
                     raise
@@ -5719,7 +5975,7 @@ def convert(
                                 output_dynamic_range_quantized_tflite=output_dynamic_range_quantized_tflite,
                                 output_integer_quantized_tflite=output_integer_quantized_tflite,
                                 enable_accumulation_type_float16=enable_accumulation_type_float16,
-                                auto_split_tflite_by_size=auto_split_tflite_by_size,
+                                force_split_manifest=force_split_manifest,
                                 report_op_coverage=report_op_coverage,
                                 output_saved_model_from_model_ir=flatbuffer_direct_output_saved_model,
                                 flatbuffer_direct_allow_custom_ops=direct_allow_custom_ops,
@@ -5800,38 +6056,12 @@ def convert(
                             f'SavedModel output complete! ({direct_outputs["saved_model_path"]})'
                         )
                     )
-                if auto_split_tflite_by_size:
-                    if 'split_plan_report_path' not in direct_outputs:
-                        raise RuntimeError(
-                            'flatbuffer_direct split plan was requested but no report was generated.'
-                        )
-                    info(
-                        Color.GREEN(
-                            f'Split plan report output complete! '
-                            f'({direct_outputs["split_plan_report_path"]})'
-                        )
-                    )
-                    if bool(direct_outputs.get('split_required_by_estimate', False)):
-                        if 'split_manifest_path' not in direct_outputs:
-                            raise RuntimeError(
-                                'flatbuffer_direct split was required by estimate, '
-                                'but split manifest was not generated.'
-                            )
-                        info(
-                            Color.GREEN(
-                                f'Split manifest output complete! '
-                                f'({direct_outputs["split_manifest_path"]}) '
-                                f'partitions={direct_outputs.get("split_partition_count", "0")}'
-                            )
-                        )
-                    else:
-                        info(
-                            Color.GREEN(
-                                'Split output was not required by estimate. '
-                                f'estimated={direct_outputs.get("split_plan_total_estimated_bytes", 0)} '
-                                f'target={tflite_split_target_bytes}'
-                            )
-                        )
+                _log_flatbuffer_direct_split_outputs(
+                    direct_outputs,
+                    split_plan_requested=split_plan_enabled,
+                    force_split_manifest=force_split_manifest,
+                    target_bytes=tflite_split_target_bytes,
+                )
                 if report_op_coverage:
                     if 'op_coverage_report_path' not in direct_outputs:
                         raise RuntimeError(
@@ -5938,17 +6168,25 @@ def convert(
                     tflite_paths=direct_eval_paths,
                     source_label='flatbuffer_direct',
                     contains_custom_ops=direct_contains_custom_ops,
+                    split_manifest_path=direct_outputs.get('split_manifest_path', None),
                 )
-                _run_saved_model_inference_check(
-                    saved_model_path=direct_outputs.get('saved_model_path', None),
-                    float32_tflite_path=direct_outputs.get('float32_tflite_path', None),
-                    source_label='flatbuffer_direct',
-                )
-                if eval_split_models:
+                if 'split_saved_model_dirs' in direct_outputs:
+                    _maybe_run_split_saved_model_inference_check(
+                        split_manifest_path=direct_outputs.get('split_manifest_path', None),
+                        reference_tflite_path=direct_outputs.get('float32_tflite_path', None),
+                        source_label='flatbuffer_direct',
+                    )
+                else:
+                    _maybe_run_saved_model_inference_check(
+                        saved_model_path=direct_outputs.get('saved_model_path', None),
+                        float32_tflite_path=direct_outputs.get('float32_tflite_path', None),
+                        source_label='flatbuffer_direct',
+                    )
+                if eval_split_models is not None:
                     if 'split_manifest_path' not in direct_outputs:
                         raise RuntimeError(
-                            'eval_split_models=True but split manifest is not available. '
-                            'Ensure auto_split_tflite_by_size=True and split is required by estimate.'
+                            'eval_split_models is set but split manifest is not available. '
+                            'Ensure enable_auto_split_model=True so split manifest output is generated.'
                         )
                     from onnx2tf.tflite_builder.split_accuracy_evaluator import evaluate_split_manifest_outputs
                     split_accuracy_report_path = os.path.join(
@@ -5956,12 +6194,12 @@ def convert(
                         f'{output_file_name}_split_accuracy_report.json',
                     )
                     reference_tflite_path = None
-                    if eval_split_reference == 'unsplit_tflite':
+                    if eval_split_models == 'unsplit_tflite':
                         reference_tflite_path = direct_outputs['float32_tflite_path']
                     split_report = evaluate_split_manifest_outputs(
                         onnx_graph=onnx_graph,
                         split_manifest_path=direct_outputs['split_manifest_path'],
-                        reference_mode=eval_split_reference,
+                        reference_mode=eval_split_models,
                         reference_tflite_path=reference_tflite_path,
                         output_report_path=split_accuracy_report_path,
                         num_samples=eval_num_samples,
@@ -6909,7 +7147,7 @@ def main():
         '-it',
         '--input_tflite_file_path',
         type=str,
-        help='Input tflite file path for direct SavedModel export.'
+        help='Input tflite file path for direct import mode.'
     )
     iV_group.add_argument(
         '-V',
@@ -7071,31 +7309,21 @@ def main():
     )
     parser.add_argument(
         '--eval_split_models',
-        action='store_true',
-        help=\
-            'Evaluate split partitions sequentially using split manifest output.'
-    )
-    parser.add_argument(
-        '--eval_split_reference',
         type=str,
         choices=['unsplit_tflite', 'onnx'],
-        default='unsplit_tflite',
+        default=None,
         help=\
-            'Reference for split evaluation. \n' +
-            '"unsplit_tflite"(default) or "onnx".'
+            'Evaluate split partitions sequentially using split manifest output. \n' +
+            'Specify "unsplit_tflite" to compare against the unsplit/base TFLite model, \n' +
+            'or "onnx" to compare against ONNX Runtime output. \n' +
+            'Writes *_split_accuracy_report.json. \n' +
+            '*_accuracy_report.json remains the unsplit base float32 TFLite vs ONNX report.'
     )
     parser.add_argument(
         '--eval_split_fail_on_threshold',
         action='store_true',
         help=\
             'Return failure when split-model evaluation thresholds are not satisfied.'
-    )
-    parser.add_argument(
-        '--auto_split_tflite_by_size',
-        action='store_true',
-        help=\
-            'Estimate flatbuffer split partitions and output *_split_plan.json. \n' +
-            'Currently available only with --tflite_backend flatbuffer_direct.'
     )
     parser.add_argument(
         '--report_op_coverage',
@@ -7109,7 +7337,8 @@ def main():
         '--flatbuffer_direct_output_saved_model',
         action='store_true',
         help=\
-            'Output SavedModel directly from flatbuffer_direct ModelIR (float32).'
+            'Output SavedModel directly from flatbuffer_direct ModelIR (float32). \n' +
+            'With split output, partition SavedModels are emitted instead of a single root SavedModel.'
     )
     parser.add_argument(
         '--flatbuffer_direct_allow_custom_ops',
@@ -7443,7 +7672,9 @@ def main():
         action='store_true',
         help=\
             'Force auto split regardless of the ONNX file size. \n' +
-            'Uses --auto_split_max_size as the target partition size.'
+            'Uses --auto_split_max_size as the target partition size. \n' +
+            'With --tflite_backend flatbuffer_direct, this forces the shared ModelIR split planner \n' +
+            'and split manifest output even when the estimated size fits in one partition.'
     )
     parser.add_argument(
         '-asms',
@@ -7454,7 +7685,7 @@ def main():
             'Target maximum size per partition when auto-split is triggered or forced. \n' +
             'Supported units: KB, MB, GB (e.g. 900MB, 1GB, 1536KB). \n' +
             'Bare numbers are treated as MB. \n' +
-            'When specified, this value is also used as the target size for --auto_split_tflite_by_size. \n' +
+            'When specified, this value is also used as the target size for --enable_auto_split_model. \n' +
             'Default: 1GB'
     )
     parser.add_argument(
@@ -7862,9 +8093,7 @@ def main():
         eval_target_tflite=args.eval_target_tflite,
         eval_compare_mode=args.eval_compare_mode,
         eval_split_models=args.eval_split_models,
-        eval_split_reference=args.eval_split_reference,
         eval_split_fail_on_threshold=args.eval_split_fail_on_threshold,
-        auto_split_tflite_by_size=args.auto_split_tflite_by_size,
         report_op_coverage=args.report_op_coverage,
         flatbuffer_direct_output_saved_model=args.flatbuffer_direct_output_saved_model,
         flatbuffer_direct_allow_custom_ops=args.flatbuffer_direct_allow_custom_ops,

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -42,6 +42,9 @@ from onnx2tf.tflite_builder.split_planner import (
     write_split_model_files_and_manifest,
     write_split_plan_report,
 )
+from onnx2tf.tflite_builder.split_saved_model_exporter import (
+    export_split_saved_models,
+)
 from onnx2tf.utils.common_functions import weights_export
 
 
@@ -106,7 +109,7 @@ def _create_progress_bar(
 def _build_export_progress_labels(
     *,
     report_op_coverage: bool,
-    auto_split_tflite_by_size: bool,
+    split_plan_requested: bool,
     output_dynamic_range_quantized_tflite: bool,
     output_integer_quantized_tflite: bool,
     output_weights: bool,
@@ -117,7 +120,7 @@ def _build_export_progress_labels(
     ]
     if report_op_coverage:
         labels.append("op coverage report")
-    if auto_split_tflite_by_size:
+    if split_plan_requested:
         labels.append("split planning")
     labels.extend(
         [
@@ -256,9 +259,8 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
     enable_accumulation_type_float16 = bool(
         kwargs.get("enable_accumulation_type_float16", False)
     )
-    auto_split_tflite_by_size = bool(
-        kwargs.get("auto_split_tflite_by_size", False)
-    )
+    force_split_manifest = bool(kwargs.get("force_split_manifest", False))
+    split_plan_requested = bool(force_split_manifest)
     report_op_coverage = bool(kwargs.get("report_op_coverage", False))
     output_nms_with_argmax = bool(kwargs.get("output_nms_with_argmax", False))
     switch_nms_version = str(kwargs.get("switch_nms_version", "v4")).strip().lower()
@@ -453,7 +455,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
 
     export_progress_labels = _build_export_progress_labels(
         report_op_coverage=report_op_coverage,
-        auto_split_tflite_by_size=auto_split_tflite_by_size,
+        split_plan_requested=split_plan_requested,
         output_dynamic_range_quantized_tflite=output_dynamic_range_quantized_tflite,
         output_integer_quantized_tflite=output_integer_quantized_tflite,
         output_weights=output_weights,
@@ -550,7 +552,8 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         split_partition_paths = None
         split_partition_count = 0
         write_timing_report: Dict[str, Dict[str, Any]] = {}
-        if auto_split_tflite_by_size:
+        split_saved_model_dirs = None
+        if split_plan_requested:
             _set_export_progress_desc("split planning")
             split_plan_report = plan_contiguous_partitions_by_size(
                 model_ir=model_ir,
@@ -569,7 +572,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                     f"{output_file_name}_split_plan.json",
                 ),
             )
-            if split_required_by_estimate:
+            if split_required_by_estimate or force_split_manifest:
                 from ai_edge_litert.interpreter import Interpreter
 
                 def _validate_split_tflite_loadable(tflite_path: str) -> None:
@@ -624,13 +627,22 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
 
         if output_saved_model_from_model_ir:
             _set_export_progress_desc("write saved_model")
-            from onnx2tf.tflite_builder.saved_model_exporter import (
-                export_saved_model_from_model_ir,
-            )
-            saved_model_path = export_saved_model_from_model_ir(
-                model_ir=model_ir_fp32,
-                output_folder_path=output_folder_path,
-            )
+            if split_manifest_path is not None:
+                split_saved_model_outputs = export_split_saved_models(
+                    model_ir=model_ir,
+                    split_manifest_path=split_manifest_path,
+                    output_folder_path=output_folder_path,
+                    output_file_name=output_file_name,
+                )
+                split_saved_model_dirs = split_saved_model_outputs["split_saved_model_dirs"]
+            else:
+                from onnx2tf.tflite_builder.saved_model_exporter import (
+                    export_saved_model_from_model_ir,
+                )
+                saved_model_path = export_saved_model_from_model_ir(
+                    model_ir=model_ir_fp32,
+                    output_folder_path=output_folder_path,
+                )
             _advance_export_progress()
 
         _set_export_progress_desc("write float16 tflite")
@@ -933,6 +945,9 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
     if split_partition_paths is not None:
         outputs["split_partition_paths"] = split_partition_paths
         outputs["split_partition_count"] = int(split_partition_count)
+    if split_saved_model_dirs is not None:
+        outputs["split_saved_model_dirs"] = list(split_saved_model_dirs)
+        outputs["split_saved_model_count"] = int(len(split_saved_model_dirs))
     if op_coverage_report_path is not None:
         outputs["op_coverage_report_path"] = op_coverage_report_path
     outputs["tensor_correspondence_report_path"] = tensor_correspondence_report_path

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -8,6 +8,7 @@ import numpy as np
 import onnx
 from onnx import numpy_helper
 
+from onnx2tf.utils.common_functions import check_model_has_external_data
 from onnx2tf.tflite_builder.dispatcher import dispatch_node
 from onnx2tf.tflite_builder.op_registry import (
     NodeValidationError,
@@ -405,6 +406,9 @@ def _graph_has_missing_rank_info(onnx_graph: onnx.ModelProto) -> bool:
 
 
 def _infer_shapes_with_fallback(onnx_graph: onnx.ModelProto) -> onnx.ModelProto:
+    if check_model_has_external_data(onnx_graph):
+        return onnx_graph
+
     inferred_graph = onnx_graph
     try:
         inferred_graph = onnx.shape_inference.infer_shapes(inferred_graph)

--- a/onnx2tf/tflite_builder/model_writer.py
+++ b/onnx2tf/tflite_builder/model_writer.py
@@ -90,6 +90,21 @@ def _prune_dead_operators_in_place(model_ir: ModelIR) -> None:
     ]
 
 
+def _strip_embedded_constant_inputs_in_place(model_ir: ModelIR) -> None:
+    sanitized_inputs: List[str] = []
+    seen_inputs = set()
+    for tensor_name in model_ir.inputs:
+        normalized_name = str(tensor_name)
+        if normalized_name == "" or normalized_name in seen_inputs:
+            continue
+        seen_inputs.add(normalized_name)
+        tensor = model_ir.tensors.get(normalized_name, None)
+        if tensor is not None and tensor.data is not None:
+            continue
+        sanitized_inputs.append(normalized_name)
+    model_ir.inputs = sanitized_inputs
+
+
 def _sanitize_model_ir_for_serialization(model_ir: ModelIR) -> ModelIR:
     # Keep serialization side-effect free because one ModelIR instance can be
     # reused across multiple output variants.
@@ -109,6 +124,7 @@ def _sanitize_model_ir_for_serialization(model_ir: ModelIR) -> ModelIR:
         metadata=dict(model_ir.metadata),
     )
     _prune_dead_operators_in_place(sanitized_model_ir)
+    _strip_embedded_constant_inputs_in_place(sanitized_model_ir)
     _prune_unused_tensors_in_place(sanitized_model_ir)
     return sanitized_model_ir
 

--- a/onnx2tf/tflite_builder/op_builders/index.py
+++ b/onnx2tf/tflite_builder/op_builders/index.py
@@ -31,20 +31,12 @@ def _prefer_int32_index_output_dtype(
     requested_dtype: str,
 ) -> str:
     dtype = str(requested_dtype).upper()
-    if dtype == "INT32":
-        return "INT32"
-    if dtype == "UINT32":
-        return "UINT32"
-    # LiteRT.js cannot consume 64-bit integers; prefer 32-bit index-like outputs.
-    preferred_dtype = "INT32"
-    if dtype == "UINT64":
-        preferred_dtype = "UINT32"
     tensor = ctx.model_ir.tensors.get(tensor_name, None)
     if tensor is not None:
-        tensor.dtype = preferred_dtype
+        tensor.dtype = dtype
     if hasattr(ctx, "dtype_map") and isinstance(ctx.dtype_map, dict):
-        ctx.dtype_map[str(tensor_name)] = preferred_dtype
-    return preferred_dtype
+        ctx.dtype_map[str(tensor_name)] = dtype
+    return dtype
 
 
 def _propagate_shape(ctx: Any, src_tensor_name: str, dst_tensor_name: str) -> None:

--- a/onnx2tf/tflite_builder/split_accuracy_evaluator.py
+++ b/onnx2tf/tflite_builder/split_accuracy_evaluator.py
@@ -8,6 +8,7 @@ import numpy as np
 import onnx
 
 from onnx2tf.tflite_builder.accuracy_evaluator import (
+    _adapt_input_layout_for_tflite_input,
     _MetricAccumulator,
     _build_tflite_detail_map,
     _collect_onnx_input_specs,
@@ -23,6 +24,7 @@ from onnx2tf.tflite_builder.accuracy_evaluator import (
     _QUANT_METRIC_THRESHOLDS,
     _resolve_compare_mode,
     _resolve_metric_thresholds,
+    _resize_tflite_inputs_if_needed,
 )
 
 
@@ -44,11 +46,36 @@ def _run_tflite_model(
     compare_mode: str,
 ) -> Dict[str, np.ndarray]:
     input_details = interpreter.get_input_details()
-    output_details = interpreter.get_output_details()
     input_map = _build_tflite_detail_map(
         onnx_names=model_input_names,
         tflite_details=input_details,
     )
+
+    adapted_inputs: Dict[str, np.ndarray] = {}
+    for input_name in model_input_names:
+        if input_name not in provided_inputs:
+            raise ValueError(
+                f"Missing model input tensor for tflite run. input_name={input_name}"
+            )
+        adapted_inputs[input_name] = _adapt_input_layout_for_tflite_input(
+            provided_inputs[input_name],
+            input_map[input_name],
+        )
+
+    resized = _resize_tflite_inputs_if_needed(
+        interpreter=interpreter,
+        onnx_input_names=model_input_names,
+        tflite_input_map=input_map,
+        adapted_inputs=adapted_inputs,
+    )
+    if resized:
+        interpreter.allocate_tensors()
+        input_details = interpreter.get_input_details()
+        input_map = _build_tflite_detail_map(
+            onnx_names=model_input_names,
+            tflite_details=input_details,
+        )
+    output_details = interpreter.get_output_details()
     output_map = _build_tflite_detail_map(
         onnx_names=model_output_names,
         tflite_details=output_details,
@@ -56,13 +83,9 @@ def _run_tflite_model(
 
     for input_name in model_input_names:
         input_detail = input_map[input_name]
-        if input_name not in provided_inputs:
-            raise ValueError(
-                f"Missing model input tensor for tflite run. input_name={input_name}"
-            )
         interpreter.set_tensor(
             input_detail["index"],
-            _quantize_for_tflite_input(provided_inputs[input_name], input_detail),
+            _quantize_for_tflite_input(adapted_inputs[input_name], input_detail),
         )
     interpreter.invoke()
 

--- a/onnx2tf/tflite_builder/split_planner.py
+++ b/onnx2tf/tflite_builder/split_planner.py
@@ -104,6 +104,69 @@ def _collect_inputs(operators: Sequence[OperatorIR]) -> List[str]:
     return inputs
 
 
+def _collect_required_operator_indices_for_outputs(
+    *,
+    operators: Sequence[OperatorIR],
+    partition_outputs: Sequence[str],
+) -> List[int]:
+    producer_index: Dict[str, int] = {}
+    for op_idx, op in enumerate(operators):
+        for output_name in op.outputs:
+            if output_name and output_name not in producer_index:
+                producer_index[output_name] = int(op_idx)
+
+    required_ops: Set[int] = set()
+    pending_tensors: List[str] = [
+        str(tensor_name) for tensor_name in partition_outputs if str(tensor_name) != ""
+    ]
+    visited_tensors: Set[str] = set()
+    while pending_tensors:
+        tensor_name = str(pending_tensors.pop())
+        if tensor_name == "" or tensor_name in visited_tensors:
+            continue
+        visited_tensors.add(tensor_name)
+        producer_op_idx = producer_index.get(tensor_name, None)
+        if producer_op_idx is None:
+            continue
+        if producer_op_idx in required_ops:
+            continue
+        required_ops.add(int(producer_op_idx))
+        for input_name in operators[producer_op_idx].inputs:
+            if input_name:
+                pending_tensors.append(str(input_name))
+    return sorted(list(required_ops))
+
+
+def _collect_partition_boundary_inputs(
+    *,
+    model_ir: ModelIR,
+    consumed_tensor_names: Sequence[str],
+    produced_tensor_names: Set[str],
+) -> List[str]:
+    runtime_input_names = {
+        str(tensor_name)
+        for tensor_name in model_ir.inputs
+        if str(tensor_name) != ""
+    }
+    partition_inputs: List[str] = []
+    seen_inputs: Set[str] = set()
+    for tensor_name in consumed_tensor_names:
+        normalized_name = str(tensor_name)
+        if normalized_name == "":
+            continue
+        if normalized_name in seen_inputs or normalized_name in produced_tensor_names:
+            continue
+        seen_inputs.add(normalized_name)
+        if normalized_name in runtime_input_names:
+            partition_inputs.append(normalized_name)
+            continue
+        tensor = model_ir.tensors.get(normalized_name, None)
+        if tensor is not None and tensor.data is not None:
+            continue
+        partition_inputs.append(normalized_name)
+    return partition_inputs
+
+
 def build_partition_model_ir(
     *,
     model_ir: ModelIR,
@@ -122,9 +185,11 @@ def build_partition_model_ir(
     produced_set = set(produced_in_range)
     consumed_in_range = _collect_inputs(range_ops)
 
-    partition_inputs: List[str] = [
-        name for name in consumed_in_range if name not in produced_set
-    ]
+    partition_inputs = _collect_partition_boundary_inputs(
+        model_ir=model_ir,
+        consumed_tensor_names=consumed_in_range,
+        produced_tensor_names=produced_set,
+    )
     consumed_after: Set[str] = set()
     for op in model_ir.operators[end_op_index:]:
         for input_name in op.inputs:
@@ -139,6 +204,28 @@ def build_partition_model_ir(
         for name in range_ops[-1].outputs:
             if name:
                 partition_outputs.append(name)
+
+    required_op_indices = _collect_required_operator_indices_for_outputs(
+        operators=range_ops,
+        partition_outputs=partition_outputs,
+    )
+    if len(required_op_indices) > 0:
+        range_ops = [range_ops[op_idx] for op_idx in required_op_indices]
+        produced_in_range = _collect_outputs(range_ops)
+        produced_set = set(produced_in_range)
+        consumed_in_range = _collect_inputs(range_ops)
+        partition_inputs = _collect_partition_boundary_inputs(
+            model_ir=model_ir,
+            consumed_tensor_names=consumed_in_range,
+            produced_tensor_names=produced_set,
+        )
+        partition_outputs = [
+            name for name in partition_outputs if name in produced_set
+        ]
+        if len(partition_outputs) == 0 and len(range_ops) > 0:
+            for name in range_ops[-1].outputs:
+                if name:
+                    partition_outputs.append(name)
 
     required_tensor_names: Set[str] = set(partition_inputs + partition_outputs)
     for op in range_ops:

--- a/onnx2tf/tflite_builder/split_saved_model_evaluator.py
+++ b/onnx2tf/tflite_builder/split_saved_model_evaluator.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import tensorflow as tf
+
+from onnx2tf.tflite_builder.accuracy_evaluator import (
+    _align_output_layout_for_compare,
+    _build_tflite_detail_map,
+    _create_tflite_interpreter,
+    _quantize_for_tflite_input,
+)
+
+
+def _read_split_manifest(split_manifest_path: str) -> Dict[str, Any]:
+    if not os.path.exists(split_manifest_path):
+        raise FileNotFoundError(
+            f"Split manifest does not exist. path={split_manifest_path}"
+        )
+    with open(split_manifest_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _normalize_name(name: str) -> str:
+    normalized = str(name).split(":")[0]
+    if normalized.startswith("serving_default_"):
+        normalized = normalized[len("serving_default_") :]
+    return normalized
+
+
+def _runtime_shape_from_detail(detail: Dict[str, Any]) -> Tuple[int, ...]:
+    shape_signature = detail.get("shape_signature", None)
+    if shape_signature is None:
+        shape_signature = detail.get("shape", None)
+    values = [int(v) for v in np.asarray(shape_signature).reshape(-1).tolist()]
+    runtime_shape: List[int] = []
+    for axis, dim in enumerate(values):
+        runtime_shape.append(1 if int(dim) <= 0 else int(dim))
+    if len(runtime_shape) == 0:
+        runtime_shape = [1]
+    return tuple(runtime_shape)
+
+
+def _fallback_shape_from_tensor_spec(tensor_spec: tf.TensorSpec) -> Tuple[int, ...]:
+    shape: List[int] = []
+    for axis, dim in enumerate(tensor_spec.shape.as_list()):
+        if dim is None or int(dim) <= 0:
+            shape.append(1 if axis == 0 else 16)
+        else:
+            shape.append(int(dim))
+    if len(shape) == 0:
+        shape = [1]
+    return tuple(shape)
+
+
+def _cast_array_for_tensor_spec(
+    *,
+    value: np.ndarray,
+    tensor_spec: tf.TensorSpec,
+) -> np.ndarray:
+    casted = np.asarray(value)
+    expected_shape = _fallback_shape_from_tensor_spec(tensor_spec)
+    if casted.size == int(np.prod(expected_shape, dtype=np.int64)):
+        casted = casted.reshape(expected_shape)
+    elif tuple(casted.shape) != expected_shape:
+        raise ValueError(
+            "SavedModel input shape mismatch. "
+            f"input_name={tensor_spec.name} expected={expected_shape} actual={tuple(casted.shape)}"
+        )
+
+    target_dtype = np.dtype(tensor_spec.dtype.as_numpy_dtype)
+    if casted.dtype != target_dtype:
+        if np.issubdtype(target_dtype, np.bool_):
+            casted = (casted.astype(np.float32) > 0.0).astype(np.bool_)
+        else:
+            casted = casted.astype(target_dtype)
+    return casted
+
+
+def _resolve_saved_model_input_name(
+    *,
+    requested_name: str,
+    signature_inputs: Dict[str, tf.TensorSpec],
+) -> str:
+    normalized_requested = _normalize_name(requested_name)
+    for candidate in signature_inputs.keys():
+        if str(candidate) == str(requested_name):
+            return str(candidate)
+    for candidate in signature_inputs.keys():
+        if _normalize_name(str(candidate)) == normalized_requested:
+            return str(candidate)
+    raise ValueError(
+        "Failed to map split SavedModel input. "
+        f"requested_name={requested_name} available={list(signature_inputs.keys())}"
+    )
+
+
+def _resolve_saved_model_outputs(
+    *,
+    requested_outputs: List[str],
+    raw_outputs: Dict[str, Any],
+) -> Dict[str, np.ndarray]:
+    output_arrays: Dict[str, np.ndarray] = {}
+    normalized_outputs = {
+        _normalize_name(str(name)): np.asarray(value)
+        for name, value in raw_outputs.items()
+    }
+    ordered_names = [str(name) for name in raw_outputs.keys()]
+    for output_index, requested_name in enumerate(requested_outputs):
+        if requested_name in raw_outputs:
+            output_arrays[requested_name] = np.asarray(raw_outputs[requested_name])
+            continue
+        normalized_name = _normalize_name(requested_name)
+        if normalized_name in normalized_outputs:
+            output_arrays[requested_name] = np.asarray(normalized_outputs[normalized_name])
+            continue
+        if output_index < len(ordered_names):
+            output_arrays[requested_name] = np.asarray(raw_outputs[ordered_names[output_index]])
+            continue
+        raise ValueError(
+            "Failed to map split SavedModel output. "
+            f"requested_name={requested_name} available={ordered_names}"
+        )
+    return output_arrays
+
+
+def _run_split_saved_models(
+    *,
+    split_manifest: Dict[str, Any],
+    base_folder_path: str,
+    sample_inputs: Dict[str, np.ndarray],
+) -> Dict[str, np.ndarray]:
+    tensor_store: Dict[str, np.ndarray] = dict(sample_inputs)
+    last_outputs: Dict[str, np.ndarray] = {}
+    for partition in list(split_manifest.get("partitions", [])):
+        saved_model_dir = str(partition.get("saved_model_dir", "")).strip()
+        if saved_model_dir == "":
+            raise ValueError(
+                "Split manifest partition is missing saved_model_dir. "
+                f"partition_id={partition.get('partition_id')}"
+            )
+        saved_model_path = os.path.join(base_folder_path, saved_model_dir)
+        if not os.path.exists(saved_model_path):
+            raise FileNotFoundError(
+                f"Split SavedModel directory does not exist. path={saved_model_path}"
+            )
+
+        module = tf.saved_model.load(saved_model_path)
+        signature_fn = module.signatures.get("serving_default", None)
+        if signature_fn is None:
+            raise RuntimeError(
+                "serving_default signature is missing in split SavedModel. "
+                f"path={saved_model_path}"
+            )
+        signature_inputs = signature_fn.structured_input_signature[1]
+        if not isinstance(signature_inputs, dict):
+            raise RuntimeError(
+                "Split SavedModel serving_default signature inputs are invalid. "
+                f"path={saved_model_path}"
+            )
+
+        serving_inputs: Dict[str, tf.Tensor] = {}
+        for input_name in list(partition.get("inputs", [])):
+            input_value = tensor_store.get(str(input_name), None)
+            if input_value is None:
+                input_value = tensor_store.get(_normalize_name(str(input_name)), None)
+            if input_value is None:
+                raise ValueError(
+                    "Split SavedModel input is missing from tensor store. "
+                    f"partition_id={partition.get('partition_id')} input_name={input_name}"
+                )
+            signature_input_name = _resolve_saved_model_input_name(
+                requested_name=str(input_name),
+                signature_inputs=signature_inputs,
+            )
+            tensor_spec = signature_inputs[signature_input_name]
+            casted_input = _cast_array_for_tensor_spec(
+                value=np.asarray(input_value),
+                tensor_spec=tensor_spec,
+            )
+            serving_inputs[signature_input_name] = tf.convert_to_tensor(
+                casted_input,
+                dtype=tensor_spec.dtype,
+            )
+
+        with tf.device("/CPU:0"):
+            raw_outputs = signature_fn(**serving_inputs)
+        if not isinstance(raw_outputs, dict):
+            raise RuntimeError(
+                "Split SavedModel serving_default did not return a dict. "
+                f"path={saved_model_path}"
+            )
+
+        current_outputs = _resolve_saved_model_outputs(
+            requested_outputs=[str(v) for v in list(partition.get("outputs", []))],
+            raw_outputs=raw_outputs,
+        )
+        tensor_store.update(current_outputs)
+        for name, value in current_outputs.items():
+            tensor_store[_normalize_name(name)] = np.asarray(value)
+        last_outputs = current_outputs
+    return last_outputs
+
+
+def evaluate_split_saved_model_outputs(
+    *,
+    split_manifest_path: str,
+    reference_tflite_path: str,
+    output_report_path: str,
+    source_label: str,
+    rtol: float = 1.0e-4,
+    atol: float = 1.0e-4,
+) -> Dict[str, Any]:
+    split_manifest = _read_split_manifest(split_manifest_path)
+    partitions = list(split_manifest.get("partitions", []))
+    if len(partitions) == 0:
+        raise ValueError("Split manifest contains no partition entries.")
+
+    if not os.path.exists(reference_tflite_path):
+        raise FileNotFoundError(
+            f"Reference tflite does not exist. path={reference_tflite_path}"
+        )
+
+    report: Dict[str, Any] = {
+        "schema_version": 1,
+        "mode": "split_saved_model",
+        "source_label": str(source_label),
+        "split_manifest_path": str(split_manifest_path),
+        "reference_tflite_path": str(reference_tflite_path),
+        "inference": {
+            "status": "not_run",
+            "reason": "",
+            "partitions_run": 0,
+        },
+        "comparison": {
+            "status": "not_run",
+            "reason": "",
+            "pass": None,
+            "matched": 0,
+            "total": 0,
+            "max_abs": None,
+            "unmatched_outputs": [],
+        },
+        "overall_pass": False,
+    }
+
+    os.makedirs(os.path.dirname(output_report_path) or ".", exist_ok=True)
+
+    failure_reason = ""
+    try:
+        interpreter = _create_tflite_interpreter(model_path=reference_tflite_path)
+        interpreter.allocate_tensors()
+        input_details = interpreter.get_input_details()
+        output_details = interpreter.get_output_details()
+
+        rng = np.random.default_rng(0)
+        sample_inputs_by_name: Dict[str, np.ndarray] = {}
+        tflite_inputs_by_index: Dict[int, np.ndarray] = {}
+        for detail in input_details:
+            runtime_shape = _runtime_shape_from_detail(detail)
+            random_input = rng.uniform(-1.0, 1.0, size=runtime_shape).astype(np.float32)
+            sample_inputs_by_name[str(detail.get("name", ""))] = np.asarray(random_input)
+            sample_inputs_by_name[_normalize_name(str(detail.get("name", "")))] = np.asarray(random_input)
+            tflite_inputs_by_index[int(detail["index"])] = _quantize_for_tflite_input(
+                np.asarray(random_input),
+                detail,
+            )
+
+        for detail in input_details:
+            interpreter.set_tensor(
+                int(detail["index"]),
+                tflite_inputs_by_index[int(detail["index"])],
+            )
+        interpreter.invoke()
+
+        final_partition_outputs = [str(v) for v in list(partitions[-1].get("outputs", []))]
+        tflite_output_map = _build_tflite_detail_map(
+            onnx_names=final_partition_outputs,
+            tflite_details=output_details,
+        )
+        reference_outputs = {
+            output_name: np.asarray(
+                interpreter.get_tensor(int(tflite_output_map[output_name]["index"]))
+            )
+            for output_name in final_partition_outputs
+        }
+
+        split_outputs = _run_split_saved_models(
+            split_manifest=split_manifest,
+            base_folder_path=os.path.dirname(split_manifest_path),
+            sample_inputs=sample_inputs_by_name,
+        )
+        report["inference"]["status"] = "passed"
+        report["inference"]["reason"] = ""
+        report["inference"]["partitions_run"] = int(len(partitions))
+
+        comparison_total = 0
+        comparison_matched = 0
+        max_abs = 0.0
+        unmatched_outputs: List[str] = []
+        for output_name in final_partition_outputs:
+            if output_name not in split_outputs:
+                unmatched_outputs.append(str(output_name))
+                continue
+            ref = np.asarray(reference_outputs[output_name])
+            pred = np.asarray(split_outputs[output_name])
+            aligned_pred = np.asarray(pred)
+            try:
+                aligned_pred, _, _ = _align_output_layout_for_compare(
+                    onnx_output=ref,
+                    tflite_output=pred,
+                    rtol=float(rtol),
+                    atol=float(atol),
+                )
+            except Exception:
+                if ref.size == pred.size and ref.shape != pred.shape:
+                    aligned_pred = np.asarray(pred).reshape(ref.shape)
+            comparison_total += 1
+            if bool(np.allclose(ref, aligned_pred, rtol=float(rtol), atol=float(atol), equal_nan=True)):
+                comparison_matched += 1
+            else:
+                unmatched_outputs.append(str(output_name))
+            if ref.size > 0:
+                with np.errstate(invalid="ignore"):
+                    diff = np.abs(
+                        np.asarray(ref, dtype=np.float64) - np.asarray(aligned_pred, dtype=np.float64)
+                    )
+                    if np.any(np.isfinite(diff)):
+                        local_max_abs = float(np.nanmax(diff))
+                        if local_max_abs > max_abs:
+                            max_abs = local_max_abs
+
+        comparison_pass = (
+            int(comparison_total) == int(comparison_matched)
+            and len(unmatched_outputs) == 0
+        )
+        report["comparison"]["status"] = "passed" if comparison_pass else "failed"
+        report["comparison"]["reason"] = "" if comparison_pass else "output_mismatch"
+        report["comparison"]["pass"] = bool(comparison_pass)
+        report["comparison"]["matched"] = int(comparison_matched)
+        report["comparison"]["total"] = int(comparison_total)
+        report["comparison"]["max_abs"] = float(max_abs)
+        report["comparison"]["unmatched_outputs"] = sorted(set(unmatched_outputs))
+        report["overall_pass"] = bool(comparison_pass)
+
+        if not comparison_pass:
+            failure_reason = (
+                "Split SavedModel/TFLite output comparison failed. "
+                f"source={source_label} matched={comparison_matched}/{comparison_total} "
+                f"max_abs={max_abs:.6g} unmatched_outputs={sorted(set(unmatched_outputs))}"
+            )
+            raise RuntimeError(failure_reason)
+    except Exception as ex:
+        if report["inference"]["status"] != "passed":
+            report["inference"]["status"] = "failed"
+            report["inference"]["reason"] = str(ex)
+            report["comparison"]["status"] = "skipped"
+            report["comparison"]["reason"] = "inference_failed"
+            report["comparison"]["pass"] = False
+        report["overall_pass"] = False
+        with open(output_report_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, ensure_ascii=False, indent=2)
+        if failure_reason == "":
+            failure_reason = (
+                "Split SavedModel inference check failed. "
+                f"source={source_label} reason={ex}"
+            )
+        raise RuntimeError(failure_reason) from ex
+
+    with open(output_report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, ensure_ascii=False, indent=2)
+    return report

--- a/onnx2tf/tflite_builder/split_saved_model_exporter.py
+++ b/onnx2tf/tflite_builder/split_saved_model_exporter.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List
+
+from onnx2tf.tflite_builder.ir import (
+    optimize_redundant_transpose_operators,
+    prune_identity_cast_operators,
+)
+from onnx2tf.tflite_builder.saved_model_exporter import (
+    export_saved_model_from_model_ir,
+)
+from onnx2tf.tflite_builder.split_planner import build_partition_model_ir
+
+
+def export_split_saved_models(
+    *,
+    model_ir: Any,
+    split_manifest_path: str,
+    output_folder_path: str,
+    output_file_name: str,
+) -> Dict[str, Any]:
+    if not os.path.exists(split_manifest_path):
+        raise FileNotFoundError(
+            f"Split manifest does not exist. path={split_manifest_path}"
+        )
+
+    with open(split_manifest_path, "r", encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    partitions = list(manifest.get("partitions", []))
+    if len(partitions) == 0:
+        raise ValueError("Split manifest contains no partition entries.")
+
+    saved_model_dirs: List[str] = []
+    for partition in partitions:
+        partition_id = int(partition["partition_id"])
+        part_model_ir = build_partition_model_ir(
+            model_ir=model_ir,
+            start_op_index=int(partition["start_op_index"]),
+            end_op_index=int(partition["end_op_index"]),
+            partition_id=partition_id,
+        )
+        prune_identity_cast_operators(
+            part_model_ir,
+            preserve_model_outputs=True,
+        )
+        optimize_redundant_transpose_operators(
+            part_model_ir,
+            preserve_model_outputs=True,
+        )
+        saved_model_dir_name = f"{output_file_name}_saved_model_{partition_id:04d}"
+        export_saved_model_from_model_ir(
+            model_ir=part_model_ir,
+            output_folder_path=os.path.join(output_folder_path, saved_model_dir_name),
+        )
+        partition["saved_model_dir"] = saved_model_dir_name
+        saved_model_dirs.append(saved_model_dir_name)
+
+    with open(split_manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+
+    return {
+        "split_saved_model_dirs": saved_model_dirs,
+        "split_saved_model_count": len(saved_model_dirs),
+    }

--- a/onnx2tf/utils/common_functions.py
+++ b/onnx2tf/utils/common_functions.py
@@ -7486,8 +7486,7 @@ def define_reduceXXX(
         )
     return reduced_tensor
 
-def check_has_external_data(input_onnx_file_path: str) -> bool:
-    model = onnx.load(input_onnx_file_path, load_external_data=False)
+def check_model_has_external_data(model: onnx.ModelProto) -> bool:
     def iter_tensors_in_graph(g):
         for t in g.initializer:
             yield t
@@ -7509,3 +7508,8 @@ def check_has_external_data(input_onnx_file_path: str) -> bool:
         isinstance(t, onnx.TensorProto) and uses_external_data(t)
         for t in iter_tensors_in_graph(model.graph)
     )
+
+
+def check_has_external_data(input_onnx_file_path: str) -> bool:
+    model = onnx.load(input_onnx_file_path, load_external_data=False)
+    return check_model_has_external_data(model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.3.0"
+version = "2.3.1"
 description = "Self-Created Tools to convert ONNX files (NCHW) to TensorFlow/TFLite/Keras format (NHWC). The purpose of this tool is to solve the massive Transpose extrapolation problem in onnx-tensorflow (onnx-tf)."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -43,6 +43,7 @@ dependencies = [
     "ml_dtypes==0.5.1",
     "flatbuffers==25.12.19",
     "tqdm==4.67.1",
+    "pytest>=9.0.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_tflite2sm_phase1.py
+++ b/tests/test_tflite2sm_phase1.py
@@ -1,6 +1,7 @@
 import json
 import os
 import tempfile
+from typing import Any
 
 import flatbuffers
 import numpy as np
@@ -109,7 +110,8 @@ def _run_saved_model_single_output(
     input_value: np.ndarray,
     output_name: str,
 ) -> np.ndarray:
-    module = tf.saved_model.load(saved_model_path)
+    module: Any = tf.saved_model.load(saved_model_path)
+    assert module is not None
     fn = module.signatures["serving_default"]
     outputs = fn(**{input_name: tf.constant(input_value)})
     return np.asarray(outputs[output_name].numpy())
@@ -161,7 +163,9 @@ def test_flatbuffer_direct_output_saved_model_validation(
             )
 
 
-def test_flatbuffer_direct_cotof_without_fdosm_skips_saved_model_check() -> None:
+def test_flatbuffer_direct_cotof_without_fdosm_skips_saved_model_check(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         model_path = _save_model(tmpdir, "add_skip_sm_check", _make_add_model())
         onnx2tf.convert(
@@ -177,11 +181,11 @@ def test_flatbuffer_direct_cotof_without_fdosm_skips_saved_model_check() -> None
             tmpdir,
             "add_skip_sm_check_saved_model_validation_report.json",
         )
-        assert os.path.exists(report_path)
-        with open(report_path, "r", encoding="utf-8") as f:
-            report = json.load(f)
-        assert report["inference"]["status"] == "skipped"
-        assert report["inference"]["reason"] == "saved_model_unavailable"
+        assert not os.path.exists(report_path)
+        captured = capsys.readouterr()
+        assert "SavedModel inference check skipped because SavedModel path is unavailable" not in (
+            captured.out + captured.err
+        )
 
 
 def test_saved_model_exporter_add_smoke() -> None:
@@ -221,7 +225,8 @@ def test_saved_model_exporter_add_smoke() -> None:
             output_folder_path=tmpdir,
         )
         assert os.path.exists(os.path.join(saved_model_path, "saved_model.pb"))
-        module = tf.saved_model.load(saved_model_path)
+        module: Any = tf.saved_model.load(saved_model_path)
+        assert module is not None
         fn = module.signatures["serving_default"]
         outputs = fn(
             x=tf.constant([[1.0, 2.0, 3.0]], dtype=tf.float32),
@@ -759,6 +764,83 @@ def test_tflite_direct_input_saved_model_with_cotof_smoke() -> None:
         assert report["overall_pass"] is True
 
 
+def test_tflite_direct_input_split_outputs_smoke() -> None:
+    model_ir = _make_add_model_ir()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tflite_path = _write_model_ir_as_tflite(tmpdir, "add_tflite_direct_input_split", model_ir)
+        output_dir = os.path.join(tmpdir, "sm_out")
+        onnx2tf.convert(
+            input_tflite_file_path=tflite_path,
+            output_folder_path=output_dir,
+            verbosity="error",
+            tflite_backend="flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+        )
+        assert os.path.exists(os.path.join(output_dir, "add_tflite_direct_input_split.tflite"))
+        assert os.path.exists(os.path.join(output_dir, "add_tflite_direct_input_split_split_plan.json"))
+        manifest_path = os.path.join(output_dir, "add_tflite_direct_input_split_split_manifest.json")
+        assert os.path.exists(manifest_path)
+        assert os.path.exists(os.path.join(output_dir, "add_tflite_direct_input_split_0001.tflite"))
+        assert os.path.exists(os.path.join(output_dir, "saved_model.pb"))
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert manifest["base_model"] == "add_tflite_direct_input_split.tflite"
+        assert len(manifest["partitions"]) == 1
+
+
+def test_tflite_direct_input_split_saved_model_smoke() -> None:
+    model_ir = _make_add_model_ir()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tflite_path = _write_model_ir_as_tflite(tmpdir, "add_tflite_direct_input_split_sm", model_ir)
+        output_dir = os.path.join(tmpdir, "sm_out")
+        onnx2tf.convert(
+            input_tflite_file_path=tflite_path,
+            output_folder_path=output_dir,
+            verbosity="error",
+            tflite_backend="flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+            flatbuffer_direct_output_saved_model=True,
+        )
+        assert os.path.exists(os.path.join(output_dir, "add_tflite_direct_input_split_sm.tflite"))
+        assert not os.path.exists(os.path.join(output_dir, "saved_model.pb"))
+        manifest_path = os.path.join(output_dir, "add_tflite_direct_input_split_sm_split_manifest.json")
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert len(manifest["partitions"]) == 1
+        saved_model_dir = manifest["partitions"][0]["saved_model_dir"]
+        assert os.path.exists(os.path.join(output_dir, saved_model_dir, "saved_model.pb"))
+
+
+def test_tflite_direct_input_split_saved_model_cotof_smoke() -> None:
+    model_ir = _make_add_model_ir()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tflite_path = _write_model_ir_as_tflite(tmpdir, "add_tflite_direct_input_split_cotof", model_ir)
+        output_dir = os.path.join(tmpdir, "sm_out")
+        onnx2tf.convert(
+            input_tflite_file_path=tflite_path,
+            output_folder_path=output_dir,
+            verbosity="error",
+            tflite_backend="flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+            flatbuffer_direct_output_saved_model=True,
+            check_onnx_tf_outputs_elementwise_close_full=True,
+        )
+        report_path = os.path.join(
+            output_dir,
+            "add_tflite_direct_input_split_cotof_saved_model_validation_report.json",
+        )
+        assert os.path.exists(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["mode"] == "split_saved_model"
+        assert report["comparison"]["status"] == "passed"
+        assert report["comparison"]["pass"] is True
+        assert report["overall_pass"] is True
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -836,6 +918,56 @@ def test_flatbuffer_direct_output_saved_model_cotof_smoke() -> None:
         with open(report_path, "r", encoding="utf-8") as f:
             report = json.load(f)
         assert report["inference"]["status"] == "passed"
+        assert report["comparison"]["status"] == "passed"
+        assert report["comparison"]["pass"] is True
+        assert report["overall_pass"] is True
+
+
+def test_flatbuffer_direct_output_saved_model_split_smoke() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = _save_model(tmpdir, "add_split_sm", _make_add_model())
+        onnx2tf.convert(
+            input_onnx_file_path=model_path,
+            output_folder_path=tmpdir,
+            verbosity="error",
+            disable_strict_mode=True,
+            tflite_backend="flatbuffer_direct",
+            flatbuffer_direct_output_saved_model=True,
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+        )
+        assert not os.path.exists(os.path.join(tmpdir, "saved_model.pb"))
+        manifest_path = os.path.join(tmpdir, "add_split_sm_split_manifest.json")
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert len(manifest["partitions"]) == 1
+        saved_model_dir = manifest["partitions"][0]["saved_model_dir"]
+        assert os.path.exists(os.path.join(tmpdir, saved_model_dir, "saved_model.pb"))
+        assert os.path.exists(os.path.join(tmpdir, "add_split_sm_float32.tflite"))
+
+
+def test_flatbuffer_direct_output_saved_model_split_cotof_smoke() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = _save_model(tmpdir, "add_split_sm_cotof", _make_add_model())
+        onnx2tf.convert(
+            input_onnx_file_path=model_path,
+            output_folder_path=tmpdir,
+            verbosity="error",
+            disable_strict_mode=True,
+            tflite_backend="flatbuffer_direct",
+            flatbuffer_direct_output_saved_model=True,
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+            check_onnx_tf_outputs_elementwise_close_full=True,
+        )
+        report_path = os.path.join(
+            tmpdir,
+            "add_split_sm_cotof_saved_model_validation_report.json",
+        )
+        assert os.path.exists(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["mode"] == "split_saved_model"
         assert report["comparison"]["status"] == "passed"
         assert report["comparison"]["pass"] is True
         assert report["overall_pass"] is True

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -3,15 +3,26 @@ import json
 import math
 import os
 import shutil
+import sys
 import tempfile
+import types
 from contextlib import contextmanager
 from typing import Any
 
 import numpy as np
 import onnx
 import onnx2tf
+import onnxruntime as ort
 import pytest
 from onnx import TensorProto, helper, numpy_helper
+from onnx2tf.tflite_builder.accuracy_evaluator import (
+    _adapt_input_layout_for_tflite_input,
+    _build_tflite_detail_map,
+    _collect_onnx_input_specs,
+    _create_tflite_interpreter,
+    _quantize_for_tflite_input,
+    _resize_tflite_inputs_if_needed,
+)
 from onnx2tf.tflite_builder.ir import (
     ModelIR,
     OperatorIR,
@@ -24,6 +35,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _align_boundary_signature_to_current_shape,
     _apply_safe_transpose_reduction_lite,
     _dtype_from_onnx_elem_type,
+    _infer_shapes_with_fallback,
     _infer_rank4_signature_from_input,
     _optimize_asin_transpose_passthrough_chains,
     _optimize_erf_transpose_passthrough_chains,
@@ -136,6 +148,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _repair_rank4_channelwise_broadcast_constants_to_runtime_layout,
     lower_onnx_to_ir,
 )
+from onnx2tf.utils.common_functions import check_model_has_external_data
 from onnx2tf.tflite_builder.model_writer import serialize_model
 from onnx2tf.tflite_builder.preprocess import (
     configure_pseudo_ops_wave1_targets,
@@ -171,10 +184,9 @@ def _convert(
     eval_fail_on_threshold: bool = False,
     eval_target_tflite: str = "float32",
     eval_compare_mode: str = "auto",
-    eval_split_models: bool = False,
-    eval_split_reference: str = "unsplit_tflite",
+    eval_split_models: str | None = None,
     eval_split_fail_on_threshold: bool = False,
-    auto_split_tflite_by_size: bool = False,
+    enable_auto_split_model: bool = False,
     report_op_coverage: bool = False,
     flatbuffer_direct_allow_custom_ops: bool = False,
     flatbuffer_direct_custom_op_allowlist: list[str] | None = None,
@@ -202,9 +214,8 @@ def _convert(
         eval_target_tflite=eval_target_tflite,
         eval_compare_mode=eval_compare_mode,
         eval_split_models=eval_split_models,
-        eval_split_reference=eval_split_reference,
         eval_split_fail_on_threshold=eval_split_fail_on_threshold,
-        auto_split_tflite_by_size=auto_split_tflite_by_size,
+        enable_auto_split_model=enable_auto_split_model,
         report_op_coverage=report_op_coverage,
         flatbuffer_direct_allow_custom_ops=flatbuffer_direct_allow_custom_ops,
         flatbuffer_direct_custom_op_allowlist=flatbuffer_direct_custom_op_allowlist,
@@ -236,12 +247,185 @@ def _run_add_inference(tflite_path: str) -> np.ndarray:
     return interpreter.get_tensor(output_details[0]["index"])
 
 
+def _make_seeded_sample_inputs(
+    onnx_model: onnx.ModelProto,
+    *,
+    seed: int = 0,
+) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(seed)
+    sample_inputs: dict[str, np.ndarray] = {}
+    for input_name, input_dtype, input_shape in _collect_onnx_input_specs(onnx_model):
+        sample_inputs[str(input_name)] = rng.standard_normal(size=input_shape).astype(input_dtype)
+    return sample_inputs
+
+
+def _run_tflite_and_collect_tensors(
+    *,
+    tflite_path: str,
+    onnx_model: onnx.ModelProto,
+    sample_inputs: dict[str, np.ndarray],
+    tensor_names: list[str],
+) -> dict[str, np.ndarray]:
+    interpreter = _create_tflite_interpreter(model_path=tflite_path)
+    interpreter.allocate_tensors()
+    onnx_input_names = [name for name, _, _ in _collect_onnx_input_specs(onnx_model)]
+    input_map = _build_tflite_detail_map(
+        onnx_names=onnx_input_names,
+        tflite_details=interpreter.get_input_details(),
+    )
+    adapted_inputs = {
+        input_name: _adapt_input_layout_for_tflite_input(
+            sample_inputs[input_name],
+            input_map[input_name],
+        )
+        for input_name in onnx_input_names
+    }
+    resized = _resize_tflite_inputs_if_needed(
+        interpreter=interpreter,
+        onnx_input_names=onnx_input_names,
+        tflite_input_map=input_map,
+        adapted_inputs=adapted_inputs,
+    )
+    if resized:
+        interpreter.allocate_tensors()
+        input_map = _build_tflite_detail_map(
+            onnx_names=onnx_input_names,
+            tflite_details=interpreter.get_input_details(),
+        )
+    for input_name in onnx_input_names:
+        detail = input_map[input_name]
+        interpreter.set_tensor(
+            int(detail["index"]),
+            _quantize_for_tflite_input(adapted_inputs[input_name], detail),
+        )
+    interpreter.invoke()
+
+    detail_by_name = {
+        str(detail["name"]).split(":")[0]: detail
+        for detail in interpreter.get_tensor_details()
+    }
+    collected: dict[str, np.ndarray] = {}
+    for tensor_name in tensor_names:
+        detail = detail_by_name.get(str(tensor_name), None)
+        if detail is None:
+            raise KeyError(f"TFLite tensor detail not found. tensor_name={tensor_name}")
+        collected[str(tensor_name)] = np.asarray(
+            interpreter.get_tensor(int(detail["index"]))
+        )
+    return collected
+
+
+def _run_onnx_and_collect_outputs(
+    *,
+    onnx_model: onnx.ModelProto,
+    sample_inputs: dict[str, np.ndarray],
+    output_names: list[str],
+) -> dict[str, np.ndarray]:
+    model_for_eval = onnx.ModelProto()
+    model_for_eval.CopyFrom(onnx_model)
+    if not check_model_has_external_data(model_for_eval):
+        try:
+            model_for_eval = onnx.shape_inference.infer_shapes(model_for_eval)
+        except Exception:
+            pass
+    value_info_map = {
+        str(value_info.name): value_info
+        for value_info in list(model_for_eval.graph.input)
+        + list(model_for_eval.graph.value_info)
+        + list(model_for_eval.graph.output)
+    }
+    existing_output_names = {str(output.name) for output in model_for_eval.graph.output}
+    for output_name in output_names:
+        if output_name in existing_output_names:
+            continue
+        if output_name not in value_info_map:
+            raise KeyError(f"ONNX value_info not found. output_name={output_name}")
+        model_for_eval.graph.output.append(value_info_map[output_name])
+    try:
+        session = ort.InferenceSession(
+            model_for_eval.SerializeToString(),
+            providers=["CPUExecutionProvider"],
+        )
+    except Exception:
+        model_for_eval.ir_version = min(int(model_for_eval.ir_version), 10)
+        session = ort.InferenceSession(
+            model_for_eval.SerializeToString(),
+            providers=["CPUExecutionProvider"],
+        )
+    outputs = session.run(output_names, sample_inputs)
+    return {
+        output_name: np.asarray(value)
+        for output_name, value in zip(output_names, outputs)
+    }
+
+
 def _make_add_model() -> onnx.ModelProto:
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3])
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
     z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])
     node = helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")
     graph = helper.make_graph([node], "add_graph", [x, y], [z])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _mark_tensor_external_data(
+    tensor: onnx.TensorProto,
+    *,
+    location: str,
+) -> onnx.TensorProto:
+    tensor.data_location = onnx.TensorProto.EXTERNAL
+    del tensor.external_data[:]
+    location_entry = tensor.external_data.add()
+    location_entry.key = "location"
+    location_entry.value = str(location)
+    return tensor
+
+
+def _make_external_data_add_model(*, unknown_rank: bool = False) -> onnx.ModelProto:
+    input_shape = None if unknown_rank else [1, 3]
+    output_shape = None if unknown_rank else [1, 3]
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, input_shape)
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, output_shape)
+    w = _mark_tensor_external_data(
+        numpy_helper.from_array(np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32), name="w"),
+        location="weights.bin",
+    )
+    node = helper.make_node("Add", ["x", "w"], ["y"], name="ExternalAddNode")
+    graph = helper.make_graph([node], "external_add_graph", [x], [y], initializer=[w])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_external_data_subgraph_model() -> onnx.ModelProto:
+    cond = helper.make_tensor_value_info("cond", TensorProto.BOOL, [])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1])
+    then_value = _mark_tensor_external_data(
+        numpy_helper.from_array(np.asarray([1.0], dtype=np.float32), name="then_value"),
+        location="then_value.bin",
+    )
+    else_value = numpy_helper.from_array(np.asarray([0.0], dtype=np.float32), name="else_value")
+    then_const = helper.make_node("Constant", [], ["then_out"], name="ThenConst", value=then_value)
+    else_const = helper.make_node("Constant", [], ["else_out"], name="ElseConst", value=else_value)
+    then_branch = helper.make_graph(
+        [then_const],
+        "then_branch",
+        [],
+        [helper.make_tensor_value_info("then_out", TensorProto.FLOAT, [1])],
+    )
+    else_branch = helper.make_graph(
+        [else_const],
+        "else_branch",
+        [],
+        [helper.make_tensor_value_info("else_out", TensorProto.FLOAT, [1])],
+    )
+    if_node = helper.make_node(
+        "If",
+        ["cond"],
+        ["y"],
+        name="ExternalIfNode",
+        then_branch=then_branch,
+        else_branch=else_branch,
+    )
+    graph = helper.make_graph([if_node], "external_if_graph", [cond], [y])
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -309,6 +493,101 @@ def test_flatbuffer_direct_where_uint64_inputs_lower_to_uint32() -> None:
     ]
     assert len(uint64_cast_ops) >= 1
     assert all(str(op.options.get("outDataType", "")).upper() == "UINT32" for op in uint64_cast_ops)
+
+
+def test_check_model_has_external_data_detects_subgraph_tensor() -> None:
+    assert check_model_has_external_data(_make_external_data_add_model()) is True
+    assert check_model_has_external_data(_make_external_data_subgraph_model()) is True
+    assert check_model_has_external_data(_make_add_model()) is False
+
+
+def test_infer_shapes_with_fallback_skips_external_data_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    external_model = _make_external_data_add_model(unknown_rank=True)
+    infer_shapes_called = False
+
+    def _unexpected_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+        nonlocal infer_shapes_called
+        infer_shapes_called = True
+        raise AssertionError("infer_shapes must not run for external_data models")
+
+    fake_symbolic_module = types.ModuleType("onnxruntime.tools.symbolic_shape_infer")
+
+    class _UnexpectedSymbolicShapeInference:
+        @staticmethod
+        def infer_shapes(*args: Any, **kwargs: Any) -> onnx.ModelProto:
+            raise AssertionError("symbolic shape inference must not run for external_data models")
+
+    fake_symbolic_module.SymbolicShapeInference = _UnexpectedSymbolicShapeInference
+    monkeypatch.setattr(onnx.shape_inference, "infer_shapes", _unexpected_infer_shapes)
+    monkeypatch.setitem(
+        sys.modules,
+        "onnxruntime.tools.symbolic_shape_infer",
+        fake_symbolic_module,
+    )
+
+    inferred_model = _infer_shapes_with_fallback(external_model)
+
+    assert inferred_model is external_model
+    assert infer_shapes_called is False
+
+
+def test_infer_shapes_with_fallback_still_runs_for_non_external_models(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    infer_shapes_called = False
+
+    def _record_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+        nonlocal infer_shapes_called
+        infer_shapes_called = True
+        return model
+
+    monkeypatch.setattr(onnx.shape_inference, "infer_shapes", _record_infer_shapes)
+
+    inferred_model = _infer_shapes_with_fallback(_make_add_model())
+
+    assert infer_shapes_called is True
+    assert isinstance(inferred_model, onnx.ModelProto)
+
+
+def test_run_onnx_and_collect_outputs_skips_infer_shapes_for_external_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    external_model = _make_external_data_add_model()
+    infer_shapes_called = False
+
+    def _unexpected_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+        nonlocal infer_shapes_called
+        infer_shapes_called = True
+        return model
+
+    class _FakeSession:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def run(
+            self,
+            output_names: list[str],
+            sample_inputs: dict[str, np.ndarray],
+        ) -> list[np.ndarray]:
+            x = np.asarray(sample_inputs["x"], dtype=np.float32)
+            return [x + np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32) for _ in output_names]
+
+    monkeypatch.setattr(onnx.shape_inference, "infer_shapes", _unexpected_infer_shapes)
+    monkeypatch.setattr(ort, "InferenceSession", _FakeSession)
+
+    outputs = _run_onnx_and_collect_outputs(
+        onnx_model=external_model,
+        sample_inputs={"x": np.asarray([[10.0, 20.0, 30.0]], dtype=np.float32)},
+        output_names=["y"],
+    )
+
+    assert infer_shapes_called is False
+    assert np.array_equal(
+        outputs["y"],
+        np.asarray([[11.0, 22.0, 33.0]], dtype=np.float32),
+    )
 
 
 def test_flatbuffer_direct_topological_sort_reorders_producer_before_consumer() -> None:
@@ -3066,6 +3345,52 @@ def _make_topk_dynamic_k_indices_reshape_flat_model() -> onnx.ModelProto:
         [x],
         [values, indices, flat_indices],
         initializer=[axis_index, k_limit, flatten_shape],
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _make_postprocessor_topk_chain_model() -> onnx.ModelProto:
+    scores = helper.make_tensor_value_info("scores", TensorProto.FLOAT, [1, 6])
+    label = helper.make_tensor_value_info("label_xyxy_score", TensorProto.FLOAT, [1, 3, 6])
+    boxes = numpy_helper.from_array(
+        np.asarray(
+            [
+                [
+                    [0.1, 0.2, 0.3, 0.4],
+                    [1.1, 1.2, 1.3, 1.4],
+                    [2.1, 2.2, 2.3, 2.4],
+                    [3.1, 3.2, 3.3, 3.4],
+                    [4.1, 4.2, 4.3, 4.4],
+                    [5.1, 5.2, 5.3, 5.4],
+                ]
+            ],
+            dtype=np.float32,
+        ),
+        name="boxes",
+    )
+    k_const = numpy_helper.from_array(np.asarray([3], dtype=np.int64), name="topk_k_const")
+    unsqueeze_axes = numpy_helper.from_array(np.asarray([2], dtype=np.int64), name="unsqueeze_axes")
+    tile_repeats = numpy_helper.from_array(np.asarray([1, 1, 4], dtype=np.int64), name="tile_repeats")
+    one_i64 = numpy_helper.from_array(np.asarray([1], dtype=np.int64), name="one_i64")
+    nodes = [
+        helper.make_node("Sigmoid", ["scores"], ["sigmoid_scores"], name="SigmoidNode"),
+        helper.make_node("Flatten", ["sigmoid_scores"], ["flat_scores"], name="FlattenNode", axis=1),
+        helper.make_node("TopK", ["flat_scores", "topk_k_const"], ["top_values", "top_indices"], name="TopKNode", axis=1),
+        helper.make_node("Unsqueeze", ["top_indices", "unsqueeze_axes"], ["top_indices_unsqueezed"], name="UnsqueezeIndices"),
+        helper.make_node("Div", ["top_indices_unsqueezed", "one_i64"], ["top_indices_div"], name="DivIndices"),
+        helper.make_node("Mul", ["top_indices_div", "one_i64"], ["top_indices_mul"], name="MulIndices"),
+        helper.make_node("Tile", ["top_indices_mul", "tile_repeats"], ["top_indices_tiled"], name="TileIndices"),
+        helper.make_node("GatherElements", ["boxes", "top_indices_tiled"], ["gathered_boxes"], name="GatherBoxes", axis=1),
+        helper.make_node("Cast", ["top_indices_mul"], ["top_indices_float"], name="CastIndices", to=TensorProto.FLOAT),
+        helper.make_node("Unsqueeze", ["top_values", "unsqueeze_axes"], ["top_values_unsqueezed"], name="UnsqueezeValues"),
+        helper.make_node("Concat", ["top_indices_float", "gathered_boxes", "top_values_unsqueezed"], ["label_xyxy_score"], name="ConcatLabel", axis=2),
+    ]
+    graph = helper.make_graph(
+        nodes,
+        "postprocessor_topk_chain_graph",
+        [scores],
+        [label],
+        initializer=[boxes, k_const, unsqueeze_axes, tile_repeats, one_i64],
     )
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
@@ -10878,13 +11203,14 @@ def test_flatbuffer_direct_min_topk_dynamic_k_lowering() -> None:
     assert len(k_input_producers) == 1
 
     indices_out = model_ir.tensors["indices"]
-    assert str(indices_out.dtype).upper() == "INT32"
+    assert str(indices_out.dtype).upper() == "INT64"
     cast_to_i64 = [
         op
         for op in model_ir.operators
         if str(op.op_type) == "CAST" and str(op.outputs[0]) == "indices"
     ]
-    assert len(cast_to_i64) == 0
+    assert len(cast_to_i64) == 1
+    assert list(cast_to_i64[0].inputs) == ["indices_topk_indices_raw"]
 
 
 def test_flatbuffer_direct_topk_const_k_constantized_to_i32_scalar() -> None:
@@ -31857,10 +32183,10 @@ def test_flatbuffer_direct_integration_split_eval_coverage_smoke() -> None:
             model_path,
             out_dir,
             "flatbuffer_direct",
-            auto_split_tflite_by_size=True,
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
             tflite_split_max_bytes=10_000_000,
-            tflite_split_target_bytes=1,
-            eval_split_models=True,
+            eval_split_models="unsplit_tflite",
             eval_num_samples=2,
             report_op_coverage=True,
         )
@@ -32247,7 +32573,7 @@ def test_flatbuffer_direct_split_plan_report_smoke() -> None:
             model_path,
             out_dir,
             "flatbuffer_direct",
-            auto_split_tflite_by_size=True,
+            enable_auto_split_model=True,
             tflite_split_max_bytes=10_000_000,
             tflite_split_target_bytes=9_000_000,
         )
@@ -32280,7 +32606,7 @@ def test_flatbuffer_direct_split_plan_uses_auto_split_max_size_when_specified() 
             model_path,
             out_dir,
             "flatbuffer_direct",
-            auto_split_tflite_by_size=True,
+            enable_auto_split_model=True,
             auto_split_max_size="256KB",
             tflite_split_max_bytes=10_000_000,
             tflite_split_target_bytes=9_000_000,
@@ -32303,9 +32629,9 @@ def test_flatbuffer_direct_split_manifest_and_partition_outputs() -> None:
             model_path,
             out_dir,
             "flatbuffer_direct",
-            auto_split_tflite_by_size=True,
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
             tflite_split_max_bytes=10_000_000,
-            tflite_split_target_bytes=1,
         )
 
         manifest_path = os.path.join(out_dir, "add_chain_split_split_manifest.json")
@@ -32314,7 +32640,7 @@ def test_flatbuffer_direct_split_manifest_and_partition_outputs() -> None:
             manifest = json.load(f)
         assert manifest["schema_version"] == 1
         assert manifest["base_model"] == "add_chain_split.tflite"
-        assert manifest["target_max_bytes"] == 1
+        assert manifest["target_max_bytes"] == 1024
         assert len(manifest["partitions"]) >= 1
         assert "edges" in manifest
 
@@ -32328,6 +32654,108 @@ def test_flatbuffer_direct_split_manifest_and_partition_outputs() -> None:
 
 
 @pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_enable_auto_split_model_forces_manifest_without_legacy_parts() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_model()
+        model_path = _save_model(tmpdir, "add_force_split", model)
+        out_dir = os.path.join(tmpdir, "out")
+        _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+            tflite_split_max_bytes=10_000_000,
+        )
+
+        manifest_path = os.path.join(out_dir, "add_force_split_split_manifest.json")
+        assert os.path.isfile(manifest_path)
+        assert os.path.isfile(os.path.join(out_dir, "add_force_split_float32.tflite"))
+        assert not os.path.isdir(os.path.join(out_dir, "part_0001"))
+
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+        assert manifest["base_model"] == "add_force_split.tflite"
+        assert len(manifest["partitions"]) == 1
+
+        part_files = sorted(
+            glob.glob(os.path.join(out_dir, "add_force_split_[0-9][0-9][0-9][0-9].tflite"))
+        )
+        assert len(part_files) == 1
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_split_manifest_excludes_embedded_constant_inputs() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_conv_model()
+        model_path = _save_model(tmpdir, "conv_force_split", model)
+        out_dir = os.path.join(tmpdir, "out")
+        _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+            tflite_split_max_bytes=10_000_000,
+        )
+
+        manifest_path = os.path.join(out_dir, "conv_force_split_split_manifest.json")
+        assert os.path.isfile(manifest_path)
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+
+        assert len(manifest["partitions"]) == 1
+        partition_entry = manifest["partitions"][0]
+        assert partition_entry["inputs"] == ["x"]
+        assert "W" not in partition_entry["inputs"]
+        assert "B" not in partition_entry["inputs"]
+
+        partition_path = os.path.join(out_dir, partition_entry["file"])
+        interpreter = Interpreter(model_path=partition_path)
+        interpreter.allocate_tensors()
+        input_names = {str(detail["name"]) for detail in interpreter.get_input_details()}
+        assert "x" in input_names
+        assert "W" not in input_names
+        assert "B" not in input_names
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_enable_auto_split_model_and_size_split_share_single_manifest_flow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_chain_model()
+        model_path = _save_model(tmpdir, "add_force_and_size_split", model)
+        out_dir = os.path.join(tmpdir, "out")
+        _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
+            tflite_split_max_bytes=10_000_000,
+        )
+
+        manifest_path = os.path.join(
+            out_dir,
+            "add_force_and_size_split_split_manifest.json",
+        )
+        assert os.path.isfile(manifest_path)
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            manifest = json.load(f)
+
+        part_files = sorted(
+            glob.glob(
+                os.path.join(
+                    out_dir,
+                    "add_force_and_size_split_[0-9][0-9][0-9][0-9].tflite",
+                )
+            )
+        )
+        assert len(part_files) == len(manifest["partitions"])
+        assert len(glob.glob(os.path.join(out_dir, "*_split_manifest.json"))) == 1
+        assert not os.path.isdir(os.path.join(out_dir, "part_0001"))
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
 def test_flatbuffer_direct_split_accuracy_report_with_unsplit_reference() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         model = _make_add_chain_model()
@@ -32337,11 +32765,10 @@ def test_flatbuffer_direct_split_accuracy_report_with_unsplit_reference() -> Non
             model_path,
             out_dir,
             "flatbuffer_direct",
-            auto_split_tflite_by_size=True,
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
             tflite_split_max_bytes=10_000_000,
-            tflite_split_target_bytes=1,
-            eval_split_models=True,
-            eval_split_reference="unsplit_tflite",
+            eval_split_models="unsplit_tflite",
             eval_num_samples=3,
         )
         report_path = os.path.join(out_dir, "add_chain_eval_split_split_accuracy_report.json")
@@ -32351,6 +32778,192 @@ def test_flatbuffer_direct_split_accuracy_report_with_unsplit_reference() -> Non
         assert report["reference_mode"] == "unsplit_tflite"
         assert report["evaluation_pass"] is True
         assert report["allclose_summary"]["pass"] is True
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_split_accuracy_report_with_onnx_reference() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_chain_model()
+        model_path = _save_model(tmpdir, "add_chain_eval_split_onnx", model)
+        out_dir = os.path.join(tmpdir, "out")
+        _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
+            tflite_split_max_bytes=10_000_000,
+            eval_split_models="onnx",
+            eval_num_samples=3,
+        )
+        report_path = os.path.join(out_dir, "add_chain_eval_split_onnx_split_accuracy_report.json")
+        assert os.path.isfile(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["reference_mode"] == "onnx"
+        assert report["evaluation_pass"] is True
+        assert report["allclose_summary"]["pass"] is True
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_split_accuracy_report_adapts_nhwc_partition_inputs() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_conv_model()
+        model_path = _save_model(tmpdir, "conv_eval_split_nhwc", model)
+        out_dir = os.path.join(tmpdir, "out")
+        _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="256MB",
+            tflite_split_max_bytes=10_000_000,
+            eval_split_models="unsplit_tflite",
+            eval_num_samples=1,
+        )
+        report_path = os.path.join(out_dir, "conv_eval_split_nhwc_split_accuracy_report.json")
+        assert os.path.isfile(report_path)
+        with open(report_path, "r", encoding="utf-8") as f:
+            report = json.load(f)
+        assert report["reference_mode"] == "unsplit_tflite"
+        assert report["evaluation_pass"] is True
+        assert report["allclose_summary"]["pass"] is True
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_eval_with_onnx_split_outputs_base_accuracy_report_only() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_chain_model()
+        model_path = _save_model(tmpdir, "add_chain_eval_base_vs_split", model)
+        out_dir = os.path.join(tmpdir, "out")
+        _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
+            tflite_split_max_bytes=10_000_000,
+            eval_with_onnx=True,
+            eval_num_samples=1,
+        )
+        assert os.path.isfile(
+            os.path.join(out_dir, "add_chain_eval_base_vs_split_accuracy_report.json")
+        )
+        assert not os.path.exists(
+            os.path.join(out_dir, "add_chain_eval_base_vs_split_split_accuracy_report.json")
+        )
+        assert os.path.isfile(
+            os.path.join(out_dir, "add_chain_eval_base_vs_split_split_manifest.json")
+        )
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_postprocessor_topk_chain_preserves_requested_indices_dtype_and_intermediates() -> None:
+    model = _make_postprocessor_topk_chain_model()
+    register_default_preprocess_rules()
+    preprocessed_model, _ = run_preprocess_pipeline(onnx_graph=model)
+    model_ir = lower_onnx_to_ir(
+        onnx_graph=preprocessed_model,
+        output_file_name="postprocessor_topk_chain_test",
+        allow_custom_ops=False,
+    )
+
+    assert str(model_ir.tensors["top_indices"].dtype).upper() == "INT64"
+    cast_to_i64 = [
+        op
+        for op in model_ir.operators
+        if str(op.op_type) == "CAST" and str(op.outputs[0]) == "top_indices"
+    ]
+    assert len(cast_to_i64) == 1
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = _save_model(tmpdir, "postprocessor_topk_chain", model)
+        out_dir = os.path.join(tmpdir, "out")
+        tflite_path = _convert(
+            model_path,
+            out_dir,
+            "flatbuffer_direct",
+        )
+        tensor_names = [
+            "sigmoid_scores",
+            "top_values",
+            "top_indices",
+            "top_indices_div",
+            "top_indices_mul",
+            "top_indices_tiled",
+            "gathered_boxes",
+            "top_indices_float",
+            "label_xyxy_score",
+        ]
+        sample_inputs = _make_seeded_sample_inputs(model, seed=0)
+        onnx_outputs = _run_onnx_and_collect_outputs(
+            onnx_model=model,
+            sample_inputs=sample_inputs,
+            output_names=tensor_names,
+        )
+        tflite_outputs = _run_tflite_and_collect_tensors(
+            tflite_path=tflite_path,
+            onnx_model=model,
+            sample_inputs=sample_inputs,
+            tensor_names=tensor_names,
+        )
+        for tensor_name in tensor_names:
+            onnx_tensor = np.asarray(onnx_outputs[tensor_name])
+            tflite_tensor = np.asarray(tflite_outputs[tensor_name])
+            assert onnx_tensor.shape == tflite_tensor.shape
+            if np.issubdtype(onnx_tensor.dtype, np.integer) or np.issubdtype(onnx_tensor.dtype, np.bool_):
+                np.testing.assert_array_equal(tflite_tensor, onnx_tensor)
+            else:
+                np.testing.assert_allclose(tflite_tensor, onnx_tensor, rtol=1.0e-6, atol=1.0e-6)
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_eval_split_models_rejects_invalid_mode() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_chain_model()
+        model_path = _save_model(tmpdir, "add_chain_eval_split_invalid", model)
+        out_dir = os.path.join(tmpdir, "out")
+        with pytest.raises(SystemExit):
+            _convert(
+                model_path,
+                out_dir,
+                "flatbuffer_direct",
+                enable_auto_split_model=True,
+                auto_split_max_size="1KB",
+                tflite_split_max_bytes=10_000_000,
+                eval_split_models="invalid",
+            )
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_eval_split_models_requires_flatbuffer_direct_backend() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_chain_model()
+        model_path = _save_model(tmpdir, "add_chain_eval_split_tf_backend", model)
+        out_dir = os.path.join(tmpdir, "out")
+        with pytest.raises(SystemExit):
+            _convert(
+                model_path,
+                out_dir,
+                "tf_converter",
+                enable_auto_split_model=True,
+                eval_split_models="onnx",
+            )
+
+
+@pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
+def test_flatbuffer_direct_eval_split_models_requires_enable_auto_split_model() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model = _make_add_chain_model()
+        model_path = _save_model(tmpdir, "add_chain_eval_split_requires_split", model)
+        out_dir = os.path.join(tmpdir, "out")
+        with pytest.raises(SystemExit):
+            _convert(
+                model_path,
+                out_dir,
+                "flatbuffer_direct",
+                eval_split_models="onnx",
+            )
 
 
 @pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
@@ -32365,9 +32978,9 @@ def test_split_accuracy_report_fail_on_threshold() -> None:
             model_path,
             out_dir,
             "flatbuffer_direct",
-            auto_split_tflite_by_size=True,
+            enable_auto_split_model=True,
+            auto_split_max_size="1KB",
             tflite_split_max_bytes=10_000_000,
-            tflite_split_target_bytes=1,
         )
         split_manifest_path = os.path.join(out_dir, "add_chain_eval_split_fail_split_manifest.json")
         reference_tflite_path = os.path.join(out_dir, "add_chain_eval_split_fail_float32.tflite")

--- a/tests/test_tflite_builder_op_coverage.py
+++ b/tests/test_tflite_builder_op_coverage.py
@@ -1,7 +1,9 @@
 import numpy as np
 import onnx
+import pytest
 from onnx import TensorProto, helper, numpy_helper
 
+import onnx2tf.tflite_builder.lower_from_onnx2tf as lower_from_onnx2tf
 from onnx2tf.tflite_builder.lower_from_onnx2tf import build_op_coverage_report
 
 
@@ -11,6 +13,31 @@ def _make_add_model() -> onnx.ModelProto:
     z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])
     node = helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")
     graph = helper.make_graph([node], "add_graph", [x, y], [z])
+    return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+
+def _mark_tensor_external_data(
+    tensor: onnx.TensorProto,
+    *,
+    location: str,
+) -> onnx.TensorProto:
+    tensor.data_location = onnx.TensorProto.EXTERNAL
+    del tensor.external_data[:]
+    location_entry = tensor.external_data.add()
+    location_entry.key = "location"
+    location_entry.value = str(location)
+    return tensor
+
+
+def _make_external_data_initializer_add_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
+    w = _mark_tensor_external_data(
+        numpy_helper.from_array(np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32), name="w"),
+        location="weights.bin",
+    )
+    node = helper.make_node("Add", ["x", "w"], ["y"], name="ExternalAddNode")
+    graph = helper.make_graph([node], "external_add_graph", [x], [y], initializer=[w])
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
 
 
@@ -631,6 +658,39 @@ def test_op_coverage_report_keys_compatibility_snapshot() -> None:
         "total_matched_nodes",
         "total_rewritten_nodes",
     ]
+
+
+def test_op_coverage_report_skips_infer_shapes_for_external_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    infer_shapes_called = False
+    original_to_array = lower_from_onnx2tf.numpy_helper.to_array
+
+    def _unexpected_infer_shapes(model: onnx.ModelProto) -> onnx.ModelProto:
+        nonlocal infer_shapes_called
+        infer_shapes_called = True
+        return model
+
+    def _to_array_with_external_data(tensor: onnx.TensorProto) -> np.ndarray:
+        if (
+            isinstance(tensor, onnx.TensorProto)
+            and tensor.name == "w"
+            and tensor.data_location == onnx.TensorProto.EXTERNAL
+        ):
+            return np.asarray([[1.0, 2.0, 3.0]], dtype=np.float32)
+        return original_to_array(tensor)
+
+    monkeypatch.setattr(onnx.shape_inference, "infer_shapes", _unexpected_infer_shapes)
+    monkeypatch.setattr(lower_from_onnx2tf.numpy_helper, "to_array", _to_array_with_external_data)
+
+    report = build_op_coverage_report(
+        onnx_graph=_make_external_data_initializer_add_model(),
+        output_file_name="external_data_cov_snapshot",
+    )
+
+    assert infer_shapes_called is False
+    assert report["graph_summary"]["supported_nodes"] == 1
+    assert report["graph_summary"]["unsupported_nodes"] == 0
 
 
 def test_op_coverage_reason_code_snapshot_validation_failures() -> None:

--- a/tests/test_tflite_split_planner.py
+++ b/tests/test_tflite_split_planner.py
@@ -1,7 +1,9 @@
+import numpy as np
 import pytest
 
 from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
 from onnx2tf.tflite_builder.split_planner import (
+    build_partition_model_ir,
     find_dependency_safe_split_points,
     plan_contiguous_partitions_by_size,
     validate_partition_ranges,
@@ -60,6 +62,108 @@ def test_dependency_safe_split_points_chain() -> None:
     model_ir = _make_chain_model_ir(op_count=6)
     points = find_dependency_safe_split_points(model_ir)
     assert [point["index"] for point in points] == [1, 2, 3, 4, 5]
+
+
+def test_build_partition_model_ir_prunes_dead_branch_ops_and_inputs() -> None:
+    model_ir = ModelIR(name="branch_prune")
+    model_ir.inputs = ["x", "y"]
+    model_ir.outputs = ["b"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1])
+    model_ir.tensors["a"] = TensorIR(name="a", dtype="FLOAT32", shape=[1])
+    model_ir.tensors["b"] = TensorIR(name="b", dtype="FLOAT32", shape=[1])
+    model_ir.tensors["dead"] = TensorIR(name="dead", dtype="FLOAT32", shape=[1])
+    model_ir.operators.extend(
+        [
+            OperatorIR(
+                op_type="DUMMY",
+                inputs=["x"],
+                outputs=["a"],
+                options={},
+                version=1,
+            ),
+            OperatorIR(
+                op_type="DUMMY",
+                inputs=["a"],
+                outputs=["b"],
+                options={},
+                version=1,
+            ),
+            OperatorIR(
+                op_type="DUMMY",
+                inputs=["y"],
+                outputs=["dead"],
+                options={},
+                version=1,
+            ),
+        ]
+    )
+
+    part_model = build_partition_model_ir(
+        model_ir=model_ir,
+        start_op_index=0,
+        end_op_index=3,
+        partition_id=1,
+    )
+
+    assert [op.outputs[0] for op in part_model.operators] == ["a", "b"]
+    assert part_model.inputs == ["x"]
+    assert part_model.outputs == ["b"]
+    assert "dead" not in part_model.tensors
+    assert "y" not in part_model.tensors
+
+
+def test_build_partition_model_ir_excludes_embedded_constants_from_partition_inputs() -> None:
+    model_ir = ModelIR(name="constant_boundary_inputs")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["z"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 1, 4, 4])
+    model_ir.tensors["weight"] = TensorIR(
+        name="weight",
+        dtype="FLOAT32",
+        shape=[1, 1, 3, 3],
+        data=np.ones((1, 1, 3, 3), dtype=np.float32),
+    )
+    model_ir.tensors["bias"] = TensorIR(
+        name="bias",
+        dtype="FLOAT32",
+        shape=[1],
+        data=np.zeros((1,), dtype=np.float32),
+    )
+    model_ir.tensors["conv_out"] = TensorIR(name="conv_out", dtype="FLOAT32", shape=[1, 1, 2, 2])
+    model_ir.tensors["z"] = TensorIR(name="z", dtype="FLOAT32", shape=[1, 1, 2, 2])
+    model_ir.operators.extend(
+        [
+            OperatorIR(
+                op_type="CONV_2D",
+                inputs=["x", "weight", "bias"],
+                outputs=["conv_out"],
+                options={"padding": "VALID"},
+                version=1,
+            ),
+            OperatorIR(
+                op_type="RELU",
+                inputs=["conv_out"],
+                outputs=["z"],
+                options={},
+                version=1,
+            ),
+        ]
+    )
+
+    part_model = build_partition_model_ir(
+        model_ir=model_ir,
+        start_op_index=0,
+        end_op_index=2,
+        partition_id=1,
+    )
+
+    assert part_model.inputs == ["x"]
+    assert part_model.outputs == ["z"]
+    assert "weight" in part_model.tensors
+    assert "bias" in part_model.tensors
+    assert part_model.tensors["weight"].data is not None
+    assert part_model.tensors["bias"].data is not None
 
 
 def test_split_planner_rejects_oversized_single_partition() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -244,6 +244,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "keras"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -482,6 +491,7 @@ dependencies = [
     { name = "opencv-python" },
     { name = "protobuf" },
     { name = "psutil" },
+    { name = "pytest" },
     { name = "requests" },
     { name = "sne4onnx" },
     { name = "sng4onnx" },
@@ -510,6 +520,7 @@ requires-dist = [
     { name = "opencv-python", specifier = "==4.11.0.86" },
     { name = "protobuf", specifier = "==4.25.5" },
     { name = "psutil", specifier = "==5.9.5" },
+    { name = "pytest", specifier = ">=9.0.2" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "sne4onnx", specifier = "==2.0.1" },
     { name = "sng4onnx", specifier = "==2.0.1" },
@@ -689,6 +700,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "4.25.5"
 source = { registry = "https://pypi.org/simple" }
@@ -723,6 +743,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR substantially expands the `flatbuffer_direct` split workflow and makes the direct path more coherent across export, validation, TFLite input import, and SavedModel output.

The main goal of this branch is to turn split handling into a first-class `ModelIR`-based feature for `flatbuffer_direct`, rather than relying on the legacy ONNX/GraphSurgeon split flow.

## Main improvements

### 1. Unified split behavior under `enable_auto_split_model`

`flatbuffer_direct` now uses a single `ModelIR`-based split planner for direct export.

Key behavior changes:
- `enable_auto_split_model=True` is the public split entry point for `flatbuffer_direct`.
- Split planning now runs directly against `ModelIR` and produces the manifest-based artifact set.
- The legacy ONNX recursive split path is no longer used for `flatbuffer_direct`.
- Small models still succeed and emit a valid single-partition manifest instead of failing or falling back.

This makes split behavior deterministic and consistent with the direct backend’s internal representation.

```bash
onnx2tf \
-i deim_hgnetv2_s_wholebody28_ft_1250query_fixed.onnx \
-cotof \
-tb flatbuffer_direct \
-easm \
-asms 5MB # KB or MB or GB
```

<img width="827" height="554" alt="image" src="https://github.com/user-attachments/assets/22477679-7a70-4225-a0d5-66b132517325" />

<img width="2192" height="888" alt="image" src="https://github.com/user-attachments/assets/d2de788d-47f6-4558-9ca9-c97659c069c4" />

### 2. Cleaner split artifacts and partition boundaries

The partition builder was tightened so split artifacts are more faithful and easier to inspect.

Improvements include:
- embedded weights/constants are no longer exposed as partition runtime inputs
- dead branch operators are pruned from partition subgraphs
- split manifests now reflect only real runtime / cross-partition inputs
- partition TFLite graphs avoid the misleading “isolated constant/input” appearance that previously showed up in viewers such as Netron

This specifically addresses the issue where split partitions appeared to have many disconnected constants despite being otherwise executable.

### 3. Split SavedModel export and validation

The direct split pipeline now supports partition-level SavedModel output.

New capabilities:
- `flatbuffer_direct + enable_auto_split_model + flatbuffer_direct_output_saved_model` exports partition SavedModels
- split SavedModel validation runs partition-by-partition in manifest order and compares against the appropriate TFLite reference
- when split SavedModel output is requested, the workflow is aligned across ONNX-input and TFLite-input direct paths

This closes the gap between split TFLite output and SavedModel output for the direct backend.

### 4. `-it` / TFLite-input direct split support

TFLite-import (`-it`) can now participate in the direct split flow.

That means:
- imported TFLite can be lowered into `ModelIR`
- the same split planner can be applied to imported TFLite models
- split artifacts and optional split SavedModels can be generated from TFLite input as well

This makes the direct backend’s split functionality available beyond ONNX-originated conversions.

### 5. Evaluation and validation cleanup

Split evaluation and direct validation behavior were simplified and clarified.

Changes include:
- `eval_split_models` is now the single split evaluation interface and directly encodes the reference mode (`onnx` or `unsplit_tflite`)
- the separate `eval_split_reference` option was removed
- split evaluation now adapts NHWC partition inputs correctly, fixing false failures caused by input layout mismatches
- `-cotof` no longer emits a SavedModel inference warning when the workflow did not actually produce a SavedModel
- logs and reports now distinguish unsplit base accuracy evaluation from split-manifest evaluation more clearly

These changes reduce ambiguity in both CLI usage and generated reports.

### 6. External-data safety for ONNX shape inference

The branch also hardens ONNX handling by enforcing a repository-wide runtime policy:
- `onnx.shape_inference.infer_shapes` is not run when an ONNX model uses `external_data`
- the same policy is applied to the shared lowering helper and relevant test helpers
- symbolic fallback inference is also skipped in that case

This avoids unsafe shape-inference calls on external-data models while preserving the existing behavior for regular in-memory ONNX models.

## Public-facing behavior changes

Notable interface changes:
- `auto_split_tflite_by_size` was removed as a public `flatbuffer_direct` split entry point
- `enable_auto_split_model` is the public split trigger for `flatbuffer_direct`
- `auto_split_max_size` remains the split target-size control
- `eval_split_reference` was removed
- `eval_split_models` now takes the reference mode directly (`onnx` or `unsplit_tflite`)

These changes intentionally reduce redundant split/evaluation options and make the direct backend easier to operate.

## Testing

I ran the flatbuffer-direct-focused regression suite:

```bash
pytest -q \
  tests/test_tflite_builder_direct.py \
  tests/test_tflite_builder_op_coverage.py \
  tests/test_flatbuffer_direct_op_error_report.py \
  tests/test_accuracy_evaluator_input_layout.py \
  tests/test_accuracy_evaluator_name_map.py \
  tests/test_accuracy_evaluator_seeded_input.py \
  tests/test_accuracy_evaluator_subprocess.py \
  tests/test_tflite_split_planner.py \
  tests/test_tflite_builder_gridsample_validation.py
```

Result:
- `625 passed, 1 warning`

The remaining warning is an existing float16 cast overflow warning during one direct-path test and does not fail the suite.

## Why this PR matters

Before this branch, `flatbuffer_direct` split support was fragmented across multiple partially overlapping flags and code paths. This branch consolidates the split workflow around the direct backend’s own `ModelIR`, aligns TFLite and SavedModel outputs, improves artifact correctness, and removes several confusing validation/reporting edge cases.

As a result, `feat-split` turns split export from an experimental side path into a much more coherent and reviewable feature set for `flatbuffer_direct`.
