### PR TITLE
Support ScatterElements reduction="add"

### DIFF
--- a/onnx2tf/ops/ScatterElements.py
+++ b/onnx2tf/ops/ScatterElements.py
@@ -125,7 +125,7 @@ def make_node(
         before_op_output_shape_trans=before_op_output_shape_trans,
     )
     reduction = graph_node.attrs.get('reduction', 'none')
-    enable_reductions = ['none']
+    enable_reductions = ['none', 'add']
     if reduction not in enable_reductions:
         error(
             f'ScatterElements currently supports only reduction={enable_reductions}. '+
@@ -246,7 +246,13 @@ def make_node(
 
     indices = tf.reshape(coordinate, [-1, input_tensor_rank])
     updates = tf.reshape(updates_tensor_for_scatter, [-1])
-    output = tf.tensor_scatter_nd_update(
+
+    if reduction == 'none':
+        scatter_op = tf.tensor_scatter_nd_update
+    elif reduction == 'add':
+        scatter_op = tf.tensor_scatter_nd_add
+
+    output = scatter_op(
         tensor=input_tensor,
         indices=indices,
         updates=updates,
@@ -269,7 +275,7 @@ def make_node(
     tf_layers_dict[graph_node_output.name]['tf_node_info'] = \
         make_tf_node_info(
             node_info={
-                'tf_op_type': tf.tensor_scatter_nd_update,
+                'tf_op_type': scatter_op,
                 'tf_inputs': {
                     'tensor': input_tensor,
                     'indices': indices_tensor,

--- a/onnx2tf/tflite_builder/op_builders/index.py
+++ b/onnx2tf/tflite_builder/op_builders/index.py
@@ -2283,6 +2283,7 @@ def build_scatter_elements_op(node: Any, ctx: Any) -> None:
         axis=int(node.attrs.get("axis", 0)),
         rank=rank,
     )
+    reduction = str(node.attrs.get("reduction", "none")).lower()
 
     data_dtype = str(ctx.get_tensor_dtype(data_name)).upper()
     output_tensor = ctx.model_ir.tensors[output_name]
@@ -2745,6 +2746,30 @@ def build_scatter_elements_op(node: Any, ctx: Any) -> None:
             )
         )
 
+    data_meta_shape = _tensor_shape_with_signature(ctx, data_name)
+    scattered_updates_name = ctx.add_intermediate_tensor(
+        f"{output_name}_scatter_elements_updates_scattered",
+        dtype=data_dtype,
+        shape=data_meta_shape,
+    )
+    ctx.add_operator(
+        OperatorIR(
+            op_type="SCATTER_ND",
+            inputs=[indices_flat_name, updates_flat_name, shape_for_scatter],
+            outputs=[scattered_updates_name],
+        )
+    )
+
+    if reduction == "add":
+        _add_binary_op(
+            ctx=ctx,
+            op_type="ADD",
+            lhs_name=data_name,
+            rhs_name=scattered_updates_name,
+            output_name=output_name,
+        )
+        return
+
     one_name = ctx.add_const_tensor(
         f"{output_name}_scatter_elements_one",
         np.asarray(1, dtype=_DTYPE_TO_NP[data_dtype]),
@@ -2779,7 +2804,6 @@ def build_scatter_elements_op(node: Any, ctx: Any) -> None:
         )
     )
 
-    data_meta_shape = _tensor_shape_with_signature(ctx, data_name)
     mask_scatter_name = ctx.add_intermediate_tensor(
         f"{output_name}_scatter_elements_mask",
         dtype=data_dtype,
@@ -2792,11 +2816,6 @@ def build_scatter_elements_op(node: Any, ctx: Any) -> None:
     )
     retained_name = ctx.add_intermediate_tensor(
         f"{output_name}_scatter_elements_retained",
-        dtype=data_dtype,
-        shape=data_meta_shape,
-    )
-    scattered_updates_name = ctx.add_intermediate_tensor(
-        f"{output_name}_scatter_elements_updates_scattered",
         dtype=data_dtype,
         shape=data_meta_shape,
     )
@@ -2820,13 +2839,6 @@ def build_scatter_elements_op(node: Any, ctx: Any) -> None:
         lhs_name=data_name,
         rhs_name=inverse_mask_name,
         output_name=retained_name,
-    )
-    ctx.add_operator(
-        OperatorIR(
-            op_type="SCATTER_ND",
-            inputs=[indices_flat_name, updates_flat_name, shape_for_scatter],
-            outputs=[scattered_updates_name],
-        )
     )
     _add_binary_op(
         ctx=ctx,

--- a/onnx2tf/tflite_builder/op_registry.py
+++ b/onnx2tf/tflite_builder/op_registry.py
@@ -4889,11 +4889,11 @@ def _validate_unique(node: Any, ctx: Any) -> None:
 
 def _validate_scatter_elements(node: Any, ctx: Any) -> None:
     reduction = str(node.attrs.get("reduction", "none")).lower()
-    if reduction != "none":
+    if reduction not in {"none", "add"}:
         raise NodeValidationError(
             reason_code="unsupported_attribute_value",
             message=(
-                "ScatterElements reduction attribute supports 'none' only in flatbuffer_direct. "
+                "ScatterElements reduction attribute supports 'none' and 'add' only in flatbuffer_direct. "
                 f"reduction={reduction}"
             ),
             node_name=node.name,


### PR DESCRIPTION
### 1. Content and background
Support for `ScatterElements` with `reduction="add"`.

Added support in both conversion paths.

`tf_converter`

- Uses `tf.tensor_scatter_nd_add` when `reduction="add"`

- Keeps the existing `tf.tensor_scatter_nd_update` path for `reduction="none"`

`flatbuffer_direct`

- Lowers `reduction="add"` as `output = data + SCATTER_ND(indices, updates, data_shape)`

- Keeps the existing mask/replace behavior for `reduction="none"`

### 2. Summary of corrections

### 3. Before/After (If there is an operating log that can be used as a reference)

### 4. Issue number (only if there is a related issue)
