### PR TITLE
Make flatbuffer_direct the default TFLite backend

### DIFF
--- a/FLATBUFFER_DIRECT_MIGRATION_GUIDE.md
+++ b/FLATBUFFER_DIRECT_MIGRATION_GUIDE.md
@@ -1,12 +1,12 @@
 # flatbuffer_direct Migration Guide
 
 ## Goal
-Migrate from the default `tf_converter` backend to `flatbuffer_direct` in controlled stages while preserving production stability and diagnosability.
+Operate with the default `flatbuffer_direct` backend while preserving production stability and diagnosability, and keep `tf_converter` available only as an explicit compatibility path when needed.
 
 ## Backend differences (quick view)
 |Item|`tf_converter`|`flatbuffer_direct`|
 |:-|:-|:-|
-|Default|Yes|No (opt-in)|
+|Default|No (explicit fallback)|Yes|
 |Final generation path|TensorFlow Lite Converter|Direct FlatBuffer builder|
 |Optimization behavior|TF-path accumulated rewrites/heuristics|Direct preprocess + strict dispatch constraints|
 |Failure model|Many patterns absorbed by TF conversion|Explicit failure with `reason_code`|
@@ -14,9 +14,9 @@ Migrate from the default `tf_converter` backend to `flatbuffer_direct` in contro
 |Fallback|N/A|N/A (no fallback)|
 
 ## Recommended rollout
-1. Keep baseline CI on `--tflite_backend tf_converter`.
-2. Add one additional CI lane with `--tflite_backend flatbuffer_direct --report_op_coverage`.
-3. Resolve failures by `reason_code` and adjust model/export options.
+1. Keep the default CI lane on `flatbuffer_direct` and enable `--report_op_coverage` there.
+2. Add an explicit compatibility lane with `--tflite_backend tf_converter` if you still need to monitor legacy behavior.
+3. Resolve direct-path failures by `reason_code` and adjust model/export options.
 4. Only after stable float32/float16 conversion, enable quantization and split evaluation.
 
 ## Stage-by-stage commands
@@ -25,7 +25,6 @@ Migrate from the default `tf_converter` backend to `flatbuffer_direct` in contro
 python -m onnx2tf.onnx2tf \
   -i model.onnx \
   -o out \
-  --tflite_backend flatbuffer_direct \
   --report_op_coverage
 ```
 
@@ -34,7 +33,6 @@ python -m onnx2tf.onnx2tf \
 python -m onnx2tf.onnx2tf \
   -i model.onnx \
   -o out \
-  --tflite_backend flatbuffer_direct \
   -odrqt -oiqt \
   --eval_with_onnx \
   --eval_target_tflite full_integer_quant \
@@ -47,7 +45,6 @@ python -m onnx2tf.onnx2tf \
 python -m onnx2tf.onnx2tf \
   -i model.onnx \
   -o out \
-  --tflite_backend flatbuffer_direct \
   --auto_split_tflite_by_size \
   --tflite_split_target_bytes 1060000000 \
   --tflite_split_max_bytes 1073741824 \
@@ -59,11 +56,10 @@ python -m onnx2tf.onnx2tf \
 ```bash
 python -m onnx2tf.onnx2tf \
   -i model.onnx \
