### PR TITLE
fix: support Python 3.13 by updating numpy pin to 2.2.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,11 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "numpy==1.26.4",
+    "numpy==2.2.6",
     "onnx==1.20.1",
     "onnxruntime==1.24.3",
     "opencv-python==4.11.0.86",
@@ -69,7 +70,7 @@ override-dependencies = [
     "onnx==1.20.1",
     "onnxsim-prebuilt==0.4.39.post2",
     "ml-dtypes==0.5.1",
-    "numpy==1.26.4",
+    "numpy==2.2.6",
 ]
 
 [tool.uv.build-backend]


### PR DESCRIPTION
## Problem

`onnx2tf v2.x` is completely uninstallable on Python 3.13 due to a self-contradictory dependency specification:

- `onnx2tf` requires `numpy==1.26.4`
- `onnx2tf` requires `ml_dtypes==0.5.1`
- `ml_dtypes==0.5.1` on Python 3.13 (cp313) requires `numpy>=2.1.0`

These are mutually exclusive, causing a resolver error on any Python 3.13 environment.

## Fix

Bump numpy pin from `1.26.4` to `2.2.6` (latest stable) in both `[project].dependencies` and `[tool.uv].override-dependencies`.

## Verification

- `onnxruntime==1.24.3`: ships cp313 wheels, requires numpy>=1.21.6
- `ai-edge-litert==2.1.2`: ships cp313 wheels, requires numpy>=1.23.2
- `uv pip install --dry-run` resolves successfully on Python 3.13

## Changes

- `numpy==1.26.4` to `numpy==2.2.6` in dependencies and uv overrides
- Added `Programming Language :: Python :: 3.13` classifier