### PR TITLE
Prefer layout-preserving tie-break for InstanceNormalization

### DIFF
--- a/onnx2tf/ops/InstanceNormalization.py
+++ b/onnx2tf/ops/InstanceNormalization.py
@@ -214,7 +214,12 @@ def make_node(
     # Automatic correction of accuracy degradation
     min_abs_err = sys.maxsize
     min_abs_err_perm_1: list[int] = [idx for idx in range(input_tensor_rank)]
+    identity_permutation = [idx for idx in range(input_tensor_rank)]
+    layout_preserving_tolerance = 1e-2
+    identity_candidate_err = None
     axes = [idx for idx in range(1, input_tensor_rank - 1)]
+    input_nhwc = tf_layers_dict.get(graph_node_input.name, {}).get('nhwc', False) \
+        if isinstance(graph_node_input, gs.Variable) else False
 
     if not disable_strict_mode:
         if onnx_tensor_infos is not None and validation_data is not None:
@@ -285,11 +290,20 @@ def make_node(
                         atol=0.0,
                     )
                     result_err = sum([val[2] for val in check_results.values()])
-                    if result_err < min_abs_err:
-                        min_abs_err = result_err
-                        min_abs_err_perm_1 = list(tensor_1_candidate_for_transposition)
-                        if min_abs_err < 1e-2:
-                            break
+                    tensor_1_candidate_for_transposition_list = list(tensor_1_candidate_for_transposition)
+                    is_identity_candidate = tensor_1_candidate_for_transposition_list == identity_permutation
+                    if is_identity_candidate:
+                        identity_candidate_err = result_err
+
+                    if is_identity_candidate \
+                        or (not input_nhwc) \
+                        or identity_candidate_err is None \
+                        or result_err < identity_candidate_err - layout_preserving_tolerance:
+                        if result_err < min_abs_err:
+                            min_abs_err = result_err
+                            min_abs_err_perm_1 = tensor_1_candidate_for_transposition_list
+                            if min_abs_err < 1e-2:
+                                break
                 except Exception as ex:
                     pass
 


### PR DESCRIPTION
## Summary
- prefer the identity permutation for NHWC-preserved InstanceNormalization inputs when candidate permutation errors are effectively tied
- require non-identity permutations to beat identity by more than the existing 1e-2 strict-mode acceptance threshold before selecting them
- keep the original minimum-error behavior for non-NHWC inputs and clear non-identity wins

Refs #930

## Review notes
The issue attachment was downloadable and the reported command path was exercised locally. In this scratch environment, that full model still fails later in a downstream Conv shape mismatch, so this PR focuses on the InstanceNormalization permutation tie-break described in the issue rather than claiming full model conversion success.

## Checks
- python3 -m py_compile onnx2tf/ops/InstanceNormalization.py
- git diff --check
- lightweight tie-break assertion script for near-tie, clear-win, and non-NHWC cases

## Local smoke context
A synthetic InstanceNormalization conversion completed in the side-run scratch environment before review. A follow-up tf_converter smoke after review reached TensorFlow/TFLite converter logging but hung in this local environment, so it was terminated without changing the repo.