-  -o out \
-  --tflite_backend flatbuffer_direct
+  -o out
 ```
 
-When direct export fails, conversion stops with an explicit error. Use `tf_converter` explicitly if fallback behavior is required operationally.
+When direct export fails, conversion stops with an explicit error. Use `tf_converter` explicitly if the legacy TensorFlow Lite Converter path is still required operationally.
 
 ## Preprocess scope in direct path
 `flatbuffer_direct` applies staged preprocess rules before lowering:
@@ -114,8 +110,9 @@ Behavior:
 5. OP coverage: `*_op_coverage_report.json`
 
 ## Operational checklist
-1. Keep `tf_converter` lane green at all times.
-2. Gate `flatbuffer_direct` rollout by model family (small -> medium -> large).
-3. Require `--report_op_coverage` in CI for direct lane.
-4. Review `unsupported_reason_counts` and `custom_op_policy` for every failure.
-5. Avoid custom-op expansion unless runtime/serving side is ready.
+1. Keep the default `flatbuffer_direct` lane green at all times.
+2. Keep an explicit `tf_converter` lane only if you still rely on that compatibility path.
+3. Gate `flatbuffer_direct` rollout by model family (small -> medium -> large).
+4. Require `--report_op_coverage` in CI for the direct lane.
+5. Review `unsupported_reason_counts` and `custom_op_policy` for every failure.
+6. Avoid custom-op expansion unless runtime/serving side is ready.

--- a/README.md
+++ b/README.md
@@ -9,10 +9,7 @@ You should use LiteRT Torch rather than onnx2tf. https://github.com/google-ai-ed
 
 [![Downloads](https://static.pepy.tech/personalized-badge/onnx2tf?period=total&units=none&left_color=grey&right_color=brightgreen&left_text=Downloads)](https://pepy.tech/project/onnx2tf) ![GitHub](https://img.shields.io/github/license/PINTO0309/onnx2tf?color=2BAF2B) [![Python](https://img.shields.io/badge/Python-3.12-2BAF2B)](https://img.shields.io/badge/Python-3.8-2BAF2B) [![PyPI](https://img.shields.io/pypi/v/onnx2tf?color=2BAF2B)](https://pypi.org/project/onnx2tf/) [![CodeQL](https://github.com/PINTO0309/onnx2tf/workflows/CodeQL/badge.svg)](https://github.com/PINTO0309/onnx2tf/actions?query=workflow%3ACodeQL) ![Model Convert Test Status](https://github.com/PINTO0309/onnx2tf/workflows/Model%20Convert%20Test/badge.svg) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7230085.svg)](https://doi.org/10.5281/zenodo.7230085) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/PINTO0309/onnx2tf)
 
-## Model Conversion Status
-https://github.com/PINTO0309/onnx2tf/wiki/model_status
-
-## Supported layers
+## `tf_converter` supported layers
 - https://github.com/onnx/onnx/blob/main/docs/Operators.md
 - :heavy_check_mark:: Supported　:white_check_mark:: Partial support　**Help wanted**: Pull Request are welcome
 
@@ -233,14 +230,14 @@ https://github.com/PINTO0309/onnx2tf/wiki/model_status
 
 ## `flatbuffer_direct` execution path
 
-Currently, the `flatbuffer_direct` backend is faster and has a higher success rate than the default `tf_converter` backend. The simplest conversion command for `flatbuffer_direct` outputs only a LiteRT model, but if you add `--flatbuffer_direct_output_saved_model`, it will output a `saved_model` as before. However, what is different from the previous behavior is that it will build the graph of the `saved_model` from the LiteRT model.
+`flatbuffer_direct` is now the default backend. It is faster and has a higher success rate than `tf_converter` for the supported direct path. The simplest conversion command now outputs only a LiteRT model by default, but if you add `--flatbuffer_direct_output_saved_model`, it will also output a `saved_model`. Unlike the legacy `tf_converter` path, this SavedModel is built from the LiteRT-side ModelIR.
 
 > [!IMPORTANT]
-> **Starting with onnx2tf v2.4.0, `tf_converter` will be deprecated and the default backend will be switched to `flatbuffer_direct`. With the v2.3.3 update, all backward compatible conversion options have been migrated to `flatbuffer_direct`, so I will only be doing minor bug fixes until April. If you provide us with ONNX sample models, I will consider incorporating them into `flatbuffer_direct`. I'll incorporate [ai-edge-quantizer](https://github.com/google-ai-edge/ai-edge-quantizer) when I feel like it, but that will probably be about 10 years from now.**
+> **`flatbuffer_direct` is the current default backend. Use `--tflite_backend tf_converter` only when you explicitly need the legacy TensorFlow Lite Converter compatibility path.**
 
 <img width="1390" height="680" alt="image" src="https://github.com/user-attachments/assets/04c5d8e2-2465-4dac-b3ea-37d7e7f987cc" />
 
-When `--tflite_backend flatbuffer_direct` is selected, onnx2tf now uses a direct fast path for both ONNX input and `-it/--input_tflite_file_path` input:
+With the default `flatbuffer_direct` backend, onnx2tf uses a direct fast path for both ONNX input and `-it/--input_tflite_file_path` input:
 
 1. ONNX graph preprocessing (`tflite_builder.preprocess`) and direct lowering (`lower_onnx_to_ir`)
 2. Direct FlatBuffer export (`*_float32.tflite`, `*_float16.tflite`, and optional quantized variants)
@@ -528,7 +525,7 @@ via `--shape_hints`, `--test_data_nhwc_path`, or `-cind`.
 
 <details><summary>Click to expand</summary>
 
-- Scope: ONNX ops listed in the `Supported layers` table above.
+- Scope: ONNX ops listed in the ``tf_converter` supported layers` table above.
 - Source of truth: `onnx2tf/tflite_builder/op_registry.py` and `--report_op_coverage` output.
 - Current summary:
   - Listed ONNX ops in the builtin table below: `192`
@@ -920,7 +917,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.3.19
+  ghcr.io/pinto0309/onnx2tf:2.4.0
 
   or
 
@@ -929,7 +926,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.3.19
+  docker.io/pinto0309/onnx2tf:2.4.0
 
   or
 
@@ -939,7 +936,7 @@ Video speed is adjusted approximately 50 times slower than actual speed.
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.3.19 \
+  docker.io/pinto0309/onnx2tf:2.4.0 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or
@@ -1031,14 +1028,14 @@ Only patterns that are considered to be used particularly frequently are describ
 ```bash
 # Float32, Float16
 # This is the fastest way to generate tflite.
