### PR TITLE
Make TensorFlow/PyTorch optional and decouple flatbuffer_direct -cotof from TensorFlow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,10 @@ https://github.com/PINTO0309/onnx2tf/issues
     && pip install -U simple_onnx_processing_tools \
     && pip install -U onnx2tf \
     && pip install -U h5py==3.7.0
-    && pip install -U tensorflow==2.19.0 \
+    && pip install -U 'onnx2tf[tensorflow]' \
+    && pip install -U 'onnx2tf[torch]' \
     && pip install -U ai_edge_litert==1.2.0 \
     && pip install -U protobuf==4.25.5 \
-    && pip install -U tf-keras==2.19.0 \
     && pip install -U ai-edge-litert==1.2.0
     ```
 

--- a/README.md
+++ b/README.md
@@ -920,7 +920,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.3.18
+  ghcr.io/pinto0309/onnx2tf:2.3.19
 
   or
 
@@ -929,7 +929,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.3.18
+  docker.io/pinto0309/onnx2tf:2.3.19
 
   or
 
@@ -939,7 +939,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.3.18 \
+  docker.io/pinto0309/onnx2tf:2.3.19 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or
@@ -2313,8 +2313,6 @@ optional arguments:
     Cannot be used with --disable_model_save.
     Fails explicitly if CUSTOM ops are present.
     With split output, partition SavedModels are emitted instead of a single root SavedModel.
-    When used with -cotof, also outputs `<model_name>_saved_model_validation_report.json`
-    in the output directory (inference status + SavedModel/TFLite comparison metrics).
 
   -fdopt, --flatbuffer_direct_output_pytorch
     Output a reloadable PyTorch package directly from flatbuffer_direct ModelIR.
@@ -2830,7 +2828,8 @@ optional arguments:
     values are compared, causing OutOfMemory.
     It is very time consuming because it performs as many inferences as
     there are operations.
-    With `--tflite_backend flatbuffer_direct`, the base report is
+    With `--tflite_backend flatbuffer_direct`, this uses the TensorFlow-free
+    ONNX/TFLite comparison path. The base report is
     `<model_name>_accuracy_report.json` (`ONNX↔TFLite`).
     If `--flatbuffer_direct_output_pytorch` is also enabled, onnx2tf additionally
     emits `<model_name>_pytorch_accuracy_report.json` (`ONNX↔PyTorch`) and
@@ -2839,10 +2838,6 @@ optional arguments:
     `--flatbuffer_direct_output_pytorch`, onnx2tf emits
     `<model_name>_pytorch_accuracy_report.json` (`TFLite↔PyTorch`) and
     `<model_name>_accuracy_comparison_report.json`.
-    SavedModel validation remains separate and, if enabled, emits
-    `<model_name>_saved_model_validation_report.json`.
-    If split SavedModels are emitted, they are executed sequentially in
-    split-manifest order before comparison.
 
   -coton, --check_onnx_tf_outputs_sample_data_normalization
     norm: Validate using random data normalized to the range 0.0 to 1.0
@@ -3092,8 +3087,6 @@ convert(
       Fails explicitly if `CUSTOM` ops are present.
       When used together with split output, partition SavedModels are emitted
       instead of a single root SavedModel.
-      When used with `check_onnx_tf_outputs_elementwise_close_full=True`,
-      `<model_name>_saved_model_validation_report.json` is generated.
 
     flatbuffer_direct_output_pytorch: Optional[bool]
       Output a reloadable PyTorch package directly from flatbuffer_direct

--- a/README.md
+++ b/README.md
@@ -884,8 +884,9 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 - onnxoptimizer==0.4.2
 - sne4onnx>=2.0.1
 - sng4onnx>=2.0.1
-- tensorflow==2.19.0
-- tf-keras==2.19.0
+- tensorflow==2.19.0 (optional: TensorFlow-backed export / tf_converter only)
+- tf-keras==2.19.0 (optional: TensorFlow-backed export / tf_converter only)
+- torch==2.11.0 (optional: PyTorch-backed export / validation only)
 - ai-edge-litert==2.1.2
 - h5py==3.12.1
 - psutil==5.9.5
@@ -949,9 +950,20 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   source .venv/bin/activate
   uv pip install -U onnx2tf
 
-  Note: onnx2tf's uv configuration excludes package versions published within the last 7 days.
-  If no compatible version older than 7 days exists, dependency resolution may fail.
-  PyTorch packages from the official PyTorch index are exempt from this cooldown.
+  or
+
+  # Install TensorFlow-backed features too (tf_converter, SavedModel/H5/Keras exports).
+  uv pip install -U 'onnx2tf[tensorflow]'
+
+  or
+
+  # Install PyTorch-backed features too (native package / TorchScript / Dynamo ONNX / ExportedProgram).
+  uv pip install -U 'onnx2tf[torch]'
+
+  or
+
+  # Install all optional features at once.
+  uv pip install -U 'onnx2tf[tensorflow,torch]'
 
   or
 
@@ -963,7 +975,34 @@ Video speed is adjusted approximately 50 times slower than actual speed.
 
   or
 
+  # Sync with TensorFlow-backed features enabled.
+  uv sync --extra tensorflow
+
+  or
+
+  # Sync with PyTorch-backed features enabled.
+  uv sync --extra torch
+
+  or
+
+  # Sync with all optional features enabled.
+  uv sync --all-extras
+
+  or
+
   pip install -e .
+
+  or
+
+  pip install -e '.[tensorflow]'
+
+  or
+
+  pip install -e '.[torch]'
+
+  or
+
+  pip install -e '.[tensorflow,torch]'
 
   or
 

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -1,3 +1,21 @@
-from onnx2tf.onnx2tf import convert, main
+from __future__ import annotations
 
-__version__ = '2.3.18'
+from typing import Any
+
+__version__ = "2.3.18"
+
+
+def _load_impl():
+    from onnx2tf.onnx2tf import convert as _convert, main as _main
+
+    return _convert, _main
+
+
+def convert(*args: Any, **kwargs: Any):
+    _convert, _ = _load_impl()
+    return _convert(*args, **kwargs)
+
+
+def main(*args: Any, **kwargs: Any):
+    _, _main = _load_impl()
+    return _main(*args, **kwargs)

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "2.3.18"
+__version__ = "2.3.19"
 
 
 def _load_impl():

--- a/onnx2tf/__main__.py
+++ b/onnx2tf/__main__.py
@@ -1,4 +1,4 @@
-from . import main
+from . import main as lazy_main
 
 if __name__ == '__main__':
-    main()
+    lazy_main()

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1496,9 +1496,7 @@ def convert(
         Export SavedModel directly from flatbuffer_direct ModelIR (float32 path)
         without tf_converter fallback.\n
         When used together with split output, partition SavedModels are emitted
-        instead of a single root SavedModel.\n
-        With `check_onnx_tf_outputs_elementwise_close_full=True`, onnx2tf writes
-        `<model_name>_saved_model_validation_report.json`.
+        instead of a single root SavedModel.
 
     flatbuffer_direct_output_pytorch: Optional[bool]
         Export a reloadable PyTorch package directly from flatbuffer_direct
@@ -2351,6 +2349,7 @@ def convert(
     )
     run_saved_model_inference_check = bool(
         check_onnx_tf_outputs_elementwise_close_full
+        and tflite_backend == 'tf_converter'
     )
     run_flatbuffer_direct_op_error_report = bool(
         check_onnx_tf_outputs_elementwise_close_full
@@ -9250,8 +9249,9 @@ def main():
             'values are compared, causing OutOfMemory. ' +
             'It is very time consuming because it performs as many inferences as '+
             'there are operations. '+
-            'With -it and -fdopt, this compares TFLite and PyTorch outputs instead of ONNX-based outputs. '+
-            'In addition, final ONNX vs generated TFLite output error check is automatically executed.'
+            'With --tflite_backend flatbuffer_direct, this runs the TensorFlow-free ONNX/TFLite '+
+            'comparison path and final ONNX vs generated TFLite output error check. '+
+            'With -it and -fdopt, this compares TFLite and PyTorch outputs instead of ONNX-based outputs. '
     )
     parser.add_argument(
         '-coton',

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 #! /usr/bin/env python
 
 import os
@@ -30,61 +32,6 @@ import random
 random.seed(0)
 import numpy as np
 np.random.seed(0)
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-os.environ["TF_USE_LEGACY_KERAS"] = '1'
-
-
-def _should_suppress_tf_startup_stderr() -> bool:
-    raw = str(
-        os.environ.get(
-            'ONNX2TF_SUPPRESS_TF_STARTUP_STDERR',
-            '1',
-        )
-    ).strip().lower()
-    return raw not in {'0', 'false', 'off', 'no'}
-
-
-@contextlib.contextmanager
-def _suppress_stderr_fd_for_tf_startup():
-    if not _should_suppress_tf_startup_stderr():
-        yield
-        return
-    try:
-        stderr_fd = sys.stderr.fileno()
-    except Exception:
-        yield
-        return
-    saved_fd = None
-    devnull_fd = None
-    try:
-        saved_fd = os.dup(stderr_fd)
-        devnull_fd = os.open(os.devnull, os.O_WRONLY)
-        os.dup2(devnull_fd, stderr_fd)
-        yield
-    finally:
-        try:
-            if saved_fd is not None:
-                os.dup2(saved_fd, stderr_fd)
-        finally:
-            if saved_fd is not None:
-                os.close(saved_fd)
-            if devnull_fd is not None:
-                os.close(devnull_fd)
-
-
-with _suppress_stderr_fd_for_tf_startup():
-    import tensorflow as tf
-    from tensorflow.python.saved_model.load import _WrapperFunction
-    import tf_keras
-
-tf.random.set_seed(0)
-tf_keras.utils.set_random_seed(0)
-tf.config.experimental.enable_op_determinism()
-tf.get_logger().setLevel('INFO')
-tf.autograph.set_verbosity(0)
-tf.get_logger().setLevel(logging.FATAL)
-from absl import logging as absl_logging
-absl_logging.set_verbosity(absl_logging.ERROR)
 
 import onnx
 import onnx2tf.gs as gs
@@ -92,24 +39,25 @@ from typing import Optional, List, Any, Dict, cast
 from argparse import ArgumentParser, SUPPRESS
 
 import importlib
-import onnx2tf.utils.common_functions as common_functions
-from onnx2tf.utils.common_functions import (
-    dummy_onnx_inference,
-    dummy_tf_inference,
-    onnx_tf_tensor_validation,
-    weights_export,
-    get_tf_model_inputs,
-    get_tf_model_outputs,
-    rewrite_tflite_inout_opname,
-    check_cuda_enabled,
-    check_has_external_data,
-)
 from onnx2tf.utils.json_auto_generator import (
     generate_auto_replacement_json,
     save_auto_replacement_json,
 )
-from onnx2tf.utils.enums import (
-    CUDA_ONLY_OPS,
+from onnx2tf.utils.onnx_litert_runtime import (
+    check_cuda_enabled,
+    check_has_external_data,
+    dummy_onnx_inference,
+    set_dummy_shape_hints,
+    set_dummy_value_hints,
+    weights_export,
+)
+from onnx2tf.utils.tf_optional import (
+    OptionalTensorFlowDependencyError,
+    require_tensorflow,
+)
+from onnx2tf.utils.torch_optional import (
+    OptionalPyTorchDependencyError,
+    require_torch,
 )
 from onnx2tf.tflite_builder.preprocess.rules.cleanup_unused_initializers import (
     prune_unused_initializers_inplace,
@@ -122,6 +70,76 @@ from sng4onnx import generate as op_name_auto_generate
 
 
 _SAVED_MODEL_BRIDGE_SIGNATURE_CACHE: Dict[tuple[str, str], Any] = {}
+_SAVED_MODEL_BRIDGE_LAYER_CLS: Optional[type] = None
+_CURRENT_DUMMY_SHAPE_HINTS: Optional[List[str]] = None
+_CURRENT_DUMMY_VALUE_HINTS: Optional[List[str]] = None
+CUDA_ONLY_OPS = [
+    'GroupNorm',
+]
+
+
+class _TensorFlowModuleProxy:
+    def __init__(self, module_name: str) -> None:
+        self._module_name = str(module_name)
+
+    def _load(self) -> Any:
+        modules = require_tensorflow('TensorFlow-backed onnx2tf feature')
+        return getattr(modules, self._module_name)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
+
+
+tf = _TensorFlowModuleProxy('tf')
+tf_keras = _TensorFlowModuleProxy('tf_keras')
+
+
+def _load_common_functions():
+    module = importlib.import_module('onnx2tf.utils.common_functions')
+    module.set_dummy_shape_hints(_CURRENT_DUMMY_SHAPE_HINTS)
+    module.set_dummy_value_hints(_CURRENT_DUMMY_VALUE_HINTS)
+    return module
+
+
+def dummy_tf_inference(*args: Any, **kwargs: Any):
+    return _load_common_functions().dummy_tf_inference(*args, **kwargs)
+
+
+def onnx_tf_tensor_validation(*args: Any, **kwargs: Any):
+    return _load_common_functions().onnx_tf_tensor_validation(*args, **kwargs)
+
+
+def get_tf_model_inputs(*args: Any, **kwargs: Any):
+    return _load_common_functions().get_tf_model_inputs(*args, **kwargs)
+
+
+def get_tf_model_outputs(*args: Any, **kwargs: Any):
+    return _load_common_functions().get_tf_model_outputs(*args, **kwargs)
+
+
+def rewrite_tflite_inout_opname(*args: Any, **kwargs: Any):
+    return _load_common_functions().rewrite_tflite_inout_opname(*args, **kwargs)
+
+
+def _set_dummy_inference_defaults(
+    *,
+    shape_hints: Optional[List[str]],
+    value_hints: Optional[List[str]],
+) -> None:
+    global _CURRENT_DUMMY_SHAPE_HINTS
+    global _CURRENT_DUMMY_VALUE_HINTS
+    _CURRENT_DUMMY_SHAPE_HINTS = shape_hints
+    _CURRENT_DUMMY_VALUE_HINTS = value_hints
+    set_dummy_shape_hints(shape_hints)
+    set_dummy_value_hints(value_hints)
+
+
+def _require_tensorflow_for_feature(feature: str) -> None:
+    require_tensorflow(str(feature))
+
+
+def _require_torch_for_feature(feature: str) -> None:
+    require_torch(str(feature))
 
 
 def _generated_pytorch_export_skip_reason(
@@ -160,6 +178,7 @@ def _get_saved_model_bridge_signature(
     saved_model_path: str,
     endpoint: str = 'serving_default',
 ):
+    require_tensorflow('flatbuffer_direct SavedModel bridge')
     cache_key = (os.path.abspath(str(saved_model_path)), str(endpoint))
     if cache_key not in _SAVED_MODEL_BRIDGE_SIGNATURE_CACHE:
         module = tf.saved_model.load(str(saved_model_path))
@@ -174,66 +193,76 @@ def _get_saved_model_bridge_signature(
     return _SAVED_MODEL_BRIDGE_SIGNATURE_CACHE[cache_key]
 
 
-@tf_keras.utils.register_keras_serializable(package='onnx2tf')
-class SavedModelBridgeLayer(tf_keras.layers.Layer):
-    def __init__(
-        self,
-        *,
-        saved_model_path: str,
-        input_names: List[str],
-        output_names: Optional[List[str]] = None,
-        endpoint: str = 'serving_default',
-        **kwargs,
-    ):
-        kwargs.setdefault('trainable', False)
-        super().__init__(**kwargs)
-        self.saved_model_path = str(saved_model_path)
-        self.input_names = [str(v) for v in list(input_names)]
-        self.output_names = (
-            [str(v) for v in list(output_names)]
-            if output_names is not None
-            else []
-        )
-        self.endpoint = str(endpoint)
+def _get_saved_model_bridge_layer_cls():
+    global _SAVED_MODEL_BRIDGE_LAYER_CLS
+    if _SAVED_MODEL_BRIDGE_LAYER_CLS is not None:
+        return _SAVED_MODEL_BRIDGE_LAYER_CLS
 
-    def call(self, inputs, *args, **kwargs):
-        call_inputs = list(inputs) if isinstance(inputs, (list, tuple)) else [inputs]
-        signature_fn = _get_saved_model_bridge_signature(
-            saved_model_path=self.saved_model_path,
-            endpoint=self.endpoint,
-        )
-        outputs = signature_fn(
-            **{
-                input_name: tensor
-                for input_name, tensor in zip(self.input_names, call_inputs)
-            }
-        )
-        if not isinstance(outputs, dict):
-            return outputs
-        ordered_output_names = (
-            list(self.output_names)
-            if len(self.output_names) > 0
-            else [str(name) for name in outputs.keys()]
-        )
-        ordered_outputs = [
-            outputs[str(output_name)]
-            for output_name in ordered_output_names
-        ]
-        if len(ordered_outputs) == 1:
-            return ordered_outputs[0]
-        return ordered_outputs
+    require_tensorflow('flatbuffer_direct SavedModel bridge')
 
-    def get_config(self):
-        config = super().get_config()
-        config.update(
-            {
-                'saved_model_path': self.saved_model_path,
-                'input_names': list(self.input_names),
-                'output_names': list(self.output_names),
-                'endpoint': self.endpoint,
-            }
-        )
-        return config
+    @tf_keras.utils.register_keras_serializable(package='onnx2tf')
+    class SavedModelBridgeLayer(tf_keras.layers.Layer):
+        def __init__(
+            self,
+            *,
+            saved_model_path: str,
+            input_names: List[str],
+            output_names: Optional[List[str]] = None,
+            endpoint: str = 'serving_default',
+            **kwargs,
+        ):
+            kwargs.setdefault('trainable', False)
+            super().__init__(**kwargs)
+            self.saved_model_path = str(saved_model_path)
+            self.input_names = [str(v) for v in list(input_names)]
+            self.output_names = (
+                [str(v) for v in list(output_names)]
+                if output_names is not None
+                else []
+            )
+            self.endpoint = str(endpoint)
+
+        def call(self, inputs, *args, **kwargs):
+            call_inputs = list(inputs) if isinstance(inputs, (list, tuple)) else [inputs]
+            signature_fn = _get_saved_model_bridge_signature(
+                saved_model_path=self.saved_model_path,
+                endpoint=self.endpoint,
+            )
+            outputs = signature_fn(
+                **{
+                    input_name: tensor
+                    for input_name, tensor in zip(self.input_names, call_inputs)
+                }
+            )
+            if not isinstance(outputs, dict):
+                return outputs
+            ordered_output_names = (
+                list(self.output_names)
+                if len(self.output_names) > 0
+                else [str(name) for name in outputs.keys()]
+            )
+            ordered_outputs = [
+                outputs[str(output_name)]
+                for output_name in ordered_output_names
+            ]
+            if len(ordered_outputs) == 1:
+                return ordered_outputs[0]
+            return ordered_outputs
+
+        def get_config(self):
+            config = super().get_config()
+            config.update(
+                {
+                    'saved_model_path': self.saved_model_path,
+                    'input_names': list(self.input_names),
+                    'output_names': list(self.output_names),
+                    'endpoint': self.endpoint,
+                }
+            )
+            return config
+
+    _SAVED_MODEL_BRIDGE_LAYER_CLS = SavedModelBridgeLayer
+    return _SAVED_MODEL_BRIDGE_LAYER_CLS
 
 def _sanitize_split_input_name(name: str) -> str:
     if not name:
@@ -1967,8 +1996,10 @@ def convert(
     if verbosity is None:
         verbosity = 'debug'
     set_log_level('error' if non_verbose else verbosity)
-    common_functions.set_dummy_shape_hints(shape_hints)
-    common_functions.set_dummy_value_hints(value_hints)
+    _set_dummy_inference_defaults(
+        shape_hints=shape_hints,
+        value_hints=value_hints,
+    )
 
     # If output_folder_path is empty, set the initial value
     if not output_folder_path:
@@ -2324,6 +2355,32 @@ def convert(
     run_flatbuffer_direct_op_error_report = bool(
         check_onnx_tf_outputs_elementwise_close_full
     )
+    required_pytorch_feature: Optional[str] = None
+    if flatbuffer_direct_output_torchscript:
+        required_pytorch_feature = 'flatbuffer_direct TorchScript export'
+    elif flatbuffer_direct_output_dynamo_onnx:
+        required_pytorch_feature = 'flatbuffer_direct Dynamo ONNX export'
+    elif flatbuffer_direct_output_exported_program:
+        required_pytorch_feature = 'flatbuffer_direct ExportedProgram export'
+    elif flatbuffer_direct_output_pytorch:
+        required_pytorch_feature = 'flatbuffer_direct PyTorch package export'
+    if required_pytorch_feature is not None:
+        _require_torch_for_feature(required_pytorch_feature)
+    required_tensorflow_feature: Optional[str] = None
+    if tflite_backend == 'tf_converter':
+        required_tensorflow_feature = 'tflite_backend="tf_converter"'
+    elif output_h5:
+        required_tensorflow_feature = 'flatbuffer_direct H5 export'
+    elif output_keras_v3:
+        required_tensorflow_feature = 'flatbuffer_direct Keras v3 export'
+    elif output_tfv1_pb:
+        required_tensorflow_feature = 'flatbuffer_direct TFv1 PB export'
+    elif flatbuffer_direct_output_saved_model:
+        required_tensorflow_feature = 'flatbuffer_direct SavedModel export'
+    elif run_saved_model_inference_check:
+        required_tensorflow_feature = 'SavedModel-based validation'
+    if required_tensorflow_feature is not None:
+        _require_tensorflow_for_feature(required_tensorflow_feature)
     runtime_output_folder_path = output_folder_path
 
     def _run_onnx_tflite_output_check(
@@ -4005,7 +4062,7 @@ def convert(
             )
             input_names.append(str(input_name))
         layer_inputs = keras_inputs if len(keras_inputs) > 1 else keras_inputs[0]
-        bridge_outputs = SavedModelBridgeLayer(
+        bridge_outputs = _get_saved_model_bridge_layer_cls()(
             saved_model_path=saved_model_path,
             input_names=input_names,
             output_names=output_names,
@@ -9332,96 +9389,103 @@ def main():
     )
 
     # Convert
-    model = convert(
-        input_onnx_file_path=args.input_onnx_file_path,
-        input_tflite_file_path=args.input_tflite_file_path,
-        output_folder_path=args.output_folder_path,
-        output_signaturedefs=args.output_signaturedefs,
-        output_h5=args.output_h5,
-        output_keras_v3=args.output_keras_v3,
-        output_tfv1_pb=args.output_tfv1_pb,
-        output_weights=args.output_weights,
-        copy_onnx_input_output_names_to_tflite=args.copy_onnx_input_output_names_to_tflite,
-        output_dynamic_range_quantized_tflite=args.output_dynamic_range_quantized_tflite,
-        output_integer_quantized_tflite=args.output_integer_quantized_tflite,
-        eval_with_onnx=args.eval_with_onnx,
-        eval_num_samples=args.eval_num_samples,
-        eval_rtol=args.eval_rtol,
-        eval_atol=args.eval_atol,
-        eval_fail_on_threshold=args.eval_fail_on_threshold,
-        eval_target_tflite=args.eval_target_tflite,
-        eval_compare_mode=args.eval_compare_mode,
-        eval_split_models=args.eval_split_models,
-        eval_split_fail_on_threshold=args.eval_split_fail_on_threshold,
-        report_op_coverage=args.report_op_coverage,
-        flatbuffer_direct_output_saved_model=args.flatbuffer_direct_output_saved_model,
-        flatbuffer_direct_output_pytorch=args.flatbuffer_direct_output_pytorch,
-        flatbuffer_direct_output_torchscript=args.flatbuffer_direct_output_torchscript,
-        flatbuffer_direct_output_dynamo_onnx=args.flatbuffer_direct_output_dynamo_onnx,
-        flatbuffer_direct_output_exported_program=args.flatbuffer_direct_output_exported_program,
-        native_pytorch_generation_timeout_sec=args.native_pytorch_generation_timeout_sec,
-        flatbuffer_direct_allow_custom_ops=args.flatbuffer_direct_allow_custom_ops,
-        flatbuffer_direct_custom_op_allowlist=flatbuffer_direct_custom_op_allowlist,
-        tflite_split_max_bytes=args.tflite_split_max_bytes,
-        tflite_split_target_bytes=args.tflite_split_target_bytes,
-        tflite_backend=args.tflite_backend,
-        quant_norm_mean=args.quant_norm_mean,
-        quant_norm_std=args.quant_norm_std,
-        quant_type=args.quant_type,
-        custom_input_op_name_np_data_path=custom_params,
-        input_quant_dtype=args.input_quant_dtype,
-        output_quant_dtype=args.output_quant_dtype,
-        not_use_onnxsim=args.not_use_onnxsim,
-        not_use_opname_auto_generate=args.not_use_opname_auto_generate,
-        batch_size=args.batch_size,
-        overwrite_input_shape=args.overwrite_input_shape,
-        shape_hints=args.shape_hints,
-        value_hints=args.value_hints,
-        no_large_tensor=args.no_large_tensor,
-        output_nms_with_dynamic_tensor=args.output_nms_with_dynamic_tensor,
-        output_nms_with_argmax=args.output_nms_with_argmax,
-        switch_nms_version=args.switch_nms_version,
-        keep_ncw_or_nchw_or_ncdhw_input_names=args.keep_ncw_or_nchw_or_ncdhw_input_names,
-        keep_nwc_or_nhwc_or_ndhwc_input_names=args.keep_nwc_or_nhwc_or_ndhwc_input_names,
-        keep_shape_absolutely_input_names=args.keep_shape_absolutely_input_names,
-        input_names_to_interrupt_model_conversion=args.input_names_to_interrupt_model_conversion,
-        output_names_to_interrupt_model_conversion=args.output_names_to_interrupt_model_conversion,
-        disable_group_convolution=args.disable_group_convolution,
-        enable_accumulation_type_float16=args.enable_accumulation_type_float16,
-        enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
-        enable_rnn_unroll=args.enable_rnn_unroll,
-        disable_suppression_flextranspose=args.disable_suppression_flextranspose,
-        disable_strict_mode=args.disable_strict_mode,
-        onnxruntime_output_memmap=not args.disable_onnxruntime_output_memmap,
-        onnxruntime_output_memmap_dir=args.onnxruntime_output_memmap_dir,
-        number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
-        disable_suppression_flexstridedslice=args.disable_suppression_flexstridedslice,
-        number_of_dimensions_after_flexstridedslice_compression=args.number_of_dimensions_after_flexstridedslice_compression,
-        optimization_for_gpu_delegate=args.optimization_for_gpu_delegate,
-        replace_argmax_to_reducemax_and_indices_is_int64=args.replace_argmax_to_reducemax_and_indices_is_int64,
-        replace_argmax_to_reducemax_and_indices_is_float32=args.replace_argmax_to_reducemax_and_indices_is_float32,
-        replace_argmax_to_fused_argmax_and_indices_is_int64=args.replace_argmax_to_fused_argmax_and_indices_is_int64,
-        replace_argmax_to_fused_argmax_and_indices_is_float32=args.replace_argmax_to_fused_argmax_and_indices_is_float32,
-        fused_argmax_scale_ratio=args.fused_argmax_scale_ratio,
-        replace_to_pseudo_operators=args.replace_to_pseudo_operators,
-        param_replacement_file=args.param_replacement_file,
-        auto_generate_json=args.auto_generate_json,
-        auto_generate_json_on_error=args.auto_generate_json_on_error,
-        enable_auto_split_model=args.enable_auto_split_model,
-        auto_split_max_size=args.auto_split_max_size,
-        auto_split_max_size_mb=args.auto_split_max_size_mb,
-        check_gpu_delegate_compatibility=args.check_gpu_delegate_compatibility,
-        check_onnx_tf_outputs_elementwise_close=args.check_onnx_tf_outputs_elementwise_close,
-        check_onnx_tf_outputs_elementwise_close_full=args.check_onnx_tf_outputs_elementwise_close_full,
-        check_onnx_tf_outputs_sample_data_normalization=args.check_onnx_tf_outputs_sample_data_normalization,
-        check_onnx_tf_outputs_elementwise_close_rtol=args.check_onnx_tf_outputs_elementwise_close_rtol,
-        check_onnx_tf_outputs_elementwise_close_atol=args.check_onnx_tf_outputs_elementwise_close_atol,
-        test_data_nhwc_path=args.test_data_nhwc_path,
-        mvn_epsilon=args.mvn_epsilon,
-        disable_model_save=args.disable_model_save,
-        non_verbose=args.non_verbose,
-        verbosity=args.verbosity,
-    )
+    try:
+        model = convert(
+            input_onnx_file_path=args.input_onnx_file_path,
+            input_tflite_file_path=args.input_tflite_file_path,
+            output_folder_path=args.output_folder_path,
+            output_signaturedefs=args.output_signaturedefs,
+            output_h5=args.output_h5,
+            output_keras_v3=args.output_keras_v3,
+            output_tfv1_pb=args.output_tfv1_pb,
+            output_weights=args.output_weights,
+            copy_onnx_input_output_names_to_tflite=args.copy_onnx_input_output_names_to_tflite,
+            output_dynamic_range_quantized_tflite=args.output_dynamic_range_quantized_tflite,
+            output_integer_quantized_tflite=args.output_integer_quantized_tflite,
+            eval_with_onnx=args.eval_with_onnx,
+            eval_num_samples=args.eval_num_samples,
+            eval_rtol=args.eval_rtol,
+            eval_atol=args.eval_atol,
+            eval_fail_on_threshold=args.eval_fail_on_threshold,
+            eval_target_tflite=args.eval_target_tflite,
+            eval_compare_mode=args.eval_compare_mode,
+            eval_split_models=args.eval_split_models,
+            eval_split_fail_on_threshold=args.eval_split_fail_on_threshold,
+            report_op_coverage=args.report_op_coverage,
+            flatbuffer_direct_output_saved_model=args.flatbuffer_direct_output_saved_model,
+            flatbuffer_direct_output_pytorch=args.flatbuffer_direct_output_pytorch,
+            flatbuffer_direct_output_torchscript=args.flatbuffer_direct_output_torchscript,
+            flatbuffer_direct_output_dynamo_onnx=args.flatbuffer_direct_output_dynamo_onnx,
+            flatbuffer_direct_output_exported_program=args.flatbuffer_direct_output_exported_program,
+            native_pytorch_generation_timeout_sec=args.native_pytorch_generation_timeout_sec,
+            flatbuffer_direct_allow_custom_ops=args.flatbuffer_direct_allow_custom_ops,
+            flatbuffer_direct_custom_op_allowlist=flatbuffer_direct_custom_op_allowlist,
+            tflite_split_max_bytes=args.tflite_split_max_bytes,
+            tflite_split_target_bytes=args.tflite_split_target_bytes,
+            tflite_backend=args.tflite_backend,
+            quant_norm_mean=args.quant_norm_mean,
+            quant_norm_std=args.quant_norm_std,
+            quant_type=args.quant_type,
+            custom_input_op_name_np_data_path=custom_params,
+            input_quant_dtype=args.input_quant_dtype,
+            output_quant_dtype=args.output_quant_dtype,
+            not_use_onnxsim=args.not_use_onnxsim,
+            not_use_opname_auto_generate=args.not_use_opname_auto_generate,
+            batch_size=args.batch_size,
+            overwrite_input_shape=args.overwrite_input_shape,
+            shape_hints=args.shape_hints,
+            value_hints=args.value_hints,
+            no_large_tensor=args.no_large_tensor,
+            output_nms_with_dynamic_tensor=args.output_nms_with_dynamic_tensor,
+            output_nms_with_argmax=args.output_nms_with_argmax,
+            switch_nms_version=args.switch_nms_version,
+            keep_ncw_or_nchw_or_ncdhw_input_names=args.keep_ncw_or_nchw_or_ncdhw_input_names,
+            keep_nwc_or_nhwc_or_ndhwc_input_names=args.keep_nwc_or_nhwc_or_ndhwc_input_names,
+            keep_shape_absolutely_input_names=args.keep_shape_absolutely_input_names,
+            input_names_to_interrupt_model_conversion=args.input_names_to_interrupt_model_conversion,
+            output_names_to_interrupt_model_conversion=args.output_names_to_interrupt_model_conversion,
+            disable_group_convolution=args.disable_group_convolution,
+            enable_accumulation_type_float16=args.enable_accumulation_type_float16,
+            enable_batchmatmul_unfold=args.enable_batchmatmul_unfold,
+            enable_rnn_unroll=args.enable_rnn_unroll,
+            disable_suppression_flextranspose=args.disable_suppression_flextranspose,
+            disable_strict_mode=args.disable_strict_mode,
+            onnxruntime_output_memmap=not args.disable_onnxruntime_output_memmap,
+            onnxruntime_output_memmap_dir=args.onnxruntime_output_memmap_dir,
+            number_of_dimensions_after_flextranspose_compression=args.number_of_dimensions_after_flextranspose_compression,
+            disable_suppression_flexstridedslice=args.disable_suppression_flexstridedslice,
+            number_of_dimensions_after_flexstridedslice_compression=args.number_of_dimensions_after_flexstridedslice_compression,
+            optimization_for_gpu_delegate=args.optimization_for_gpu_delegate,
+            replace_argmax_to_reducemax_and_indices_is_int64=args.replace_argmax_to_reducemax_and_indices_is_int64,
+            replace_argmax_to_reducemax_and_indices_is_float32=args.replace_argmax_to_reducemax_and_indices_is_float32,
+            replace_argmax_to_fused_argmax_and_indices_is_int64=args.replace_argmax_to_fused_argmax_and_indices_is_int64,
+            replace_argmax_to_fused_argmax_and_indices_is_float32=args.replace_argmax_to_fused_argmax_and_indices_is_float32,
+            fused_argmax_scale_ratio=args.fused_argmax_scale_ratio,
+            replace_to_pseudo_operators=args.replace_to_pseudo_operators,
+            param_replacement_file=args.param_replacement_file,
+            auto_generate_json=args.auto_generate_json,
+            auto_generate_json_on_error=args.auto_generate_json_on_error,
+            enable_auto_split_model=args.enable_auto_split_model,
+            auto_split_max_size=args.auto_split_max_size,
+            auto_split_max_size_mb=args.auto_split_max_size_mb,
+            check_gpu_delegate_compatibility=args.check_gpu_delegate_compatibility,
+            check_onnx_tf_outputs_elementwise_close=args.check_onnx_tf_outputs_elementwise_close,
+            check_onnx_tf_outputs_elementwise_close_full=args.check_onnx_tf_outputs_elementwise_close_full,
+            check_onnx_tf_outputs_sample_data_normalization=args.check_onnx_tf_outputs_sample_data_normalization,
+            check_onnx_tf_outputs_elementwise_close_rtol=args.check_onnx_tf_outputs_elementwise_close_rtol,
+            check_onnx_tf_outputs_elementwise_close_atol=args.check_onnx_tf_outputs_elementwise_close_atol,
+            test_data_nhwc_path=args.test_data_nhwc_path,
+            mvn_epsilon=args.mvn_epsilon,
+            disable_model_save=args.disable_model_save,
+            non_verbose=args.non_verbose,
+            verbosity=args.verbosity,
+        )
+    except (
+        OptionalTensorFlowDependencyError,
+        OptionalPyTorchDependencyError,
+    ) as ex:
+        error(str(ex))
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -49,10 +49,9 @@ from onnx2tf.tflite_builder.split_planner import (
     write_split_model_files_and_manifest,
     write_split_plan_report,
 )
-from onnx2tf.tflite_builder.split_saved_model_exporter import (
-    export_split_saved_models,
-)
-from onnx2tf.utils.common_functions import weights_export
+from onnx2tf.utils.onnx_litert_runtime import weights_export
+from onnx2tf.utils.tf_optional import require_tensorflow
+from onnx2tf.utils.torch_optional import require_torch
 
 
 def _progress_write(*, message: str, enabled: bool) -> None:
@@ -319,6 +318,17 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         or output_exported_program_from_model_ir
     ):
         output_pytorch_from_model_ir = True
+    required_pytorch_feature: Optional[str] = None
+    if output_torchscript_from_model_ir:
+        required_pytorch_feature = "flatbuffer_direct TorchScript export"
+    elif output_dynamo_onnx_from_model_ir:
+        required_pytorch_feature = "flatbuffer_direct Dynamo ONNX export"
+    elif output_exported_program_from_model_ir:
+        required_pytorch_feature = "flatbuffer_direct ExportedProgram export"
+    elif output_pytorch_from_model_ir:
+        required_pytorch_feature = "flatbuffer_direct PyTorch package export"
+    if required_pytorch_feature is not None:
+        require_torch(required_pytorch_feature)
     saved_model_output_folder_path = kwargs.get(
         "saved_model_output_folder_path",
         None,
@@ -821,8 +831,13 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         _advance_export_progress()
 
         if output_saved_model_from_model_ir:
+            require_tensorflow("flatbuffer_direct SavedModel export")
             _set_export_progress_desc("write saved_model")
             if split_manifest_path is not None:
+                from onnx2tf.tflite_builder.split_saved_model_exporter import (
+                    export_split_saved_models,
+                )
+
                 split_saved_model_outputs = export_split_saved_models(
                     model_ir=model_ir,
                     split_manifest_path=split_manifest_path,
@@ -838,9 +853,10 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                     model_ir=model_ir_fp32,
                     output_folder_path=saved_model_output_folder_path,
                 )
-            _advance_export_progress()
+        _advance_export_progress()
 
         if output_pytorch_from_model_ir:
+            require_torch(required_pytorch_feature or "flatbuffer_direct PyTorch package export")
             _set_export_progress_desc("write pytorch")
             if split_manifest_path is not None:
                 from onnx2tf.tflite_builder.split_pytorch_exporter import (
@@ -888,6 +904,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                     if fallback_saved_model_path is not None and str(fallback_saved_model_path).strip() != "":
                         return str(fallback_saved_model_path)
                     try:
+                        require_tensorflow("flatbuffer_direct PyTorch SavedModel bridge")
                         from onnx2tf.tflite_builder.saved_model_exporter import (
                             export_saved_model_from_model_ir,
                         )

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -10,7 +10,7 @@ import numpy as np
 import onnx
 from onnx import numpy_helper
 
-from onnx2tf.utils.common_functions import check_model_has_external_data
+from onnx2tf.utils.onnx_litert_runtime import check_model_has_external_data
 from onnx2tf.tflite_builder.dispatcher import dispatch_node
 from onnx2tf.tflite_builder.op_registry import (
     NodeValidationError,

--- a/onnx2tf/tflite_builder/pytorch_accuracy_evaluator.py
+++ b/onnx2tf/tflite_builder/pytorch_accuracy_evaluator.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import onnx
-import torch
 
 from onnx2tf.tflite_builder.accuracy_evaluator import (
     _FLOAT_METRIC_THRESHOLDS,
@@ -31,6 +30,21 @@ from onnx2tf.tflite_builder.accuracy_evaluator import (
     _resize_tflite_inputs_if_needed,
     _resolve_metric_thresholds,
 )
+from onnx2tf.utils.torch_optional import require_torch
+
+
+class _TorchModuleProxy:
+    def __init__(self, feature: str) -> None:
+        self._feature = str(feature)
+
+    def _load(self) -> Any:
+        return require_torch(self._feature).torch
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
+
+
+torch = _TorchModuleProxy("PyTorch evaluator")
 
 
 def _import_generated_package(package_path: str) -> Any:
@@ -355,6 +369,7 @@ def evaluate_pytorch_package_outputs(
     custom_input_op_name_np_data_path: Optional[List[Any]] = None,
 ) -> Dict[str, Any]:
     import onnxruntime as ort
+    require_torch("ONNX/PyTorch validation")
 
     if int(num_samples) <= 0:
         raise ValueError(f"num_samples must be > 0. got: {num_samples}")
@@ -627,6 +642,7 @@ def evaluate_tflite_pytorch_package_outputs(
     atol: float = 1.0e-4,
     metric_thresholds: Optional[Dict[str, float]] = None,
 ) -> Dict[str, Any]:
+    require_torch("TFLite/PyTorch validation")
     if int(num_samples) <= 0:
         raise ValueError(f"num_samples must be > 0. got: {num_samples}")
     if not os.path.exists(tflite_path):
@@ -876,6 +892,7 @@ def smoke_test_pytorch_package_inference(
     num_samples: int = 1,
     seed: int = 0,
 ) -> Dict[str, Any]:
+    require_torch("PyTorch package inference smoke test")
     if int(num_samples) <= 0:
         raise ValueError(f"num_samples must be > 0. got: {num_samples}")
     if not os.path.exists(package_dir):

--- a/onnx2tf/tflite_builder/pytorch_package_runtime.py
+++ b/onnx2tf/tflite_builder/pytorch_package_runtime.py
@@ -7,8 +7,6 @@ import re
 from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
 import numpy as np
-import torch
-import torch.nn.functional as F
 
 from onnx2tf.tflite_builder.accuracy_evaluator import (
     _adapt_input_layout_for_tflite_input,
@@ -19,18 +17,52 @@ from onnx2tf.tflite_builder.accuracy_evaluator import (
     _quantize_for_tflite_input,
     _resize_tflite_inputs_if_needed,
 )
+from onnx2tf.utils.torch_optional import require_torch
 
 
-_TORCH_DTYPE_BY_TFLITE_DTYPE: Dict[str, torch.dtype] = {
-    "BOOL": torch.bool,
-    "INT8": torch.int8,
-    "INT16": torch.int16,
-    "INT32": torch.int32,
-    "INT64": torch.int64,
-    "UINT8": torch.uint8,
-    "FLOAT16": torch.float16,
-    "FLOAT32": torch.float32,
-    "FLOAT64": torch.float64,
+class _TorchModuleProxy:
+    def __init__(self, feature: str) -> None:
+        self._feature = str(feature)
+
+    def _load(self) -> Any:
+        return require_torch(self._feature).torch
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
+
+
+class _TorchFunctionalProxy:
+    def __init__(self, feature: str) -> None:
+        self._feature = str(feature)
+
+    def _load(self) -> Any:
+        return require_torch(self._feature).torch.nn.functional
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._load(), name)
+
+
+class _EvalModeMixin:
+    def eval(self):
+        return self
+
+    def train(self, mode: bool = True):
+        return self
+
+
+torch = _TorchModuleProxy("PyTorch package runtime")
+F = _TorchFunctionalProxy("PyTorch package runtime")
+
+_TORCH_DTYPE_BY_TFLITE_DTYPE: Dict[str, str] = {
+    "BOOL": "bool",
+    "INT8": "int8",
+    "INT16": "int16",
+    "INT32": "int32",
+    "INT64": "int64",
+    "UINT8": "uint8",
+    "FLOAT16": "float16",
+    "FLOAT32": "float32",
+    "FLOAT64": "float64",
 }
 
 
@@ -38,7 +70,7 @@ def _torch_dtype(dtype_name: str) -> torch.dtype:
     key = str(dtype_name).upper()
     if key not in _TORCH_DTYPE_BY_TFLITE_DTYPE:
         raise RuntimeError(f"Unsupported dtype for PyTorch runtime: {dtype_name}")
-    return _TORCH_DTYPE_BY_TFLITE_DTYPE[key]
+    return getattr(torch, _TORCH_DTYPE_BY_TFLITE_DTYPE[key])
 
 
 def _module_device(module: Any) -> torch.device:
@@ -1831,63 +1863,173 @@ def _register_supported_kernels() -> Dict[str, Callable[[_GraphExecutor, Dict[st
 
 
 SUPPORTED_TORCH_KERNEL_OP_TYPES = {
-    op_type for op_type in _register_supported_kernels().keys() if str(op_type) != "CUSTOM"
+    "ABS",
+    "ADD",
+    "ARG_MAX",
+    "ARG_MIN",
+    "ATAN",
+    "ATAN2",
+    "AVERAGE_POOL_2D",
+    "BATCH_MATMUL",
+    "BROADCAST_TO",
+    "CAST",
+    "CEIL",
+    "CONCATENATION",
+    "CONV_2D",
+    "CONV_3D",
+    "CONV_3D_TRANSPOSE",
+    "COS",
+    "CUMSUM",
+    "DEPTHWISE_CONV_2D",
+    "DEPTH_TO_SPACE",
+    "DIV",
+    "ELU",
+    "EQUAL",
+    "EXP",
+    "EXPAND_DIMS",
+    "FILL",
+    "FLOOR",
+    "FLOOR_MOD",
+    "GATHER",
+    "GATHER_ND",
+    "GELU",
+    "GREATER",
+    "GREATER_EQUAL",
+    "IDENTITY",
+    "L2_NORMALIZATION",
+    "LEAKY_RELU",
+    "LESS",
+    "LESS_EQUAL",
+    "LOG",
+    "LOGICAL_AND",
+    "LOGICAL_NOT",
+    "LOGICAL_OR",
+    "LOGISTIC",
+    "MAXIMUM",
+    "MAX_POOL_2D",
+    "MEAN",
+    "MINIMUM",
+    "MIRROR_PAD",
+    "MUL",
+    "NEG",
+    "NON_MAX_SUPPRESSION_V4",
+    "NOT_EQUAL",
+    "ONE_HOT",
+    "PACK",
+    "PAD",
+    "PADV2",
+    "POW",
+    "PRELU",
+    "RANGE",
+    "REDUCE_ANY",
+    "REDUCE_MAX",
+    "REDUCE_MIN",
+    "REDUCE_PROD",
+    "RELU",
+    "RELU6",
+    "RELU_0_TO_1",
+    "RELU_N1_TO_1",
+    "RESHAPE",
+    "RESIZE_BILINEAR",
+    "RESIZE_NEAREST_NEIGHBOR",
+    "REVERSE_V2",
+    "RIGHT_SHIFT",
+    "SCATTER_ND",
+    "SELECT",
+    "SELECT_V2",
+    "SHAPE",
+    "SIGN",
+    "SIN",
+    "SLICE",
+    "SOFTMAX",
+    "SPACE_TO_DEPTH",
+    "SPLIT",
+    "SQRT",
+    "SQUEEZE",
+    "STRIDED_SLICE",
+    "SUB",
+    "SUM",
+    "TANH",
+    "TILE",
+    "TOPK_V2",
+    "TRANSPOSE",
+    "TRANSPOSE_CONV",
+    "UNPACK",
+    "WHERE",
 }
 
 
-class _GeneratedModel(torch.nn.Module):
-    def __init__(self, *, metadata: Dict[str, Any]) -> None:
-        super().__init__()
-        self._metadata = metadata
-        self.input_names = list(metadata.get("inputs", []))
-        self.output_names = list(metadata.get("outputs", []))
-        self.tensor_storage_names = _tensor_storage_name_map_from_metadata(metadata)
-        self._executor = _GraphExecutor(model=self, metadata=metadata)
-        for tensor_name, tensor_meta in sorted(metadata.get("tensors", {}).items()):
-            if not bool(tensor_meta.get("has_data", False)):
-                continue
-            dtype = _torch_dtype(str(tensor_meta["dtype"]))
-            shape = [int(v) for v in list(tensor_meta.get("shape", []))]
-            if len(shape) == 0:
-                shape = []
-            value = torch.zeros(shape, dtype=dtype)
-            storage_name = self.tensor_storage_names.get(
-                str(tensor_name),
-                _default_tensor_storage_name(str(tensor_name)),
-            )
-            if bool(tensor_meta.get("is_variable", False)):
-                self.register_parameter(storage_name, torch.nn.Parameter(value, requires_grad=False))
-            else:
-                self.register_buffer(storage_name, value, persistent=True)
+_NATIVE_GENERATED_MODEL_CLS: Optional[type] = None
 
-    def forward(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> Any:
-        if len(args) > 0 and len(kwargs) > 0:
-            raise RuntimeError("Use either positional inputs or keyword inputs, not both.")
-        if len(kwargs) > 0:
-            inputs = {
-                str(name): _resolve_named_input_value(kwargs, str(name))
-                for name in self.input_names
-            }
-        else:
-            if len(args) != len(self.input_names):
-                raise RuntimeError(
-                    f"Input arity mismatch. expected={len(self.input_names)} actual={len(args)}"
+
+def _get_generated_model_cls():
+    global _NATIVE_GENERATED_MODEL_CLS
+    if _NATIVE_GENERATED_MODEL_CLS is not None:
+        return _NATIVE_GENERATED_MODEL_CLS
+
+    require_torch("PyTorch package runtime")
+
+    class _GeneratedModel(torch.nn.Module):
+        def __init__(self, *, metadata: Dict[str, Any]) -> None:
+            super().__init__()
+            self._metadata = metadata
+            self.input_names = list(metadata.get("inputs", []))
+            self.output_names = list(metadata.get("outputs", []))
+            self.tensor_storage_names = _tensor_storage_name_map_from_metadata(metadata)
+            self._executor = _GraphExecutor(model=self, metadata=metadata)
+            for tensor_name, tensor_meta in sorted(metadata.get("tensors", {}).items()):
+                if not bool(tensor_meta.get("has_data", False)):
+                    continue
+                dtype = _torch_dtype(str(tensor_meta["dtype"]))
+                shape = [int(v) for v in list(tensor_meta.get("shape", []))]
+                if len(shape) == 0:
+                    shape = []
+                value = torch.zeros(shape, dtype=dtype)
+                storage_name = self.tensor_storage_names.get(
+                    str(tensor_name),
+                    _default_tensor_storage_name(str(tensor_name)),
                 )
-            inputs = {str(name): value for name, value in zip(self.input_names, args)}
-        env = self._executor.run(inputs)
-        outputs = [self._executor._resolve_tensor(str(name), env) for name in self.output_names]
-        if len(outputs) == 1:
-            return outputs[0]
-        return tuple(outputs)
+                if bool(tensor_meta.get("is_variable", False)):
+                    self.register_parameter(storage_name, torch.nn.Parameter(value, requires_grad=False))
+                else:
+                    self.register_buffer(storage_name, value, persistent=True)
 
-    def forward_named(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> Dict[str, torch.Tensor]:
-        result = self.forward(*args, **kwargs)
-        if len(self.output_names) == 1:
-            return {str(self.output_names[0]): result}
-        return {str(name): value for name, value in zip(self.output_names, result)}
+        def forward(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> Any:
+            if len(args) > 0 and len(kwargs) > 0:
+                raise RuntimeError("Use either positional inputs or keyword inputs, not both.")
+            if len(kwargs) > 0:
+                inputs = {
+                    str(name): _resolve_named_input_value(kwargs, str(name))
+                    for name in self.input_names
+                }
+            else:
+                if len(args) != len(self.input_names):
+                    raise RuntimeError(
+                        f"Input arity mismatch. expected={len(self.input_names)} actual={len(args)}"
+                    )
+                inputs = {str(name): value for name, value in zip(self.input_names, args)}
+            env = self._executor.run(inputs)
+            outputs = [self._executor._resolve_tensor(str(name), env) for name in self.output_names]
+            if len(outputs) == 1:
+                return outputs[0]
+            return tuple(outputs)
+
+        def forward_named(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> Dict[str, torch.Tensor]:
+            result = self.forward(*args, **kwargs)
+            if len(self.output_names) == 1:
+                return {str(self.output_names[0]): result}
+            return {str(name): value for name, value in zip(self.output_names, result)}
+
+    _NATIVE_GENERATED_MODEL_CLS = _GeneratedModel
+    return _NATIVE_GENERATED_MODEL_CLS
 
 
-GeneratedModelBase = _GeneratedModel
+class _GeneratedModelBaseProxy:
+    def __mro_entries__(self, bases: tuple[Any, ...]) -> tuple[type, ...]:
+        return (_get_generated_model_cls(),)
+
+
+GeneratedModelBase = _GeneratedModelBaseProxy()
 
 
 def prepare_generated_model_metadata(
@@ -1942,7 +2084,7 @@ def load_generated_model_weights(
     return model
 
 
-class _TFLiteBackedGeneratedModel(torch.nn.Module):
+class _TFLiteBackedGeneratedModel(_EvalModeMixin):
     def __init__(
         self,
         *,
@@ -2132,7 +2274,7 @@ class _TFLiteBackedGeneratedModel(torch.nn.Module):
         return {str(name): value for name, value in zip(self.output_names, result)}
 
 
-class _StringNormalizerGeneratedModel(torch.nn.Module):
+class _StringNormalizerGeneratedModel(_EvalModeMixin):
     def __init__(self, *, metadata: Dict[str, Any]) -> None:
         super().__init__()
         self._metadata = metadata
@@ -2191,7 +2333,7 @@ class _StringNormalizerGeneratedModel(torch.nn.Module):
         return {str(self.output_names[0]): self.forward(*args, **kwargs)}
 
 
-class _SavedModelBackedGeneratedModel(torch.nn.Module):
+class _SavedModelBackedGeneratedModel(_EvalModeMixin):
     def __init__(
         self,
         *,
@@ -2356,6 +2498,7 @@ def load_generated_model_package(
     device: Optional[str] = None,
     eval_mode: bool = True,
 ) -> torch.nn.Module:
+    require_torch("PyTorch package runtime")
     metadata_path = os.path.join(package_dir, "metadata.json")
     state_dict_path = os.path.join(package_dir, "state_dict.pth")
     with open(metadata_path, "r", encoding="utf-8") as f:

--- a/onnx2tf/tflite_builder/schema_loader.py
+++ b/onnx2tf/tflite_builder/schema_loader.py
@@ -4,7 +4,7 @@ import os
 from functools import lru_cache
 from typing import Dict, Any
 
-from onnx2tf.utils.common_functions import ensure_tflite_schema_artifacts
+from onnx2tf.utils.onnx_litert_runtime import ensure_tflite_schema_artifacts
 
 
 @lru_cache(maxsize=16)

--- a/onnx2tf/utils/flatbuffer_direct_op_error_report.py
+++ b/onnx2tf/utils/flatbuffer_direct_op_error_report.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Protocol, Tuple
 import numpy as np
 import onnx
 
-from onnx2tf import gs
+import onnx2tf.gs as gs
 from onnx2tf.tflite_builder.accuracy_evaluator import (
     _MetricAccumulator,
     _adapt_input_layout_for_tflite_input,
@@ -31,7 +31,7 @@ from onnx2tf.tflite_builder.accuracy_evaluator import (
     _resize_tflite_inputs_if_needed,
 )
 from onnx2tf.utils.tempdir_cleanup import make_managed_tempdir
-from onnx2tf.utils.common_functions import dummy_onnx_inference
+from onnx2tf.utils.onnx_litert_runtime import dummy_onnx_inference
 
 
 class _LiteInterpreterProtocol(Protocol):

--- a/onnx2tf/utils/onnx_litert_runtime.py
+++ b/onnx2tf/utils/onnx_litert_runtime.py
@@ -1,0 +1,826 @@
+from __future__ import annotations
+
+import ast
+import os
+import re
+import subprocess
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import onnx
+import psutil
+from ai_edge_litert.interpreter import Interpreter
+from onnx.external_data_helper import uses_external_data
+from onnx.serialization import ProtoSerializer
+
+import onnx2tf.gs as gs
+from onnx2tf.utils.logging import info
+from onnx2tf.utils.tempdir_cleanup import make_managed_tempdir
+
+try:
+    import cv2
+except Exception:
+    cv2 = None
+
+try:
+    import onnxruntime as ort
+except Exception:
+    ort = None
+
+
+_DEFAULT_DUMMY_SHAPE_HINTS: Optional[List[str]] = None
+_DEFAULT_DUMMY_VALUE_HINTS: Optional[List[str]] = None
+_DEFAULT_TFLITE_SCHEMA_REPOSITORY: str = "google-ai-edge/LiteRT"
+_DEFAULT_TFLITE_SCHEMA_TAG: str = "v2.1.2"
+_DEFAULT_TFLITE_SCHEMA_RELATIVE_PATH: str = "tflite/converter/schema/schema.fbs"
+_BUNDLED_SCHEMA_DIR: str = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "tflite_builder",
+    "schema",
+)
+_BUNDLED_SCHEMA_FBS_PATH: str = os.path.join(_BUNDLED_SCHEMA_DIR, "schema.fbs")
+_BUNDLED_SCHEMA_PY_PATH: str = os.path.join(_BUNDLED_SCHEMA_DIR, "schema_generated.py")
+
+
+def set_dummy_shape_hints(shape_hints: Optional[List[str]]) -> None:
+    global _DEFAULT_DUMMY_SHAPE_HINTS
+    _DEFAULT_DUMMY_SHAPE_HINTS = shape_hints
+
+
+def set_dummy_value_hints(value_hints: Optional[List[str]]) -> None:
+    global _DEFAULT_DUMMY_VALUE_HINTS
+    _DEFAULT_DUMMY_VALUE_HINTS = value_hints
+
+
+def get_tflite_schema_fbs_url() -> str:
+    repository = os.environ.get(
+        "ONNX2TF_TFLITE_SCHEMA_REPOSITORY",
+        _DEFAULT_TFLITE_SCHEMA_REPOSITORY,
+    ).strip().strip("/")
+    schema_tag = os.environ.get(
+        "ONNX2TF_TFLITE_SCHEMA_TAG",
+        _DEFAULT_TFLITE_SCHEMA_TAG,
+    ).strip()
+    schema_relative_path = os.environ.get(
+        "ONNX2TF_TFLITE_SCHEMA_RELATIVE_PATH",
+        _DEFAULT_TFLITE_SCHEMA_RELATIVE_PATH,
+    ).strip().lstrip("/")
+    if repository == "":
+        repository = _DEFAULT_TFLITE_SCHEMA_REPOSITORY
+    if schema_tag == "":
+        schema_tag = _DEFAULT_TFLITE_SCHEMA_TAG
+    if schema_relative_path == "":
+        schema_relative_path = _DEFAULT_TFLITE_SCHEMA_RELATIVE_PATH
+    return f"https://raw.githubusercontent.com/{repository}/{schema_tag}/{schema_relative_path}"
+
+
+def _get_default_tflite_schema_fbs_url() -> str:
+    return (
+        f"https://raw.githubusercontent.com/"
+        f"{_DEFAULT_TFLITE_SCHEMA_REPOSITORY}/"
+        f"{_DEFAULT_TFLITE_SCHEMA_TAG}/"
+        f"{_DEFAULT_TFLITE_SCHEMA_RELATIVE_PATH}"
+    )
+
+
+def _is_default_tflite_schema_source() -> bool:
+    return get_tflite_schema_fbs_url() == _get_default_tflite_schema_fbs_url()
+
+
+def _copy_schema_artifact_if_needed(
+    *,
+    src_path: str,
+    dst_path: str,
+    force_copy: bool = False,
+) -> bool:
+    if not os.path.isfile(src_path) or os.path.getsize(src_path) <= 0:
+        return False
+    if force_copy or not os.path.isfile(dst_path) or os.path.getsize(dst_path) <= 0:
+        import shutil
+
+        shutil.copyfile(src_path, dst_path)
+        return True
+    return True
+
+
+def ensure_tflite_schema_artifacts(
+    *,
+    output_folder_path: str,
+    force_regenerate_schema_py: bool = False,
+) -> Tuple[str, str]:
+    os.makedirs(output_folder_path, exist_ok=True)
+
+    schema_fbs_path = os.path.join(output_folder_path, "schema.fbs")
+    schema_py_path = os.path.join(output_folder_path, "schema_generated.py")
+    default_schema_source = _is_default_tflite_schema_source()
+    bundled_schema_available = (
+        os.path.isfile(_BUNDLED_SCHEMA_PY_PATH)
+        and os.path.getsize(_BUNDLED_SCHEMA_PY_PATH) > 0
+        and os.path.isfile(_BUNDLED_SCHEMA_FBS_PATH)
+        and os.path.getsize(_BUNDLED_SCHEMA_FBS_PATH) > 0
+    )
+    if not bundled_schema_available:
+        raise RuntimeError(
+            "Bundled TFLite schema artifacts are missing. "
+            f"expected={_BUNDLED_SCHEMA_DIR}"
+        )
+
+    if not default_schema_source:
+        print(
+            "WARNING: ONNX2TF_TFLITE_SCHEMA_TAG/REPOSITORY/RELATIVE_PATH are set, "
+            "but schema override is no longer used. Falling back to bundled schema artifacts.",
+            flush=True,
+        )
+
+    _copy_schema_artifact_if_needed(
+        src_path=_BUNDLED_SCHEMA_PY_PATH,
+        dst_path=schema_py_path,
+        force_copy=force_regenerate_schema_py,
+    )
+    _copy_schema_artifact_if_needed(
+        src_path=_BUNDLED_SCHEMA_FBS_PATH,
+        dst_path=schema_fbs_path,
+        force_copy=False,
+    )
+    return schema_fbs_path, schema_py_path
+
+
+def _parse_value_hint_scalar(value: str) -> Optional[Any]:
+    try:
+        parsed = ast.literal_eval(value)
+    except Exception:
+        try:
+            parsed = float(value)
+        except Exception:
+            return None
+    if isinstance(parsed, (list, tuple, dict, set, np.ndarray)):
+        return None
+    if isinstance(parsed, (int, float, bool, np.number)):
+        return parsed
+    return None
+
+
+def _parse_value_hints(
+    value_hints: Optional[List[str]]
+) -> Tuple[Dict[str, Any], Optional[Any], bool]:
+    if not value_hints:
+        return {}, None, False
+    hints: Dict[str, Any] = {}
+    default_value: Optional[Any] = None
+    for hint in value_hints:
+        if not isinstance(hint, str):
+            continue
+        parts = hint.split(":", 1)
+        if len(parts) != 2:
+            continue
+        key = parts[0].strip()
+        parsed = _parse_value_hint_scalar(parts[1].strip())
+        if parsed is None:
+            continue
+        if key == "*":
+            default_value = parsed
+        elif key != "":
+            hints[key] = parsed
+    return hints, default_value, default_value is not None
+
+
+def _make_safe_ort_memmap_filename(
+    *,
+    output_index: int,
+    output_name: str,
+) -> str:
+    safe_name = re.sub(r"[^0-9A-Za-z._-]+", "_", str(output_name))
+    safe_name = re.sub(r"_+", "_", safe_name).strip("._")
+    if safe_name == "":
+        safe_name = "output"
+    max_stem_len = 220
+    stem = f"ort_output_{int(output_index)}_{safe_name}"
+    if len(stem) > max_stem_len:
+        stem = stem[:max_stem_len].rstrip("._")
+    return f"{stem}.npy"
+
+
+def check_cuda_enabled() -> bool:
+    try:
+        output = subprocess.check_output("nvidia-smi", shell=True)
+        return "nvidia-smi" in output.decode().lower()
+    except Exception:
+        return False
+
+
+def check_model_has_external_data(model: onnx.ModelProto) -> bool:
+    def iter_tensors_in_graph(g):
+        for t in g.initializer:
+            yield t
+        for t in g.sparse_initializer:
+            yield t
+        for n in g.node:
+            for a in n.attribute:
+                if a.type == onnx.AttributeProto.TENSOR:
+                    yield a.t
+                elif a.type == onnx.AttributeProto.TENSORS:
+                    for t in a.tensors:
+                        yield t
+                elif a.type == onnx.AttributeProto.GRAPH:
+                    yield from iter_tensors_in_graph(a.g)
+                elif a.type == onnx.AttributeProto.GRAPHS:
+                    for sg in a.graphs:
+                        yield from iter_tensors_in_graph(sg)
+
+    return any(
+        isinstance(t, onnx.TensorProto) and uses_external_data(t)
+        for t in iter_tensors_in_graph(model.graph)
+    )
+
+
+def check_has_external_data(input_onnx_file_path: str) -> bool:
+    model = onnx.load(input_onnx_file_path, load_external_data=False)
+    return check_model_has_external_data(model)
+
+
+def _resize_test_data_to_nchw(
+    *,
+    test_data_nhwc: np.ndarray,
+    input_shape: tuple[int, ...],
+    np_input_dtype: np.dtype,
+) -> np.ndarray:
+    if len(input_shape) != 4:
+        raise ValueError(
+            "test_data_nhwc-backed dummy inference currently supports rank-4 inputs only. "
+            f"shape={input_shape}"
+        )
+    if cv2 is None:
+        raise ImportError(
+            "opencv-python is required for test_data_nhwc-backed dummy inference without TensorFlow."
+        )
+
+    resized = [
+        cv2.resize(
+            np.asarray(image),
+            dsize=(int(input_shape[3]), int(input_shape[2])),
+            interpolation=cv2.INTER_LINEAR,
+        )
+        for image in np.asarray(test_data_nhwc)
+    ]
+    resized_nhwc = np.asarray(resized, dtype=np.float32)
+    return np.transpose(resized_nhwc, (0, 3, 1, 2)).astype(np_input_dtype)
+
+
+def dummy_onnx_inference(
+    *,
+    onnx_graph: onnx.ModelProto,
+    output_names: List[str],
+    test_data_nhwc: Optional[np.ndarray] = None,
+    custom_input_op_name_np_data_path: Optional[Any] = None,
+    tf_layers_dict: Optional[Dict] = None,
+    use_cuda: bool = False,
+    disable_strict_mode: bool = False,
+    enable_ort_output_memmap: bool = False,
+    ort_output_memmap_dir: Optional[str] = None,
+    ort_output_memmap_paths_for_cleanup: Optional[List[str]] = None,
+    ort_disable_graph_optimization: bool = False,
+    shape_hints: Optional[List[str]] = None,
+    value_hints: Optional[List[str]] = None,
+    input_datas_for_validation: Optional[Dict[str, np.ndarray]] = None,
+) -> List[np.ndarray]:
+    if shape_hints is None:
+        shape_hints = _DEFAULT_DUMMY_SHAPE_HINTS
+    if value_hints is None:
+        value_hints = _DEFAULT_DUMMY_VALUE_HINTS
+    if ort is None:
+        raise ImportError("onnxruntime is required for dummy_onnx_inference.")
+
+    domain: str = onnx_graph.domain
+    ir_version: int = onnx_graph.ir_version
+    meta_data = {"domain": domain, "ir_version": ir_version}
+    metadata_props = None
+    if hasattr(onnx_graph, "metadata_props"):
+        metadata_props = onnx_graph.metadata_props
+    gs_graph = gs.import_onnx(onnx_graph)
+
+    for node in gs_graph.nodes:
+        input_shape = node.inputs[0].shape if len(node.inputs) > 0 else None
+        input_rank = len(input_shape) if input_shape is not None else 0
+        default_axes = [axis for axis in range(1, input_rank)] if input_rank > 1 else [0]
+        if (
+            gs_graph.opset <= 17
+            and node.op in ["ReduceMax", "ReduceMean", "ReduceMin", "ReduceProd"]
+            and "axes" not in node.attrs
+        ):
+            node.attrs["axes"] = default_axes
+        elif (
+            gs_graph.opset > 17
+            and node.op in ["ReduceMax", "ReduceMean", "ReduceMin", "ReduceProd"]
+            and len(node.inputs) == 1
+        ):
+            node.inputs.append(
+                gs.Constant(
+                    f"{node.name}_axes",
+                    values=np.asarray(default_axes, dtype=np.int64),
+                )
+            )
+        elif gs_graph.opset <= 12 and node.op in ["ReduceSum"] and "axes" not in node.attrs:
+            node.attrs["axes"] = default_axes
+        elif gs_graph.opset > 12 and node.op in ["ReduceSum"] and len(node.inputs) == 1:
+            node.inputs.append(
+                gs.Constant(
+                    f"{node.name}_axes",
+                    values=np.asarray(default_axes, dtype=np.int64),
+                )
+            )
+
+    inferred_output_dtype_by_name: Dict[str, Any] = {}
+    producer_op_type_by_output_name: Dict[str, str] = {}
+    initializer_dtype_by_name: Dict[str, Any] = {}
+    value_info_dtype_by_name: Dict[str, Any] = {}
+    for initializer in onnx_graph.graph.initializer:
+        try:
+            initializer_dtype_by_name[initializer.name] = np.asarray(
+                onnx.numpy_helper.to_array(initializer)
+            ).dtype
+        except Exception:
+            continue
+    for value_info in (
+        list(onnx_graph.graph.value_info)
+        + list(onnx_graph.graph.output)
+        + list(onnx_graph.graph.input)
+    ):
+        try:
+            tensor_type = value_info.type.tensor_type
+            if int(tensor_type.elem_type) != 0:
+                value_info_dtype_by_name[value_info.name] = onnx.helper.tensor_dtype_to_np_dtype(
+                    int(tensor_type.elem_type)
+                )
+        except Exception:
+            continue
+
+    def _resolve_dtype_from_tensor_name(tensor_name: str) -> Optional[Any]:
+        if tensor_name in initializer_dtype_by_name:
+            return initializer_dtype_by_name[tensor_name]
+        if tensor_name in value_info_dtype_by_name:
+            return value_info_dtype_by_name[tensor_name]
+        return None
+
+    def _resolve_qlinear_output_zero_point_input_index(
+        node_op_type: str,
+        input_count: int,
+    ) -> Optional[int]:
+        if node_op_type == "QuantizeLinear":
+            return 2 if input_count >= 3 else None
+        if node_op_type == "QLinearConcat":
+            return 1 if input_count >= 2 else None
+        if node_op_type in {"QLinearConv", "QLinearMatMul", "QLinearAdd", "QLinearMul"}:
+            return 7 if input_count >= 8 else None
+        if node_op_type == "QGemm":
+            return 8 if input_count >= 9 else None
+        if node_op_type in {
+            "QLinearLeakyRelu",
+            "QLinearSigmoid",
+            "QLinearSoftmax",
+            "QLinearAveragePool",
+            "QLinearGlobalAveragePool",
+        }:
+            return 4 if input_count >= 5 else None
+        if node_op_type.startswith("QLinear") and input_count >= 1:
+            return input_count - 1
+        return None
+
+    for node in onnx_graph.graph.node:
+        node_op_type = str(node.op_type)
+        zp_index = _resolve_qlinear_output_zero_point_input_index(
+            node_op_type=node_op_type,
+            input_count=len(node.input),
+        )
+        zero_point_dtype = None
+        if zp_index is not None:
+            zero_point_dtype = _resolve_dtype_from_tensor_name(str(node.input[zp_index]))
+        for node_output_name in node.output:
+            if not node_output_name:
+                continue
+            producer_op_type_by_output_name[node_output_name] = node_op_type
+            if zero_point_dtype is not None:
+                inferred_output_dtype_by_name[node_output_name] = zero_point_dtype
+            elif node_output_name in value_info_dtype_by_name:
+                inferred_output_dtype_by_name[node_output_name] = value_info_dtype_by_name[
+                    node_output_name
+                ]
+
+    passthrough_ops = {
+        "Transpose",
+        "Reshape",
+        "Split",
+        "Resize",
+        "Identity",
+        "Squeeze",
+        "Unsqueeze",
+        "Flatten",
+        "Slice",
+        "Pad",
+    }
+    known_dtype_by_tensor: Dict[str, Any] = {}
+    known_dtype_by_tensor.update(initializer_dtype_by_name)
+    known_dtype_by_tensor.update(value_info_dtype_by_name)
+    known_dtype_by_tensor.update(inferred_output_dtype_by_name)
+    changed = True
+    while changed:
+        changed = False
+        for node in onnx_graph.graph.node:
+            node_op_type = str(node.op_type)
+            if node_op_type not in passthrough_ops or len(node.input) == 0:
+                continue
+            src_dtype = known_dtype_by_tensor.get(str(node.input[0]), None)
+            if src_dtype is None:
+                continue
+            for node_output_name in node.output:
+                if not node_output_name:
+                    continue
+                if known_dtype_by_tensor.get(node_output_name, None) is None:
+                    known_dtype_by_tensor[node_output_name] = src_dtype
+                    changed = True
+    for tensor_name, tensor_dtype in known_dtype_by_tensor.items():
+        if tensor_name not in inferred_output_dtype_by_name:
+            inferred_output_dtype_by_name[tensor_name] = tensor_dtype
+
+    gs_graph.outputs = []
+    for graph_node in gs_graph.nodes:
+        for node_output in graph_node.outputs:
+            if node_output.name in output_names:
+                if node_output.dtype is None:
+                    inferred_dtype = inferred_output_dtype_by_name.get(node_output.name, None)
+                    if inferred_dtype is None:
+                        producer_op_type = producer_op_type_by_output_name.get(node_output.name, "")
+                        if producer_op_type == "DequantizeLinear":
+                            inferred_dtype = np.float32
+                        elif (
+                            producer_op_type == "QuantizeLinear"
+                            or producer_op_type.startswith("QLinear")
+                            or producer_op_type == "QGemm"
+                        ):
+                            inferred_dtype = np.int8
+                        else:
+                            inferred_dtype = np.float32
+                    node_output.dtype = inferred_dtype
+                gs_graph.outputs.append(node_output)
+
+    new_onnx_graph = gs.export_onnx(graph=gs_graph, do_type_check=False, **meta_data)
+    if metadata_props is not None:
+        new_onnx_graph.metadata_props.extend(metadata_props)
+    ms_domain_rewrite_targets = {
+        "FusedConv",
+        "FusedMatMul",
+        "Gelu",
+        "GroupNorm",
+        "Inverse",
+        "MultiHeadAttention",
+        "QGemm",
+        "QLinearAdd",
+        "QLinearAveragePool",
+        "QLinearConcat",
+        "QLinearGlobalAveragePool",
+        "QLinearLeakyRelu",
+        "QLinearMul",
+        "QLinearSoftmax",
+        "QLinearSigmoid",
+    }
+    rewritten_ms_domains = False
+    for node in new_onnx_graph.graph.node:
+        if node.op_type in ms_domain_rewrite_targets and node.domain in ["", "ai.onnx"]:
+            node.domain = "com.microsoft"
+            rewritten_ms_domains = True
+    if rewritten_ms_domains and not any(
+        opset.domain == "com.microsoft" for opset in new_onnx_graph.opset_import
+    ):
+        new_onnx_graph.opset_import.append(onnx.helper.make_operatorsetid("com.microsoft", 1))
+
+    tmp_onnx_path = ""
+    tmp_onnx_external_weights_path = ""
+    try:
+        serializer: ProtoSerializer = onnx._get_serializer(fmt="protobuf")
+        serialized_graph = serializer.serialize_proto(proto=new_onnx_graph)
+    except ValueError:
+        tmp_onnx_path = "tmp.onnx"
+        tmp_onnx_external_weights_path = "tmp_external.weights"
+        onnx.save(
+            proto=new_onnx_graph,
+            f=tmp_onnx_path,
+            save_as_external_data=True,
+            location=tmp_onnx_external_weights_path,
+        )
+        serialized_graph = tmp_onnx_path
+
+    sess_options = ort.SessionOptions()
+    logical_cpu_count = psutil.cpu_count(logical=True) or 1
+    sess_options.intra_op_num_threads = max(1, logical_cpu_count - 1)
+    if bool(ort_disable_graph_optimization):
+        try:
+            sess_options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+        except Exception:
+            pass
+
+    if use_cuda and check_cuda_enabled():
+        try:
+            onnx_session = ort.InferenceSession(
+                path_or_bytes=serialized_graph,
+                sess_options=sess_options,
+                providers=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            )
+        except Exception:
+            onnx_session = ort.InferenceSession(
+                path_or_bytes=serialized_graph,
+                sess_options=sess_options,
+                providers=["CPUExecutionProvider"],
+            )
+    else:
+        onnx_session = ort.InferenceSession(
+            path_or_bytes=serialized_graph,
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"],
+        )
+
+    onnx_inputs = gs_graph.inputs
+    input_names: List[str] = [inp.name for inp in onnx_inputs]
+    input_sizes: List[List[Optional[Union[int, str]]]] = [
+        list(inp.shape) if inp.shape is not None else []
+        for inp in onnx_inputs
+    ]
+
+    if shape_hints is None:
+        first_input_batch_dim: Optional[int] = None
+        if len(input_sizes) > 0 and len(input_sizes[0]) > 0:
+            first_dim = input_sizes[0][0]
+            if isinstance(first_dim, int):
+                first_input_batch_dim = first_dim
+        new_input_sizes = []
+        for input_size in input_sizes:
+            new_input_size = []
+            for idx, dim in enumerate(input_size):
+                if (
+                    idx == 0
+                    and first_input_batch_dim is not None
+                    and len(input_sizes[0]) == len(input_size)
+                    and (dim is None or isinstance(dim, str))
+                ):
+                    new_input_size.append(first_input_batch_dim)
+                elif dim is None or isinstance(dim, str):
+                    new_input_size.append(1)
+                else:
+                    new_input_size.append(dim)
+            new_input_sizes.append(new_input_size)
+        input_sizes = new_input_sizes
+    else:
+        shape_hints_dict = {}
+        for hint in shape_hints:
+            parts = hint.split(":")
+            if len(parts) == 2:
+                shape_hints_dict[parts[0]] = [int(val) for val in parts[1].split(",")]
+        for i, (input_name, original_shape) in enumerate(zip(input_names, input_sizes)):
+            if input_name in shape_hints_dict:
+                updated_shape = shape_hints_dict[input_name]
+                for j, (orig_dim, hint_dim) in enumerate(zip(original_shape, updated_shape)):
+                    if orig_dim is not None and not isinstance(orig_dim, str):
+                        updated_shape[j] = orig_dim
+                    else:
+                        updated_shape[j] = hint_dim
+                input_sizes[i] = updated_shape
+
+    input_sizes = [
+        [int(dim) if not isinstance(dim, str) and dim is not None else 1 for dim in input_size]
+        for input_size in input_sizes
+    ]
+
+    input_dtypes: List[Any] = [inp.dtype for inp in onnx_inputs]
+    input_size_map = {name: tuple(size) for name, size in zip(input_names, input_sizes)}
+    input_datas: Dict[str, np.ndarray] = {}
+    value_hints_dict, default_value, has_default = _parse_value_hints(value_hints)
+
+    if custom_input_op_name_np_data_path:
+        for param in custom_input_op_name_np_data_path:
+            input_op_name = str(param[0])
+            numpy_file_path = str(param[1])
+            custom_input_data: np.ndarray = np.load(numpy_file_path)
+            input_op_info: Optional[Dict[str, Any]] = (
+                tf_layers_dict.get(input_op_name, None)
+                if isinstance(tf_layers_dict, dict)
+                else None
+            )
+            if input_op_info is not None:
+                ncw_nchw_ncdhw_perm: Optional[List[int]] = input_op_info.get(
+                    "ncw_nchw_ncdhw_perm",
+                    None,
+                )
+                if ncw_nchw_ncdhw_perm is not None:
+                    expected_shape = input_size_map.get(input_op_name, tuple(custom_input_data.shape))
+                    if tuple(custom_input_data.shape) != expected_shape:
+                        permuted_shape = tuple(
+                            custom_input_data.shape[i] for i in ncw_nchw_ncdhw_perm
+                        )
+                        if permuted_shape == expected_shape:
+                            custom_input_data = custom_input_data.transpose(ncw_nchw_ncdhw_perm)
+                onnx_batch_size = input_op_info["shape"][0]
+                cdata_batch_size = custom_input_data.shape[0]
+                if (
+                    isinstance(onnx_batch_size, int)
+                    and onnx_batch_size != cdata_batch_size
+                    and cdata_batch_size > 1
+                ):
+                    custom_input_data = custom_input_data[0:onnx_batch_size, ...]
+                elif isinstance(onnx_batch_size, str) and cdata_batch_size > 1:
+                    custom_input_data = custom_input_data[0:1, ...]
+
+            input_datas[input_op_name] = custom_input_data
+    else:
+        for input_name, input_size, input_dtype in zip(input_names, input_sizes, input_dtypes):
+            input_shape = tuple(dim if isinstance(dim, int) else 1 for dim in input_size)
+            np_input_dtype = np.dtype(input_dtype)
+            hint_value = value_hints_dict.get(
+                input_name,
+                default_value if has_default else None,
+            )
+            if hint_value is not None:
+                input_datas[input_name] = np.full(input_shape, hint_value, dtype=np_input_dtype)
+            elif test_data_nhwc is None:
+                if np.issubdtype(np_input_dtype, np.integer) or np.issubdtype(
+                    np_input_dtype,
+                    np.bool_,
+                ):
+                    input_datas[input_name] = np.zeros(input_shape, dtype=np_input_dtype)
+                else:
+                    input_datas[input_name] = np.ones(input_shape, dtype=np_input_dtype)
+            else:
+                input_datas[input_name] = _resize_test_data_to_nchw(
+                    test_data_nhwc=np.asarray(test_data_nhwc),
+                    input_shape=input_shape,
+                    np_input_dtype=np_input_dtype,
+                )
+
+    if input_datas_for_validation is not None:
+        input_datas_for_validation.update(input_datas)
+
+    dtype_sizes = {
+        np.dtype("float16"): 2,
+        np.dtype("float32"): 4,
+        np.dtype("float64"): 8,
+        np.dtype("uint8"): 1,
+        np.dtype("uint16"): 2,
+        np.dtype("uint32"): 4,
+        np.dtype("uint64"): 8,
+        np.dtype("int8"): 1,
+        np.dtype("int16"): 2,
+        np.dtype("int32"): 4,
+        np.dtype("int64"): 8,
+        np.dtype("bool_"): 1,
+    }
+    total_output_size = 0
+    for gs_graph_output in gs_graph.outputs:
+        op_output_size = 1
+        if gs_graph_output.shape is not None:
+            for s in gs_graph_output.shape:
+                if isinstance(s, (int, np.integer)):
+                    op_output_size *= s
+            total_output_size += op_output_size * dtype_sizes.get(gs_graph_output.dtype, 4)
+
+    mem_available = psutil.virtual_memory().available * 0.80 // 1024 // 1024 // 1024
+    total_output_size_gb = total_output_size // 1024 // 1024 // 1024
+    use_memmap_outputs = bool(enable_ort_output_memmap)
+    if (
+        not disable_strict_mode
+        and total_output_size_gb > mem_available
+        and not use_memmap_outputs
+    ):
+        if tmp_onnx_path:
+            os.remove(tmp_onnx_path)
+            os.remove(tmp_onnx_external_weights_path)
+        raise Exception(
+            "The tool skipped dummy inference to avoid SWAP processing because the total size "
+            f"of the tensor of inference results exceeded about {mem_available} GB. "
+            f"(results: {total_output_size_gb} GB)"
+        )
+
+    output_names_order = [out.name for out in gs_graph.outputs]
+    if use_memmap_outputs:
+        output_shapes: List[List[int]] = []
+        for out in gs_graph.outputs:
+            shape = out.shape
+            if shape is None:
+                if tmp_onnx_path:
+                    os.remove(tmp_onnx_path)
+                    os.remove(tmp_onnx_external_weights_path)
+                raise Exception(
+                    "onnxruntime output memmap requires static output shapes. "
+                    "Provide --shape_hints or reduce validation outputs."
+                )
+            normalized_shape: List[int] = []
+            for dim in shape:
+                if not isinstance(dim, (int, np.integer)):
+                    if tmp_onnx_path:
+                        os.remove(tmp_onnx_path)
+                        os.remove(tmp_onnx_external_weights_path)
+                    raise Exception(
+                        "onnxruntime output memmap requires static output shapes. "
+                        "Provide --shape_hints or reduce validation outputs."
+                    )
+                normalized_shape.append(int(dim))
+            output_shapes.append(normalized_shape)
+
+        memmap_dir = ort_output_memmap_dir
+        if memmap_dir is None:
+            memmap_dir = make_managed_tempdir(
+                prefix="onnx2tf_ort_mm_",
+                stale_prefixes=["onnx2tf_ort_mm_"],
+            )
+        os.makedirs(memmap_dir, exist_ok=True)
+
+        disk_free = psutil.disk_usage(memmap_dir).free
+        if total_output_size > disk_free:
+            if tmp_onnx_path:
+                os.remove(tmp_onnx_path)
+                os.remove(tmp_onnx_external_weights_path)
+            raise Exception(
+                "Not enough disk space for memmap outputs. "
+                f"Required: {total_output_size} bytes, Free: {disk_free} bytes."
+            )
+
+        info(
+            f"onnxruntime output memmap enabled. Outputs: {len(output_names_order)}, Path: {memmap_dir}"
+        )
+
+        io_binding = onnx_session.io_binding()
+        for input_name, input_data in input_datas.items():
+            if not input_data.flags["C_CONTIGUOUS"]:
+                input_data = np.ascontiguousarray(input_data)
+                input_datas[input_name] = input_data
+            io_binding.bind_input(
+                input_name,
+                "cpu",
+                0,
+                input_data.dtype,
+                input_data.shape,
+                input_data.__array_interface__["data"][0],
+            )
+
+        memmap_outputs = {}
+        for idx, (output_name, output_shape) in enumerate(zip(output_names_order, output_shapes)):
+            memmap_path = os.path.join(
+                memmap_dir,
+                _make_safe_ort_memmap_filename(output_index=idx, output_name=output_name),
+            )
+            if ort_output_memmap_paths_for_cleanup is not None:
+                ort_output_memmap_paths_for_cleanup.append(memmap_path)
+            output_dtype = gs_graph.outputs[idx].dtype
+            if output_dtype is None:
+                output_dtype = inferred_output_dtype_by_name.get(output_name, np.float32)
+            output_dtype = np.dtype(output_dtype)
+            memmap_array = np.memmap(
+                memmap_path,
+                dtype=output_dtype,
+                mode="w+",
+                shape=tuple(output_shape),
+            )
+            memmap_outputs[output_name] = memmap_array
+            io_binding.bind_output(
+                output_name,
+                "cpu",
+                0,
+                output_dtype,
+                output_shape,
+                memmap_array.__array_interface__["data"][0],
+            )
+
+        onnx_session.run_with_iobinding(io_binding)
+        io_binding.synchronize_outputs()
+        for memmap_array in memmap_outputs.values():
+            memmap_array.flush()
+        outputs = [memmap_outputs[name] for name in output_names_order]
+    else:
+        outputs = onnx_session.run(output_names_order, input_datas)
+
+    if tmp_onnx_path:
+        os.remove(tmp_onnx_path)
+        os.remove(tmp_onnx_external_weights_path)
+    return [np.asarray(output) for output in outputs]
+
+
+def weights_export(
+    *,
+    extract_target_tflite_file_path: str,
+    output_weights_file_path: str,
+) -> None:
+    import h5py
+
+    interpreter = Interpreter(model_path=extract_target_tflite_file_path)
+    interpreter.allocate_tensors()
+    input_indexes = [input_detail["index"] for input_detail in interpreter.get_input_details()]
+    output_indexes = [output_detail["index"] for output_detail in interpreter.get_output_details()]
+    with h5py.File(output_weights_file_path, "w") as f:
+        for tensor_detail in interpreter.get_tensor_details():
+            tensor_index = tensor_detail["index"]
+            if tensor_index in input_indexes or tensor_index in output_indexes:
+                continue
+            try:
+                dataset = f.create_dataset(
+                    name=tensor_detail["name"],
+                    data=interpreter.get_tensor(tensor_index),
+                )
+                del dataset
+            except Exception:
+                pass

--- a/onnx2tf/utils/pytorch_bulk_runner.py
+++ b/onnx2tf/utils/pytorch_bulk_runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import hashlib
+import importlib
 import json
 import os
 import shlex
@@ -13,9 +14,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import onnx
 
-from onnx2tf.tflite_builder.pytorch_accuracy_evaluator import (
-    evaluate_pytorch_package_outputs,
-    smoke_test_pytorch_package_inference,
+from onnx2tf.utils.torch_optional import (
+    OptionalPyTorchDependencyError,
+    require_torch,
 )
 
 
@@ -30,6 +31,27 @@ _ACCEPTED_ACCURACY_MISMATCH_PREFIXES = (
 _DEFAULT_SKIP_MODEL_NAMES = (
     "dehaze_maxim_2022aug_opt_sim_special_05_max_to_relu.onnx",
 )
+
+
+def _load_pytorch_accuracy_evaluator():
+    require_torch("PyTorch bulk verification")
+    return importlib.import_module(
+        "onnx2tf.tflite_builder.pytorch_accuracy_evaluator"
+    )
+
+
+def evaluate_pytorch_package_outputs(*args: Any, **kwargs: Any):
+    return _load_pytorch_accuracy_evaluator().evaluate_pytorch_package_outputs(
+        *args,
+        **kwargs,
+    )
+
+
+def smoke_test_pytorch_package_inference(*args: Any, **kwargs: Any):
+    return _load_pytorch_accuracy_evaluator().smoke_test_pytorch_package_inference(
+        *args,
+        **kwargs,
+    )
 
 
 def _utc_now_iso() -> str:
@@ -491,18 +513,23 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    state = run_bulk_pytorch_verification(
-        list_path=args.list_path,
-        output_dir=args.output_dir,
-        resume=bool(args.resume),
-        onnx2tf_command=str(args.onnx2tf_command),
-        num_samples=int(args.num_samples),
-        rtol=float(args.rtol),
-        atol=float(args.atol),
-        timeout_sec=int(args.timeout_sec),
-        smoke_only=bool(args.smoke_only),
-        skip_model_names=list(args.skip_model_name),
-    )
+    try:
+        require_torch("PyTorch bulk verification")
+        state = run_bulk_pytorch_verification(
+            list_path=args.list_path,
+            output_dir=args.output_dir,
+            resume=bool(args.resume),
+            onnx2tf_command=str(args.onnx2tf_command),
+            num_samples=int(args.num_samples),
+            rtol=float(args.rtol),
+            atol=float(args.atol),
+            timeout_sec=int(args.timeout_sec),
+            smoke_only=bool(args.smoke_only),
+            skip_model_names=list(args.skip_model_name),
+        )
+    except OptionalPyTorchDependencyError as ex:
+        print(str(ex))
+        sys.exit(1)
     print(
         "Bulk PyTorch verification complete. "
         f"total_entries={len(state.get('entries', []))} "

--- a/onnx2tf/utils/tf_optional.py
+++ b/onnx2tf/utils/tf_optional.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class OptionalTensorFlowDependencyError(RuntimeError):
+    """Raised when a TensorFlow-backed feature is requested without TensorFlow."""
+
+
+@dataclass(frozen=True)
+class TensorFlowModules:
+    tf: Any
+    tf_keras: Any
+    wrapper_function_type: Any
+
+
+_TF_MODULES: Optional[TensorFlowModules] = None
+
+
+def _should_suppress_tf_startup_stderr() -> bool:
+    raw = str(
+        os.environ.get(
+            "ONNX2TF_SUPPRESS_TF_STARTUP_STDERR",
+            "1",
+        )
+    ).strip().lower()
+    return raw not in {"0", "false", "off", "no"}
+
+
+@contextlib.contextmanager
+def _suppress_stderr_fd_for_tf_startup():
+    if not _should_suppress_tf_startup_stderr():
+        yield
+        return
+    try:
+        stderr_fd = sys.stderr.fileno()
+    except Exception:
+        yield
+        return
+    saved_fd = None
+    devnull_fd = None
+    try:
+        saved_fd = os.dup(stderr_fd)
+        devnull_fd = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull_fd, stderr_fd)
+        yield
+    finally:
+        try:
+            if saved_fd is not None:
+                os.dup2(saved_fd, stderr_fd)
+        finally:
+            if saved_fd is not None:
+                os.close(saved_fd)
+            if devnull_fd is not None:
+                os.close(devnull_fd)
+
+
+def _build_missing_dependency_message(feature: str) -> str:
+    normalized_feature = str(feature).strip() or "TensorFlow-backed onnx2tf feature"
+    return (
+        f"{normalized_feature} requires optional dependencies: tensorflow, tf_keras. "
+        'Install them with: uv pip install -U "onnx2tf[tensorflow]"'
+    )
+
+
+def require_tensorflow(feature: str) -> TensorFlowModules:
+    global _TF_MODULES
+    if _TF_MODULES is not None:
+        return _TF_MODULES
+
+    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+    os.environ["TF_USE_LEGACY_KERAS"] = "1"
+    try:
+        with _suppress_stderr_fd_for_tf_startup():
+            import tensorflow as tf
+            from tensorflow.python.saved_model.load import _WrapperFunction
+            import tf_keras
+    except ModuleNotFoundError as ex:
+        missing_name = str(getattr(ex, "name", "") or "")
+        if missing_name in {"tensorflow", "tf_keras"}:
+            raise OptionalTensorFlowDependencyError(
+                _build_missing_dependency_message(feature)
+            ) from ex
+        raise
+    except ImportError as ex:
+        missing_name = str(getattr(ex, "name", "") or "")
+        if missing_name in {"tensorflow", "tf_keras"}:
+            raise OptionalTensorFlowDependencyError(
+                _build_missing_dependency_message(feature)
+            ) from ex
+        raise
+
+    tf.random.set_seed(0)
+    tf_keras.utils.set_random_seed(0)
+    tf.config.experimental.enable_op_determinism()
+    tf.get_logger().setLevel("INFO")
+    tf.autograph.set_verbosity(0)
+    tf.get_logger().setLevel(logging.FATAL)
+    from absl import logging as absl_logging
+
+    absl_logging.set_verbosity(absl_logging.ERROR)
+
+    _TF_MODULES = TensorFlowModules(
+        tf=tf,
+        tf_keras=tf_keras,
+        wrapper_function_type=_WrapperFunction,
+    )
+    return _TF_MODULES

--- a/onnx2tf/utils/torch_optional.py
+++ b/onnx2tf/utils/torch_optional.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+import sysconfig
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+class OptionalPyTorchDependencyError(RuntimeError):
+    """Raised when a PyTorch-backed feature is requested without PyTorch."""
+
+
+@dataclass(frozen=True)
+class PyTorchModules:
+    torch: Any
+
+
+_TORCH_MODULES: Optional[PyTorchModules] = None
+
+
+def _build_missing_dependency_message(feature: str) -> str:
+    normalized_feature = str(feature).strip() or "PyTorch-backed onnx2tf feature"
+    return (
+        f"{normalized_feature} requires optional dependency: torch. "
+        'Install it with: uv pip install -U "onnx2tf[torch]"'
+    )
+
+
+def _normalize_path(path: str) -> str:
+    if str(path).strip() == "":
+        return ""
+    try:
+        return os.path.normcase(os.path.realpath(str(path)))
+    except Exception:
+        return os.path.normcase(os.path.abspath(str(path)))
+
+
+def _current_environment_roots() -> list[str]:
+    roots: list[str] = []
+    for candidate in {
+        sys.prefix,
+        sys.exec_prefix,
+        os.environ.get("VIRTUAL_ENV", ""),
+    }:
+        normalized = _normalize_path(str(candidate))
+        if normalized and normalized not in roots:
+            roots.append(normalized)
+    return roots
+
+
+def _is_foreign_path(path: str) -> bool:
+    normalized = _normalize_path(path)
+    if normalized == "":
+        return False
+    env_roots = _current_environment_roots()
+    return not any(
+        normalized == env_root or normalized.startswith(f"{env_root}{os.sep}")
+        for env_root in env_roots
+    )
+
+
+def _find_foreign_torch_runtime_references() -> list[str]:
+    suspects: list[str] = []
+    for env_name in ("PYTHONPATH", "LD_LIBRARY_PATH"):
+        raw = str(os.environ.get(env_name, "") or "")
+        if raw.strip() == "":
+            continue
+        for entry in raw.split(os.pathsep):
+            if entry.strip() == "":
+                continue
+            lowered_entry = entry.lower()
+            if "torch" not in lowered_entry and "site-packages" not in lowered_entry:
+                continue
+            if _is_foreign_path(entry):
+                suspects.append(f"{env_name}={entry}")
+    return suspects
+
+
+def _extract_importerror_path(ex: ImportError) -> str:
+    match = re.search(r"(/[^\s:]+)", str(ex))
+    if match is None:
+        return ""
+    return str(match.group(1))
+
+
+def _expected_torch_lib_path() -> str:
+    try:
+        purelib = Path(sysconfig.get_paths()["purelib"])
+    except Exception:
+        return ""
+    candidate = purelib / "torch" / "lib"
+    if not candidate.exists():
+        return ""
+    return str(candidate)
+
+
+def _build_broken_runtime_message(feature: str, ex: ImportError) -> str:
+    normalized_feature = str(feature).strip() or "PyTorch-backed onnx2tf feature"
+    referenced_path = _extract_importerror_path(ex)
+    foreign_references = _find_foreign_torch_runtime_references()
+    lines = [
+        f"{normalized_feature} requires a working torch runtime, but importing torch failed.",
+    ]
+    if referenced_path and _is_foreign_path(referenced_path):
+        lines.append(
+            "Detected a foreign torch runtime from another Python environment: "
+            f"{referenced_path}"
+        )
+    elif foreign_references:
+        lines.append(
+            "Detected foreign torch-related environment entries: "
+            + ", ".join(foreign_references)
+        )
+    else:
+        lines.append(f"ImportError: {ex}")
+    expected_torch_lib = _expected_torch_lib_path()
+    if expected_torch_lib:
+        lines.append(
+            "Unset PYTHONPATH and remove incompatible torch paths from "
+            f"LD_LIBRARY_PATH, then retry with this environment's torch libs: {expected_torch_lib}"
+        )
+    else:
+        lines.append(
+            "Unset PYTHONPATH and remove incompatible torch paths from LD_LIBRARY_PATH, "
+            'or reinstall with: uv pip install -U "onnx2tf[torch]"'
+        )
+    return " ".join(lines)
+
+
+def require_torch(feature: str) -> PyTorchModules:
+    global _TORCH_MODULES
+    if _TORCH_MODULES is not None:
+        return _TORCH_MODULES
+
+    try:
+        import torch
+    except ModuleNotFoundError as ex:
+        missing_name = str(getattr(ex, "name", "") or "")
+        if missing_name == "torch":
+            raise OptionalPyTorchDependencyError(
+                _build_missing_dependency_message(feature)
+            ) from ex
+        raise
+    except ImportError as ex:
+        missing_name = str(getattr(ex, "name", "") or "")
+        if missing_name == "torch":
+            raise OptionalPyTorchDependencyError(
+                _build_missing_dependency_message(feature)
+            ) from ex
+        raise OptionalPyTorchDependencyError(
+            _build_broken_runtime_message(feature, ex)
+        ) from ex
+
+    _TORCH_MODULES = PyTorchModules(
+        torch=torch,
+    )
+    return _TORCH_MODULES

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.3.18"
+version = "2.3.19"
 description = "A tool for converting ONNX files to LiteRT/TFLite/TensorFlow, PyTorch native code (nn.Module), TorchScript (.pt), state_dict (.pt), Exported Program (.pt2), and Dynamo ONNX. It also supports direct conversion from LiteRT to PyTorch."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "requests==2.32.5",
     "numpy==1.26.4",
     "onnx==1.20.1",
     "onnxruntime==1.24.3",
@@ -34,8 +33,6 @@ dependencies = [
     "onnxoptimizer==0.4.2",
     "onnxscript==0.6.2",
     "ai-edge-litert==2.1.2",
-    "tensorflow==2.19.0",
-    "tf-keras==2.19.0",
     "sne4onnx==2.0.1",
     "sng4onnx==2.0.1",
     "psutil==5.9.5",
@@ -48,8 +45,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+tensorflow = [
+    "tensorflow==2.19.0",
+    "tf-keras==2.19.0",
+]
 torch = [
-    "torch==2.9.0+cu128",
+    "torch==2.11.0",
 ]
 
 [project.scripts]
@@ -64,8 +65,6 @@ Documentation = "https://github.com/PINTO0309/onnx2tf#readme"
 Issues = "https://github.com/PINTO0309/onnx2tf/issues"
 
 [tool.uv]
-exclude-newer = "7 days"
-exclude-newer-package = { torch = false, torchvision = false, torchaudio = false }
 override-dependencies = [
     "onnx==1.20.1",
     "onnxsim-prebuilt==0.4.39.post2",
@@ -73,21 +72,17 @@ override-dependencies = [
     "numpy==1.26.4",
 ]
 
-[tool.uv.pip]
-exclude-newer = "7 days"
-exclude-newer-package = { torch = false, torchvision = false, torchaudio = false }
-
 [tool.uv.build-backend]
 module-root = ""
 
 [tool.uv.sources]
-torch = { index = "pytorch-cu128" }
-torchvision = { index = "pytorch-cu128" }
-torchaudio = { index = "pytorch-cu128" }
+torch = { index = "pytorch-cpu" }
+torchvision = { index = "pytorch-cpu" }
+torchaudio = { index = "pytorch-cpu" }
 
 [[tool.uv.index]]
-name = "pytorch-cu128"
-url = "https://download.pytorch.org/whl/cu128"
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [tool.pyright]

--- a/tests/test_optional_pytorch.py
+++ b/tests/test_optional_pytorch.py
@@ -1,0 +1,278 @@
+import os
+import subprocess
+import sys
+import tempfile
+from importlib import reload
+from pathlib import Path
+
+import onnx
+import pytest
+from onnx import TensorProto, helper
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BLOCK_TORCH_IMPORTS = """
+import importlib.abc
+import sys
+
+class _BlockTorch(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "torch" or fullname.startswith("torch."):
+            raise ModuleNotFoundError(
+                "blocked torch import for test",
+                name="torch",
+            )
+        if fullname == "torchvision" or fullname.startswith("torchvision."):
+            raise ModuleNotFoundError(
+                "blocked torchvision import for test",
+                name="torchvision",
+            )
+        if fullname == "torchaudio" or fullname.startswith("torchaudio."):
+            raise ModuleNotFoundError(
+                "blocked torchaudio import for test",
+                name="torchaudio",
+            )
+        return None
+
+sys.meta_path.insert(0, _BlockTorch())
+"""
+
+
+def _run_python(code: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-c", code, *args],
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def _make_add_model(path: Path) -> None:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
+    z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])
+    node = helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")
+    graph = helper.make_graph([node], "add_graph", [x, y], [z])
+    model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+    onnx.save(model, path)
+
+
+def test_imports_do_not_load_pytorch_when_blocked() -> None:
+    template = BLOCK_TORCH_IMPORTS + """
+import sys
+import {module_name}
+print('torch' in sys.modules)
+"""
+    modules = [
+        "onnx2tf",
+        "onnx2tf.onnx2tf",
+        "onnx2tf.tflite_builder.__init__",
+        "onnx2tf.utils.pytorch_bulk_runner",
+        "onnx2tf.tflite_builder.pytorch_accuracy_evaluator",
+        "onnx2tf.tflite_builder.pytorch_package_runtime",
+    ]
+    for module_name in modules:
+        result = _run_python(template.format(module_name=module_name))
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "False", module_name
+
+
+def test_pytorch_bulk_help_works_without_pytorch() -> None:
+    result = _run_python(
+        BLOCK_TORCH_IMPORTS
+        + "import sys, onnx2tf.utils.pytorch_bulk_runner as m; sys.argv=['onnx2tf-pytorch-bulk', '--help']; m.main()"
+    )
+    assert result.returncode == 0
+    assert "--list_path" in result.stdout
+
+
+def test_flatbuffer_direct_pytorch_export_fails_fast_without_pytorch() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TORCH_IMPORTS
+            + """
+import sys
+import onnx2tf
+
+try:
+    onnx2tf.convert(
+        input_onnx_file_path=sys.argv[1],
+        output_folder_path=sys.argv[2],
+        tflite_backend='flatbuffer_direct',
+        flatbuffer_direct_output_pytorch=True,
+        disable_strict_mode=True,
+        verbosity='error',
+    )
+except Exception as ex:
+    print(type(ex).__name__)
+    print(str(ex))
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OptionalPyTorchDependencyError" in result.stdout
+        assert "flatbuffer_direct PyTorch package export" in result.stdout
+        assert 'uv pip install -U "onnx2tf[torch]"' in result.stdout
+        assert 'onnx2tf[torch]' in result.stdout
+
+
+def test_main_torchscript_export_fails_fast_without_pytorch() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TORCH_IMPORTS
+            + """
+import sys
+import onnx2tf
+
+sys.argv = [
+    'onnx2tf',
+    '-i', sys.argv[1],
+    '-o', sys.argv[2],
+    '--tflite_backend', 'flatbuffer_direct',
+    '--flatbuffer_direct_output_torchscript',
+]
+onnx2tf.main()
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 1
+        assert "flatbuffer_direct TorchScript export" in result.stdout
+        assert 'uv pip install -U "onnx2tf[torch]"' in result.stdout
+        assert 'onnx2tf[torch]' in result.stdout
+        assert "Traceback" not in result.stderr
+
+
+def test_pytorch_bulk_runner_fails_fast_without_pytorch() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        list_path = Path(tmpdir) / "list.txt"
+        output_dir = Path(tmpdir) / "out"
+        list_path.write_text("", encoding="utf-8")
+        result = _run_python(
+            BLOCK_TORCH_IMPORTS
+            + """
+import sys
+import onnx2tf.utils.pytorch_bulk_runner as m
+
+sys.argv = [
+    'onnx2tf-pytorch-bulk',
+    '-l', sys.argv[1],
+    '-o', sys.argv[2],
+]
+m.main()
+""",
+            str(list_path),
+            str(output_dir),
+        )
+        assert result.returncode == 1
+        assert "PyTorch bulk verification" in result.stdout
+        assert 'uv pip install -U "onnx2tf[torch]"' in result.stdout
+        assert 'onnx2tf[torch]' in result.stdout
+        assert "Traceback" not in result.stderr
+
+
+def test_pytorch_evaluator_call_fails_fast_without_pytorch() -> None:
+    result = _run_python(
+        BLOCK_TORCH_IMPORTS
+        + """
+import onnx
+from onnx import TensorProto, helper
+from onnx2tf.tflite_builder.pytorch_accuracy_evaluator import evaluate_tflite_pytorch_package_outputs
+
+graph = helper.make_graph(
+    [helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")],
+    "add_graph",
+    [
+        helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3]),
+        helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3]),
+    ],
+    [helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])],
+)
+model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+
+try:
+    evaluate_tflite_pytorch_package_outputs(
+        tflite_path="dummy.tflite",
+        package_dir="dummy_pkg",
+        output_report_path="dummy.json",
+    )
+except Exception as ex:
+    print(type(ex).__name__)
+    print(str(ex))
+""",
+        )
+    assert result.returncode == 0, result.stderr
+    assert "OptionalPyTorchDependencyError" in result.stdout
+    assert "TFLite/PyTorch validation" in result.stdout
+    assert 'uv pip install -U "onnx2tf[torch]"' in result.stdout
+    assert 'onnx2tf[torch]' in result.stdout
+
+
+def test_pytorch_runtime_call_fails_fast_without_pytorch() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        package_dir = Path(tmpdir) / "pkg"
+        package_dir.mkdir()
+        result = _run_python(
+            BLOCK_TORCH_IMPORTS
+            + """
+import sys
+from onnx2tf.tflite_builder.pytorch_package_runtime import load_generated_model_package
+
+try:
+    load_generated_model_package(package_dir=sys.argv[1])
+except Exception as ex:
+    print(type(ex).__name__)
+    print(str(ex))
+""",
+            str(package_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OptionalPyTorchDependencyError" in result.stdout
+        assert "PyTorch package runtime" in result.stdout
+        assert 'uv pip install -U "onnx2tf[torch]"' in result.stdout
+        assert 'onnx2tf[torch]' in result.stdout
+
+
+def test_require_torch_reports_foreign_runtime_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    import builtins
+
+    import onnx2tf.utils.torch_optional as torch_optional
+
+    reload(torch_optional)
+    monkeypatch.setenv("PYTHONPATH", "/usr/local/lib/python3.10/dist-packages:")
+    monkeypatch.setenv(
+        "LD_LIBRARY_PATH",
+        "/home/example/.local/lib/python3.10/site-packages/torch/lib",
+    )
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ImportError(
+                "/home/example/.local/lib/python3.10/site-packages/torch/lib/"
+                "libtorch_python.so: undefined symbol: _PyCode_GetExtra"
+            )
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(torch_optional.OptionalPyTorchDependencyError) as ex:
+        torch_optional.require_torch("flatbuffer_direct TorchScript export")
+
+    message = str(ex.value)
+    assert "flatbuffer_direct TorchScript export requires a working torch runtime" in message
+    assert "foreign torch runtime from another Python environment" in message
+    assert "/home/example/.local/lib/python3.10/site-packages/torch/lib/libtorch_python.so" in message
+    assert "Unset PYTHONPATH" in message

--- a/tests/test_optional_tensorflow.py
+++ b/tests/test_optional_tensorflow.py
@@ -1,0 +1,230 @@
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import onnx
+from onnx import TensorProto, helper
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BLOCK_TF_IMPORTS = """
+import importlib.abc
+import sys
+
+class _BlockTensorFlow(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "tensorflow" or fullname.startswith("tensorflow."):
+            raise ModuleNotFoundError(
+                "blocked tensorflow import for test",
+                name="tensorflow",
+            )
+        if fullname == "tf_keras" or fullname.startswith("tf_keras."):
+            raise ModuleNotFoundError(
+                "blocked tf_keras import for test",
+                name="tf_keras",
+            )
+        return None
+
+sys.meta_path.insert(0, _BlockTensorFlow())
+"""
+
+
+def _run_python(code: str, *args: str) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-c", code, *args],
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+
+
+def _make_add_model(path: Path) -> None:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 3])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 3])
+    z = helper.make_tensor_value_info("z", TensorProto.FLOAT, [1, 3])
+    node = helper.make_node("Add", ["x", "y"], ["z"], name="AddNode")
+    graph = helper.make_graph([node], "add_graph", [x, y], [z])
+    model = helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 13)])
+    onnx.save(model, path)
+
+
+def test_imports_do_not_load_tensorflow_when_blocked() -> None:
+    template = BLOCK_TF_IMPORTS + """
+import sys
+import {module_name}
+print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
+"""
+    modules = [
+        "onnx2tf",
+        "onnx2tf.utils.flatbuffer_direct_bulk_runner",
+        "onnx2tf.utils.flatbuffer_direct_op_error_report",
+        "onnx2tf.tflite_builder.accuracy_evaluator",
+        "onnx2tf.onnx2tf",
+    ]
+    for module_name in modules:
+        result = _run_python(template.format(module_name=module_name))
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "False False", module_name
+
+
+def test_python_m_help_works_without_tensorflow() -> None:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            BLOCK_TF_IMPORTS
+            + "import runpy, sys; sys.argv=['onnx2tf','--help']; runpy.run_module('onnx2tf', run_name='__main__')",
+        ],
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "--tflite_backend" in result.stdout
+
+
+def test_main_help_works_without_tensorflow() -> None:
+    result = _run_python(
+        BLOCK_TF_IMPORTS
+        + "import sys, onnx2tf; sys.argv=['onnx2tf', '--help']; onnx2tf.main()"
+    )
+    assert result.returncode == 0
+    assert "--tflite_backend" in result.stdout
+
+
+def test_flatbuffer_direct_convert_succeeds_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import os
+import sys
+import onnx2tf
+
+model_path = sys.argv[1]
+output_dir = sys.argv[2]
+onnx2tf.convert(
+    input_onnx_file_path=model_path,
+    output_folder_path=output_dir,
+    tflite_backend='flatbuffer_direct',
+    disable_strict_mode=True,
+    verbosity='error',
+)
+print(os.path.exists(os.path.join(output_dir, 'add_float32.tflite')))
+print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        assert lines[-2] == "True"
+        assert lines[-1] == "False False"
+
+
+def test_tf_converter_fails_fast_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import sys
+import onnx2tf
+
+try:
+    onnx2tf.convert(
+        input_onnx_file_path=sys.argv[1],
+        output_folder_path=sys.argv[2],
+        tflite_backend='tf_converter',
+        verbosity='error',
+    )
+except Exception as ex:
+    print(type(ex).__name__)
+    print(str(ex))
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OptionalTensorFlowDependencyError" in result.stdout
+        assert 'tflite_backend="tf_converter"' in result.stdout
+        assert 'uv pip install -U "onnx2tf[tensorflow]"' in result.stdout
+        assert 'onnx2tf[tensorflow]' in result.stdout
+
+
+def test_main_tf_converter_fails_fast_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import sys
+import onnx2tf
+
+sys.argv = [
+    'onnx2tf',
+    '-i', sys.argv[1],
+    '-o', sys.argv[2],
+    '--tflite_backend', 'tf_converter',
+]
+onnx2tf.main()
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 1
+        assert 'tflite_backend="tf_converter"' in result.stdout
+        assert 'uv pip install -U "onnx2tf[tensorflow]"' in result.stdout
+        assert 'onnx2tf[tensorflow]' in result.stdout
+        assert "Traceback" not in result.stderr
+
+
+def test_flatbuffer_direct_h5_fails_fast_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import sys
+import onnx2tf
+
+try:
+    onnx2tf.convert(
+        input_onnx_file_path=sys.argv[1],
+        output_folder_path=sys.argv[2],
+        tflite_backend='flatbuffer_direct',
+        output_h5=True,
+        disable_strict_mode=True,
+        verbosity='error',
+    )
+except Exception as ex:
+    print(type(ex).__name__)
+    print(str(ex))
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OptionalTensorFlowDependencyError" in result.stdout
+        assert "flatbuffer_direct H5 export" in result.stdout
+        assert 'uv pip install -U "onnx2tf[tensorflow]"' in result.stdout
+        assert 'onnx2tf[tensorflow]' in result.stdout

--- a/tests/test_optional_tensorflow.py
+++ b/tests/test_optional_tensorflow.py
@@ -135,6 +135,42 @@ print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
         assert lines[-1] == "False False"
 
 
+def test_flatbuffer_direct_cotof_succeeds_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import os
+import sys
+import onnx2tf
+
+model_path = sys.argv[1]
+output_dir = sys.argv[2]
+onnx2tf.convert(
+    input_onnx_file_path=model_path,
+    output_folder_path=output_dir,
+    tflite_backend='flatbuffer_direct',
+    check_onnx_tf_outputs_elementwise_close_full=True,
+    disable_strict_mode=True,
+    verbosity='error',
+)
+print(os.path.exists(os.path.join(output_dir, 'add_accuracy_report.json')))
+print(os.path.exists(os.path.join(output_dir, 'add_saved_model_validation_report.json')))
+print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        assert lines[-3] == "True"
+        assert lines[-2] == "False"
+        assert lines[-1] == "False False"
+
+
 def test_tf_converter_fails_fast_without_tensorflow() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         model_path = Path(tmpdir) / "add.onnx"
@@ -226,5 +262,40 @@ except Exception as ex:
         assert result.returncode == 0, result.stderr
         assert "OptionalTensorFlowDependencyError" in result.stdout
         assert "flatbuffer_direct H5 export" in result.stdout
+        assert 'uv pip install -U "onnx2tf[tensorflow]"' in result.stdout
+        assert 'onnx2tf[tensorflow]' in result.stdout
+
+
+def test_flatbuffer_direct_saved_model_with_cotof_fails_fast_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import sys
+import onnx2tf
+
+try:
+    onnx2tf.convert(
+        input_onnx_file_path=sys.argv[1],
+        output_folder_path=sys.argv[2],
+        tflite_backend='flatbuffer_direct',
+        flatbuffer_direct_output_saved_model=True,
+        check_onnx_tf_outputs_elementwise_close_full=True,
+        disable_strict_mode=True,
+        verbosity='error',
+    )
+except Exception as ex:
+    print(type(ex).__name__)
+    print(str(ex))
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "OptionalTensorFlowDependencyError" in result.stdout
+        assert "flatbuffer_direct SavedModel export" in result.stdout
         assert 'uv pip install -U "onnx2tf[tensorflow]"' in result.stdout
         assert 'onnx2tf[tensorflow]' in result.stdout

--- a/tests/test_tflite2sm_phase1.py
+++ b/tests/test_tflite2sm_phase1.py
@@ -1720,17 +1720,16 @@ def test_tflite_direct_input_saved_model_with_cotof_smoke() -> None:
             tflite_backend="flatbuffer_direct",
             check_onnx_tf_outputs_elementwise_close_full=True,
         )
-        report_path = os.path.join(
-            output_dir,
-            "add_tflite_direct_input_cotof_saved_model_validation_report.json",
+        assert os.path.exists(os.path.join(output_dir, "saved_model.pb"))
+        assert not os.path.exists(
+            os.path.join(
+                output_dir,
+                "add_tflite_direct_input_cotof_saved_model_validation_report.json",
+            )
         )
-        assert os.path.exists(report_path)
-        with open(report_path, "r", encoding="utf-8") as f:
-            report = json.load(f)
-        assert report["inference"]["status"] == "passed"
-        assert report["comparison"]["status"] == "passed"
-        assert report["comparison"]["pass"] is True
-        assert report["overall_pass"] is True
+        assert not os.path.exists(
+            os.path.join(output_dir, "add_tflite_direct_input_cotof_accuracy_report.json")
+        )
 
 
 def test_tflite_direct_input_split_outputs_smoke() -> None:
@@ -1797,17 +1796,15 @@ def test_tflite_direct_input_split_saved_model_cotof_smoke() -> None:
             flatbuffer_direct_output_saved_model=True,
             check_onnx_tf_outputs_elementwise_close_full=True,
         )
-        report_path = os.path.join(
-            output_dir,
-            "add_tflite_direct_input_split_cotof_saved_model_validation_report.json",
+        assert os.path.exists(
+            os.path.join(output_dir, "add_tflite_direct_input_split_cotof_accuracy_report.json")
         )
-        assert os.path.exists(report_path)
-        with open(report_path, "r", encoding="utf-8") as f:
-            report = json.load(f)
-        assert report["source_label"] == "tflite_direct_input"
-        assert report["comparison"]["status"] == "passed"
-        assert report["comparison"]["pass"] is True
-        assert report["overall_pass"] is True
+        assert not os.path.exists(
+            os.path.join(
+                output_dir,
+                "add_tflite_direct_input_split_cotof_saved_model_validation_report.json",
+            )
+        )
 
 
 @pytest.mark.parametrize(
@@ -2038,17 +2035,10 @@ def test_flatbuffer_direct_output_saved_model_cotof_smoke() -> None:
         )
         assert os.path.exists(os.path.join(tmpdir, "saved_model.pb"))
         assert os.path.exists(os.path.join(tmpdir, "add_float32.tflite"))
-        report_path = os.path.join(
-            tmpdir,
-            "add_saved_model_validation_report.json",
+        assert os.path.exists(os.path.join(tmpdir, "add_accuracy_report.json"))
+        assert not os.path.exists(
+            os.path.join(tmpdir, "add_saved_model_validation_report.json")
         )
-        assert os.path.exists(report_path)
-        with open(report_path, "r", encoding="utf-8") as f:
-            report = json.load(f)
-        assert report["inference"]["status"] == "passed"
-        assert report["comparison"]["status"] == "passed"
-        assert report["comparison"]["pass"] is True
-        assert report["overall_pass"] is True
 
 
 def test_flatbuffer_direct_output_pytorch_cotof_generates_comparison_report() -> None:
@@ -2160,20 +2150,15 @@ def test_flatbuffer_direct_output_saved_model_split_cotof_smoke() -> None:
             auto_split_max_size="256MB",
             check_onnx_tf_outputs_elementwise_close_full=True,
         )
-        report_path = os.path.join(
-            tmpdir,
-            "add_split_sm_cotof_saved_model_validation_report.json",
+        assert os.path.exists(
+            os.path.join(tmpdir, "add_split_sm_cotof_accuracy_report.json")
         )
-        assert os.path.exists(report_path)
-        with open(report_path, "r", encoding="utf-8") as f:
-            report = json.load(f)
-        assert report["mode"] == "split_saved_model"
-        assert report["comparison"]["status"] == "passed"
-        assert report["comparison"]["pass"] is True
-        assert report["overall_pass"] is True
+        assert not os.path.exists(
+            os.path.join(tmpdir, "add_split_sm_cotof_saved_model_validation_report.json")
+        )
 
 
-def test_flatbuffer_direct_output_saved_model_cotof_runs_saved_model_inference_check(
+def test_flatbuffer_direct_output_saved_model_cotof_does_not_run_saved_model_inference_check(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -2183,26 +2168,20 @@ def test_flatbuffer_direct_output_saved_model_cotof_runs_saved_model_inference_c
             raise RuntimeError("saved model load failure for test")
 
         monkeypatch.setattr(tf.saved_model, "load", _raise_saved_model_load)
-        with pytest.raises(RuntimeError, match="SavedModel inference check failed"):
-            onnx2tf.convert(
-                input_onnx_file_path=model_path,
-                output_folder_path=tmpdir,
-                verbosity="error",
-                disable_strict_mode=True,
-                tflite_backend="flatbuffer_direct",
-                flatbuffer_direct_output_saved_model=True,
-                check_onnx_tf_outputs_elementwise_close_full=True,
-            )
-        report_path = os.path.join(
-            tmpdir,
-            "add_saved_model_validation_report.json",
+        onnx2tf.convert(
+            input_onnx_file_path=model_path,
+            output_folder_path=tmpdir,
+            verbosity="error",
+            disable_strict_mode=True,
+            tflite_backend="flatbuffer_direct",
+            flatbuffer_direct_output_saved_model=True,
+            check_onnx_tf_outputs_elementwise_close_full=True,
         )
-        assert os.path.exists(report_path)
-        with open(report_path, "r", encoding="utf-8") as f:
-            report = json.load(f)
-        assert report["inference"]["status"] == "failed"
-        assert report["comparison"]["status"] == "skipped"
-        assert report["overall_pass"] is False
+        assert os.path.exists(os.path.join(tmpdir, "saved_model.pb"))
+        assert os.path.exists(os.path.join(tmpdir, "add_accuracy_report.json"))
+        assert not os.path.exists(
+            os.path.join(tmpdir, "add_saved_model_validation_report.json")
+        )
 
 
 def test_saved_model_exporter_kernel_registry_completeness() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2,18 +2,11 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version >= '3.13' and sys_platform != 'darwin'",
+    "python_full_version < '3.13' and sys_platform != 'darwin'",
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
-
-[options]
-exclude-newer = "2026-03-25T05:07:53.372380983Z"
-exclude-newer-span = "P7D"
-
-[options.exclude-newer-package]
-torchvision = false
-torchaudio = false
-torch = false
 
 [manifest]
 overrides = [
@@ -187,11 +180,11 @@ wheels = [
 
 [[package]]
 name = "fsspec"
-version = "2026.2.0"
+version = "2026.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
 ]
 
 [[package]]
@@ -217,43 +210,43 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.78.0"
+version = "1.80.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/8a/3d098f35c143a89520e568e6539cc098fcd294495910e359889ce8741c84/grpcio-1.78.0.tar.gz", hash = "sha256:7382b95189546f375c174f53a5fa873cef91c4b8005faa05cc5b3beea9c4f1c5", size = 12852416, upload-time = "2026-02-06T09:57:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/f4/7384ed0178203d6074446b3c4f46c90a22ddf7ae0b3aee521627f54cfc2a/grpcio-1.78.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:f9ab915a267fc47c7e88c387a3a28325b58c898e23d4995f765728f4e3dedb97", size = 5913985, upload-time = "2026-02-06T09:55:26.832Z" },
-    { url = "https://files.pythonhosted.org/packages/81/ed/be1caa25f06594463f685b3790b320f18aea49b33166f4141bfdc2bfb236/grpcio-1.78.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3f8904a8165ab21e07e58bf3e30a73f4dffc7a1e0dbc32d51c61b5360d26f43e", size = 11811853, upload-time = "2026-02-06T09:55:29.224Z" },
-    { url = "https://files.pythonhosted.org/packages/24/a7/f06d151afc4e64b7e3cc3e872d331d011c279aaab02831e40a81c691fb65/grpcio-1.78.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:859b13906ce098c0b493af92142ad051bf64c7870fa58a123911c88606714996", size = 6475766, upload-time = "2026-02-06T09:55:31.825Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/a8/4482922da832ec0082d0f2cc3a10976d84a7424707f25780b82814aafc0a/grpcio-1.78.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b2342d87af32790f934a79c3112641e7b27d63c261b8b4395350dad43eff1dc7", size = 7170027, upload-time = "2026-02-06T09:55:34.7Z" },
-    { url = "https://files.pythonhosted.org/packages/54/bf/f4a3b9693e35d25b24b0b39fa46d7d8a3c439e0a3036c3451764678fec20/grpcio-1.78.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:12a771591ae40bc65ba67048fa52ef4f0e6db8279e595fd349f9dfddeef571f9", size = 6690766, upload-time = "2026-02-06T09:55:36.902Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/b9/521875265cc99fe5ad4c5a17010018085cae2810a928bf15ebe7d8bcd9cc/grpcio-1.78.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:185dea0d5260cbb2d224c507bf2a5444d5abbb1fa3594c1ed7e4c709d5eb8383", size = 7266161, upload-time = "2026-02-06T09:55:39.824Z" },
-    { url = "https://files.pythonhosted.org/packages/05/86/296a82844fd40a4ad4a95f100b55044b4f817dece732bf686aea1a284147/grpcio-1.78.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:51b13f9aed9d59ee389ad666b8c2214cc87b5de258fa712f9ab05f922e3896c6", size = 8253303, upload-time = "2026-02-06T09:55:42.353Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/e4/ea3c0caf5468537f27ad5aab92b681ed7cc0ef5f8c9196d3fd42c8c2286b/grpcio-1.78.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd5f135b1bd58ab088930b3c613455796dfa0393626a6972663ccdda5b4ac6ce", size = 7698222, upload-time = "2026-02-06T09:55:44.629Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/47/7f05f81e4bb6b831e93271fb12fd52ba7b319b5402cbc101d588f435df00/grpcio-1.78.0-cp312-cp312-win32.whl", hash = "sha256:94309f498bcc07e5a7d16089ab984d42ad96af1d94b5a4eb966a266d9fcabf68", size = 4066123, upload-time = "2026-02-06T09:55:47.644Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/e7/d6914822c88aa2974dbbd10903d801a28a19ce9cd8bad7e694cbbcf61528/grpcio-1.78.0-cp312-cp312-win_amd64.whl", hash = "sha256:9566fe4ababbb2610c39190791e5b829869351d14369603702e890ef3ad2d06e", size = 4797657, upload-time = "2026-02-06T09:55:49.86Z" },
-    { url = "https://files.pythonhosted.org/packages/05/a9/8f75894993895f361ed8636cd9237f4ab39ef87fd30db17467235ed1c045/grpcio-1.78.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:ce3a90455492bf8bfa38e56fbbe1dbd4f872a3d8eeaf7337dc3b1c8aa28c271b", size = 5920143, upload-time = "2026-02-06T09:55:52.035Z" },
-    { url = "https://files.pythonhosted.org/packages/55/06/0b78408e938ac424100100fd081189451b472236e8a3a1f6500390dc4954/grpcio-1.78.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:2bf5e2e163b356978b23652c4818ce4759d40f4712ee9ec5a83c4be6f8c23a3a", size = 11803926, upload-time = "2026-02-06T09:55:55.494Z" },
-    { url = "https://files.pythonhosted.org/packages/88/93/b59fe7832ff6ae3c78b813ea43dac60e295fa03606d14d89d2e0ec29f4f3/grpcio-1.78.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8f2ac84905d12918e4e55a16da17939eb63e433dc11b677267c35568aa63fc84", size = 6478628, upload-time = "2026-02-06T09:55:58.533Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/df/e67e3734527f9926b7d9c0dde6cd998d1d26850c3ed8eeec81297967ac67/grpcio-1.78.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b58f37edab4a3881bc6c9bca52670610e0c9ca14e2ea3cf9debf185b870457fb", size = 7173574, upload-time = "2026-02-06T09:56:01.786Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/62/cc03fffb07bfba982a9ec097b164e8835546980aec25ecfa5f9c1a47e022/grpcio-1.78.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:735e38e176a88ce41840c21bb49098ab66177c64c82426e24e0082500cc68af5", size = 6692639, upload-time = "2026-02-06T09:56:04.529Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/9a/289c32e301b85bdb67d7ec68b752155e674ee3ba2173a1858f118e399ef3/grpcio-1.78.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2045397e63a7a0ee7957c25f7dbb36ddc110e0cfb418403d110c0a7a68a844e9", size = 7268838, upload-time = "2026-02-06T09:56:08.397Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/79/1be93f32add280461fa4773880196572563e9c8510861ac2da0ea0f892b6/grpcio-1.78.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:a9f136fbafe7ccf4ac7e8e0c28b31066e810be52d6e344ef954a3a70234e1702", size = 8251878, upload-time = "2026-02-06T09:56:10.914Z" },
-    { url = "https://files.pythonhosted.org/packages/65/65/793f8e95296ab92e4164593674ae6291b204bb5f67f9d4a711489cd30ffa/grpcio-1.78.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:748b6138585379c737adc08aeffd21222abbda1a86a0dca2a39682feb9196c20", size = 7695412, upload-time = "2026-02-06T09:56:13.593Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/1e233fe697ecc82845942c2822ed06bb522e70d6771c28d5528e4c50f6a4/grpcio-1.78.0-cp313-cp313-win32.whl", hash = "sha256:271c73e6e5676afe4fc52907686670c7cea22ab2310b76a59b678403ed40d670", size = 4064899, upload-time = "2026-02-06T09:56:15.601Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/27/d86b89e36de8a951501fb06a0f38df19853210f341d0b28f83f4aa0ffa08/grpcio-1.78.0-cp313-cp313-win_amd64.whl", hash = "sha256:f2d4e43ee362adfc05994ed479334d5a451ab7bc3f3fee1b796b8ca66895acb4", size = 4797393, upload-time = "2026-02-06T09:56:17.882Z" },
-    { url = "https://files.pythonhosted.org/packages/29/f2/b56e43e3c968bfe822fa6ce5bca10d5c723aa40875b48791ce1029bb78c7/grpcio-1.78.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:e87cbc002b6f440482b3519e36e1313eb5443e9e9e73d6a52d43bd2004fcfd8e", size = 5920591, upload-time = "2026-02-06T09:56:20.758Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/81/1f3b65bd30c334167bfa8b0d23300a44e2725ce39bba5b76a2460d85f745/grpcio-1.78.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c41bc64626db62e72afec66b0c8a0da76491510015417c127bfc53b2fe6d7f7f", size = 11813685, upload-time = "2026-02-06T09:56:24.315Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/1c/bbe2f8216a5bd3036119c544d63c2e592bdf4a8ec6e4a1867592f4586b26/grpcio-1.78.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfffba826efcf366b1e3ccc37e67afe676f290e13a3b48d31a46739f80a8724", size = 6487803, upload-time = "2026-02-06T09:56:27.367Z" },
-    { url = "https://files.pythonhosted.org/packages/16/5c/a6b2419723ea7ddce6308259a55e8e7593d88464ce8db9f4aa857aba96fa/grpcio-1.78.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:74be1268d1439eaaf552c698cdb11cd594f0c49295ae6bb72c34ee31abbe611b", size = 7173206, upload-time = "2026-02-06T09:56:29.876Z" },
-    { url = "https://files.pythonhosted.org/packages/df/1e/b8801345629a415ea7e26c83d75eb5dbe91b07ffe5210cc517348a8d4218/grpcio-1.78.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be63c88b32e6c0f1429f1398ca5c09bc64b0d80950c8bb7807d7d7fb36fb84c7", size = 6693826, upload-time = "2026-02-06T09:56:32.305Z" },
-    { url = "https://files.pythonhosted.org/packages/34/84/0de28eac0377742679a510784f049738a80424b17287739fc47d63c2439e/grpcio-1.78.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3c586ac70e855c721bda8f548d38c3ca66ac791dc49b66a8281a1f99db85e452", size = 7277897, upload-time = "2026-02-06T09:56:34.915Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/9c/ad8685cfe20559a9edb66f735afdcb2b7d3de69b13666fdfc542e1916ebd/grpcio-1.78.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:35eb275bf1751d2ffbd8f57cdbc46058e857cf3971041521b78b7db94bdaf127", size = 8252404, upload-time = "2026-02-06T09:56:37.553Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/05/33a7a4985586f27e1de4803887c417ec7ced145ebd069bc38a9607059e2b/grpcio-1.78.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:207db540302c884b8848036b80db352a832b99dfdf41db1eb554c2c2c7800f65", size = 7696837, upload-time = "2026-02-06T09:56:40.173Z" },
-    { url = "https://files.pythonhosted.org/packages/73/77/7382241caf88729b106e49e7d18e3116216c778e6a7e833826eb96de22f7/grpcio-1.78.0-cp314-cp314-win32.whl", hash = "sha256:57bab6deef2f4f1ca76cc04565df38dc5713ae6c17de690721bdf30cb1e0545c", size = 4142439, upload-time = "2026-02-06T09:56:43.258Z" },
-    { url = "https://files.pythonhosted.org/packages/48/b2/b096ccce418882fbfda4f7496f9357aaa9a5af1896a9a7f60d9f2b275a06/grpcio-1.78.0-cp314-cp314-win_amd64.whl", hash = "sha256:dce09d6116df20a96acfdbf85e4866258c3758180e8c49845d6ba8248b6d0bbb", size = 4929852, upload-time = "2026-02-06T09:56:45.885Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
 ]
 
 [[package]]
@@ -502,155 +495,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/99/db44d685f0e257ff0e213ade1964fc459b4a690a73293220e98feb3307cf/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b86f6dd8935884615a0683b663891d43781b819ac4f2ba2b0c9604676af346d0", size = 590537124, upload-time = "2025-03-07T01:43:53.556Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1f/b3bd73445e5cb342727fd24fe1f7b748f690b460acadc27ea22f904502c8/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4412396548808ddfed3f17a467b104ba7751e6b58678a4b840675c56d21cf7ed", size = 9533318, upload-time = "2025-03-07T01:40:10.421Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d1/e50d0acaab360482034b84b6e27ee83c6738f7d32182b987f9c7a4e32962/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc1fec1e1637854b4c0a65fb9a8346b51dd9ee69e61ebaccc82058441f15bce8", size = 43106076, upload-time = "2025-03-07T01:41:59.817Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/75/f865a3b236e4647605ea34cc450900854ba123834a5f1598e160b9530c3a/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:52bf7bbee900262ffefe5e9d5a2a69a30d97e2bc5bb6cc866688caa976966e3d", size = 965265, upload-time = "2025-03-07T01:39:43.533Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f5/5607710447a6fe9fd9b3283956fceeee8a06cda1d2f56ce31371f595db2a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:4beb6d4cce47c1a0f1013d72e02b0994730359e17801d395bdcbf20cfb3bb00a", size = 1120705, upload-time = "2025-03-07T01:45:41.434Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/5e/92aa15eca622a388b80fbf8375d4760738df6285b1e92c43d37390a33a9a/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:dfab99248034673b779bc6decafdc3404a8a6f502462201f2f31f11354204acd", size = 63625754, upload-time = "2025-03-07T01:46:10.735Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-]
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/b9/598f6ff36faaece4b3c50d26f50e38661499ff34346f00e057760b35cc9d/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8878dce784d0fac90131b6817b607e803c36e629ba34dc5b433471382196b6a5", size = 283835557, upload-time = "2025-02-26T00:16:54.265Z" },
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/a2/8cee5da30d13430e87bf99bb33455d2724d0a4a9cb5d7926d80ccb96d008/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:adccd7161ace7261e01bb91e44e88da350895c270d23f744f0820c818b7229e7", size = 38386204, upload-time = "2025-03-07T01:49:43.612Z" },
-]
-
-[[package]]
-name = "nvidia-nvshmem-cu12"
-version = "3.3.20"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/9d/3dd98852568fb845ec1f7902c90a22b240fe1cbabda411ccedf2fd737b7b/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0b0b960da3842212758e4fa4696b94f129090b30e5122fea3c5345916545cff0", size = 124484616, upload-time = "2025-08-04T20:24:59.172Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/c0/1b303feea90d296f6176f32a2a70b5ef230f9bdeb3a72bddb0dc922dc137/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7ad891da111ebafbf7e015d34879f7112832fc239ff0d7d776b6cb685274615", size = 91161, upload-time = "2025-03-07T01:42:23.922Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
-]
-
-[[package]]
 name = "onnx"
 version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -710,17 +554,19 @@ dependencies = [
     { name = "protobuf" },
     { name = "psutil" },
     { name = "pytest" },
-    { name = "requests" },
     { name = "sne4onnx" },
     { name = "sng4onnx" },
-    { name = "tensorflow" },
-    { name = "tf-keras" },
     { name = "tqdm" },
 ]
 
 [package.optional-dependencies]
+tensorflow = [
+    { name = "tensorflow" },
+    { name = "tf-keras" },
+]
 torch = [
-    { name = "torch" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.metadata]
@@ -739,15 +585,14 @@ requires-dist = [
     { name = "protobuf", specifier = "==4.25.5" },
     { name = "psutil", specifier = "==5.9.5" },
     { name = "pytest", specifier = "==9.0.2" },
-    { name = "requests", specifier = "==2.32.5" },
     { name = "sne4onnx", specifier = "==2.0.1" },
     { name = "sng4onnx", specifier = "==2.0.1" },
-    { name = "tensorflow", specifier = "==2.19.0" },
-    { name = "tf-keras", specifier = "==2.19.0" },
-    { name = "torch", marker = "extra == 'torch'", specifier = "==2.9.0+cu128", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "tensorflow", marker = "extra == 'tensorflow'", specifier = "==2.19.0" },
+    { name = "tf-keras", marker = "extra == 'tensorflow'", specifier = "==2.19.0" },
+    { name = "torch", marker = "extra == 'torch'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "tqdm", specifier = "==4.67.1" },
 ]
-provides-extras = ["torch"]
+provides-extras = ["tensorflow", "torch"]
 
 [[package]]
 name = "onnxoptimizer"
@@ -975,11 +820,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
@@ -1028,11 +873,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]
@@ -1161,49 +1006,67 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.9.0+cu128"
-source = { registry = "https://download.pytorch.org/whl/cu128" }
+version = "2.11.0"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:e1765625084e320f1eb2f4eb5fd9d14d39d08d7a1880c10a307ce5de20831d27" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:87c62d3b95f1a2270bd116dbd47dc515c0b2035076fbb4a03b4365ea289e89c4" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp312-cp312-win_amd64.whl", hash = "sha256:c97dc47a1f64745d439dd9471a96d216b728d528011029b4f9ae780e985529e0" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4d76f71345af47f022c7fa55edd0c1810d01af89dcb9edcfdfafe3d2a0f7a6b8" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:97def0087f8ef171b9002ea500baffdd440c7bdd559c23c38bbf8781b67e9364" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp313-cp313-win_amd64.whl", hash = "sha256:9cba9f0fa2e1b70fffdcec1235a1bb727cbff7e7b118ba111b2b7f984b7087e2" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:dacbfc19608e60f78975c47d605c7d39b81afdf1983e93e94c17f60646b131e0" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8ce575fb71b878f5016df0a8a438c7c28f7f4be270af4119b5ad9ab62b0e470a" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp313-cp313t-win_amd64.whl", hash = "sha256:26effd07b9ee31c2db8988860317ba74361967bb4f9228af5a56907215cc27b5" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:eedef2e65d48c7dc9bb03f92c2a62bdae904382fc5c2773de3de41dce5ffd80a" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:55a2184ed89f2120bc1e2c887ee98e5280dee48bc330e9dfe296aa135a370f7d" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp314-cp314-win_amd64.whl", hash = "sha256:758978c4f0895fd76dd6a434c9157f7d70e8c2fea0bab452322f8b2252fe2e85" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4b51281e08ec36cd6748c71ac32fa1e45d30090b1c3fdf99ebb30776437734b7" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ef5939ebcacfe3d4f70774941e79a7c7e23f7918d7d3242428c8f48cc7440c0a" },
-    { url = "https://download.pytorch.org/whl/cu128/torch-2.9.0%2Bcu128-cp314-cp314t-win_amd64.whl", hash = "sha256:f11dae3d2534d985144f5b87d5f15d3d7219f63870c91d82e049fbb12779b3aa" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:442ec9dc78592564fdad69cf0beaa9da2f82ab810ccb4f13903869a90bf3f15d" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cc3a195701bba2239c313ee311487f80f8aaebe9e89b9073dddbcf2f93b5a0ba" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:072a0d6e4865e8b0dc0dbfe6ebed68fae235124222835ef03e5814d414d8c012" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23ec7789017da9d95b6d543d790814785e6f30905c5443efa8257d1490d73f79" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.13' and sys_platform != 'darwin'",
+    "python_full_version < '3.13' and sys_platform != 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-linux_s390x.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-linux_s390x.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-linux_s390x.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp313-cp313t-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-linux_s390x.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314-win_amd64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-linux_s390x.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl" },
+    { url = "https://download.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp314-cp314t-win_amd64.whl" },
 ]
 
 [[package]]
@@ -1216,23 +1079,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
-]
-
-[[package]]
-name = "triton"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/9b/30988039e1e84df7554fba24e6a734d2d0e847af33cabdf9b532b3c51456/triton-3.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da21fccceafc163e3a5e857abe34351ef76345af06cabf9637a914742671f0b", size = 159946647, upload-time = "2025-10-15T19:15:56.325Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/3a/e991574f3102147b642e49637e0281e9bb7c4ba254edb2bab78247c85e01/triton-3.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9e71db82261c4ffa3921cd050cd5faa18322d2d405c30eb56084afaff3b0833", size = 170476535, upload-time = "2025-10-13T16:38:05.18Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/85/e37f1197acb04c8f3d83851d23d5d6ed5060ef74580668b112e23fdfa203/triton-3.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:188da5b81fa2f8322c27fec1627703eac24cb9bb7ab0dfbe9925973bc1b070d3", size = 159958970, upload-time = "2025-10-15T19:16:01.717Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/29/10728de8a6e932e517c10773486b8e99f85d1b1d9dd87d9a9616e1fef4a1/triton-3.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e6bb9aa5519c084a333acdba443789e50012a4b851cd486c54f0b8dc2a8d3a12", size = 170487289, upload-time = "2025-10-13T16:38:11.662Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/1d/38258f05010ac17a7b058c022911c9cae6526e149b7397134a048cf5a6c2/triton-3.5.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:03127d9b33aaf979c856676b394bc059ec1d68cb6da68ae03f62dd8ad77a04ae", size = 160073012, upload-time = "2025-10-15T19:16:07.477Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/38/db80e48b9220c9bce872b0f616ad0446cdf554a40b85c7865cbca99ab3c2/triton-3.5.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c83f2343e1a220a716c7b3ab9fccfcbe3ad4020d189549200e2d2e8d5868bed9", size = 170577179, upload-time = "2025-10-13T16:38:17.865Z" },
-    { url = "https://files.pythonhosted.org/packages/91/fe/8f5771d00227f4eb1ee034f218ed427102b989366d2275fe3b3c105a3921/triton-3.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:468936651d383f4a6d10068d34a627505e13af55be5d002b9f27b987e7a5f0ac", size = 159957460, upload-time = "2025-10-15T19:16:12.626Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/60/1810655d1d856c9a4fcc90ee8966d85f552d98c53a6589f95ab2cbe27bb8/triton-3.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da0fa67ccd76c3dcfb0bffe1b1c57c685136a6bd33d141c24d9655d4185b1289", size = 170487949, upload-time = "2025-10-13T16:38:24.881Z" },
-    { url = "https://files.pythonhosted.org/packages/78/59/99edd103958fe6e42b50b9ad8ce4f223ddf4ccf475259cf7d2b53381dc6c/triton-3.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7ceef21410229ac23173a28eee5cfc0e37c1dfdb8b4bc11ecda2e3ecec7c686", size = 160075629, upload-time = "2025-10-15T19:16:18.746Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/b7/1dec8433ac604c061173d0589d99217fe7bf90a70bdc375e745d044b8aad/triton-3.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:317fe477ea8fd4524a6a8c499fb0a36984a56d0b75bf9c9cb6133a1c56d5a6e7", size = 170580176, upload-time = "2025-10-13T16:38:31.14Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "onnx2tf"
-version = "2.3.18"
+version = "2.3.19"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
### 1. Content and background

This PR manually ports the optional dependency work from the experimental branch into `feat-torch15` and updates the current codebase so that TensorFlow and PyTorch are no longer forced at base install time.

The main goal is to make the default `onnx2tf` installation lighter and safer for LiteRT / flatbuffer_direct users while keeping TensorFlow-backed and PyTorch-backed features available through explicit extras.

The branch also removes the remaining implicit TensorFlow dependency from `-cotof` when `--tflite_backend flatbuffer_direct` is used.

Important compatibility note:
TensorFlow is now fully optional. Users who need SavedModel export, H5 export, Keras v3 export, TFv1 PB export, or `tf_converter` must install the TensorFlow extra explicitly.

Recommended commands:

```bash
uv pip install -U "onnx2tf[tensorflow]"
```

or

```bash
uv sync --extra tensorflow
```

or

```bash
uv sync --all-extras
```

Without that extra, TensorFlow-backed features now fail fast with an explicit install hint instead of importing TensorFlow eagerly at module import time.

Additional note for reviewers: on the current `flatbuffer_direct` path, a root SavedModel is still written by default unless `--disable_model_save` is specified. `--flatbuffer_direct_output_saved_model` is only needed when the intent is to request/guarantee the explicit flatbuffer_direct SavedModel export behavior, especially for split output handling. In all such cases, TensorFlow extra installation is still required because SavedModel generation itself is TensorFlow-backed.

### 2. Summary of corrections

This PR includes the following functional changes.

1. TensorFlow is no longer a mandatory base dependency.
- `tensorflow` and `tf-keras` were moved out of the base dependency set into `onnx2tf[tensorflow]`.
- `import onnx2tf` and `python -m onnx2tf --help` no longer require TensorFlow.
- TensorFlow-backed features now go through lazy loading and explicit fail-fast checks.

2. PyTorch is no longer a mandatory base dependency.
- PyTorch-backed export and validation features were isolated behind `onnx2tf[torch]`.
- Native package export, TorchScript export, Dynamo ONNX export, ExportedProgram export, and PyTorch validation now fail fast with explicit install guidance if PyTorch is not available.
- The torch extra is pinned to `torch==2.11.0` and uses the CPU wheel index in the uv configuration.

3. TensorFlow-free runtime helpers were extracted for flatbuffer_direct.
- TensorFlow-independent runtime / schema / dummy-inference helpers were moved into a dedicated LiteRT runtime utility module.
- This allows flatbuffer_direct report generation and runtime checks to execute without pulling TensorFlow into the import path.

4. `flatbuffer_direct` `-cotof` no longer depends on TensorFlow.
- For `--tflite_backend flatbuffer_direct`, `-cotof` now means the TensorFlow-free report path only.
- The flag continues to generate ONNX↔TFLite comparison output and, when requested, ONNX↔PyTorch or TFLite↔PyTorch comparison output.
- The implicit SavedModel validation path was removed from the flatbuffer_direct `-cotof` flow, so `-cotof` itself no longer forces TensorFlow there.
- `tf_converter` keeps the existing TensorFlow-dependent behavior.

5. SavedModel behavior is now explicit.
- SavedModel export is still supported, but it is now clearly treated as a TensorFlow-backed optional feature.
- Users who need SavedModel-related workflows must install `onnx2tf[tensorflow]`.
- Documentation was updated so this requirement is visible from the install section and from the relevant option descriptions.

6. Failure messages and developer ergonomics were improved.
- Optional dependency errors now suggest `uv`-based install commands.
- PyTorch runtime import failures caused by foreign `PYTHONPATH` / `LD_LIBRARY_PATH` contamination now return a clearer diagnostic instead of a raw traceback.

7. Documentation and tests were updated.
- README / CONTRIBUTING were updated for the new extras-based installation model.
- New regression tests were added for TensorFlow-absent and PyTorch-absent environments.
- Existing tests were updated to match the new `flatbuffer_direct -cotof` behavior.

### 3. Before/After (If there is an operating log that can be used as a reference)

Before:
- Base installation always pulled TensorFlow.
- Base installation also effectively assumed PyTorch for several flatbuffer_direct-related flows.
- `import onnx2tf` and some CLI entrypoints could fail early if TensorFlow / PyTorch were not available.
- `flatbuffer_direct -cotof` still implicitly required TensorFlow because it triggered SavedModel validation.
- SavedModel-capable flows were not clearly separated from the lightweight LiteRT-only installation path.

After:
- Base installation is lightweight and does not force TensorFlow or PyTorch.
- TensorFlow-backed features are explicitly installed with `onnx2tf[tensorflow]`.
- PyTorch-backed features are explicitly installed with `onnx2tf[torch]`.
- `import onnx2tf` and CLI help work without TensorFlow / PyTorch.
- `flatbuffer_direct -cotof` works without TensorFlow and stays on the TensorFlow-free evaluation/report path.
- SavedModel users now have a clearer contract: install the TensorFlow extra before using SavedModel export or other TensorFlow-backed outputs.

Validation executed on this branch:

```bash
pytest -q tests/test_optional_tensorflow.py tests/test_optional_pytorch.py
pytest -q tests/test_flatbuffer_direct_op_error_report.py tests/test_pytorch_bulk_runner.py
pytest -q tests/test_tflite_builder_direct.py -k 'flatbuffer_direct_accuracy_report_generation or split_accuracy_report_fail_on_threshold'
pytest -q tests/test_optional_tensorflow.py
pytest -q tests/test_tflite2sm_phase1.py -k 'cotof and (flatbuffer_direct_output_saved_model or tflite_direct_input_saved_model)'
```

### 4. Issue number (only if there is a related issue)

N/A

