### PR TITLE
Fix SavedModel Conv3D filter layouts

### DIFF
--- a/onnx2tf/tflite_builder/saved_model_exporter.py
+++ b/onnx2tf/tflite_builder/saved_model_exporter.py
@@ -1242,8 +1242,8 @@ def _kernel_conv3d(
     x = executor._resolve_tensor(op.inputs[0], env)
     w = executor._resolve_tensor(op.inputs[1], env)
     b = executor._resolve_optional_tensor(op.inputs[2], env) if len(op.inputs) >= 3 else None
-    # TFLite conv3d filter: [out, d, h, w, in] -> TF: [d, h, w, in, out]
-    w_tf = tf.transpose(w, perm=[1, 2, 3, 4, 0])
+    # TFLite CONV_3D and tf.nn.conv3d both use [d, h, w, in, out].
+    w_tf = w
     strides = [
         1,
         int(op.options.get("strideD", 1)),
@@ -1280,8 +1280,8 @@ def _kernel_conv3d_transpose(
     w = executor._resolve_tensor(op.inputs[1], env)
     x = executor._resolve_tensor(op.inputs[2], env)
     b = executor._resolve_optional_tensor(op.inputs[3], env) if len(op.inputs) >= 4 else None
-    # TFLite conv3d-transpose filter: [out, d, h, w, in] -> TF: [d, h, w, out, in]
-    w_tf = tf.transpose(w, perm=[1, 2, 3, 0, 4])
+    # TFLite CONV_3D_TRANSPOSE and tf.nn.conv3d_transpose both use [d, h, w, out, in].
+    w_tf = w
     strides = [
         1,
         int(op.options.get("strideD", 1)),

--- a/tests/test_tflite2sm_phase1.py
+++ b/tests/test_tflite2sm_phase1.py
@@ -931,6 +931,113 @@ def _make_grouped_conv_model_ir() -> ModelIR:
     return model_ir
 
 
+def _make_conv3d_model_ir() -> ModelIR:
+    rng = np.random.default_rng(14)
+    model_ir = ModelIR(name="conv3d_saved_model")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 6, 4],
+        shape_signature=[1, 4, 5, 6, 4],
+    )
+    model_ir.tensors["w"] = TensorIR(
+        name="w",
+        dtype="FLOAT32",
+        shape=[3, 3, 3, 4, 32],
+        shape_signature=[3, 3, 3, 4, 32],
+        data=rng.standard_normal((3, 3, 3, 4, 32)).astype(np.float32),
+    )
+    model_ir.tensors["b"] = TensorIR(
+        name="b",
+        dtype="FLOAT32",
+        shape=[32],
+        shape_signature=[32],
+        data=rng.standard_normal((32,)).astype(np.float32),
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 6, 32],
+        shape_signature=[1, 4, 5, 6, 32],
+    )
+    model_ir.operators.append(
+        OperatorIR(
+            op_type="CONV_3D",
+            inputs=["x", "w", "b"],
+            outputs=["y"],
+            options={
+                "padding": "SAME",
+                "strideD": 1,
+                "strideH": 1,
+                "strideW": 1,
+                "dilationDFactor": 1,
+                "dilationHFactor": 1,
+                "dilationWFactor": 1,
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    )
+    return model_ir
+
+
+def _make_conv3d_transpose_model_ir() -> ModelIR:
+    rng = np.random.default_rng(15)
+    model_ir = ModelIR(name="conv3d_transpose_saved_model")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    output_shape = [1, 4, 5, 6, 3]
+    model_ir.tensors["x"] = TensorIR(
+        name="x",
+        dtype="FLOAT32",
+        shape=[1, 4, 5, 6, 4],
+        shape_signature=[1, 4, 5, 6, 4],
+    )
+    model_ir.tensors["output_shape"] = TensorIR(
+        name="output_shape",
+        dtype="INT32",
+        shape=[5],
+        shape_signature=[5],
+        data=np.asarray(output_shape, dtype=np.int32),
+    )
+    model_ir.tensors["w"] = TensorIR(
+        name="w",
+        dtype="FLOAT32",
+        shape=[1, 1, 1, 3, 4],
+        shape_signature=[1, 1, 1, 3, 4],
+        data=rng.standard_normal((1, 1, 1, 3, 4)).astype(np.float32),
+    )
+    model_ir.tensors["b"] = TensorIR(
+        name="b",
+        dtype="FLOAT32",
+        shape=[3],
+        shape_signature=[3],
+        data=rng.standard_normal((3,)).astype(np.float32),
+    )
+    model_ir.tensors["y"] = TensorIR(
+        name="y",
+        dtype="FLOAT32",
+        shape=output_shape,
+        shape_signature=output_shape,
+    )
+    model_ir.operators.append(
+        OperatorIR(
+            op_type="CONV_3D_TRANSPOSE",
+            inputs=["output_shape", "w", "x", "b"],
+            outputs=["y"],
+            options={
+                "padding": "SAME",
+                "strideD": 1,
+                "strideH": 1,
+                "strideW": 1,
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    )
+    return model_ir
+
+
 def _make_batched_matmul_model_ir() -> ModelIR:
     model_ir = ModelIR(name="batched_matmul")
     model_ir.inputs = ["lhs", "rhs"]
@@ -1003,6 +1110,49 @@ def test_saved_model_exporter_recurrent_smoke(
         expected_shape = tuple(int(v) for v in model_ir.tensors["y"].shape)
         assert tuple(sm_out.shape) == expected_shape
         assert np.isfinite(sm_out).all()
+
+
+def test_saved_model_exporter_conv3d_uses_tflite_filter_layout() -> None:
+    model_ir = _make_conv3d_model_ir()
+    rng = np.random.default_rng(16)
+    input_data = rng.standard_normal(model_ir.tensors["x"].shape).astype(np.float32)
+    expected = tf.nn.conv3d(
+        input_data,
+        filters=model_ir.tensors["w"].data,
+        strides=[1, 1, 1, 1, 1],
+        padding="SAME",
+    )
+    expected = expected + tf.reshape(model_ir.tensors["b"].data, [1, 1, 1, 1, -1])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        saved_model_path = export_saved_model_from_model_ir(
+            model_ir=model_ir,
+            output_folder_path=os.path.join(tmpdir, "sm"),
+        )
+        sm_out = _run_saved_model_single_output(saved_model_path, "x", input_data, "y")
+        np.testing.assert_allclose(sm_out, expected.numpy(), rtol=1e-5, atol=1e-5)
+
+
+def test_saved_model_exporter_conv3d_transpose_uses_tflite_filter_layout() -> None:
+    model_ir = _make_conv3d_transpose_model_ir()
+    rng = np.random.default_rng(17)
+    input_data = rng.standard_normal(model_ir.tensors["x"].shape).astype(np.float32)
+    expected = tf.nn.conv3d_transpose(
+        input_data,
+        filters=model_ir.tensors["w"].data,
+        output_shape=model_ir.tensors["y"].shape,
+        strides=[1, 1, 1, 1, 1],
+        padding="SAME",
+    )
+    expected = expected + tf.reshape(model_ir.tensors["b"].data, [1, 1, 1, 1, -1])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        saved_model_path = export_saved_model_from_model_ir(
+            model_ir=model_ir,
+            output_folder_path=os.path.join(tmpdir, "sm"),
+        )
+        sm_out = _run_saved_model_single_output(saved_model_path, "x", input_data, "y")
+        np.testing.assert_allclose(sm_out, expected.numpy(), rtol=1e-5, atol=1e-5)
 
 
 def test_rewrite_model_ir_disable_group_convolution_smoke() -> None:


### PR DESCRIPTION
Fixes #928.

## Summary
- stop re-transposing `CONV_3D` filters in the SavedModel exporter; flatbuffer-direct ModelIR already stores them as `[d, h, w, in, out]`, which matches `tf.nn.conv3d`
- stop re-transposing `CONV_3D_TRANSPOSE` filters for the same reason; ModelIR stores `[d, h, w, out, in]`, matching `tf.nn.conv3d_transpose`
- add SavedModel regression coverage for both 3D convolution kernels using TFLite/TF filter layouts

## Validation
- `.venv/bin/python -m py_compile onnx2tf/tflite_builder/saved_model_exporter.py tests/test_tflite2sm_phase1.py`
- direct exporter smoke for `CONV_3D` and `CONV_3D_TRANSPOSE` SavedModel export/load/inference, both matching TensorFlow native outputs with `np.testing.assert_allclose(..., rtol=1e-5, atol=1e-5)`