-# Improved to automatically generate `signature` without `-osd` starting from v1.25.3.
+# Add `-fdosm` if you also want SavedModel output on the default backend.
 # Also, starting from v1.24.0, efficient TFLite can be generated
 # without unrolling `GroupConvolution`. e.g. YOLOv9, YOLOvN
 # Conversion to other frameworks. e.g. TensorFlow.js, CoreML, etc
 # https://github.com/PINTO0309/onnx2tf#19-conversion-to-tensorflowjs
 # https://github.com/PINTO0309/onnx2tf#20-conversion-to-coreml
 wget https://github.com/PINTO0309/onnx2tf/releases/download/0.0.2/resnet18-v1-7.onnx
-onnx2tf -i resnet18-v1-7.onnx
+onnx2tf -i resnet18-v1-7.onnx -fdosm
 
 ls -lh saved_model/
 
@@ -1234,7 +1231,7 @@ Quick difference between `-tdnp` and `-cind`:
 - `-tdnp` (`--test_data_nhwc_path`): Validation-only test data for accuracy checks. Expects one NHWC RGB `.npy` (`[N,H,W,3]`). No `mean/std`. For multi-input models, this single array is reused across inputs (per-input mapping is not supported). Also accepted by `-fdots` for eligible 4D RGB inputs.
 - `-cind` (`--custom_input_op_name_np_data_path`): Per-input custom data mapping by input name. Supports multi-input/non-image inputs. Also used for `-fdots` trace inputs and INT8 calibration (`-oiqt`) with optional `mean/std`.
 
-The `-cotof` option evaluates Float32 accuracy only. In the default path it checks ONNX against TensorFlow/TFLite outputs. When `--tflite_backend flatbuffer_direct` is used, the base report is ONNX↔TFLite. If `--flatbuffer_direct_output_pytorch` is also enabled, onnx2tf additionally emits ONNX↔PyTorch and combined comparison reports using the same input samples.
+The `-cotof` option evaluates Float32 accuracy only. On the default `flatbuffer_direct` path, the base report is ONNX↔TFLite. When `--tflite_backend tf_converter` is explicitly used, it checks ONNX against TensorFlow/TFLite outputs. If `--flatbuffer_direct_output_pytorch` is also enabled, onnx2tf additionally emits ONNX↔PyTorch and combined comparison reports using the same input samples.
 
 ```
 onnx2tf -i mobilenetv2-12.onnx -ois input:1,3,224,224 -cotof -cotoa 1e-1
@@ -1524,7 +1521,7 @@ e.g. How to specify calibration data in CLI or Script respectively.
 
 If you do not need to perform INT8 quantization with this tool alone, the following method is the easiest.
 
-The `-osd` option will output a `saved_model.pb` in the `saved_model` folder with the full size required for quantization. That is, a default signature named `serving_default` is embedded in `.pb`. The `-b` option is used to convert the batch size by rewriting it as a static integer.
+On the default `flatbuffer_direct` backend, combine `-fdosm` with `-osd` to output a `saved_model.pb` in the `saved_model` folder with the full size required for quantization. That is, a default signature named `serving_default` is embedded in `.pb`. If you need the legacy behavior instead, use `--tflite_backend tf_converter` explicitly. The `-b` option is used to convert the batch size by rewriting it as a static integer.
 
 **Note: INT8 TFLite generated by following this procedure as is will result in a model with significantly degraded accuracy. This tutorial only demonstrates the INT8 quantization procedure; if you wish to correct for accuracy, please refer to [Parameter replacement](#parameter-replacement) to correct for transposition errors in the operation.**
 
@@ -1532,7 +1529,7 @@ The `-osd` option will output a `saved_model.pb` in the `saved_model` folder wit
 # Ref: https://github.com/onnx/models/tree/main/text/machine_comprehension/bert-squad
 wget https://s3.ap-northeast-2.wasabisys.com/temp-models/onnx2tf_248/bertsquad-12.onnx
 
-onnx2tf -i bertsquad-12.onnx -b 1 -osd -cotof
+onnx2tf -i bertsquad-12.onnx -b 1 -fdosm -osd -cotof
 ```
 
 ![image](https://user-images.githubusercontent.com/33194443/225175510-95200964-06ff-474a-8cd4-f640bec6c397.png)
@@ -1638,7 +1635,7 @@ PyTorch's `NonMaxSuppression (torchvision.ops.nms)` and ONNX's `NonMaxSuppressio
 
 3. Finally, simply convert ONNX to TFLite or saved_model or TFJS using onnx2tf. onnx2tf performs an internal operation to automatically optimize the NMS output to a fixed shape if `max_output_boxes_per_class` is set to a value other than `-Infinity` and `9223372036854775807 (Maximum value of INT64)`. Specify `--output_nms_with_dynamic_tensor` or `-onwdt` if you do not want to optimize for a fixed shape. If you want to shrink class scores in NMS from `[B, C, N]` to `[B, 1, N]`, enable `--output_nms_with_argmax` or `-onwa`.
     ```
-    onnx2tf -i nms_yolov7_update.onnx -osd -cotof
+    onnx2tf -i nms_yolov7_update.onnx -fdosm -osd -cotof
     ```
     I would be happy if this is a reference for Android + Java or TFJS implementations. There are tons more tricky model optimization techniques described in my blog posts, so you'll have to find them yourself. I don't dare to list the URL here because it is annoying to see so many `issues` being posted. And unfortunately, all articles are in Japanese.
     ![image](https://user-images.githubusercontent.com/33194443/230780749-9967a34b-abf6-47fe-827d-92e0f6bddf46.png)
@@ -1814,7 +1811,7 @@ This model calculates the similarity of features by cosine similarity. The batch
 Convert the downloaded `OSNet` to `tflite` and `saved_model` as a variable batch. If you do not specify the `-b` or `-ois` options, onnx2tf does not change the batch size as `N`. The only important point is to convert the model with the `-osd` and `-coion` options.
 
 ```
-onnx2tf -i osnet_x0_25_msmt17.onnx -osd -coion
+onnx2tf -i osnet_x0_25_msmt17.onnx -fdosm -osd -coion
 ```
 
   - `.tflite`
@@ -2074,7 +2071,7 @@ If such a model is converted without any options, TensorFlow/Keras will abort. T
 Thus, for models such as this, where all dimensions, including batch size, are dynamic shapes, it is often possible to convert by fixing the batch size to `1` with the `-b 1` or `--batch_size 1` option.
 
 ```
-onnx2tf -i model.onnx -b 1 -osd
+onnx2tf -i model.onnx -b 1 -fdosm -osd
 ```
 
 - Results
@@ -2143,7 +2140,7 @@ tensorflow_decision_forests \
 ydf \
 tensorflow_hub
 
-onnx2tf -i mobilenetv2-12.onnx -ois input:1,3,224,224 -osd -dgc
+onnx2tf -i mobilenetv2-12.onnx -ois input:1,3,224,224 -fdosm -osd -dgc
 
 tensorflowjs_converter \
 --input_format tf_saved_model \
@@ -2167,7 +2164,7 @@ When converting to CoreML, process as follows. The `-k` option is for conversion
 ```bash
 pip install coremltools==8.2
 
-onnx2tf -i mobilenetv2-12.onnx -k input -ois input:1,3,224,224 -osd
+onnx2tf -i mobilenetv2-12.onnx -k input -ois input:1,3,224,224 -fdosm -osd
 ```
 ```python
 import coremltools as ct
@@ -2303,9 +2300,10 @@ optional arguments:
   -tb {tf_converter,flatbuffer_direct}, \
     --tflite_backend {tf_converter,flatbuffer_direct}
     TFLite generation backend.
-    "tf_converter"(default): Use TensorFlow Lite Converter.
-    "flatbuffer_direct": Use direct FlatBuffer builder path (limited
+    "flatbuffer_direct"(default): Use direct FlatBuffer builder path (limited
     OP/quantization support).
+    "tf_converter": Use TensorFlow Lite Converter as an explicit compatibility
+    path.
 
   -fdosm, --flatbuffer_direct_output_saved_model
     Output SavedModel directly from flatbuffer_direct ModelIR (float32).
@@ -2924,7 +2922,7 @@ convert(
   flatbuffer_direct_output_dynamo_onnx: Optional[bool] = False,
   flatbuffer_direct_output_exported_program: Optional[bool] = False,
   native_pytorch_generation_timeout_sec: Optional[int] = 0,
-  tflite_backend: Optional[str] = 'tf_converter',
+  tflite_backend: Optional[str] = 'flatbuffer_direct',
   quant_norm_mean: Optional[str] = '[[[[0.485, 0.456, 0.406]]]]',
   quant_norm_std: Optional[str] = '[[[[0.229, 0.224, 0.225]]]]',
   quant_type: Optional[str] = 'per-channel',
@@ -3072,8 +3070,8 @@ convert(
 
     tflite_backend: Optional[str]
       TFLite generation backend.
-      "tf_converter"(default): Use TensorFlow Lite Converter.
-      "flatbuffer_direct": Experimental direct FlatBuffer builder path.
+      "flatbuffer_direct"(default): Experimental direct FlatBuffer builder path.
+      "tf_converter": Use TensorFlow Lite Converter as an explicit compatibility path.
       Note: "flatbuffer_direct" supports a limited builtin OP set,
       FP32/FP16 export, limited dynamic-range quantization,
       limited integer quantization, and limited int16-activation variants.

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "2.3.19"
+__version__ = "2.4.0"
 
 
 def _load_impl():

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -1310,7 +1310,7 @@ def convert(
     flatbuffer_direct_custom_op_allowlist: Optional[List[str]] = None,
     tflite_split_max_bytes: Optional[int] = 1073741824,
     tflite_split_target_bytes: Optional[int] = 1060000000,
-    tflite_backend: Optional[str] = 'tf_converter',
+    tflite_backend: Optional[str] = 'flatbuffer_direct',
     quant_norm_mean: Optional[str] = '[[[[0.485, 0.456, 0.406]]]]',
     quant_norm_std: Optional[str] = '[[[[0.229, 0.224, 0.225]]]]',
     quant_type: Optional[str] = 'per-channel',
@@ -1564,8 +1564,9 @@ def convert(
 
     tflite_backend: Optional[str]
         TFLite generation backend.\n
-        "tf_converter"(default): Use TensorFlow Lite Converter.\n
-        "flatbuffer_direct": Use direct FlatBuffer builder path.\n
+        "flatbuffer_direct"(default): Use direct FlatBuffer builder path.\n
+        "tf_converter": Use TensorFlow Lite Converter as an explicit\n
+        compatibility path.\n
         Note: "flatbuffer_direct" supports a limited builtin OP set,\n
         FP32/FP16 export, limited dynamic-range quantization,\n
         limited integer quantization, and limited int16-activation variants.\n
@@ -8476,11 +8477,11 @@ def main():
         '--tflite_backend',
         type=str,
         choices=['tf_converter', 'flatbuffer_direct'],
-        default='tf_converter',
+        default='flatbuffer_direct',
         help=\
             'TFLite generation backend. \n' +
-            '"tf_converter"(default): Use TensorFlow Lite Converter. \n' +
-            '"flatbuffer_direct": Use direct FlatBuffer builder path (limited OP/quantization support).'
+            '"flatbuffer_direct"(default): Use direct FlatBuffer builder path (limited OP/quantization support). \n' +
+            '"tf_converter": Use TensorFlow Lite Converter as an explicit compatibility path.'
     )
     parser.add_argument(
         '-ewo',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.3.19"
+version = "2.4.0"
 description = "A tool for converting ONNX files to LiteRT/TFLite/TensorFlow, PyTorch native code (nn.Module), TorchScript (.pt), state_dict (.pt), Exported Program (.pt2), and Dynamo ONNX. It also supports direct conversion from LiteRT to PyTorch."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_model_convert.py
+++ b/tests/test_model_convert.py
@@ -234,7 +234,7 @@ def _configure(
     output_dir=tempfile.gettempdir(),
     verbose=False,
     dry_run=False,
-    tflite_backend='tf_converter',
+    tflite_backend='flatbuffer_direct',
     report_filename='model_status.md',
     preserve_model_files=False,
     not_use_onnxsim=False,
@@ -290,7 +290,7 @@ def model_convert_report(
     output_dir=tempfile.gettempdir(),
     verbose=False,
     dry_run=False,
-    tflite_backend='tf_converter',
+    tflite_backend='flatbuffer_direct',
     report_filename='model_status.md',
     preserve_model_files=False,
     not_use_onnxsim=False,
@@ -391,9 +391,9 @@ if __name__ == '__main__':
     )
     parser.add_argument(
         '--tflite-backend',
-        default='tf_converter',
+        default='flatbuffer_direct',
         choices=['tf_converter', 'flatbuffer_direct'],
-        help='tflite backend for conversion (default: tf_converter)'
+        help='tflite backend for conversion (default: flatbuffer_direct)'
     )
     parser.add_argument(
         '--report-filename',

--- a/tests/test_optional_tensorflow.py
+++ b/tests/test_optional_tensorflow.py
@@ -135,6 +135,69 @@ print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
         assert lines[-1] == "False False"
 
 
+def test_default_backend_convert_succeeds_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import os
+import sys
+import onnx2tf
+
+model_path = sys.argv[1]
+output_dir = sys.argv[2]
+onnx2tf.convert(
+    input_onnx_file_path=model_path,
+    output_folder_path=output_dir,
+    disable_strict_mode=True,
+    verbosity='error',
+)
+print(os.path.exists(os.path.join(output_dir, 'add_float32.tflite')))
+print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        assert lines[-2] == "True"
+        assert lines[-1] == "False False"
+
+
+def test_main_default_backend_succeeds_without_tensorflow() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        model_path = Path(tmpdir) / "add.onnx"
+        output_dir = Path(tmpdir) / "out"
+        _make_add_model(model_path)
+        result = _run_python(
+            BLOCK_TF_IMPORTS
+            + """
+import os
+import sys
+import onnx2tf
+
+sys.argv = [
+    'onnx2tf',
+    '-i', sys.argv[1],
+    '-o', sys.argv[2],
+]
+onnx2tf.main()
+output_dir = sys.argv[4]
+print(os.path.exists(os.path.join(output_dir, 'add_float32.tflite')))
+print('tensorflow' in sys.modules, 'tf_keras' in sys.modules)
+""",
+            str(model_path),
+            str(output_dir),
+        )
+        assert result.returncode == 0, result.stderr
+        lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        assert lines[-2] == "True"
+        assert lines[-1] == "False False"
+
+
 def test_flatbuffer_direct_cotof_succeeds_without_tensorflow() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         model_path = Path(tmpdir) / "add.onnx"

--- a/tests/test_tflite2sm_phase1.py
+++ b/tests/test_tflite2sm_phase1.py
@@ -2018,6 +2018,7 @@ def test_tflite_direct_input_rejects_mixed_onnx_and_tflite_input() -> None:
                 input_tflite_file_path=tflite_path,
                 output_folder_path=tmpdir,
                 verbosity="error",
+                tflite_backend="flatbuffer_direct",
             )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "onnx2tf"
-version = "2.3.19"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
## Summary
This PR switches the default TFLite backend from `tf_converter` to `flatbuffer_direct` and aligns the surrounding API, CLI, tests, helper scripts, and docs with that behavior.

## What changed
- changed the default `tflite_backend` in `onnx2tf.convert()` and the CLI to `flatbuffer_direct`
- kept `tf_converter` available as an explicit compatibility path
- updated helper tooling and README examples to avoid relying on the old implicit SavedModel behavior
- clarified documentation so SavedModel-related flows now require explicit direct-export flags or an explicit `tf_converter` selection
- added regression coverage for the default-backend path without TensorFlow
- updated the migration guide to describe `flatbuffer_direct` as the current default
- renamed the README supported-layers heading to make it clear that it refers to `tf_converter` coverage
- bumped the package version/lockfile for the 2.4.0 change

## Why this improves the feature
This makes the faster direct path the out-of-the-box experience, reduces accidental dependency on TensorFlow-backed conversion, and makes the remaining legacy path explicit. It also removes ambiguity in docs and tests around which backend is responsible for SavedModel generation.

## Validation
- `pytest -q tests/test_optional_tensorflow.py`
- `pytest -q tests/test_tflite2sm_phase1.py -k "flatbuffer_direct_output_saved_model_validation or tflite_direct_input_validation or tflite_direct_input_new_conflict_validation or tflite_direct_input_rejects_mixed_onnx_and_tflite_input"`
- `python tests/test_model_convert.py --help`
