### PR TITLE
Fix flatbuffer_direct strict integer quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,7 +928,7 @@ Optional:
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.5.0
+  ghcr.io/pinto0309/onnx2tf:2.5.1
 
   or
 
@@ -937,7 +937,7 @@ Optional:
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.5.0
+  docker.io/pinto0309/onnx2tf:2.5.1
   or
 
   # Direct execution in Docker
@@ -946,7 +946,7 @@ Optional:
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.5.0 \
+  docker.io/pinto0309/onnx2tf:2.5.1 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 
 def _load_impl():

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import threading
 from typing import Any, Dict, List, Optional
@@ -24,11 +25,14 @@ from onnx2tf.tflite_builder.model_writer import (
     write_model_file,
 )
 from onnx2tf.tflite_builder.quantization import (
+    StrictFullIntegerQuantizationError,
     build_dynamic_range_quantized_model_ir,
     build_full_integer_quantized_model_ir,
     build_full_integer_quantized_with_int16_act_model_ir,
     build_integer_quantized_model_ir,
     build_integer_quantized_with_int16_act_model_ir,
+    collect_calibration_ranges_from_tflite,
+    load_calibration_samples,
 )
 from onnx2tf.tflite_builder.preprocess import (
     configure_pseudo_ops_wave1_targets,
@@ -755,6 +759,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         split_pytorch_torchscript_paths = None
         split_pytorch_dynamo_onnx_paths = None
         split_pytorch_exported_program_paths = None
+        calibration_report_path = None
         if split_plan_requested:
             _set_export_progress_desc("split planning")
             split_plan_report = plan_contiguous_partitions_by_size(
@@ -829,6 +834,66 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
             enabled=bool(flatbuffer_direct_show_progress),
         )
         _advance_export_progress()
+
+        calibration_ranges = None
+        calibration_report: Dict[str, Any] = {}
+        if output_integer_quantized_tflite:
+            calibration_samples = load_calibration_samples(
+                custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+                input_names=[str(v) for v in model_ir.inputs],
+            )
+            calibration_ranges = collect_calibration_ranges_from_tflite(
+                tflite_path=float32_path,
+                calibration_samples=calibration_samples,
+            )
+            calibration_report = {
+                "sample_count": int(len(calibration_samples)),
+                "tensor_ranges": {
+                    str(name): {
+                        "min": float(value.min_value),
+                        "max": float(value.max_value),
+                        "num_samples": int(value.num_samples),
+                    }
+                    for name, value in calibration_ranges.items()
+                },
+                "variants": {},
+            }
+
+        def _write_validated_quantized_model_file(
+            *,
+            model_ir: Any,
+            output_tflite_path: str,
+            timing: Dict[str, Any],
+        ) -> None:
+            tmp_path = f"{output_tflite_path}.tmp"
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            write_model_file(
+                schema_tflite=schema_tflite,
+                model_ir=model_ir,
+                output_tflite_path=tmp_path,
+                timing=timing,
+            )
+            try:
+                from ai_edge_litert.interpreter import Interpreter, OpResolverType
+
+                try:
+                    interpreter = Interpreter(
+                        model_path=tmp_path,
+                        experimental_op_resolver_type=OpResolverType.BUILTIN_WITHOUT_DEFAULT_DELEGATES,
+                    )
+                except TypeError:
+                    interpreter = Interpreter(model_path=tmp_path)
+                interpreter.allocate_tensors()
+            except Exception as ex:
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+                raise StrictFullIntegerQuantizationError(
+                    f"Strict integer quantized TFLite validation failed: {output_tflite_path}: {ex}"
+                ) from ex
+            os.replace(tmp_path, output_tflite_path)
 
         if output_saved_model_from_model_ir:
             require_tensorflow("flatbuffer_direct SavedModel export")
@@ -1037,7 +1102,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         full_integer_quant_path = None
         if output_integer_quantized_tflite:
             _set_export_progress_desc("write integer quant tflite")
-            integer_model_ir = build_integer_quantized_model_ir(
+            integer_result = build_integer_quantized_model_ir(
                 model_ir,
                 quant_type=str(quant_type),
                 calibration_method=quant_controls["calibration_method"],
@@ -1045,14 +1110,17 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                 min_numel=quant_controls["min_numel"],
                 min_abs_max=quant_controls["min_abs_max"],
                 scale_floor=quant_controls["scale_floor"],
+                calibration_ranges=calibration_ranges,
+                return_report=True,
             )
+            integer_model_ir = integer_result.model_ir
+            calibration_report["variants"]["integer_quant"] = integer_result.report
             integer_quant_path = os.path.join(
                 output_folder_path,
                 f"{output_file_name}_integer_quant.tflite",
             )
             integer_quant_write_timing: Dict[str, Any] = {}
-            write_model_file(
-                schema_tflite=schema_tflite,
+            _write_validated_quantized_model_file(
                 model_ir=integer_model_ir,
                 output_tflite_path=integer_quant_path,
                 timing=integer_quant_write_timing,
@@ -1068,7 +1136,7 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
             _advance_export_progress()
 
             _set_export_progress_desc("write full integer quant tflite")
-            full_integer_model_ir = build_full_integer_quantized_model_ir(
+            full_integer_result = build_full_integer_quantized_model_ir(
                 model_ir,
                 quant_type=str(quant_type),
                 input_quant_dtype=str(input_quant_dtype),
@@ -1078,14 +1146,17 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                 min_numel=quant_controls["min_numel"],
                 min_abs_max=quant_controls["min_abs_max"],
                 scale_floor=quant_controls["scale_floor"],
+                calibration_ranges=calibration_ranges,
+                return_report=True,
             )
+            full_integer_model_ir = full_integer_result.model_ir
+            calibration_report["variants"]["full_integer_quant"] = full_integer_result.report
             full_integer_quant_path = os.path.join(
                 output_folder_path,
                 f"{output_file_name}_full_integer_quant.tflite",
             )
             full_integer_quant_write_timing: Dict[str, Any] = {}
-            write_model_file(
-                schema_tflite=schema_tflite,
+            _write_validated_quantized_model_file(
                 model_ir=full_integer_model_ir,
                 output_tflite_path=full_integer_quant_path,
                 timing=full_integer_quant_write_timing,
@@ -1109,14 +1180,14 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                 min_numel=quant_controls["min_numel"],
                 min_abs_max=quant_controls["min_abs_max"],
                 scale_floor=quant_controls["scale_floor"],
+                calibration_ranges=calibration_ranges,
             )
             integer_quant_with_int16_act_path = os.path.join(
                 output_folder_path,
                 f"{output_file_name}_integer_quant_with_int16_act.tflite",
             )
             integer_quant_int16_write_timing: Dict[str, Any] = {}
-            write_model_file(
-                schema_tflite=schema_tflite,
+            _write_validated_quantized_model_file(
                 model_ir=integer_quant_with_int16_act_model_ir,
                 output_tflite_path=integer_quant_with_int16_act_path,
                 timing=integer_quant_int16_write_timing,
@@ -1140,14 +1211,14 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                 min_numel=quant_controls["min_numel"],
                 min_abs_max=quant_controls["min_abs_max"],
                 scale_floor=quant_controls["scale_floor"],
+                calibration_ranges=calibration_ranges,
             )
             full_integer_quant_with_int16_act_path = os.path.join(
                 output_folder_path,
                 f"{output_file_name}_full_integer_quant_with_int16_act.tflite",
             )
             full_integer_quant_int16_write_timing: Dict[str, Any] = {}
-            write_model_file(
-                schema_tflite=schema_tflite,
+            _write_validated_quantized_model_file(
                 model_ir=full_integer_quant_with_int16_act_model_ir,
                 output_tflite_path=full_integer_quant_with_int16_act_path,
                 timing=full_integer_quant_int16_write_timing,
@@ -1161,6 +1232,12 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
                 enabled=bool(flatbuffer_direct_show_progress),
             )
             _advance_export_progress()
+            calibration_report_path = os.path.join(
+                output_folder_path,
+                f"{output_file_name}_strict_integer_quant_calibration_report.json",
+            )
+            with open(calibration_report_path, "w", encoding="utf-8") as f:
+                json.dump(calibration_report, f, indent=2)
         else:
             integer_quant_with_int16_act_path = None
             full_integer_quant_with_int16_act_path = None
@@ -1272,6 +1349,8 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         outputs["integer_quant_with_int16_act_tflite_path"] = integer_quant_with_int16_act_path
     if full_integer_quant_with_int16_act_path is not None:
         outputs["full_integer_quant_with_int16_act_tflite_path"] = full_integer_quant_with_int16_act_path
+    if calibration_report_path is not None:
+        outputs["strict_integer_quant_calibration_report_path"] = calibration_report_path
     if split_plan_report_path is not None:
         outputs["split_plan_report_path"] = split_plan_report_path
         outputs["split_required_by_estimate"] = bool(split_required_by_estimate)

--- a/onnx2tf/tflite_builder/ir.py
+++ b/onnx2tf/tflite_builder/ir.py
@@ -41,7 +41,7 @@ class TensorIR:
     dtype: str
     shape: List[int]
     shape_signature: Optional[List[int]] = None
-    data: Optional[np.ndarray] = None
+    data: Optional[Union[np.ndarray, np.generic, bytes]] = None
     is_variable: bool = False
     quantization: Optional[Union[Dict[str, Any], QuantParamIR]] = None
     logical_layout: str = LOGICAL_LAYOUT_UNKNOWN
@@ -245,7 +245,7 @@ def clone_model_ir_with_float16(model_ir: ModelIR) -> ModelIR:
         new_dtype = tensor.dtype
         if tensor.dtype == "FLOAT32":
             new_dtype = "FLOAT16"
-            if tensor.data is not None:
+            if isinstance(tensor.data, (np.ndarray, np.generic)):
                 new_data = tensor.data.astype(np.float16)
         clone.tensors[name] = TensorIR(
             name=tensor.name,
@@ -315,7 +315,7 @@ def clone_model_ir_with_float32(model_ir: ModelIR) -> ModelIR:
         new_dtype = str(tensor.dtype).upper()
         if new_dtype == "FLOAT16":
             new_dtype = "FLOAT32"
-            if tensor.data is not None:
+            if isinstance(tensor.data, (np.ndarray, np.generic)):
                 new_data = tensor.data.astype(np.float32)
         clone.tensors[name] = TensorIR(
             name=tensor.name,

--- a/onnx2tf/tflite_builder/quantization.py
+++ b/onnx2tf/tflite_builder/quantization.py
@@ -43,20 +43,47 @@ _STRICT_FULL_INTEGER_SUPPORTED_OPS = {
     "ADD",
     "SUB",
     "MUL",
+    "DIV",
+    "MAXIMUM",
+    "MINIMUM",
+    "SELECT",
+    "SELECT_V2",
     "CONCATENATION",
     "RESHAPE",
     "TRANSPOSE",
     "SQUEEZE",
     "EXPAND_DIMS",
+    "SLICE",
+    "STRIDED_SLICE",
+    "SPLIT",
+    "GATHER",
+    "TILE",
+    "SPACE_TO_DEPTH",
+    "DEPTH_TO_SPACE",
+    "PAD",
     "MEAN",
+    "SUM",
+    "REDUCE_MAX",
+    "REDUCE_MIN",
+    "REDUCE_PROD",
     "AVERAGE_POOL_2D",
     "MAX_POOL_2D",
+    "ABS",
+    "NEG",
     "RELU",
     "RELU6",
+    "RELU_N1_TO_1",
+    "LEAKY_RELU",
+    "HARD_SWISH",
+    "TANH",
+    "PRELU",
     "SOFTMAX",
     "LOGISTIC",
+    "RESIZE_NEAREST_NEIGHBOR",
+    "RESIZE_BILINEAR",
     "CONV_2D",
     "DEPTHWISE_CONV_2D",
+    "TRANSPOSE_CONV",
     "FULLY_CONNECTED",
     "BATCH_MATMUL",
 }
@@ -68,11 +95,21 @@ _STRICT_FULL_INTEGER_PASSTHROUGH_OPS = {
     "EXPAND_DIMS",
 }
 
-_STRICT_FULL_INTEGER_REQUIRES_SAME_QPARAMS = {
-    "CONCATENATION",
-    "MEAN",
-    "AVERAGE_POOL_2D",
-    "MAX_POOL_2D",
+_STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES: Dict[str, Optional[Set[int]]] = {
+    "CONCATENATION": None,
+    "MEAN": {0},
+    "AVERAGE_POOL_2D": {0},
+    "MAX_POOL_2D": {0},
+    "SLICE": {0},
+    "STRIDED_SLICE": {0},
+    "SPLIT": {1},
+    "GATHER": {0},
+    "TILE": {0},
+    "SPACE_TO_DEPTH": {0},
+    "DEPTH_TO_SPACE": {0},
+    "PAD": {0},
+    "SELECT": {1, 2},
+    "SELECT_V2": {1, 2},
 }
 
 
@@ -587,6 +624,13 @@ def fixed_activation_qparams_for_op(
             return QuantParamIR(scale=[1.0 / 256.0], zero_point=[-128], quantized_dimension=0, min=[0.0], max=[1.0])
         if dtype_u == "INT16":
             return QuantParamIR(scale=[1.0 / 32768.0], zero_point=[0], quantized_dimension=0, min=[0.0], max=[1.0])
+    if op_u == "TANH":
+        if dtype_u == "UINT8":
+            return QuantParamIR(scale=[1.0 / 128.0], zero_point=[128], quantized_dimension=0, min=[-1.0], max=[1.0])
+        if dtype_u == "INT8":
+            return QuantParamIR(scale=[1.0 / 128.0], zero_point=[0], quantized_dimension=0, min=[-1.0], max=[1.0])
+        if dtype_u == "INT16":
+            return QuantParamIR(scale=[1.0 / 32768.0], zero_point=[0], quantized_dimension=0, min=[-1.0], max=[1.0])
     return None
 
 
@@ -626,6 +670,63 @@ def _used_tensor_names(model_ir: ModelIR) -> Set[str]:
         used.update(str(v) for v in op.inputs if str(v) != "")
         used.update(str(v) for v in op.outputs if str(v) != "")
     return used
+
+
+def _elide_identity_operators(model_ir: ModelIR) -> None:
+    rewritten: List[OperatorIR] = []
+    replacements: Dict[str, str] = {}
+    graph_outputs = {str(v) for v in model_ir.outputs}
+
+    def resolve(name: str) -> str:
+        current = str(name)
+        seen: Set[str] = set()
+        while current in replacements and current not in seen:
+            seen.add(current)
+            current = replacements[current]
+        return current
+
+    for op in model_ir.operators:
+        op.inputs = [resolve(str(v)) if str(v) != "" else v for v in op.inputs]
+        if str(op.op_type) != "IDENTITY" or len(op.inputs) != 1 or len(op.outputs) != 1:
+            rewritten.append(op)
+            continue
+        input_name = resolve(str(op.inputs[0]))
+        output_name = str(op.outputs[0])
+        if output_name in graph_outputs:
+            producer = next(
+                (
+                    candidate
+                    for candidate in reversed(rewritten)
+                    if input_name in [str(v) for v in candidate.outputs]
+                ),
+                None,
+            )
+            if producer is not None and input_name not in {str(v) for v in model_ir.inputs}:
+                producer.outputs = [output_name if str(v) == input_name else v for v in producer.outputs]
+                replacements[input_name] = output_name
+                continue
+        replacements[output_name] = input_name
+
+    for op in rewritten:
+        op.inputs = [resolve(str(v)) if str(v) != "" else v for v in op.inputs]
+        op.outputs = [resolve(str(v)) if str(v) != "" else v for v in op.outputs]
+    model_ir.outputs = [resolve(str(v)) for v in model_ir.outputs]
+    model_ir.operators = rewritten
+
+
+def _same_qparam_tensor_names_for_op(op: OperatorIR) -> List[str]:
+    input_indices = _STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES.get(str(op.op_type), None)
+    names: List[str] = []
+    if input_indices is None and str(op.op_type) in _STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES:
+        names.extend(str(v) for v in op.inputs if str(v) != "")
+    elif input_indices is not None:
+        names.extend(
+            str(input_name)
+            for idx, input_name in enumerate(op.inputs)
+            if int(idx) in input_indices and str(input_name) != ""
+        )
+    names.extend(str(v) for v in op.outputs if str(v) != "")
+    return names
 
 
 def _is_float_activation_tensor(
@@ -827,7 +928,7 @@ def _quantize_bias_tensor(
 def _kernel_weight_quant_axis_for_strict(op_type: str, tensor: TensorIR) -> int:
     if op_type == "DEPTHWISE_CONV_2D":
         return max(0, len(tensor.shape) - 1)
-    if op_type in {"CONV_2D", "FULLY_CONNECTED"}:
+    if op_type in {"CONV_2D", "FULLY_CONNECTED", "TRANSPOSE_CONV"}:
         return 0
     if op_type == "BATCH_MATMUL":
         return 0
@@ -1068,8 +1169,7 @@ def _build_strict_full_integer_model_ir(
         scale_floor=scale_floor,
     )
     clone = _clone_model_ir(model_ir)
-    graph_input_names = set(str(v) for v in clone.inputs)
-    graph_output_names = set(str(v) for v in clone.outputs)
+    _elide_identity_operators(clone)
     internal_dtype = str(internal_activation_dtype).upper()
     input_dtype = str(input_quant_dtype).upper()
     output_dtype = str(output_quant_dtype).upper()
@@ -1106,6 +1206,8 @@ def _build_strict_full_integer_model_ir(
     if not full_integer_io:
         for input_name in list(clone.inputs):
             old_tensor = clone.tensors[str(input_name)]
+            if old_tensor.dtype != "FLOAT32":
+                continue
             q_name = _make_unique_tensor_name(f"{input_name}_quantized_internal", clone.tensors)
             qparams = activation_qparams_from_range(
                 min_value=_require_tensor_range(
@@ -1139,6 +1241,8 @@ def _build_strict_full_integer_model_ir(
             }
         for output_name in list(clone.outputs):
             old_tensor = clone.tensors[str(output_name)]
+            if old_tensor.dtype != "FLOAT32":
+                continue
             q_name = str(output_name)
             float_name = _make_unique_tensor_name(f"{output_name}_dequantized_output", clone.tensors)
             clone.tensors[float_name] = TensorIR(
@@ -1156,6 +1260,8 @@ def _build_strict_full_integer_model_ir(
     else:
         for input_name in list(clone.inputs):
             old_tensor = clone.tensors[str(input_name)]
+            if old_tensor.dtype != "FLOAT32":
+                continue
             input_range = _require_tensor_range(
                 tensor_name=str(input_name),
                 calibration_ranges=calibration_ranges,
@@ -1207,9 +1313,11 @@ def _build_strict_full_integer_model_ir(
             for output_name in op.outputs
         }
         for output_name in list(clone.outputs):
+            old_tensor = clone.tensors[str(output_name)]
+            if old_tensor.dtype != "FLOAT32":
+                continue
             if output_dtype == internal_dtype:
                 continue
-            old_tensor = clone.tensors[str(output_name)]
             producer_op = producer_by_output.get(str(output_name), None)
             fixed_external = fixed_activation_qparams_for_op(
                 op_type=str(producer_op.op_type) if producer_op is not None else "",
@@ -1314,15 +1422,17 @@ def _build_strict_full_integer_model_ir(
                         fixed_qparams=output_fixed,
                     )
 
-        if op_type in {"FULLY_CONNECTED", "CONV_2D", "DEPTHWISE_CONV_2D", "BATCH_MATMUL"}:
-            if len(op.inputs) < 2:
+        if op_type in {"FULLY_CONNECTED", "CONV_2D", "DEPTHWISE_CONV_2D", "BATCH_MATMUL", "TRANSPOSE_CONV"}:
+            activation_input_idx = 2 if op_type == "TRANSPOSE_CONV" else 0
+            weight_input_idx = 1
+            if len(op.inputs) <= max(activation_input_idx, weight_input_idx):
                 raise StrictFullIntegerQuantizationError(f"{op_type} requires a weight input.")
-            input_tensor = clone.tensors[str(op.inputs[0])]
+            input_tensor = clone.tensors[str(op.inputs[activation_input_idx])]
             if not isinstance(input_tensor.quantization, QuantParamIR):
                 raise StrictFullIntegerQuantizationError(
-                    f"{op_type} input tensor is missing qparams: {op.inputs[0]}"
+                    f"{op_type} input tensor is missing qparams: {op.inputs[activation_input_idx]}"
                 )
-            weight_tensor = clone.tensors[str(op.inputs[1])]
+            weight_tensor = clone.tensors[str(op.inputs[weight_input_idx])]
             weight_qparams = _quantize_weight_tensor(
                 tensor=weight_tensor,
                 quant_type=quant_type,
@@ -1332,8 +1442,9 @@ def _build_strict_full_integer_model_ir(
                 scale_floor=float(controls["scale_floor"]),
                 report=report,
             )
-            if len(op.inputs) >= 3 and str(op.inputs[2]) != "":
-                bias_tensor = clone.tensors.get(str(op.inputs[2]), None)
+            bias_input_idx = 3 if op_type == "TRANSPOSE_CONV" else 2
+            if len(op.inputs) > bias_input_idx and str(op.inputs[bias_input_idx]) != "":
+                bias_tensor = clone.tensors.get(str(op.inputs[bias_input_idx]), None)
                 if bias_tensor is not None and bias_tensor.data is not None:
                     _quantize_bias_tensor(
                         tensor=bias_tensor,
@@ -1341,7 +1452,7 @@ def _build_strict_full_integer_model_ir(
                         weight_qparams=weight_qparams,
                         report=report,
                     )
-        elif op_type in _STRICT_FULL_INTEGER_REQUIRES_SAME_QPARAMS and len(op.outputs) > 0:
+        elif op_type in _STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES and len(op.outputs) > 0:
             out_tensor = clone.tensors[str(op.outputs[0])]
             if not isinstance(out_tensor.quantization, QuantParamIR):
                 raise StrictFullIntegerQuantizationError(
@@ -1349,7 +1460,7 @@ def _build_strict_full_integer_model_ir(
                 )
             _force_same_qparams(
                 model_ir=clone,
-                tensor_names=[str(v) for v in list(op.inputs) + list(op.outputs) if str(v) != ""],
+                tensor_names=_same_qparam_tensor_names_for_op(op),
                 qparams=out_tensor.quantization,
                 dtype=out_tensor.dtype,
                 report=report,

--- a/onnx2tf/tflite_builder/quantization.py
+++ b/onnx2tf/tflite_builder/quantization.py
@@ -1,10 +1,28 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set, Tuple, TypedDict
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypedDict
 
 import numpy as np
 
 from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, QuantParamIR, TensorIR
+
+
+class StrictFullIntegerQuantizationError(RuntimeError):
+    pass
+
+
+@dataclass
+class TensorCalibrationRange:
+    min_value: float
+    max_value: float
+    num_samples: int = 0
+
+
+@dataclass
+class QuantizedModelResult:
+    model_ir: ModelIR
+    report: Dict[str, Any]
 
 
 _DYNAMIC_RANGE_KERNEL_OPS = {
@@ -19,6 +37,42 @@ _DYNAMIC_RANGE_CONST_DEQUANT_OPS = {
     "MUL",
     "DIV",
     "CONCATENATION",
+}
+
+_STRICT_FULL_INTEGER_SUPPORTED_OPS = {
+    "ADD",
+    "SUB",
+    "MUL",
+    "CONCATENATION",
+    "RESHAPE",
+    "TRANSPOSE",
+    "SQUEEZE",
+    "EXPAND_DIMS",
+    "MEAN",
+    "AVERAGE_POOL_2D",
+    "MAX_POOL_2D",
+    "RELU",
+    "RELU6",
+    "SOFTMAX",
+    "LOGISTIC",
+    "CONV_2D",
+    "DEPTHWISE_CONV_2D",
+    "FULLY_CONNECTED",
+    "BATCH_MATMUL",
+}
+
+_STRICT_FULL_INTEGER_PASSTHROUGH_OPS = {
+    "RESHAPE",
+    "TRANSPOSE",
+    "SQUEEZE",
+    "EXPAND_DIMS",
+}
+
+_STRICT_FULL_INTEGER_REQUIRES_SAME_QPARAMS = {
+    "CONCATENATION",
+    "MEAN",
+    "AVERAGE_POOL_2D",
+    "MAX_POOL_2D",
 }
 
 
@@ -122,6 +176,160 @@ def _normalize_non_negative_float(v: float, *, name: str) -> float:
     if fv < 0.0:
         raise ValueError(f"flatbuffer_direct {name} must be >= 0.0. got: {v}")
     return fv
+
+
+def _normalize_tensor_detail_name(name: Any) -> str:
+    value = name.decode("utf-8") if isinstance(name, bytes) else str(name)
+    if value.endswith(":0"):
+        value = value[:-2]
+    return value
+
+
+def load_calibration_samples(
+    *,
+    custom_input_op_name_np_data_path: Optional[List[Any]],
+    input_names: List[str],
+) -> List[Dict[str, np.ndarray]]:
+    if not custom_input_op_name_np_data_path:
+        raise StrictFullIntegerQuantizationError(
+            "flatbuffer_direct strict integer quantization requires "
+            "custom_input_op_name_np_data_path entries with input name, npy path, mean, and std."
+        )
+
+    input_set = {str(v) for v in input_names}
+    loaded: Dict[str, np.ndarray] = {}
+    sample_count: Optional[int] = None
+    for param in custom_input_op_name_np_data_path:
+        if not isinstance(param, (list, tuple)) or len(param) != 4:
+            raise StrictFullIntegerQuantizationError(
+                "flatbuffer_direct strict integer quantization requires each calibration entry "
+                "to be [input_name, numpy_file_path, mean, std]."
+            )
+        input_name = str(param[0])
+        if input_name not in input_set:
+            raise StrictFullIntegerQuantizationError(
+                f"Calibration data references unknown input: {input_name}"
+            )
+        raw = np.load(str(param[1]))
+        mean = np.asarray(param[2], dtype=np.float32)
+        std = np.asarray(param[3], dtype=np.float32)
+        if np.any(std == 0):
+            raise StrictFullIntegerQuantizationError(
+                f"Calibration std contains zero for input: {input_name}"
+            )
+        normalized = ((np.asarray(raw, dtype=np.float32) - mean) / std).astype(np.float32)
+        if int(normalized.ndim) == 0:
+            raise StrictFullIntegerQuantizationError(
+                f"Calibration data must include a sample dimension: {input_name}"
+            )
+        if sample_count is None:
+            sample_count = int(normalized.shape[0])
+        elif int(normalized.shape[0]) != int(sample_count):
+            raise StrictFullIntegerQuantizationError(
+                "Calibration sample count mismatch: "
+                f"input={input_name} count={int(normalized.shape[0])} expected={sample_count}"
+            )
+        loaded[input_name] = normalized
+
+    missing = sorted(input_set.difference(loaded.keys()))
+    if missing:
+        raise StrictFullIntegerQuantizationError(
+            f"Missing calibration data for input(s): {', '.join(missing)}"
+        )
+    if sample_count is None or int(sample_count) <= 0:
+        raise StrictFullIntegerQuantizationError("Calibration data is empty.")
+
+    samples: List[Dict[str, np.ndarray]] = []
+    for idx in range(int(sample_count)):
+        samples.append(
+            {
+                input_name: np.expand_dims(data[idx], axis=0)
+                for input_name, data in loaded.items()
+            }
+        )
+    return samples
+
+
+def collect_calibration_ranges_from_tflite(
+    *,
+    tflite_path: str,
+    calibration_samples: List[Dict[str, np.ndarray]],
+) -> Dict[str, TensorCalibrationRange]:
+    from ai_edge_litert.interpreter import Interpreter, OpResolverType
+
+    try:
+        interpreter = Interpreter(
+            model_path=tflite_path,
+            experimental_preserve_all_tensors=True,
+            experimental_op_resolver_type=OpResolverType.BUILTIN_WITHOUT_DEFAULT_DELEGATES,
+        )
+    except TypeError:
+        interpreter = Interpreter(model_path=tflite_path)
+
+    ranges: Dict[str, TensorCalibrationRange] = {}
+
+    def update(name: str, value: np.ndarray) -> None:
+        arr = np.asarray(value)
+        if arr.size == 0 or not np.issubdtype(arr.dtype, np.floating):
+            return
+        mn = float(np.nanmin(arr))
+        mx = float(np.nanmax(arr))
+        if not np.isfinite(mn) or not np.isfinite(mx):
+            return
+        current = ranges.get(str(name), None)
+        if current is None:
+            ranges[str(name)] = TensorCalibrationRange(mn, mx, 1)
+        else:
+            current.min_value = min(float(current.min_value), mn)
+            current.max_value = max(float(current.max_value), mx)
+            current.num_samples = int(current.num_samples) + 1
+
+    for sample in calibration_samples:
+        interpreter.allocate_tensors()
+        input_details = list(interpreter.get_input_details())
+        by_name = {
+            _normalize_tensor_detail_name(detail.get("name", "")): detail
+            for detail in input_details
+        }
+        for idx, (sample_name, sample_value) in enumerate(sample.items()):
+            detail = by_name.get(str(sample_name), None)
+            if detail is None:
+                if idx >= len(input_details):
+                    raise StrictFullIntegerQuantizationError(
+                        f"TFLite input not found for calibration sample: {sample_name}"
+                    )
+                detail = input_details[idx]
+            value = np.asarray(sample_value, dtype=np.float32)
+            expected_shape = [int(v) for v in list(detail.get("shape", []))]
+            if expected_shape and list(value.shape) != expected_shape:
+                try:
+                    interpreter.resize_tensor_input(int(detail["index"]), value.shape, strict=False)
+                    interpreter.allocate_tensors()
+                    input_details = list(interpreter.get_input_details())
+                    by_name = {
+                        _normalize_tensor_detail_name(item.get("name", "")): item
+                        for item in input_details
+                    }
+                    detail = by_name.get(str(sample_name), detail)
+                except Exception as ex:
+                    raise StrictFullIntegerQuantizationError(
+                        f"Failed to resize calibration input {sample_name} to {list(value.shape)}: {ex}"
+                    ) from ex
+            interpreter.set_tensor(int(detail["index"]), value)
+            update(str(sample_name), value)
+            update(_normalize_tensor_detail_name(detail.get("name", sample_name)), value)
+        interpreter.invoke()
+        for detail in list(interpreter.get_tensor_details()):
+            name = _normalize_tensor_detail_name(detail.get("name", ""))
+            if name == "":
+                continue
+            try:
+                value = interpreter.get_tensor(int(detail["index"]))
+            except Exception:
+                continue
+            update(name, value)
+
+    return ranges
 
 
 def _compute_abs_limit(
@@ -304,6 +512,356 @@ def _const_quant_mode_and_axis(
     return "per-tensor", 0
 
 
+def activation_qparams_from_range(
+    *,
+    min_value: float,
+    max_value: float,
+    dtype: str,
+    scale_floor: float = 1e-8,
+) -> QuantParamIR:
+    dtype_u = str(dtype).upper()
+    if dtype_u == "INT8":
+        qmin, qmax = -128, 127
+    elif dtype_u == "UINT8":
+        qmin, qmax = 0, 255
+    elif dtype_u == "INT16":
+        abs_limit = max(abs(float(min_value)), abs(float(max_value)), 0.0)
+        scale = max(abs_limit / 32767.0, float(scale_floor), 1.0 if abs_limit == 0.0 else float(scale_floor))
+        return QuantParamIR(
+            scale=[float(scale)],
+            zero_point=[0],
+            quantized_dimension=0,
+            min=[float(min_value)],
+            max=[float(max_value)],
+        )
+    else:
+        raise ValueError(f"Unsupported activation quantization dtype: {dtype}")
+
+    mn = float(min_value)
+    mx = float(max_value)
+    if not np.isfinite(mn) or not np.isfinite(mx):
+        raise ValueError(f"Non-finite calibration range: min={min_value} max={max_value}")
+    if mn > mx:
+        mn, mx = mx, mn
+    mn = min(mn, 0.0)
+    mx = max(mx, 0.0)
+    if mx == mn:
+        return QuantParamIR(
+            scale=[max(float(scale_floor), 1.0)],
+            zero_point=[0],
+            quantized_dimension=0,
+            min=[mn],
+            max=[mx],
+        )
+
+    scale = max((mx - mn) / float(qmax - qmin), float(scale_floor))
+    zero_point = int(np.round(float(qmin) - (mn / scale)))
+    zero_point = int(np.clip(zero_point, qmin, qmax))
+    return QuantParamIR(
+        scale=[float(scale)],
+        zero_point=[zero_point],
+        quantized_dimension=0,
+        min=[mn],
+        max=[mx],
+    )
+
+
+def fixed_activation_qparams_for_op(
+    *,
+    op_type: str,
+    dtype: str,
+) -> Optional[QuantParamIR]:
+    dtype_u = str(dtype).upper()
+    op_u = str(op_type).upper()
+    if op_u == "SOFTMAX":
+        if dtype_u == "UINT8":
+            return QuantParamIR(scale=[1.0 / 256.0], zero_point=[0], quantized_dimension=0, min=[0.0], max=[1.0])
+        if dtype_u == "INT8":
+            return QuantParamIR(scale=[1.0 / 256.0], zero_point=[-128], quantized_dimension=0, min=[0.0], max=[1.0])
+        if dtype_u == "INT16":
+            return QuantParamIR(scale=[1.0 / 32768.0], zero_point=[0], quantized_dimension=0, min=[0.0], max=[1.0])
+    if op_u == "LOGISTIC":
+        if dtype_u == "UINT8":
+            return QuantParamIR(scale=[1.0 / 256.0], zero_point=[0], quantized_dimension=0, min=[0.0], max=[1.0])
+        if dtype_u == "INT8":
+            return QuantParamIR(scale=[1.0 / 256.0], zero_point=[-128], quantized_dimension=0, min=[0.0], max=[1.0])
+        if dtype_u == "INT16":
+            return QuantParamIR(scale=[1.0 / 32768.0], zero_point=[0], quantized_dimension=0, min=[0.0], max=[1.0])
+    return None
+
+
+def _clone_quant_param(quantization: QuantParamIR) -> QuantParamIR:
+    return QuantParamIR(
+        scale=list(quantization.scale),
+        zero_point=list(quantization.zero_point),
+        quantized_dimension=int(quantization.quantized_dimension),
+        min=list(quantization.min) if quantization.min is not None else None,
+        max=list(quantization.max) if quantization.max is not None else None,
+    )
+
+
+def _quant_param_to_report(quantization: Optional[QuantParamIR]) -> Optional[Dict[str, Any]]:
+    if quantization is None:
+        return None
+    return {
+        "scale": [float(v) for v in list(quantization.scale)],
+        "zero_point": [int(v) for v in list(quantization.zero_point)],
+        "quantized_dimension": int(quantization.quantized_dimension),
+        "min": [float(v) for v in list(quantization.min)] if quantization.min is not None else None,
+        "max": [float(v) for v in list(quantization.max)] if quantization.max is not None else None,
+    }
+
+
+def _tensor_range_to_report(value: TensorCalibrationRange) -> Dict[str, Any]:
+    return {
+        "min": float(value.min_value),
+        "max": float(value.max_value),
+        "num_samples": int(value.num_samples),
+    }
+
+
+def _used_tensor_names(model_ir: ModelIR) -> Set[str]:
+    used = set(str(v) for v in list(model_ir.inputs) + list(model_ir.outputs))
+    for op in model_ir.operators:
+        used.update(str(v) for v in op.inputs if str(v) != "")
+        used.update(str(v) for v in op.outputs if str(v) != "")
+    return used
+
+
+def _is_float_activation_tensor(
+    *,
+    tensor: TensorIR,
+    graph_input_names: Set[str],
+) -> bool:
+    if tensor.dtype != "FLOAT32":
+        return False
+    if tensor.is_variable:
+        return False
+    if tensor.name in graph_input_names:
+        return True
+    return tensor.data is None
+
+
+def _require_tensor_range(
+    *,
+    tensor_name: str,
+    calibration_ranges: Dict[str, TensorCalibrationRange],
+) -> TensorCalibrationRange:
+    if tensor_name not in calibration_ranges:
+        raise StrictFullIntegerQuantizationError(
+            f"Missing calibration range for tensor: {tensor_name}"
+        )
+    return calibration_ranges[tensor_name]
+
+
+def _activation_dtype_for_tensor(
+    *,
+    tensor_name: str,
+    model_ir: ModelIR,
+    full_integer_io: bool,
+    input_quant_dtype: str,
+    output_quant_dtype: str,
+    internal_activation_dtype: str,
+) -> str:
+    if full_integer_io and tensor_name in set(model_ir.inputs):
+        return str(input_quant_dtype).upper()
+    if full_integer_io and tensor_name in set(model_ir.outputs):
+        return str(output_quant_dtype).upper()
+    return str(internal_activation_dtype).upper()
+
+
+def _ensure_activation_quantized(
+    *,
+    model_ir: ModelIR,
+    tensor_name: str,
+    calibration_ranges: Dict[str, TensorCalibrationRange],
+    dtype: str,
+    scale_floor: float,
+    report: Dict[str, Any],
+    fixed_qparams: Optional[QuantParamIR] = None,
+) -> QuantParamIR:
+    tensor = model_ir.tensors.get(str(tensor_name), None)
+    if tensor is None:
+        raise StrictFullIntegerQuantizationError(f"Missing tensor: {tensor_name}")
+    if tensor.dtype not in {"FLOAT32", "INT8", "UINT8", "INT16"}:
+        return tensor.quantization if isinstance(tensor.quantization, QuantParamIR) else QuantParamIR(scale=[1.0], zero_point=[0])
+    if fixed_qparams is not None:
+        qparams = _clone_quant_param(fixed_qparams)
+    elif isinstance(tensor.quantization, QuantParamIR) and tensor.dtype == str(dtype).upper():
+        qparams = _clone_quant_param(tensor.quantization)
+    else:
+        rng = _require_tensor_range(
+            tensor_name=str(tensor_name),
+            calibration_ranges=calibration_ranges,
+        )
+        qparams = activation_qparams_from_range(
+            min_value=float(rng.min_value),
+            max_value=float(rng.max_value),
+            dtype=str(dtype),
+            scale_floor=float(scale_floor),
+        )
+    tensor.dtype = str(dtype).upper()
+    tensor.quantization = qparams
+    tensor.data = None
+    report["quantized_tensors"][str(tensor_name)] = {
+        "dtype": tensor.dtype,
+        "kind": "activation",
+        "qparams": _quant_param_to_report(qparams),
+    }
+    return qparams
+
+
+def _quantize_float_constant_with_qparams(
+    *,
+    tensor: TensorIR,
+    dtype: str,
+    qparams: QuantParamIR,
+) -> None:
+    if not isinstance(tensor.data, np.ndarray):
+        raise StrictFullIntegerQuantizationError(
+            f"Constant tensor requires ndarray data for quantization: {tensor.name}"
+        )
+    scale = float(qparams.scale[0])
+    zero_point = int(qparams.zero_point[0])
+    dtype_u = str(dtype).upper()
+    if dtype_u == "INT8":
+        qmin, qmax, np_dtype = -128, 127, np.int8
+    elif dtype_u == "UINT8":
+        qmin, qmax, np_dtype = 0, 255, np.uint8
+    elif dtype_u == "INT16":
+        qmin, qmax, np_dtype = -32768, 32767, np.int16
+    else:
+        raise StrictFullIntegerQuantizationError(f"Unsupported constant quant dtype: {dtype}")
+    q = np.round(np.asarray(tensor.data, dtype=np.float32) / scale) + zero_point
+    tensor.data = np.clip(q, qmin, qmax).astype(np_dtype)
+    tensor.dtype = dtype_u
+    tensor.quantization = _clone_quant_param(qparams)
+
+
+def _quantize_weight_tensor(
+    *,
+    tensor: TensorIR,
+    quant_type: str,
+    quantized_dimension: int,
+    calibration_method: str,
+    calibration_percentile: float,
+    scale_floor: float,
+    report: Dict[str, Any],
+) -> QuantParamIR:
+    if not isinstance(tensor.data, np.ndarray):
+        raise StrictFullIntegerQuantizationError(
+            f"Weight tensor must be constant for strict full integer quantization: {tensor.name}"
+        )
+    if quant_type == "per-channel" and int(tensor.data.ndim) >= 2:
+        q_data, scales = _symmetric_int8_quantize_per_channel(
+            np.asarray(tensor.data, dtype=np.float32),
+            axis=int(quantized_dimension),
+            calibration_method=str(calibration_method),
+            calibration_percentile=float(calibration_percentile),
+            scale_floor=float(scale_floor),
+        )
+        qparams = QuantParamIR(
+            scale=[float(v) for v in scales.reshape(-1).tolist()],
+            zero_point=[0 for _ in range(int(scales.size))],
+            quantized_dimension=int(quantized_dimension),
+        )
+    else:
+        q_data, scale = _symmetric_int8_quantize(
+            np.asarray(tensor.data, dtype=np.float32),
+            calibration_method=str(calibration_method),
+            calibration_percentile=float(calibration_percentile),
+            scale_floor=float(scale_floor),
+        )
+        qparams = QuantParamIR(scale=[float(scale)], zero_point=[0], quantized_dimension=0)
+    tensor.data = q_data
+    tensor.dtype = "INT8"
+    tensor.quantization = qparams
+    report["quantized_tensors"][tensor.name] = {
+        "dtype": "INT8",
+        "kind": "weight",
+        "qparams": _quant_param_to_report(qparams),
+    }
+    return qparams
+
+
+def _quantize_bias_tensor(
+    *,
+    tensor: TensorIR,
+    input_qparams: QuantParamIR,
+    weight_qparams: QuantParamIR,
+    report: Dict[str, Any],
+) -> None:
+    if not isinstance(tensor.data, np.ndarray):
+        raise StrictFullIntegerQuantizationError(
+            f"Bias tensor must be constant for strict full integer quantization: {tensor.name}"
+        )
+    input_scale = float(input_qparams.scale[0])
+    scales = np.asarray(weight_qparams.scale, dtype=np.float64).reshape(-1)
+    if scales.size == 0:
+        raise StrictFullIntegerQuantizationError(f"Weight qparams have no scales for bias: {tensor.name}")
+    if scales.size == 1:
+        bias_scales = np.asarray([input_scale * float(scales[0])], dtype=np.float64)
+    else:
+        bias_scales = input_scale * scales
+    bias_values = np.asarray(tensor.data, dtype=np.float64).reshape(-1)
+    if bias_scales.size not in {1, bias_values.size}:
+        raise StrictFullIntegerQuantizationError(
+            f"Bias scale count mismatch: tensor={tensor.name} bias={bias_values.size} scales={bias_scales.size}"
+        )
+    denom = bias_scales if bias_scales.size > 1 else np.full_like(bias_values, float(bias_scales[0]))
+    q_bias = np.round(bias_values / denom)
+    tensor.data = np.clip(q_bias, np.iinfo(np.int32).min, np.iinfo(np.int32).max).astype(np.int32)
+    tensor.dtype = "INT32"
+    tensor.quantization = QuantParamIR(
+        scale=[float(v) for v in bias_scales.reshape(-1).tolist()],
+        zero_point=[0 for _ in range(int(bias_scales.size))],
+        quantized_dimension=int(weight_qparams.quantized_dimension),
+    )
+    report["quantized_tensors"][tensor.name] = {
+        "dtype": "INT32",
+        "kind": "bias",
+        "qparams": _quant_param_to_report(tensor.quantization),
+    }
+
+
+def _kernel_weight_quant_axis_for_strict(op_type: str, tensor: TensorIR) -> int:
+    if op_type == "DEPTHWISE_CONV_2D":
+        return max(0, len(tensor.shape) - 1)
+    if op_type in {"CONV_2D", "FULLY_CONNECTED"}:
+        return 0
+    if op_type == "BATCH_MATMUL":
+        return 0
+    return 0
+
+
+def _force_same_qparams(
+    *,
+    model_ir: ModelIR,
+    tensor_names: Iterable[str],
+    qparams: QuantParamIR,
+    dtype: str,
+    report: Dict[str, Any],
+) -> None:
+    for tensor_name in tensor_names:
+        tensor = model_ir.tensors.get(str(tensor_name), None)
+        if tensor is None:
+            raise StrictFullIntegerQuantizationError(f"Missing tensor: {tensor_name}")
+        if tensor.data is not None and tensor.dtype == "FLOAT32":
+            _quantize_float_constant_with_qparams(
+                tensor=tensor,
+                dtype=dtype,
+                qparams=qparams,
+            )
+        else:
+            tensor.dtype = str(dtype).upper()
+            tensor.quantization = _clone_quant_param(qparams)
+        report["quantized_tensors"][str(tensor_name)] = {
+            "dtype": tensor.dtype,
+            "kind": "activation",
+            "qparams": _quant_param_to_report(tensor.quantization if isinstance(tensor.quantization, QuantParamIR) else None),
+        }
+
+
 def _normalize_quantization_controls(
     *,
     calibration_method: str,
@@ -460,34 +1018,422 @@ def build_integer_quantized_model_ir(
     min_numel: int = 1,
     min_abs_max: float = 0.0,
     scale_floor: float = 1e-8,
-) -> ModelIR:
-    clone = build_dynamic_range_quantized_model_ir(
+    calibration_ranges: Optional[Dict[str, TensorCalibrationRange]] = None,
+    return_report: bool = False,
+) -> Any:
+    result = _build_strict_full_integer_model_ir(
         model_ir,
         quant_type=quant_type,
+        input_quant_dtype="int8",
+        output_quant_dtype="int8",
+        internal_activation_dtype="int8",
+        full_integer_io=False,
+        calibration_method=calibration_method,
+        calibration_percentile=calibration_percentile,
+        min_numel=min_numel,
+        min_abs_max=min_abs_max,
+        scale_floor=scale_floor,
+        calibration_ranges=calibration_ranges,
+    )
+    result.model_ir.description = f"{result.model_ir.description} (strict_integer_quantized)"
+    return result if return_report else result.model_ir
+
+
+def _build_strict_full_integer_model_ir(
+    model_ir: ModelIR,
+    *,
+    quant_type: str,
+    input_quant_dtype: str,
+    output_quant_dtype: str,
+    internal_activation_dtype: str,
+    full_integer_io: bool,
+    calibration_method: str,
+    calibration_percentile: float,
+    min_numel: int,
+    min_abs_max: float,
+    scale_floor: float,
+    calibration_ranges: Optional[Dict[str, TensorCalibrationRange]],
+) -> QuantizedModelResult:
+    if calibration_ranges is None or len(calibration_ranges) == 0:
+        raise StrictFullIntegerQuantizationError(
+            "flatbuffer_direct strict integer quantization requires calibration data."
+        )
+
+    quant_type = _normalize_quant_type(quant_type)
+    controls = _normalize_quantization_controls(
         calibration_method=calibration_method,
         calibration_percentile=calibration_percentile,
         min_numel=min_numel,
         min_abs_max=min_abs_max,
         scale_floor=scale_floor,
     )
-    clone.description = f"{clone.description} (integer_quantized_limited)"
-    return clone
+    clone = _clone_model_ir(model_ir)
+    graph_input_names = set(str(v) for v in clone.inputs)
+    graph_output_names = set(str(v) for v in clone.outputs)
+    internal_dtype = str(internal_activation_dtype).upper()
+    input_dtype = str(input_quant_dtype).upper()
+    output_dtype = str(output_quant_dtype).upper()
+    if input_dtype == "FLOAT32" or output_dtype == "FLOAT32":
+        raise StrictFullIntegerQuantizationError(
+            "strict full integer quantization does not allow FLOAT32 input/output dtype."
+        )
 
+    report: Dict[str, Any] = {
+        "mode": "full_integer" if full_integer_io else "integer_float_io",
+        "strict": True,
+        "supported_ops": sorted(_STRICT_FULL_INTEGER_SUPPORTED_OPS),
+        "tensor_ranges": {
+            str(name): _tensor_range_to_report(value)
+            for name, value in calibration_ranges.items()
+        },
+        "quantized_tensors": {},
+        "quantized_ops": [],
+        "failures": [],
+    }
 
-def _normalize_quant_io_dtype(dtype: str) -> Tuple[str, QuantParamIR]:
-    d = str(dtype).strip().lower()
-    if d == "int8":
-        return "INT8", QuantParamIR(scale=[1.0 / 128.0], zero_point=[0], quantized_dimension=0)
-    if d == "uint8":
-        return "UINT8", QuantParamIR(scale=[1.0 / 255.0], zero_point=[128], quantized_dimension=0)
-    if d == "int16":
-        return "INT16", QuantParamIR(scale=[1.0 / 32768.0], zero_point=[0], quantized_dimension=0)
-    if d == "float32":
-        return "FLOAT32", QuantParamIR(scale=[1.0], zero_point=[0], quantized_dimension=0)
-    raise ValueError(
-        "flatbuffer_direct full integer quantization supports input/output dtype "
-        f"int8/uint8/int16/float32. got: {dtype}"
+    def activation_dtype(tensor_name: str) -> str:
+        return _activation_dtype_for_tensor(
+            tensor_name=str(tensor_name),
+            model_ir=clone,
+            full_integer_io=bool(full_integer_io),
+            input_quant_dtype=input_dtype,
+            output_quant_dtype=output_dtype,
+            internal_activation_dtype=internal_dtype,
+        )
+
+    pre_ops: List[OperatorIR] = []
+    post_ops: List[OperatorIR] = []
+    if not full_integer_io:
+        for input_name in list(clone.inputs):
+            old_tensor = clone.tensors[str(input_name)]
+            q_name = _make_unique_tensor_name(f"{input_name}_quantized_internal", clone.tensors)
+            qparams = activation_qparams_from_range(
+                min_value=_require_tensor_range(
+                    tensor_name=str(input_name),
+                    calibration_ranges=calibration_ranges,
+                ).min_value,
+                max_value=_require_tensor_range(
+                    tensor_name=str(input_name),
+                    calibration_ranges=calibration_ranges,
+                ).max_value,
+                dtype=internal_dtype,
+                scale_floor=float(controls["scale_floor"]),
+            )
+            clone.tensors[q_name] = TensorIR(
+                name=q_name,
+                dtype=internal_dtype,
+                shape=list(old_tensor.shape),
+                shape_signature=list(old_tensor.shape_signature) if old_tensor.shape_signature is not None else list(old_tensor.shape),
+                data=None,
+                is_variable=False,
+                quantization=qparams,
+                logical_layout=old_tensor.logical_layout,
+            )
+            pre_ops.append(OperatorIR(op_type="QUANTIZE", inputs=[str(input_name)], outputs=[q_name]))
+            for op in clone.operators:
+                op.inputs = [q_name if str(v) == str(input_name) else v for v in op.inputs]
+            report["quantized_tensors"][q_name] = {
+                "dtype": internal_dtype,
+                "kind": "activation",
+                "qparams": _quant_param_to_report(qparams),
+            }
+        for output_name in list(clone.outputs):
+            old_tensor = clone.tensors[str(output_name)]
+            q_name = str(output_name)
+            float_name = _make_unique_tensor_name(f"{output_name}_dequantized_output", clone.tensors)
+            clone.tensors[float_name] = TensorIR(
+                name=float_name,
+                dtype="FLOAT32",
+                shape=list(old_tensor.shape),
+                shape_signature=list(old_tensor.shape_signature) if old_tensor.shape_signature is not None else list(old_tensor.shape),
+                data=None,
+                is_variable=False,
+                quantization=None,
+                logical_layout=old_tensor.logical_layout,
+            )
+            post_ops.append(OperatorIR(op_type="DEQUANTIZE", inputs=[q_name], outputs=[float_name]))
+            clone.outputs = [float_name if str(v) == q_name else v for v in clone.outputs]
+    else:
+        for input_name in list(clone.inputs):
+            old_tensor = clone.tensors[str(input_name)]
+            input_range = _require_tensor_range(
+                tensor_name=str(input_name),
+                calibration_ranges=calibration_ranges,
+            )
+            external_qparams = activation_qparams_from_range(
+                min_value=float(input_range.min_value),
+                max_value=float(input_range.max_value),
+                dtype=input_dtype,
+                scale_floor=float(controls["scale_floor"]),
+            )
+            old_tensor.dtype = input_dtype
+            old_tensor.quantization = external_qparams
+            old_tensor.data = None
+            report["quantized_tensors"][str(input_name)] = {
+                "dtype": input_dtype,
+                "kind": "graph_input",
+                "qparams": _quant_param_to_report(external_qparams),
+            }
+            if input_dtype != internal_dtype:
+                internal_name = _make_unique_tensor_name(f"{input_name}_quantized_internal", clone.tensors)
+                internal_qparams = activation_qparams_from_range(
+                    min_value=float(input_range.min_value),
+                    max_value=float(input_range.max_value),
+                    dtype=internal_dtype,
+                    scale_floor=float(controls["scale_floor"]),
+                )
+                clone.tensors[internal_name] = TensorIR(
+                    name=internal_name,
+                    dtype=internal_dtype,
+                    shape=list(old_tensor.shape),
+                    shape_signature=list(old_tensor.shape_signature) if old_tensor.shape_signature is not None else list(old_tensor.shape),
+                    data=None,
+                    is_variable=False,
+                    quantization=internal_qparams,
+                    logical_layout=old_tensor.logical_layout,
+                )
+                pre_ops.append(OperatorIR(op_type="QUANTIZE", inputs=[str(input_name)], outputs=[internal_name]))
+                for op in clone.operators:
+                    op.inputs = [internal_name if str(v) == str(input_name) else v for v in op.inputs]
+                report["quantized_tensors"][internal_name] = {
+                    "dtype": internal_dtype,
+                    "kind": "activation",
+                    "qparams": _quant_param_to_report(internal_qparams),
+                }
+
+        producer_by_output = {
+            str(output_name): op
+            for op in clone.operators
+            for output_name in op.outputs
+        }
+        for output_name in list(clone.outputs):
+            if output_dtype == internal_dtype:
+                continue
+            old_tensor = clone.tensors[str(output_name)]
+            producer_op = producer_by_output.get(str(output_name), None)
+            fixed_external = fixed_activation_qparams_for_op(
+                op_type=str(producer_op.op_type) if producer_op is not None else "",
+                dtype=output_dtype,
+            )
+            if fixed_external is None:
+                output_range = _require_tensor_range(
+                    tensor_name=str(output_name),
+                    calibration_ranges=calibration_ranges,
+                )
+                external_qparams = activation_qparams_from_range(
+                    min_value=float(output_range.min_value),
+                    max_value=float(output_range.max_value),
+                    dtype=output_dtype,
+                    scale_floor=float(controls["scale_floor"]),
+                )
+            else:
+                external_qparams = fixed_external
+            internal_name = _make_unique_tensor_name(f"{output_name}_quantized_internal", clone.tensors)
+            clone.tensors[internal_name] = TensorIR(
+                name=internal_name,
+                dtype="FLOAT32",
+                shape=list(old_tensor.shape),
+                shape_signature=list(old_tensor.shape_signature) if old_tensor.shape_signature is not None else list(old_tensor.shape),
+                data=None,
+                is_variable=False,
+                quantization=None,
+                logical_layout=old_tensor.logical_layout,
+            )
+            for op in clone.operators:
+                op.outputs = [internal_name if str(v) == str(output_name) else v for v in op.outputs]
+            old_tensor.dtype = output_dtype
+            old_tensor.quantization = external_qparams
+            old_tensor.data = None
+            post_ops.append(OperatorIR(op_type="QUANTIZE", inputs=[internal_name], outputs=[str(output_name)]))
+            report["quantized_tensors"][str(output_name)] = {
+                "dtype": output_dtype,
+                "kind": "graph_output",
+                "qparams": _quant_param_to_report(external_qparams),
+            }
+
+    for op_idx, op in enumerate(clone.operators):
+        op_type = str(op.op_type)
+        if op_type not in _STRICT_FULL_INTEGER_SUPPORTED_OPS:
+            raise StrictFullIntegerQuantizationError(
+                f"Unsupported op for strict full integer quantization: index={op_idx} op_type={op_type}"
+            )
+
+        for input_name in list(op.inputs):
+            if str(input_name) == "":
+                continue
+            tensor = clone.tensors.get(str(input_name), None)
+            if tensor is None:
+                raise StrictFullIntegerQuantizationError(
+                    f"Missing input tensor for strict full integer quantization: op={op_type} tensor={input_name}"
+                )
+            if tensor.dtype == "FLOAT32" and tensor.data is None:
+                _ensure_activation_quantized(
+                    model_ir=clone,
+                    tensor_name=str(input_name),
+                    calibration_ranges=calibration_ranges,
+                    dtype=activation_dtype(str(input_name)),
+                    scale_floor=float(controls["scale_floor"]),
+                    report=report,
+                )
+
+        output_fixed = fixed_activation_qparams_for_op(
+            op_type=op_type,
+            dtype=activation_dtype(str(op.outputs[0])) if len(op.outputs) > 0 else internal_dtype,
+        )
+        for output_name in list(op.outputs):
+            if str(output_name) == "":
+                continue
+            out_tensor = clone.tensors.get(str(output_name), None)
+            if out_tensor is None:
+                raise StrictFullIntegerQuantizationError(
+                    f"Missing output tensor for strict full integer quantization: op={op_type} tensor={output_name}"
+                )
+            if out_tensor.dtype == "FLOAT32":
+                if op_type in _STRICT_FULL_INTEGER_PASSTHROUGH_OPS and len(op.inputs) > 0:
+                    ref = clone.tensors[str(op.inputs[0])]
+                    if not isinstance(ref.quantization, QuantParamIR):
+                        raise StrictFullIntegerQuantizationError(
+                            f"Passthrough op input is not quantized: op={op_type} tensor={op.inputs[0]}"
+                        )
+                    out_tensor.dtype = ref.dtype
+                    out_tensor.quantization = _clone_quant_param(ref.quantization)
+                    out_tensor.data = None
+                    report["quantized_tensors"][str(output_name)] = {
+                        "dtype": out_tensor.dtype,
+                        "kind": "activation",
+                        "qparams": _quant_param_to_report(out_tensor.quantization),
+                    }
+                else:
+                    _ensure_activation_quantized(
+                        model_ir=clone,
+                        tensor_name=str(output_name),
+                        calibration_ranges=calibration_ranges,
+                        dtype=activation_dtype(str(output_name)),
+                        scale_floor=float(controls["scale_floor"]),
+                        report=report,
+                        fixed_qparams=output_fixed,
+                    )
+
+        if op_type in {"FULLY_CONNECTED", "CONV_2D", "DEPTHWISE_CONV_2D", "BATCH_MATMUL"}:
+            if len(op.inputs) < 2:
+                raise StrictFullIntegerQuantizationError(f"{op_type} requires a weight input.")
+            input_tensor = clone.tensors[str(op.inputs[0])]
+            if not isinstance(input_tensor.quantization, QuantParamIR):
+                raise StrictFullIntegerQuantizationError(
+                    f"{op_type} input tensor is missing qparams: {op.inputs[0]}"
+                )
+            weight_tensor = clone.tensors[str(op.inputs[1])]
+            weight_qparams = _quantize_weight_tensor(
+                tensor=weight_tensor,
+                quant_type=quant_type,
+                quantized_dimension=_kernel_weight_quant_axis_for_strict(op_type, weight_tensor),
+                calibration_method=str(controls["calibration_method"]),
+                calibration_percentile=float(controls["calibration_percentile"]),
+                scale_floor=float(controls["scale_floor"]),
+                report=report,
+            )
+            if len(op.inputs) >= 3 and str(op.inputs[2]) != "":
+                bias_tensor = clone.tensors.get(str(op.inputs[2]), None)
+                if bias_tensor is not None and bias_tensor.data is not None:
+                    _quantize_bias_tensor(
+                        tensor=bias_tensor,
+                        input_qparams=input_tensor.quantization,
+                        weight_qparams=weight_qparams,
+                        report=report,
+                    )
+        elif op_type in _STRICT_FULL_INTEGER_REQUIRES_SAME_QPARAMS and len(op.outputs) > 0:
+            out_tensor = clone.tensors[str(op.outputs[0])]
+            if not isinstance(out_tensor.quantization, QuantParamIR):
+                raise StrictFullIntegerQuantizationError(
+                    f"{op_type} output tensor is missing qparams: {op.outputs[0]}"
+                )
+            _force_same_qparams(
+                model_ir=clone,
+                tensor_names=[str(v) for v in list(op.inputs) + list(op.outputs) if str(v) != ""],
+                qparams=out_tensor.quantization,
+                dtype=out_tensor.dtype,
+                report=report,
+            )
+        else:
+            for input_name in list(op.inputs):
+                tensor = clone.tensors.get(str(input_name), None)
+                if tensor is None or tensor.data is None or tensor.dtype != "FLOAT32":
+                    continue
+                rng = TensorCalibrationRange(
+                    min_value=float(np.min(np.asarray(tensor.data, dtype=np.float32))),
+                    max_value=float(np.max(np.asarray(tensor.data, dtype=np.float32))),
+                    num_samples=1,
+                )
+                qparams = activation_qparams_from_range(
+                    min_value=rng.min_value,
+                    max_value=rng.max_value,
+                    dtype=activation_dtype(str(input_name)),
+                    scale_floor=float(controls["scale_floor"]),
+                )
+                _quantize_float_constant_with_qparams(
+                    tensor=tensor,
+                    dtype=activation_dtype(str(input_name)),
+                    qparams=qparams,
+                )
+                report["quantized_tensors"][str(input_name)] = {
+                    "dtype": tensor.dtype,
+                    "kind": "constant",
+                    "qparams": _quant_param_to_report(qparams),
+                }
+
+        report["quantized_ops"].append(
+            {
+                "index": int(op_idx),
+                "op_type": op_type,
+                "inputs": [str(v) for v in op.inputs],
+                "outputs": [str(v) for v in op.outputs],
+            }
+        )
+
+    clone.operators = pre_ops + clone.operators + post_ops
+    _validate_strict_full_integer_model_ir(
+        model_ir=clone,
+        allow_float_boundary=not full_integer_io,
     )
+    return QuantizedModelResult(model_ir=clone, report=report)
+
+
+def _validate_strict_full_integer_model_ir(
+    *,
+    model_ir: ModelIR,
+    allow_float_boundary: bool,
+) -> None:
+    allowed_boundary_float_tensors: Set[str] = set()
+    if allow_float_boundary:
+        allowed_boundary_float_tensors.update(str(v) for v in model_ir.inputs)
+        allowed_boundary_float_tensors.update(str(v) for v in model_ir.outputs)
+
+    used_tensors = _used_tensor_names(model_ir)
+    for op_idx, op in enumerate(model_ir.operators):
+        op_type = str(op.op_type)
+        if op_type == "QUANTIZE":
+            continue
+        if op_type == "DEQUANTIZE" and allow_float_boundary:
+            continue
+        if op_type not in _STRICT_FULL_INTEGER_SUPPORTED_OPS:
+            raise StrictFullIntegerQuantizationError(
+                f"Unsupported op remains in strict full integer model: index={op_idx} op_type={op_type}"
+            )
+
+    for tensor_name in sorted(used_tensors):
+        tensor = model_ir.tensors.get(str(tensor_name), None)
+        if tensor is None:
+            raise StrictFullIntegerQuantizationError(f"Used tensor is missing: {tensor_name}")
+        if tensor.dtype == "FLOAT32":
+            if str(tensor_name) in allowed_boundary_float_tensors:
+                continue
+            raise StrictFullIntegerQuantizationError(
+                f"Float tensor remains in strict full integer model: {tensor_name}"
+            )
+        if tensor.dtype in {"INT8", "UINT8", "INT16"} and tensor.quantization is None:
+            raise StrictFullIntegerQuantizationError(
+                f"Quantized tensor is missing qparams: {tensor_name}"
+            )
 
 
 def build_full_integer_quantized_model_ir(
@@ -500,94 +1446,25 @@ def build_full_integer_quantized_model_ir(
     min_numel: int = 1,
     min_abs_max: float = 0.0,
     scale_floor: float = 1e-8,
-) -> ModelIR:
-    clone = build_integer_quantized_model_ir(
+    calibration_ranges: Optional[Dict[str, TensorCalibrationRange]] = None,
+    return_report: bool = False,
+) -> Any:
+    result = _build_strict_full_integer_model_ir(
         model_ir,
         quant_type=quant_type,
+        input_quant_dtype=input_quant_dtype,
+        output_quant_dtype=output_quant_dtype,
+        internal_activation_dtype="int8",
+        full_integer_io=True,
         calibration_method=calibration_method,
         calibration_percentile=calibration_percentile,
         min_numel=min_numel,
         min_abs_max=min_abs_max,
         scale_floor=scale_floor,
+        calibration_ranges=calibration_ranges,
     )
-
-    input_dtype_name, input_qparams = _normalize_quant_io_dtype(input_quant_dtype)
-    output_dtype_name, output_qparams = _normalize_quant_io_dtype(output_quant_dtype)
-
-    pre_ops: List[OperatorIR] = []
-    post_ops: List[OperatorIR] = []
-
-    new_inputs: List[str] = []
-    for input_name in list(clone.inputs):
-        old_tensor = clone.tensors[input_name]
-        if input_dtype_name == "FLOAT32":
-            new_inputs.append(input_name)
-            continue
-
-        q_input_name = _make_unique_tensor_name(f"{input_name}_quantized_input", clone.tensors)
-        clone.tensors[q_input_name] = TensorIR(
-            name=q_input_name,
-            dtype=input_dtype_name,
-            shape=list(old_tensor.shape),
-            shape_signature=list(old_tensor.shape_signature)
-            if old_tensor.shape_signature is not None
-            else list(old_tensor.shape),
-            data=None,
-            is_variable=False,
-            quantization=QuantParamIR(
-                scale=list(input_qparams.scale),
-                zero_point=list(input_qparams.zero_point),
-                quantized_dimension=int(input_qparams.quantized_dimension),
-            ),
-        )
-        pre_ops.append(
-            OperatorIR(
-                op_type="DEQUANTIZE",
-                inputs=[q_input_name],
-                outputs=[input_name],
-                options={},
-            )
-        )
-        new_inputs.append(q_input_name)
-
-    new_outputs: List[str] = []
-    for output_name in list(clone.outputs):
-        old_tensor = clone.tensors[output_name]
-        if output_dtype_name == "FLOAT32":
-            new_outputs.append(output_name)
-            continue
-
-        q_output_name = _make_unique_tensor_name(f"{output_name}_quantized_output", clone.tensors)
-        clone.tensors[q_output_name] = TensorIR(
-            name=q_output_name,
-            dtype=output_dtype_name,
-            shape=list(old_tensor.shape),
-            shape_signature=list(old_tensor.shape_signature)
-            if old_tensor.shape_signature is not None
-            else list(old_tensor.shape),
-            data=None,
-            is_variable=False,
-            quantization=QuantParamIR(
-                scale=list(output_qparams.scale),
-                zero_point=list(output_qparams.zero_point),
-                quantized_dimension=int(output_qparams.quantized_dimension),
-            ),
-        )
-        post_ops.append(
-            OperatorIR(
-                op_type="QUANTIZE",
-                inputs=[output_name],
-                outputs=[q_output_name],
-                options={},
-            )
-        )
-        new_outputs.append(q_output_name)
-
-    clone.inputs = new_inputs
-    clone.outputs = new_outputs
-    clone.operators = pre_ops + clone.operators + post_ops
-    clone.description = f"{clone.description} (full_integer_quantized_limited)"
-    return clone
+    result.model_ir.description = f"{result.model_ir.description} (strict_full_integer_quantized)"
+    return result if return_report else result.model_ir
 
 
 def build_integer_quantized_with_int16_act_model_ir(
@@ -598,18 +1475,24 @@ def build_integer_quantized_with_int16_act_model_ir(
     min_numel: int = 1,
     min_abs_max: float = 0.0,
     scale_floor: float = 1e-8,
-) -> ModelIR:
-    clone = build_integer_quantized_model_ir(
+    calibration_ranges: Optional[Dict[str, TensorCalibrationRange]] = None,
+) -> Any:
+    result = _build_strict_full_integer_model_ir(
         model_ir,
         quant_type=quant_type,
+        input_quant_dtype="int16",
+        output_quant_dtype="int16",
+        internal_activation_dtype="int16",
+        full_integer_io=False,
         calibration_method=calibration_method,
         calibration_percentile=calibration_percentile,
         min_numel=min_numel,
         min_abs_max=min_abs_max,
         scale_floor=scale_floor,
+        calibration_ranges=calibration_ranges,
     )
-    clone.description = f"{clone.description} (integer_quant_with_int16_act_limited)"
-    return clone
+    result.model_ir.description = f"{result.model_ir.description} (strict_integer_quant_with_int16_act)"
+    return result.model_ir
 
 
 def build_full_integer_quantized_with_int16_act_model_ir(
@@ -620,17 +1503,21 @@ def build_full_integer_quantized_with_int16_act_model_ir(
     min_numel: int = 1,
     min_abs_max: float = 0.0,
     scale_floor: float = 1e-8,
-) -> ModelIR:
-    clone = build_full_integer_quantized_model_ir(
+    calibration_ranges: Optional[Dict[str, TensorCalibrationRange]] = None,
+) -> Any:
+    result = _build_strict_full_integer_model_ir(
         model_ir,
         quant_type=quant_type,
         input_quant_dtype="int16",
         output_quant_dtype="int16",
+        internal_activation_dtype="int16",
+        full_integer_io=True,
         calibration_method=calibration_method,
         calibration_percentile=calibration_percentile,
         min_numel=min_numel,
         min_abs_max=min_abs_max,
         scale_floor=scale_floor,
+        calibration_ranges=calibration_ranges,
     )
-    clone.description = f"{clone.description} (full_integer_quant_with_int16_act_limited)"
-    return clone
+    result.model_ir.description = f"{result.model_ir.description} (strict_full_integer_quant_with_int16_act)"
+    return result.model_ir

--- a/onnx2tf/tflite_builder/tensor_buffer_builder.py
+++ b/onnx2tf/tflite_builder/tensor_buffer_builder.py
@@ -125,9 +125,9 @@ def build_tensors_and_buffers(
 
         if tensor.data is not None:
             b = schema_tflite["BufferT"]()
-            if isinstance(tensor.data, np.ndarray):
+            if isinstance(tensor.data, (np.ndarray, np.generic)):
                 if str(tensor.dtype).upper() == "STRING":
-                    b.data = _serialize_tflite_string_buffer(tensor.data)
+                    b.data = _serialize_tflite_string_buffer(np.asarray(tensor.data))
                 else:
                     b.data = tensor.data.tobytes()
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.5.0"
+version = "2.5.1"
 description = "A tool for converting ONNX files to LiteRT/TFLite/TensorFlow, PyTorch native code (nn.Module), TorchScript (.pt), state_dict (.pt), Exported Program (.pt2), and Dynamo ONNX. It also supports direct conversion from LiteRT to PyTorch."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_strict_integer_quantization.py
+++ b/tests/test_strict_integer_quantization.py
@@ -1,0 +1,119 @@
+import numpy as np
+import pytest
+
+from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
+from onnx2tf.tflite_builder.quantization import (
+    StrictFullIntegerQuantizationError,
+    TensorCalibrationRange,
+    activation_qparams_from_range,
+    build_full_integer_quantized_model_ir,
+    fixed_activation_qparams_for_op,
+    load_calibration_samples,
+)
+
+
+def test_activation_qparams_from_range_uint8_uses_calibrated_range() -> None:
+    qparams = activation_qparams_from_range(
+        min_value=0.0,
+        max_value=255.0,
+        dtype="uint8",
+    )
+
+    assert qparams.scale == [1.0]
+    assert qparams.zero_point == [0]
+
+
+def test_fixed_softmax_uint8_qparams_match_tflite_contract() -> None:
+    qparams = fixed_activation_qparams_for_op(op_type="SOFTMAX", dtype="uint8")
+
+    assert qparams is not None
+    assert qparams.scale == [1.0 / 256.0]
+    assert qparams.zero_point == [0]
+
+
+def test_load_calibration_samples_requires_mean_std_entries() -> None:
+    with pytest.raises(Exception, match="requires each calibration entry"):
+        load_calibration_samples(
+            custom_input_op_name_np_data_path=[["x", "unused.npy"]],
+            input_names=["x"],
+        )
+
+
+def test_strict_full_integer_builder_quantizes_fc_softmax_ir() -> None:
+    model_ir = ModelIR(name="fc_softmax")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["prob"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4])
+    model_ir.tensors["w"] = TensorIR(
+        name="w",
+        dtype="FLOAT32",
+        shape=[3, 4],
+        data=np.asarray(
+            [
+                [0.1, 0.2, 0.3, 0.4],
+                [0.2, 0.1, -0.1, -0.2],
+                [0.0, 0.3, 0.1, -0.4],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    model_ir.tensors["b"] = TensorIR(
+        name="b",
+        dtype="FLOAT32",
+        shape=[3],
+        data=np.zeros((3,), dtype=np.float32),
+    )
+    model_ir.tensors["logits"] = TensorIR(name="logits", dtype="FLOAT32", shape=[1, 3])
+    model_ir.tensors["prob"] = TensorIR(name="prob", dtype="FLOAT32", shape=[1, 3])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="FULLY_CONNECTED",
+            inputs=["x", "w", "b"],
+            outputs=["logits"],
+            options={"asymmetricQuantizeInputs": False},
+        ),
+        OperatorIR(op_type="SOFTMAX", inputs=["logits"], outputs=["prob"]),
+    ]
+    ranges = {
+        "x": TensorCalibrationRange(0.0, 255.0, 2),
+        "logits": TensorCalibrationRange(-2.0, 2.0, 2),
+        "prob": TensorCalibrationRange(0.0, 1.0, 2),
+    }
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        input_quant_dtype="uint8",
+        output_quant_dtype="uint8",
+        calibration_ranges=ranges,
+    )
+
+    assert quantized.tensors["x"].dtype == "UINT8"
+    assert quantized.tensors["x"].quantization is not None
+    assert quantized.tensors["x"].quantization.scale == [1.0]
+    assert quantized.tensors["x"].quantization.zero_point == [0]
+    assert quantized.tensors["w"].dtype == "INT8"
+    assert quantized.tensors["b"].dtype == "INT32"
+    assert quantized.tensors["prob"].dtype == "UINT8"
+    assert quantized.tensors["prob"].quantization is not None
+    assert quantized.tensors["prob"].quantization.scale == [1.0 / 256.0]
+    assert quantized.tensors["prob"].quantization.zero_point == [0]
+
+
+def test_strict_full_integer_builder_rejects_unsupported_float_op() -> None:
+    model_ir = ModelIR(name="unsupported")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 3])
+    model_ir.operators = [
+        OperatorIR(op_type="EXP", inputs=["x"], outputs=["y"]),
+    ]
+
+    with pytest.raises(StrictFullIntegerQuantizationError, match="Unsupported op"):
+        build_full_integer_quantized_model_ir(
+            model_ir,
+            calibration_ranges={
+                "x": TensorCalibrationRange(-1.0, 1.0, 1),
+                "y": TensorCalibrationRange(0.0, 2.0, 1),
+            },
+        )

--- a/tests/test_strict_integer_quantization.py
+++ b/tests/test_strict_integer_quantization.py
@@ -1,7 +1,11 @@
+import os
+import tempfile
+
 import numpy as np
 import pytest
 
 from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
+from onnx2tf.tflite_builder.model_writer import write_model_file
 from onnx2tf.tflite_builder.quantization import (
     StrictFullIntegerQuantizationError,
     TensorCalibrationRange,
@@ -10,6 +14,32 @@ from onnx2tf.tflite_builder.quantization import (
     fixed_activation_qparams_for_op,
     load_calibration_samples,
 )
+from onnx2tf.tflite_builder.schema_loader import load_schema_module
+
+
+Interpreter = pytest.importorskip("ai_edge_litert.interpreter").Interpreter
+
+
+def _calibration_ranges_for_float_activations(model_ir: ModelIR) -> dict[str, TensorCalibrationRange]:
+    return {
+        name: TensorCalibrationRange(-1.0, 1.0, 1)
+        for name, tensor in model_ir.tensors.items()
+        if str(tensor.dtype).upper() == "FLOAT32" and tensor.data is None
+    }
+
+
+def _assert_litert_allocates(model_ir: ModelIR) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema = load_schema_module(output_folder_path=tmpdir)
+        tflite_path = os.path.join(tmpdir, f"{model_ir.name}.tflite")
+        write_model_file(
+            schema_tflite=schema,
+            model_ir=model_ir,
+            output_tflite_path=tflite_path,
+            timing={},
+        )
+        interpreter = Interpreter(model_path=tflite_path)
+        interpreter.allocate_tensors()
 
 
 def test_activation_qparams_from_range_uint8_uses_calibrated_range() -> None:
@@ -117,3 +147,403 @@ def test_strict_full_integer_builder_rejects_unsupported_float_op() -> None:
                 "y": TensorCalibrationRange(0.0, 2.0, 1),
             },
         )
+
+
+def test_fixed_tanh_qparams_match_tflite_contract() -> None:
+    int8_qparams = fixed_activation_qparams_for_op(op_type="TANH", dtype="int8")
+    uint8_qparams = fixed_activation_qparams_for_op(op_type="TANH", dtype="uint8")
+    int16_qparams = fixed_activation_qparams_for_op(op_type="TANH", dtype="int16")
+
+    assert int8_qparams is not None
+    assert int8_qparams.scale == [1.0 / 128.0]
+    assert int8_qparams.zero_point == [0]
+    assert uint8_qparams is not None
+    assert uint8_qparams.scale == [1.0 / 128.0]
+    assert uint8_qparams.zero_point == [128]
+    assert int16_qparams is not None
+    assert int16_qparams.scale == [1.0 / 32768.0]
+    assert int16_qparams.zero_point == [0]
+
+
+def test_select_keeps_bool_condition_and_aligns_value_qparams() -> None:
+    model_ir = ModelIR(name="select")
+    model_ir.inputs = ["cond", "x", "z"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["cond"] = TensorIR(name="cond", dtype="BOOL", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["z"] = TensorIR(name="z", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.operators = [OperatorIR(op_type="SELECT_V2", inputs=["cond", "x", "z"], outputs=["y"])]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges={
+            "x": TensorCalibrationRange(-2.0, 2.0, 1),
+            "z": TensorCalibrationRange(-1.0, 1.0, 1),
+            "y": TensorCalibrationRange(-0.5, 0.5, 1),
+        },
+    )
+
+    assert quantized.tensors["cond"].dtype == "BOOL"
+    assert quantized.tensors["cond"].quantization is None
+    assert quantized.tensors["x"].quantization is not None
+    assert quantized.tensors["z"].quantization is not None
+    assert quantized.tensors["y"].quantization is not None
+    assert quantized.tensors["x"].quantization.scale == quantized.tensors["y"].quantization.scale
+    assert quantized.tensors["z"].quantization.scale == quantized.tensors["y"].quantization.scale
+    _assert_litert_allocates(quantized)
+
+
+def test_reduce_axes_remain_int32() -> None:
+    model_ir = ModelIR(name="reduce_sum")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["axes"] = TensorIR(
+        name="axes",
+        dtype="INT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1], shape_signature=[1])
+    model_ir.operators = [
+        OperatorIR(op_type="SUM", inputs=["x", "axes"], outputs=["y"], options={"keepDims": False})
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    assert quantized.tensors["axes"].dtype == "INT32"
+    assert quantized.tensors["axes"].quantization is None
+    _assert_litert_allocates(quantized)
+
+
+def test_transpose_conv_quantizes_weight_and_bias() -> None:
+    model_ir = ModelIR(name="transpose_conv")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["out_shape"] = TensorIR(
+        name="out_shape",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([1, 4, 4, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["w"] = TensorIR(
+        name="w",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 1],
+        shape_signature=[1, 2, 2, 1],
+        data=np.ones((1, 2, 2, 1), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["b"] = TensorIR(
+        name="b",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.zeros((1,), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3, 3, 1], shape_signature=[1, 3, 3, 1])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4, 4, 1], shape_signature=[1, 4, 4, 1])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="TRANSPOSE_CONV",
+            inputs=["out_shape", "w", "x", "b"],
+            outputs=["y"],
+            options={
+                "padding": "VALID",
+                "strideH": 1,
+                "strideW": 1,
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    assert quantized.tensors["out_shape"].dtype == "INT32"
+    assert quantized.tensors["w"].dtype == "INT8"
+    assert quantized.tensors["w"].quantization is not None
+    assert quantized.tensors["w"].quantization.quantized_dimension == 0
+    assert quantized.tensors["b"].dtype == "INT32"
+    assert quantized.tensors["b"].quantization is not None
+
+
+def test_transpose_conv_allocates_as_strict_full_integer() -> None:
+    model_ir = ModelIR(name="transpose_conv_allocate")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["out_shape"] = TensorIR(
+        name="out_shape",
+        dtype="INT32",
+        shape=[4],
+        shape_signature=[4],
+        data=np.asarray([1, 4, 4, 1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["w"] = TensorIR(
+        name="w",
+        dtype="FLOAT32",
+        shape=[1, 2, 2, 1],
+        shape_signature=[1, 2, 2, 1],
+        data=np.ones((1, 2, 2, 1), dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3, 3, 1], shape_signature=[1, 3, 3, 1])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4, 4, 1], shape_signature=[1, 4, 4, 1])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="TRANSPOSE_CONV",
+            inputs=["out_shape", "w", "x"],
+            outputs=["y"],
+            options={
+                "padding": "VALID",
+                "strideH": 1,
+                "strideW": 1,
+                "fusedActivationFunction": "NONE",
+            },
+        )
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    _assert_litert_allocates(quantized)
+
+
+def test_identity_is_elided_before_strict_full_integer_quantization() -> None:
+    model_ir = ModelIR(name="identity_elide")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["relu_out"] = TensorIR(name="relu_out", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.operators = [
+        OperatorIR(op_type="RELU", inputs=["x"], outputs=["relu_out"]),
+        OperatorIR(op_type="IDENTITY", inputs=["relu_out"], outputs=["y"]),
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges={
+            "x": TensorCalibrationRange(-1.0, 1.0, 1),
+            "relu_out": TensorCalibrationRange(0.0, 1.0, 1),
+            "y": TensorCalibrationRange(0.0, 1.0, 1),
+        },
+    )
+
+    assert [str(op.op_type) for op in quantized.operators] == ["RELU"]
+    assert quantized.outputs == ["y"]
+    assert quantized.operators[0].outputs == ["y"]
+    _assert_litert_allocates(quantized)
+
+
+def _make_single_op_model(op_type: str) -> ModelIR:
+    model_ir = ModelIR(name=str(op_type).lower())
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    if op_type in {"MAXIMUM", "MINIMUM", "DIV"}:
+        model_ir.tensors["c"] = TensorIR(
+            name="c",
+            dtype="FLOAT32",
+            shape=[1, 4],
+            shape_signature=[1, 4],
+            data=np.ones((1, 4), dtype=np.float32),
+            is_variable=False,
+        )
+        model_ir.operators = [OperatorIR(op_type=op_type, inputs=["x", "c"], outputs=["y"])]
+    elif op_type == "PRELU":
+        model_ir.tensors["alpha"] = TensorIR(
+            name="alpha",
+            dtype="FLOAT32",
+            shape=[1, 4],
+            shape_signature=[1, 4],
+            data=np.full((1, 4), 0.25, dtype=np.float32),
+            is_variable=False,
+        )
+        model_ir.operators = [OperatorIR(op_type=op_type, inputs=["x", "alpha"], outputs=["y"])]
+    elif op_type == "LEAKY_RELU":
+        model_ir.operators = [OperatorIR(op_type=op_type, inputs=["x"], outputs=["y"], options={"alpha": 0.1})]
+    else:
+        model_ir.operators = [OperatorIR(op_type=op_type, inputs=["x"], outputs=["y"])]
+    return model_ir
+
+
+def _make_shape_op_model(op_type: str) -> ModelIR:
+    model_ir = ModelIR(name=str(op_type).lower())
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    if op_type == "SLICE":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.tensors["begin"] = TensorIR(name="begin", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([0, 1], dtype=np.int32), is_variable=False)
+        model_ir.tensors["size"] = TensorIR(name="size", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([1, 2], dtype=np.int32), is_variable=False)
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 2], shape_signature=[1, 2])
+        model_ir.operators = [OperatorIR(op_type="SLICE", inputs=["x", "begin", "size"], outputs=["y"])]
+    elif op_type == "STRIDED_SLICE":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.tensors["begin"] = TensorIR(name="begin", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([0, 0], dtype=np.int32), is_variable=False)
+        model_ir.tensors["end"] = TensorIR(name="end", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([1, 4], dtype=np.int32), is_variable=False)
+        model_ir.tensors["stride"] = TensorIR(name="stride", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([1, 1], dtype=np.int32), is_variable=False)
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.operators = [
+            OperatorIR(
+                op_type="STRIDED_SLICE",
+                inputs=["x", "begin", "end", "stride"],
+                outputs=["y"],
+                options={"beginMask": 0, "endMask": 0, "ellipsisMask": 0, "newAxisMask": 0, "shrinkAxisMask": 0},
+            )
+        ]
+    elif op_type == "SPLIT":
+        model_ir.outputs = ["y0", "y1"]
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.tensors["axis"] = TensorIR(name="axis", dtype="INT32", shape=[1], shape_signature=[1], data=np.asarray([1], dtype=np.int32), is_variable=False)
+        model_ir.tensors["y0"] = TensorIR(name="y0", dtype="FLOAT32", shape=[1, 2], shape_signature=[1, 2])
+        model_ir.tensors["y1"] = TensorIR(name="y1", dtype="FLOAT32", shape=[1, 2], shape_signature=[1, 2])
+        model_ir.operators = [OperatorIR(op_type="SPLIT", inputs=["axis", "x"], outputs=["y0", "y1"], options={"numSplits": 2})]
+    elif op_type == "GATHER":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.tensors["idx"] = TensorIR(name="idx", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([0, 2], dtype=np.int32), is_variable=False)
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 2], shape_signature=[1, 2])
+        model_ir.operators = [OperatorIR(op_type="GATHER", inputs=["x", "idx"], outputs=["y"], options={"axis": 1, "batchDims": 0})]
+    elif op_type == "TILE":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.tensors["reps"] = TensorIR(name="reps", dtype="INT32", shape=[2], shape_signature=[2], data=np.asarray([1, 2], dtype=np.int32), is_variable=False)
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 8], shape_signature=[1, 8])
+        model_ir.operators = [OperatorIR(op_type="TILE", inputs=["x", "reps"], outputs=["y"])]
+    elif op_type == "PAD":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+        model_ir.tensors["pads"] = TensorIR(name="pads", dtype="INT32", shape=[2, 2], shape_signature=[2, 2], data=np.asarray([[0, 0], [1, 1]], dtype=np.int32), is_variable=False)
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 6], shape_signature=[1, 6])
+        model_ir.operators = [OperatorIR(op_type="PAD", inputs=["x", "pads"], outputs=["y"])]
+    elif op_type == "SPACE_TO_DEPTH":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4, 4, 1], shape_signature=[1, 4, 4, 1])
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 2, 2, 4], shape_signature=[1, 2, 2, 4])
+        model_ir.operators = [OperatorIR(op_type="SPACE_TO_DEPTH", inputs=["x"], outputs=["y"], options={"blockSize": 2})]
+    elif op_type == "DEPTH_TO_SPACE":
+        model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 2, 2, 4], shape_signature=[1, 2, 2, 4])
+        model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4, 4, 1], shape_signature=[1, 4, 4, 1])
+        model_ir.operators = [OperatorIR(op_type="DEPTH_TO_SPACE", inputs=["x"], outputs=["y"], options={"blockSize": 2})]
+    else:
+        raise AssertionError(f"Unexpected shape op: {op_type}")
+    return model_ir
+
+
+@pytest.mark.parametrize(
+    "op_type",
+    [
+        "ABS",
+        "NEG",
+        "RELU_N1_TO_1",
+        "TANH",
+        "HARD_SWISH",
+        "LEAKY_RELU",
+        "MAXIMUM",
+        "MINIMUM",
+        "DIV",
+        "PRELU",
+    ],
+)
+def test_additional_activation_ops_allocate_as_strict_full_integer(op_type: str) -> None:
+    model_ir = _make_single_op_model(op_type)
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    _assert_litert_allocates(quantized)
+
+
+@pytest.mark.parametrize(
+    "op_type",
+    [
+        "SLICE",
+        "STRIDED_SLICE",
+        "SPLIT",
+        "GATHER",
+        "TILE",
+        "PAD",
+        "SPACE_TO_DEPTH",
+        "DEPTH_TO_SPACE",
+    ],
+)
+def test_additional_forwarding_ops_allocate_as_strict_full_integer(op_type: str) -> None:
+    model_ir = _make_shape_op_model(op_type)
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    _assert_litert_allocates(quantized)
+
+
+@pytest.mark.parametrize("op_type", ["SUM", "REDUCE_MAX", "REDUCE_MIN", "REDUCE_PROD"])
+def test_additional_reduce_ops_allocate_as_strict_full_integer(op_type: str) -> None:
+    model_ir = ModelIR(name=str(op_type).lower())
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["axes"] = TensorIR(
+        name="axes",
+        dtype="INT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([1], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1], shape_signature=[1])
+    model_ir.operators = [
+        OperatorIR(op_type=op_type, inputs=["x", "axes"], outputs=["y"], options={"keepDims": False})
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    _assert_litert_allocates(quantized)
+
+
+@pytest.mark.parametrize("op_type", ["RESIZE_NEAREST_NEIGHBOR", "RESIZE_BILINEAR"])
+def test_additional_resize_ops_allocate_as_strict_full_integer(op_type: str) -> None:
+    model_ir = ModelIR(name=str(op_type).lower())
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 2, 2, 1], shape_signature=[1, 2, 2, 1])
+    model_ir.tensors["size"] = TensorIR(
+        name="size",
+        dtype="INT32",
+        shape=[2],
+        shape_signature=[2],
+        data=np.asarray([4, 4], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 4, 4, 1], shape_signature=[1, 4, 4, 1])
+    model_ir.operators = [
+        OperatorIR(
+            op_type=op_type,
+            inputs=["x", "size"],
+            outputs=["y"],
+            options={"alignCorners": False, "halfPixelCenters": False},
+        )
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    _assert_litert_allocates(quantized)

--- a/tests/test_tensor_buffer_builder.py
+++ b/tests/test_tensor_buffer_builder.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+from onnx2tf.tflite_builder.ir import TensorIR
+from onnx2tf.tflite_builder.tensor_buffer_builder import build_tensors_and_buffers
+
+
+class _BufferT:
+    def __init__(self) -> None:
+        self.data = None
+
+
+class _TensorT:
+    def __init__(self) -> None:
+        self.name = None
+        self.shape = None
+        self.shapeSignature = None
+        self.type = None
+        self.isVariable = None
+        self.quantization = None
+        self.buffer = None
+
+
+class _TensorType:
+    INT8 = 9
+
+
+class _QuantizationParametersT:
+    pass
+
+
+_SCHEMA_TFLITE_STUB = {
+    "BufferT": _BufferT,
+    "TensorT": _TensorT,
+    "TensorType": _TensorType,
+    "QuantizationParametersT": _QuantizationParametersT,
+}
+
+
+def test_build_tensors_and_buffers_serializes_numpy_scalar_int8_data() -> None:
+    tensors = {
+        "neg": TensorIR(
+            name="neg",
+            dtype="INT8",
+            shape=[1],
+            data=np.int8(-127),
+        ),
+        "pos": TensorIR(
+            name="pos",
+            dtype="INT8",
+            shape=[1],
+            data=np.int8(5),
+        ),
+    }
+
+    _, buffers, _ = build_tensors_and_buffers(
+        schema_tflite=_SCHEMA_TFLITE_STUB,
+        tensors=tensors,
+    )
+
+    assert getattr(buffers[1], "data") == np.int8(-127).tobytes()
+    assert getattr(buffers[2], "data") == np.int8(5).tobytes()

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -2,14 +2,13 @@ import glob
 import json
 import math
 import os
-import shutil
 import subprocess
 import sys
 import tempfile
 import textwrap
 import types
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import onnx
@@ -19,7 +18,6 @@ import pytest
 from onnx import TensorProto, helper, numpy_helper
 from onnx2tf.tflite_builder.accuracy_evaluator import (
     _adapt_input_layout_for_tflite_input,
-    _align_output_layout_for_compare,
     _build_tflite_detail_map,
     _collect_onnx_input_specs,
     _create_tflite_interpreter,
@@ -208,6 +206,11 @@ def _write_x_calibration_data(
     path = os.path.join(tmpdir, f"{name}.npy")
     np.save(path, np.asarray(values, dtype=np.float32))
     return [["x", path, np.asarray(0.0, dtype=np.float32), np.asarray(1.0, dtype=np.float32)]]
+
+
+def _shape_signature(tensor: TensorIR) -> list[int]:
+    assert tensor.shape_signature is not None
+    return list(tensor.shape_signature)
 
 
 def _convert(
@@ -608,7 +611,7 @@ def test_infer_shapes_with_fallback_skips_external_data_models(
         def infer_shapes(*args: Any, **kwargs: Any) -> onnx.ModelProto:
             raise AssertionError("symbolic shape inference must not run for external_data models")
 
-    fake_symbolic_module.SymbolicShapeInference = _UnexpectedSymbolicShapeInference
+    setattr(fake_symbolic_module, "SymbolicShapeInference", _UnexpectedSymbolicShapeInference)
     monkeypatch.setattr(onnx.shape_inference, "infer_shapes", _unexpected_infer_shapes)
     monkeypatch.setitem(
         sys.modules,
@@ -680,7 +683,7 @@ def test_run_onnx_and_collect_outputs_skips_infer_shapes_for_external_data(
 
 
 def test_flatbuffer_direct_topological_sort_reorders_producer_before_consumer() -> None:
-    model_ir = ModelIR(name="topological_sort_test")
+    model_ir = ModelIR("topological_sort_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -739,7 +742,7 @@ def test_flatbuffer_direct_topological_sort_reorders_producer_before_consumer() 
 
 
 def test_flatbuffer_direct_transpose_layernorm_stats_nhwc_propagation() -> None:
-    model_ir = ModelIR(name="transpose_layernorm_stats_nhwc_propagation_test")
+    model_ir = ModelIR("transpose_layernorm_stats_nhwc_propagation_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -881,7 +884,7 @@ def test_flatbuffer_direct_transpose_layernorm_stats_nhwc_propagation() -> None:
 
 
 def test_flatbuffer_direct_layernorm_stats_via_existing_post_transpose_nhwc() -> None:
-    model_ir = ModelIR(name="layernorm_stats_via_post_transpose_nhwc_test")
+    model_ir = ModelIR("layernorm_stats_via_post_transpose_nhwc_test")
     model_ir.inputs = ["x_nchw"]
     model_ir.outputs = ["y"]
 
@@ -1061,7 +1064,7 @@ def _make_string_normalizer_constant_input_model(
         name="input_const",
         data_type=TensorProto.STRING,
         dims=[len(values)],
-        vals=[str(v) for v in values],
+        vals=cast(Any, [str(v) for v in values]),
     )
     graph = helper.make_graph([node], "string_normalizer_const_graph", [], [y], initializer=[init])
     return helper.make_model(graph, opset_imports=[helper.make_operatorsetid("", 18)])
@@ -1614,23 +1617,36 @@ def _make_fused_conv_model(
     y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 4, 8, 8])
     w = numpy_helper.from_array(np.ones((4, 3, 3, 3), dtype=np.float32), name="W")
     b = numpy_helper.from_array(np.zeros((4,), dtype=np.float32), name="B")
-    attrs: dict[str, object] = {
-        "pads": [1, 1, 1, 1],
-        "strides": [1, 1],
-        "dilations": [1, 1],
-        "group": 1,
-        "activation": str(activation),
-    }
+    fused_activation_params = None
     if activation_params is not None:
-        attrs["activation_params"] = [float(v) for v in list(activation_params)]
-    node = helper.make_node(
-        "FusedConv",
-        ["x", "W", "B"],
-        ["y"],
-        name=f"FusedConv{activation}Node",
-        domain="com.microsoft",
-        **attrs,
-    )
+        fused_activation_params = [float(v) for v in list(activation_params)]
+    if fused_activation_params is None:
+        node = helper.make_node(
+            "FusedConv",
+            ["x", "W", "B"],
+            ["y"],
+            name=f"FusedConv{activation}Node",
+            domain="com.microsoft",
+            pads=[1, 1, 1, 1],
+            strides=[1, 1],
+            dilations=[1, 1],
+            group=1,
+            activation=str(activation),
+        )
+    else:
+        node = helper.make_node(
+            "FusedConv",
+            ["x", "W", "B"],
+            ["y"],
+            name=f"FusedConv{activation}Node",
+            domain="com.microsoft",
+            pads=[1, 1, 1, 1],
+            strides=[1, 1],
+            dilations=[1, 1],
+            group=1,
+            activation=str(activation),
+            activation_params=fused_activation_params,
+        )
     graph = helper.make_graph([node], f"fused_conv_{activation.lower()}_graph", [x], [y], initializer=[w, b])
     return helper.make_model(
         graph,
@@ -2466,7 +2482,7 @@ def _make_gridsample_dynamic_sparse_width_model() -> onnx.ModelProto:
 
 
 def test_clone_model_ir_with_float32_promotes_float16_tensors_and_cast_options() -> None:
-    model_ir = ModelIR(name="clone_fp16_to_fp32_test")
+    model_ir = ModelIR("clone_fp16_to_fp32_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -2507,7 +2523,7 @@ def test_clone_model_ir_with_float32_promotes_float16_tensors_and_cast_options()
 
 
 def test_prune_identity_cast_operators_rewires_consumers() -> None:
-    model_ir = ModelIR(name="prune_identity_cast_test")
+    model_ir = ModelIR("prune_identity_cast_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
@@ -2535,7 +2551,7 @@ def test_prune_identity_cast_operators_rewires_consumers() -> None:
 
 
 def test_prune_identity_cast_operators_preserves_model_output_boundary() -> None:
-    model_ir = ModelIR(name="prune_identity_cast_keep_output_test")
+    model_ir = ModelIR("prune_identity_cast_keep_output_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
@@ -2555,7 +2571,7 @@ def test_prune_identity_cast_operators_preserves_model_output_boundary() -> None
 
 
 def test_optimize_redundant_transpose_operators_removes_inverse_pair() -> None:
-    model_ir = ModelIR(name="optimize_inverse_transpose_pair_test")
+    model_ir = ModelIR("optimize_inverse_transpose_pair_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
@@ -2595,7 +2611,7 @@ def test_optimize_redundant_transpose_operators_removes_inverse_pair() -> None:
 
 
 def test_optimize_redundant_transpose_operators_keeps_output_name_boundary() -> None:
-    model_ir = ModelIR(name="optimize_transpose_output_boundary_test")
+    model_ir = ModelIR("optimize_transpose_output_boundary_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3, 4, 5], shape_signature=[1, 3, 4, 5])
@@ -2635,7 +2651,7 @@ def test_optimize_redundant_transpose_operators_keeps_output_name_boundary() -> 
 
 
 def test_optimize_redundant_transpose_operators_composes_consecutive_pair() -> None:
-    model_ir = ModelIR(name="optimize_transpose_compose_test")
+    model_ir = ModelIR("optimize_transpose_compose_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[2, 3, 5], shape_signature=[2, 3, 5])
@@ -8052,11 +8068,11 @@ def test_flatbuffer_direct_selu_exp_preserves_dynamic_shape_signature() -> None:
     exp_out_name = str(exp_ops[0].outputs[0])
     exp_out_tensor = model_ir.tensors[exp_out_name]
     assert exp_out_tensor.shape_signature is not None
-    assert [int(v) for v in list(exp_out_tensor.shape_signature)] == [-1, 25]
+    assert [int(v) for v in _shape_signature(exp_out_tensor)] == [-1, 25]
 
 
 def test_flatbuffer_direct_layout_transpose_chain_removes_inverse_fanout_branch() -> None:
-    model_ir = ModelIR(name="layout_transpose_inverse_fanout_branch_test")
+    model_ir = ModelIR("layout_transpose_inverse_fanout_branch_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y_nchw", "z"]
     model_ir.tensors["x"] = TensorIR(
@@ -8168,7 +8184,7 @@ def test_flatbuffer_direct_keeps_input_layout_contract_for_boundary_transpose() 
 
 
 def test_flatbuffer_direct_keeps_boundary_input_layout_transpose_for_gather_nd() -> None:
-    model_ir = ModelIR(name="boundary_input_gather_nd_layout_transpose_test")
+    model_ir = ModelIR("boundary_input_gather_nd_layout_transpose_test")
     model_ir.inputs = ["x", "indices"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -8228,7 +8244,7 @@ def test_flatbuffer_direct_keeps_boundary_input_layout_transpose_for_gather_nd()
 
 
 def test_flatbuffer_direct_boundary_input_transpose_channel_slice_block_elides_op0() -> None:
-    model_ir = ModelIR(name="boundary_input_transpose_channel_slice_block_test")
+    model_ir = ModelIR("boundary_input_transpose_channel_slice_block_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y", "z"]
     model_ir.tensors["x"] = TensorIR(
@@ -8374,7 +8390,7 @@ def test_flatbuffer_direct_boundary_input_transpose_channel_slice_block_elides_o
 
 
 def test_flatbuffer_direct_internal_transpose_channel_slice_nhwc_propagation() -> None:
-    model_ir = ModelIR(name="internal_transpose_channel_slice_nhwc_propagation_test")
+    model_ir = ModelIR("internal_transpose_channel_slice_nhwc_propagation_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nchw"]
 
@@ -8613,7 +8629,7 @@ def test_flatbuffer_direct_internal_transpose_channel_slice_nhwc_propagation() -
 
 
 def test_flatbuffer_direct_transpose_channel_slice_muladd_nhwc_bridge_chain() -> None:
-    model_ir = ModelIR(name="transpose_channel_slice_muladd_nhwc_bridge_chain_test")
+    model_ir = ModelIR("transpose_channel_slice_muladd_nhwc_bridge_chain_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -8790,7 +8806,7 @@ def test_flatbuffer_direct_transpose_channel_slice_muladd_nhwc_bridge_chain() ->
 
 
 def test_flatbuffer_direct_transpose_channel_slice_dual_add_bridges_strict() -> None:
-    model_ir = ModelIR(name="transpose_channel_slice_dual_add_bridges_strict_test")
+    model_ir = ModelIR("transpose_channel_slice_dual_add_bridges_strict_test")
     model_ir.inputs = ["x_nhwc", "rhs_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -8958,7 +8974,7 @@ def test_flatbuffer_direct_transpose_channel_slice_dual_add_bridges_strict() -> 
 
 
 def test_flatbuffer_direct_transpose_slice_muladd_conv_mergeadd_strict() -> None:
-    model_ir = ModelIR(name="transpose_slice_muladd_conv_mergeadd_strict_test")
+    model_ir = ModelIR("transpose_slice_muladd_conv_mergeadd_strict_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -9156,7 +9172,7 @@ def test_flatbuffer_direct_transpose_slice_muladd_conv_mergeadd_strict() -> None
 
 
 def test_flatbuffer_direct_transpose_slice_muladd_conv_mergeadd_strict_conv_expand_channels() -> None:
-    model_ir = ModelIR(name="transpose_slice_muladd_conv_mergeadd_strict_expand_channels_test")
+    model_ir = ModelIR("transpose_slice_muladd_conv_mergeadd_strict_expand_channels_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -9233,7 +9249,7 @@ def test_flatbuffer_direct_transpose_slice_muladd_conv_mergeadd_strict_conv_expa
 
 
 def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_posttranspose_strict() -> None:
-    model_ir = ModelIR(name="transpose_slice_muladd_mergeadd_posttranspose_strict_test")
+    model_ir = ModelIR("transpose_slice_muladd_mergeadd_posttranspose_strict_test")
     model_ir.inputs = ["x_nhwc", "legacy_lhs"]
     model_ir.outputs = ["avg_out", "legacy_out"]
 
@@ -9429,7 +9445,7 @@ def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_posttranspose_strict(
 
 
 def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_posttranspose_signature_regression() -> None:
-    model_ir = ModelIR(name="transpose_slice_muladd_mergeadd_posttranspose_signature_regression_test")
+    model_ir = ModelIR("transpose_slice_muladd_mergeadd_posttranspose_signature_regression_test")
     model_ir.inputs = ["x_nhwc", "legacy_lhs"]
     model_ir.outputs = ["avg_out", "legacy_out"]
 
@@ -9472,11 +9488,11 @@ def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_posttranspose_signatu
     stats = _optimize_transpose_slice_muladd_mergeadd_posttranspose_strict(model_ir)
     assert stats["optimized_transpose_slice_muladd_mergeadd_posttranspose_strict"] == 1
     assert list(model_ir.tensors["merge_nhwc"].shape) == [1, 2, 3, 2]
-    assert list(model_ir.tensors["merge_nhwc"].shape_signature) == [1, 2, 3, 2]
+    assert _shape_signature(model_ir.tensors["merge_nhwc"]) == [1, 2, 3, 2]
 
 
 def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_legacy_only_tail_strict() -> None:
-    model_ir = ModelIR(name="transpose_slice_muladd_mergeadd_legacy_only_tail_strict_test")
+    model_ir = ModelIR("transpose_slice_muladd_mergeadd_legacy_only_tail_strict_test")
     model_ir.inputs = ["x_nhwc", "legacy_lhs"]
     model_ir.outputs = ["legacy_out"]
 
@@ -9528,7 +9544,7 @@ def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_legacy_only_tail_stri
 
 
 def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_postmultranspose_tail_strict() -> None:
-    model_ir = ModelIR(name="transpose_slice_muladd_mergeadd_postmultranspose_tail_strict_test")
+    model_ir = ModelIR("transpose_slice_muladd_mergeadd_postmultranspose_tail_strict_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -9583,7 +9599,7 @@ def test_flatbuffer_direct_transpose_slice_muladd_mergeadd_postmultranspose_tail
 
 
 def test_flatbuffer_direct_concat_mul_add_transpose_nhwc_bridge_chain() -> None:
-    model_ir = ModelIR(name="concat_mul_add_transpose_nhwc_bridge_chain_test")
+    model_ir = ModelIR("concat_mul_add_transpose_nhwc_bridge_chain_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -9705,7 +9721,7 @@ def test_flatbuffer_direct_concat_mul_add_transpose_nhwc_bridge_chain() -> None:
 
 
 def test_flatbuffer_direct_concat_mul_add_transpose_nhwc_bridge_chain_with_legacy_consumer() -> None:
-    model_ir = ModelIR(name="concat_mul_add_transpose_nhwc_bridge_chain_with_legacy_consumer_test")
+    model_ir = ModelIR("concat_mul_add_transpose_nhwc_bridge_chain_with_legacy_consumer_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["y", "legacy_out"]
 
@@ -9797,7 +9813,7 @@ def test_flatbuffer_direct_concat_mul_add_transpose_nhwc_bridge_chain_with_legac
 
 
 def test_flatbuffer_direct_concat_mul_add_add_mean_reshape_tail_nhwc_bridge_chain() -> None:
-    model_ir = ModelIR(name="concat_mul_add_add_mean_reshape_tail_nhwc_bridge_chain_test")
+    model_ir = ModelIR("concat_mul_add_add_mean_reshape_tail_nhwc_bridge_chain_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -9892,7 +9908,7 @@ def test_flatbuffer_direct_concat_mul_add_add_mean_reshape_tail_nhwc_bridge_chai
 
 
 def test_flatbuffer_direct_fold_mul_add_mul_affine_chain() -> None:
-    model_ir = ModelIR(name="fold_mul_add_mul_affine_chain_test")
+    model_ir = ModelIR("fold_mul_add_mul_affine_chain_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
 
@@ -9958,7 +9974,7 @@ def test_flatbuffer_direct_fold_mul_add_mul_affine_chain() -> None:
 
 
 def test_flatbuffer_direct_concat_mul_add_transpose_add_nhwc_bridge_chain_with_legacy_consumer() -> None:
-    model_ir = ModelIR(name="concat_mul_add_transpose_add_nhwc_bridge_chain_with_legacy_consumer_test")
+    model_ir = ModelIR("concat_mul_add_transpose_add_nhwc_bridge_chain_with_legacy_consumer_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["y", "legacy_out"]
 
@@ -10061,7 +10077,7 @@ def test_flatbuffer_direct_concat_mul_add_transpose_add_nhwc_bridge_chain_with_l
 
 
 def test_flatbuffer_direct_concat_tree_mul_add_transpose_nhwc_bridge_mixed_axes() -> None:
-    model_ir = ModelIR(name="concat_tree_mul_add_transpose_nhwc_bridge_mixed_axes_test")
+    model_ir = ModelIR("concat_tree_mul_add_transpose_nhwc_bridge_mixed_axes_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc", "x2_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -10148,7 +10164,7 @@ def test_flatbuffer_direct_concat_tree_mul_add_transpose_nhwc_bridge_mixed_axes(
 
 
 def test_flatbuffer_direct_transpose_stridedslice_pad_concat_mul_add_posttranspose_nhwc_chain() -> None:
-    model_ir = ModelIR(name="transpose_stridedslice_pad_concat_mul_add_posttranspose_nhwc_chain_test")
+    model_ir = ModelIR("transpose_stridedslice_pad_concat_mul_add_posttranspose_nhwc_chain_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -10267,7 +10283,7 @@ def test_flatbuffer_direct_transpose_stridedslice_pad_concat_mul_add_posttranspo
 
 
 def test_flatbuffer_direct_boundary_input_transpose_stridedslice_qdq_concat_elides_roundtrip() -> None:
-    model_ir = ModelIR(name="boundary_input_transpose_stridedslice_qdq_concat_test")
+    model_ir = ModelIR("boundary_input_transpose_stridedslice_qdq_concat_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y", "z"]
     model_ir.tensors["x"] = TensorIR(
@@ -10544,7 +10560,7 @@ def test_flatbuffer_direct_boundary_input_transpose_stridedslice_qdq_concat_elid
 
 
 def test_flatbuffer_direct_transpose_dequant_logistic_mul_quantize_bridges_elide_roundtrip() -> None:
-    model_ir = ModelIR(name="transpose_dequant_logistic_mul_quantize_bridge_test")
+    model_ir = ModelIR("transpose_dequant_logistic_mul_quantize_bridge_test")
     model_ir.inputs = ["x_q"]
     model_ir.outputs = ["y", "z"]
 
@@ -10675,7 +10691,7 @@ def test_flatbuffer_direct_transpose_dequant_logistic_mul_quantize_bridges_elide
 
 
 def test_flatbuffer_direct_dequant_logistic_quantize_chain_folded_to_quantized_logistic() -> None:
-    model_ir = ModelIR(name="dequant_logistic_quantize_fold_test")
+    model_ir = ModelIR("dequant_logistic_quantize_fold_test")
     model_ir.inputs = ["x_q"]
     model_ir.outputs = ["y_q"]
 
@@ -10724,7 +10740,7 @@ def test_flatbuffer_direct_dequant_logistic_quantize_chain_folded_to_quantized_l
 
 
 def test_flatbuffer_direct_dequant_logistic_quantize_chain_noncanonical_output_not_folded() -> None:
-    model_ir = ModelIR(name="dequant_logistic_quantize_no_fold_test")
+    model_ir = ModelIR("dequant_logistic_quantize_no_fold_test")
     model_ir.inputs = ["x_q"]
     model_ir.outputs = ["y_q"]
 
@@ -10766,7 +10782,7 @@ def test_flatbuffer_direct_dequant_logistic_quantize_chain_noncanonical_output_n
 
 
 def test_flatbuffer_direct_transpose_swish_qdq_nhwc_islands_elide_prepost_chain() -> None:
-    model_ir = ModelIR(name="transpose_swish_qdq_nhwc_island_test")
+    model_ir = ModelIR("transpose_swish_qdq_nhwc_island_test")
     model_ir.inputs = ["a_q", "b_q"]
     model_ir.outputs = ["y"]
 
@@ -10880,7 +10896,7 @@ def test_flatbuffer_direct_transpose_swish_qdq_nhwc_islands_elide_prepost_chain(
 
 
 def test_flatbuffer_direct_transpose_swish_residual_concat_closure_nhwc_is_spatial_agnostic() -> None:
-    model_ir = ModelIR(name="transpose_swish_residual_concat_closure_spatial_agnostic_test")
+    model_ir = ModelIR("transpose_swish_residual_concat_closure_spatial_agnostic_test")
     model_ir.inputs = ["a_q", "b_q"]
     model_ir.outputs = ["y"]
 
@@ -10990,7 +11006,7 @@ def test_flatbuffer_direct_transpose_swish_residual_concat_closure_nhwc_is_spati
 
 
 def test_flatbuffer_direct_boundary_input_slice_depthwise_nhwc_propagation_avoids_bridge_transpose() -> None:
-    model_ir = ModelIR(name="boundary_input_slice_depthwise_nhwc_propagation_test")
+    model_ir = ModelIR("boundary_input_slice_depthwise_nhwc_propagation_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11130,7 +11146,7 @@ def test_flatbuffer_direct_input_layout_respects_keep_shape_absolute() -> None:
 
 
 def test_flatbuffer_direct_depthwise_output_transpose_cast_transpose_chain_elides() -> None:
-    model_ir = ModelIR(name="depthwise_output_transpose_cast_transpose_chain_test")
+    model_ir = ModelIR("depthwise_output_transpose_cast_transpose_chain_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -11254,7 +11270,7 @@ def test_flatbuffer_direct_depthwise_output_transpose_cast_transpose_chain_elide
 
 
 def test_flatbuffer_direct_depthwise_output_transpose_hardswish_transpose_chain_elides() -> None:
-    model_ir = ModelIR(name="depthwise_output_transpose_hardswish_transpose_chain_test")
+    model_ir = ModelIR("depthwise_output_transpose_hardswish_transpose_chain_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -11467,7 +11483,7 @@ def test_flatbuffer_direct_reshape_minus_one_resolved_to_static_shape() -> None:
     assert np.asarray(shape_tensor.data).reshape(-1).tolist() == [3, 2]
     output_tensor = model_ir.tensors["y"]
     assert list(output_tensor.shape) == [3, 2]
-    assert list(output_tensor.shape_signature) == [3, 2]
+    assert _shape_signature(output_tensor) == [3, 2]
 
 
 def test_flatbuffer_direct_conv1d_input_reshape_chain_collapses_to_single_nhwc_reshape() -> None:
@@ -11497,7 +11513,7 @@ def test_flatbuffer_direct_conv1d_input_reshape_chain_collapses_to_single_nhwc_r
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_pass() -> None:
-    model_ir = ModelIR(name="reshape_fixup_test")
+    model_ir = ModelIR("reshape_fixup_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11532,12 +11548,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_pass() -> None:
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [1, 1600, 1]
     assert list(model_ir.tensors["y"].shape) == [1, 1600, 1]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 1600, 1]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 1600, 1]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, 1600, 1]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_zero_copy_dims_pass() -> None:
-    model_ir = ModelIR(name="reshape_fixup_zero_copy_test")
+    model_ir = ModelIR("reshape_fixup_zero_copy_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11576,12 +11592,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_zero_copy_dims_pass() 
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [10, 1, 3]
     assert list(model_ir.tensors["y"].shape) == [10, 1, 3]
-    assert list(model_ir.tensors["y"].shape_signature) == [10, 1, 3]
+    assert _shape_signature(model_ir.tensors["y"]) == [10, 1, 3]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [10, 1, 3]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_populates_empty_newshape_from_shape_tensor() -> None:
-    model_ir = ModelIR(name="reshape_fixup_from_shape_tensor_test")
+    model_ir = ModelIR("reshape_fixup_from_shape_tensor_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11616,16 +11632,16 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_populates_empty_newsha
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [20, 1]
     assert list(model_ir.tensors["y"].shape) == [20, 1]
-    assert list(model_ir.tensors["y"].shape_signature) == [20, 1]
+    assert _shape_signature(model_ir.tensors["y"]) == [20, 1]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [20, 1]
 
     sanitize_stats = _sanitize_static_shape_signature_consistency(model_ir)
     assert int(sanitize_stats["sanitized_static_shape_signature_consistency"]) == 0
-    assert list(model_ir.tensors["y"].shape_signature) == [20, 1]
+    assert _shape_signature(model_ir.tensors["y"]) == [20, 1]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_keeps_existing_concrete_shape_with_onnx_raw_minus_one() -> None:
-    model_ir = ModelIR(name="reshape_fixup_keep_concrete_shape_test")
+    model_ir = ModelIR("reshape_fixup_keep_concrete_shape_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11664,12 +11680,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_keeps_existing_concret
     assert stats["resolved_dynamic_reshape_shapes"] == 0
     assert list(model_ir.operators[0].options["newShape"]) == [1, 1, 20, 2]
     assert list(model_ir.tensors["y"].shape) == [1, 1, 20, 2]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 1, 20, 2]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 1, 20, 2]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, 1, 20, 2]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_prefers_runtime_minus_one_from_onnx_raw() -> None:
-    model_ir = ModelIR(name="reshape_fixup_runtime_minus_one_preference_test")
+    model_ir = ModelIR("reshape_fixup_runtime_minus_one_preference_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11711,12 +11727,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_prefers_runtime_minus_
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [1, -1, 64, 64, 2]
     assert list(model_ir.tensors["y"].shape) == [1, 1, 64, 64, 2]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, -1, 64, 64, 2]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, -1, 64, 64, 2]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, -1, 64, 64, 2]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_concretizes_static_onnx_raw_minus_one() -> None:
-    model_ir = ModelIR(name="reshape_fixup_static_onnx_raw_minus_one_test")
+    model_ir = ModelIR("reshape_fixup_static_onnx_raw_minus_one_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11758,12 +11774,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_concretizes_static_onn
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [64, 64, 3, 6, 30]
     assert list(model_ir.tensors["y"].shape) == [64, 64, 3, 6, 30]
-    assert list(model_ir.tensors["y"].shape_signature) == [64, 64, 3, 6, 30]
+    assert _shape_signature(model_ir.tensors["y"]) == [64, 64, 3, 6, 30]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [64, 64, 3, 6, 30]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_allowzero_true_preserves_zero_and_minus_one() -> None:
-    model_ir = ModelIR(name="reshape_fixup_allowzero_true_preserve_test")
+    model_ir = ModelIR("reshape_fixup_allowzero_true_preserve_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11801,12 +11817,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_allowzero_true_preserv
     stats = _resolve_dynamic_reshape_shapes(model_ir)
     assert stats["resolved_dynamic_reshape_shapes"] == 0
     assert list(model_ir.operators[0].options["newShape"]) == [0, -1, 3]
-    assert list(model_ir.tensors["y"].shape_signature) == [0, -1, 3]
+    assert _shape_signature(model_ir.tensors["y"]) == [0, -1, 3]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [0, -1, 3]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_copy_dim_zero_then_infers_minus_one() -> None:
-    model_ir = ModelIR(name="reshape_fixup_copy_dim_zero_then_infer_test")
+    model_ir = ModelIR("reshape_fixup_copy_dim_zero_then_infer_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11845,12 +11861,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_copy_dim_zero_then_inf
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [2, 5, 3]
     assert list(model_ir.tensors["y"].shape) == [2, 5, 3]
-    assert list(model_ir.tensors["y"].shape_signature) == [2, 5, 3]
+    assert _shape_signature(model_ir.tensors["y"]) == [2, 5, 3]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [2, 5, 3]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_keeps_runtime_minus_one_from_shape_tensor() -> None:
-    model_ir = ModelIR(name="reshape_fixup_runtime_minus_one_from_shape_tensor_test")
+    model_ir = ModelIR("reshape_fixup_runtime_minus_one_from_shape_tensor_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11885,12 +11901,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_shapes_keeps_runtime_minus_on
     assert stats["resolved_dynamic_reshape_shapes"] == 0
     assert list(model_ir.operators[0].options["newShape"]) == []
     assert list(model_ir.tensors["y"].shape) == [1, 1]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 1]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 1]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [-1, 1]
 
 
 def test_flatbuffer_direct_replace_squeeze_with_reshape_skips_all_ones_outputs() -> None:
-    model_ir = ModelIR(name="squeeze_rewrite_all_ones_guard_test")
+    model_ir = ModelIR("squeeze_rewrite_all_ones_guard_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -11979,11 +11995,11 @@ def test_flatbuffer_direct_unsqueeze_dynamic_rank1_uses_runtime_shape_pipeline()
     assert len(list(reshape_op.inputs)) == 2
     shape_tensor = model_ir.tensors[str(reshape_op.inputs[1])]
     assert shape_tensor.data is None
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 1]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 1]
 
 
 def test_flatbuffer_direct_rewrite_dynamic_rank1_unsqueeze_reshape_shape_inputs() -> None:
-    model_ir = ModelIR(name="rewrite_dynamic_rank1_unsqueeze_reshape_shape_inputs")
+    model_ir = ModelIR("rewrite_dynamic_rank1_unsqueeze_reshape_shape_inputs")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -12024,7 +12040,7 @@ def test_flatbuffer_direct_rewrite_dynamic_rank1_unsqueeze_reshape_shape_inputs(
 
 
 def test_flatbuffer_direct_replace_squeeze_with_reshape_rewrites_dynamic_axes() -> None:
-    model_ir = ModelIR(name="squeeze_rewrite_dynamic_axes_test")
+    model_ir = ModelIR("squeeze_rewrite_dynamic_axes_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -12057,7 +12073,7 @@ def test_flatbuffer_direct_replace_squeeze_with_reshape_rewrites_dynamic_axes() 
 
 
 def test_flatbuffer_direct_replace_expand_dims_with_reshape_skips_dynamic_axes() -> None:
-    model_ir = ModelIR(name="expand_dims_rewrite_dynamic_axes_guard_test")
+    model_ir = ModelIR("expand_dims_rewrite_dynamic_axes_guard_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -12094,7 +12110,7 @@ def test_flatbuffer_direct_replace_expand_dims_with_reshape_skips_dynamic_axes()
 
 
 def test_flatbuffer_direct_repair_unbound_shape_input_with_layout_transpose() -> None:
-    model_ir = ModelIR(name="repair_unbound_shape_input_test")
+    model_ir = ModelIR("repair_unbound_shape_input_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["shape_out"]
     model_ir.tensors["x"] = TensorIR(
@@ -12167,7 +12183,7 @@ def test_flatbuffer_direct_repair_unbound_shape_input_with_layout_transpose() ->
 
 
 def test_flatbuffer_direct_repair_unbound_split_data_input_with_layout_transpose() -> None:
-    model_ir = ModelIR(name="repair_unbound_split_data_input_test")
+    model_ir = ModelIR("repair_unbound_split_data_input_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["split0", "split1"]
     model_ir.tensors["x"] = TensorIR(
@@ -12254,7 +12270,7 @@ def test_flatbuffer_direct_repair_unbound_split_data_input_with_layout_transpose
 
 
 def test_flatbuffer_direct_repair_orphan_recurrent_step_tensors() -> None:
-    model_ir = ModelIR(name="repair_orphan_recurrent_step_tensors_test")
+    model_ir = ModelIR("repair_orphan_recurrent_step_tensors_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["hidden_out", "seq"]
     model_ir.tensors["x"] = TensorIR(
@@ -12412,7 +12428,7 @@ def test_flatbuffer_direct_lower_gru_keeps_final_step_alias_bound() -> None:
 
 
 def test_flatbuffer_direct_replace_unsupported_split_with_slice_inserts_cast_on_dtype_mismatch() -> None:
-    model_ir = ModelIR(name="unsupported_split_cast_fallback_test")
+    model_ir = ModelIR("unsupported_split_cast_fallback_test")
     model_ir.inputs = ["state_in"]
     model_ir.outputs = ["state_fw", "state_bw"]
     model_ir.tensors["state_in"] = TensorIR(
@@ -12467,7 +12483,7 @@ def test_flatbuffer_direct_replace_unsupported_split_with_slice_inserts_cast_on_
 
 
 def test_flatbuffer_direct_replace_unsupported_split_with_slice_without_cast_when_dtype_matches() -> None:
-    model_ir = ModelIR(name="unsupported_split_slice_fallback_test")
+    model_ir = ModelIR("unsupported_split_slice_fallback_test")
     model_ir.inputs = ["split_in"]
     model_ir.outputs = ["split0", "split1"]
     model_ir.tensors["split_in"] = TensorIR(
@@ -12650,7 +12666,7 @@ def test_flatbuffer_direct_instance_normalization_lowering() -> None:
 def test_flatbuffer_direct_instance_normalization_lowering_with_nhwc_internal_layout() -> None:
     class _FakeBuilderCtx:
         def __init__(self) -> None:
-            self.model_ir = ModelIR(name="instance_norm_builder_nhwc")
+            self.model_ir = ModelIR("instance_norm_builder_nhwc")
             self.model_ir.tensors["x"] = TensorIR(
                 name="x",
                 dtype="FLOAT32",
@@ -12758,7 +12774,7 @@ def test_flatbuffer_direct_square_conv_instance_normalization_keeps_nchw_axes_af
 def test_flatbuffer_direct_instance_normalization_prefers_nchw_axis_from_transpose_producer() -> None:
     class _FakeBuilderCtx:
         def __init__(self) -> None:
-            self.model_ir = ModelIR(name="instance_norm_builder_transpose_producer")
+            self.model_ir = ModelIR("instance_norm_builder_transpose_producer")
             self.model_ir.tensors["x_nhwc"] = TensorIR(
                 name="x_nhwc",
                 dtype="FLOAT32",
@@ -12995,7 +13011,7 @@ def test_flatbuffer_direct_unsqueeze_dynamic_axis2_preserves_dynamic_signature()
     )
 
     y_tensor = model_ir.tensors["y"]
-    assert list(y_tensor.shape_signature) == [1, -1, 1]
+    assert _shape_signature(y_tensor) == [1, -1, 1]
 
     y_prod = next(op for op in model_ir.operators if str(op.outputs[0]) == "y")
     assert str(y_prod.op_type) == "RESHAPE"
@@ -13144,14 +13160,14 @@ def test_flatbuffer_direct_topk_const_k_repairs_stale_output_shape_metadata() ->
     )
 
     assert list(model_ir.tensors["values"].shape) == [1, 3]
-    assert list(model_ir.tensors["values"].shape_signature) == [1, 3]
+    assert _shape_signature(model_ir.tensors["values"]) == [1, 3]
     assert list(model_ir.tensors["indices"].shape) == [1, 3]
-    assert list(model_ir.tensors["indices"].shape_signature) == [1, 3]
+    assert _shape_signature(model_ir.tensors["indices"]) == [1, 3]
     topk_op = next(op for op in model_ir.operators if str(op.op_type) == "TOPK_V2")
     for output_name in list(topk_op.outputs):
         tensor = model_ir.tensors[str(output_name)]
         assert list(tensor.shape) == [1, 3]
-        assert list(tensor.shape_signature) == [1, 3]
+        assert _shape_signature(tensor) == [1, 3]
 
 
 def test_flatbuffer_direct_topk_dynamic_k_followed_by_reshape_flat_preserves_dynamic_extent() -> None:
@@ -13173,7 +13189,7 @@ def test_flatbuffer_direct_topk_dynamic_k_followed_by_reshape_flat_preserves_dyn
     reshape_shape = np.asarray(model_ir.tensors[reshape_shape_name].data, dtype=np.int32).reshape(-1).tolist()
     assert reshape_shape == [-1]
     assert list(reshape_op.options.get("newShape", [])) == [-1]
-    assert list(model_ir.tensors["indices"].shape_signature) == [1, -1]
+    assert _shape_signature(model_ir.tensors["indices"]) == [1, -1]
 
 
 def test_flatbuffer_direct_pad_dynamic_pads_lowering() -> None:
@@ -13597,7 +13613,7 @@ def test_flatbuffer_direct_expand_dynamic_shape_uses_fill() -> None:
     assert value_tensor.data is not None
 
     output_tensor = model_ir.tensors["y"]
-    assert list(output_tensor.shape_signature) == [-1]
+    assert _shape_signature(output_tensor) == [-1]
 
 
 def test_flatbuffer_direct_matmul_integer_defaults_to_float_compute_path() -> None:
@@ -13630,7 +13646,7 @@ def test_flatbuffer_direct_unsqueeze_scalar_multi_axis_shape() -> None:
 
     y_tensor = model_ir.tensors["y"]
     assert list(y_tensor.shape) == [1, 1]
-    assert list(y_tensor.shape_signature) == [1, 1]
+    assert _shape_signature(y_tensor) == [1, 1]
 
     producer = next(op for op in model_ir.operators if "y" in list(op.outputs))
     assert str(producer.op_type) == "RESHAPE"
@@ -13788,7 +13804,7 @@ def test_flatbuffer_direct_resize_cubic_preserves_batch_dim() -> None:
     y_tensor = model_ir.tensors.get("y")
     assert y_tensor is not None
     assert int(y_tensor.shape[0]) == 2
-    assert int(y_tensor.shape_signature[0]) == 2
+    assert int(_shape_signature(y_tensor)[0]) == 2
 
     cubic_h_in_reshape = next(
         (
@@ -13992,7 +14008,7 @@ def test_flatbuffer_direct_reduce_l2_avoids_redundant_shape_reshape_identity() -
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_zero_copy_dims_pass() -> None:
-    model_ir = ModelIR(name="reshape_zero_copy_fixup_test")
+    model_ir = ModelIR("reshape_zero_copy_fixup_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14031,12 +14047,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_zero_copy_dims_pass() -> None
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [1, 1, 512]
     assert list(model_ir.tensors["y"].shape) == [1, 1, 512]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 1, 512]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 1, 512]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [1, 1, 512]
 
 
 def test_flatbuffer_direct_reconcile_bilstm_chain_and_resolve_reshape_zero_copy_dims() -> None:
-    model_ir = ModelIR(name="reshape_zero_copy_bilstm_chain_fixup_test")
+    model_ir = ModelIR("reshape_zero_copy_bilstm_chain_fixup_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14179,7 +14195,7 @@ def test_flatbuffer_direct_reconcile_bilstm_chain_and_resolve_reshape_zero_copy_
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_zero_copy_dims_with_dynamic_signature() -> None:
-    model_ir = ModelIR(name="reshape_zero_copy_dynamic_signature_fixup_test")
+    model_ir = ModelIR("reshape_zero_copy_dynamic_signature_fixup_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14218,12 +14234,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_zero_copy_dims_with_dynamic_s
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [-1, 1, 96]
     assert list(model_ir.tensors["y"].shape) == [1, 1, 96]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 1, 96]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 1, 96]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [-1, 1, 96]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_relaxes_zero_copy_axis_to_dynamic() -> None:
-    model_ir = ModelIR(name="reshape_zero_copy_relax_dynamic_axis_test")
+    model_ir = ModelIR("reshape_zero_copy_relax_dynamic_axis_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14261,12 +14277,12 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_relaxes_zero_copy_axis_to_dyn
     stats = _resolve_dynamic_reshape_shapes(model_ir)
     assert stats["resolved_dynamic_reshape_shapes"] == 1
     assert list(model_ir.operators[0].options["newShape"]) == [-1, 1, 96]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 1, 96]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 1, 96]
     assert np.asarray(model_ir.tensors["reshape_shape"].data).reshape(-1).tolist() == [-1, 1, 96]
 
 
 def test_flatbuffer_direct_resolve_dynamic_reshape_sanitizes_multi_minus_one() -> None:
-    model_ir = ModelIR(name="reshape_multi_minus_one_sanitize_test")
+    model_ir = ModelIR("reshape_multi_minus_one_sanitize_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14309,7 +14325,7 @@ def test_flatbuffer_direct_resolve_dynamic_reshape_sanitizes_multi_minus_one() -
 
 
 def test_flatbuffer_direct_reconcile_slice_preserves_static_size_on_dynamic_axes() -> None:
-    model_ir = ModelIR(name="reconcile_slice_dynamic_axis_size_test")
+    model_ir = ModelIR("reconcile_slice_dynamic_axis_size_test")
     model_ir.inputs = ["state_in"]
     model_ir.outputs = ["state_slice"]
     model_ir.tensors["state_in"] = TensorIR(
@@ -14349,12 +14365,12 @@ def test_flatbuffer_direct_reconcile_slice_preserves_static_size_on_dynamic_axes
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 0
     assert list(model_ir.tensors["state_slice"].shape) == [1, 1, 48]
-    assert list(model_ir.tensors["state_slice"].shape_signature) == [1, 1, 48]
+    assert _shape_signature(model_ir.tensors["state_slice"]) == [1, 1, 48]
     assert np.asarray(model_ir.tensors["slice_size"].data).reshape(-1).tolist() == [1, 1, 48]
 
 
 def test_flatbuffer_direct_reconcile_cast_propagates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_cast_shape_signature_test")
+    model_ir = ModelIR("reconcile_cast_shape_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14381,11 +14397,11 @@ def test_flatbuffer_direct_reconcile_cast_propagates_output_shape_signature() ->
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 2]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 2]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 2]
 
 
 def test_flatbuffer_direct_reconcile_neg_propagates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_neg_shape_signature_test")
+    model_ir = ModelIR("reconcile_neg_shape_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14411,11 +14427,11 @@ def test_flatbuffer_direct_reconcile_neg_propagates_output_shape_signature() -> 
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 2]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 2]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 2]
 
 
 def test_flatbuffer_direct_reconcile_floor_mod_propagates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_floor_mod_shape_signature_test")
+    model_ir = ModelIR("reconcile_floor_mod_shape_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14448,11 +14464,11 @@ def test_flatbuffer_direct_reconcile_floor_mod_propagates_output_shape_signature
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1]
 
 
 def test_flatbuffer_direct_reconcile_maximum_propagates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_maximum_shape_signature_test")
+    model_ir = ModelIR("reconcile_maximum_shape_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14485,11 +14501,11 @@ def test_flatbuffer_direct_reconcile_maximum_propagates_output_shape_signature()
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 3, 4]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 3, 4]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 3, 4]
 
 
 def test_flatbuffer_direct_reconcile_minimum_propagates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_minimum_shape_signature_test")
+    model_ir = ModelIR("reconcile_minimum_shape_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14522,11 +14538,11 @@ def test_flatbuffer_direct_reconcile_minimum_propagates_output_shape_signature()
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 3, 4]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 3, 4]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 3, 4]
 
 
 def test_flatbuffer_direct_reconcile_batch_matmul_propagates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_batch_matmul_shape_signature_test")
+    model_ir = ModelIR("reconcile_batch_matmul_shape_signature_test")
     model_ir.inputs = ["a", "b"]
     model_ir.outputs = ["y"]
     model_ir.tensors["a"] = TensorIR(
@@ -14559,11 +14575,11 @@ def test_flatbuffer_direct_reconcile_batch_matmul_propagates_output_shape_signat
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 2, 3]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, 2, 3]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, 2, 3]
 
 
 def test_flatbuffer_direct_reconcile_slice_preserves_dynamic_full_extent_size() -> None:
-    model_ir = ModelIR(name="reconcile_slice_dynamic_full_extent_test")
+    model_ir = ModelIR("reconcile_slice_dynamic_full_extent_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14605,11 +14621,11 @@ def test_flatbuffer_direct_reconcile_slice_preserves_dynamic_full_extent_size() 
     _ = _reconcile_static_tensor_shapes(model_ir)
     slice_size_values = np.asarray(model_ir.tensors["slice_size"].data, dtype=np.int32).reshape(-1).tolist()
     assert slice_size_values == [-1, -1, -1, 1]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 1, -1, 1]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 1, -1, 1]
 
 
 def test_flatbuffer_direct_reconcile_slice_fixed_size_overrides_stale_dynamic_signature() -> None:
-    model_ir = ModelIR(name="reconcile_slice_fixed_size_signature_test")
+    model_ir = ModelIR("reconcile_slice_fixed_size_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14650,11 +14666,11 @@ def test_flatbuffer_direct_reconcile_slice_fixed_size_overrides_stale_dynamic_si
 
     _ = _reconcile_static_tensor_shapes(model_ir)
     assert list(model_ir.tensors["y"].shape) == [2]
-    assert list(model_ir.tensors["y"].shape_signature) == [2]
+    assert _shape_signature(model_ir.tensors["y"]) == [2]
 
 
 def test_flatbuffer_direct_reconcile_pad_updates_output_shape_signature() -> None:
-    model_ir = ModelIR(name="reconcile_pad_shape_signature_test")
+    model_ir = ModelIR("reconcile_pad_shape_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14696,11 +14712,11 @@ def test_flatbuffer_direct_reconcile_pad_updates_output_shape_signature() -> Non
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert int(stats["reconciled_static_tensor_shapes"]) >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 59, 59, 192]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 59, 59, 192]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 59, 59, 192]
 
 
 def test_flatbuffer_direct_reconcile_pad_preserves_dynamic_spatial_signature() -> None:
-    model_ir = ModelIR(name="reconcile_pad_dynamic_signature_test")
+    model_ir = ModelIR("reconcile_pad_dynamic_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14741,11 +14757,11 @@ def test_flatbuffer_direct_reconcile_pad_preserves_dynamic_spatial_signature() -
 
     _ = _reconcile_static_tensor_shapes(model_ir)
     assert list(model_ir.tensors["y"].shape) == [1, 59, 59, 192]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, -1, -1, 192]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, -1, -1, 192]
 
 
 def test_flatbuffer_direct_reconcile_conv2d_complements_static_output_channel_from_filter() -> None:
-    model_ir = ModelIR(name="reconcile_conv2d_static_output_channel_signature_test")
+    model_ir = ModelIR("reconcile_conv2d_static_output_channel_signature_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -14795,7 +14811,7 @@ def test_flatbuffer_direct_reconcile_conv2d_complements_static_output_channel_fr
     stats = _reconcile_static_tensor_shapes(model_ir)
     assert stats["reconciled_static_tensor_shapes"] >= 1
     assert list(model_ir.tensors["y"].shape) == [1, 1, 1, 64]
-    assert list(model_ir.tensors["y"].shape_signature) == [-1, -1, -1, 64]
+    assert _shape_signature(model_ir.tensors["y"]) == [-1, -1, -1, 64]
 
 
 def test_flatbuffer_direct_rank4_signature_inference_ignores_stale_unrelated_unknown_axes() -> None:
@@ -14819,7 +14835,7 @@ def test_flatbuffer_direct_align_boundary_signature_to_current_shape_recovers_st
 
 
 def test_flatbuffer_direct_realign_dynamic_boundary_shape_signature_map_tracks_layout_change() -> None:
-    model_ir = ModelIR(name="realign_dynamic_boundary_signature_map_test")
+    model_ir = ModelIR("realign_dynamic_boundary_signature_map_test")
     model_ir.tensors["out"] = TensorIR(
         name="out",
         dtype="FLOAT32",
@@ -14836,7 +14852,7 @@ def test_flatbuffer_direct_realign_dynamic_boundary_shape_signature_map_tracks_l
 
 
 def test_flatbuffer_direct_sanitize_static_shape_signature_preserves_dynamic_lineage() -> None:
-    model_ir = ModelIR(name="sanitize_dynamic_lineage_test")
+    model_ir = ModelIR("sanitize_dynamic_lineage_test")
     model_ir.inputs = ["input"]
     model_ir.outputs = ["q_out"]
     model_ir.metadata["onnx_dynamic_input_tensor_names"] = ["input"]
@@ -14873,13 +14889,13 @@ def test_flatbuffer_direct_sanitize_static_shape_signature_preserves_dynamic_lin
 
     stats = _sanitize_static_shape_signature_consistency(model_ir)
     assert int(stats["preserved_dynamic_lineage_shape_signature"]) >= 1
-    assert list(model_ir.tensors["input"].shape_signature) == [-1, -1, -1, 3]
-    assert list(model_ir.tensors["q_out"].shape_signature) == [-1, -1, -1, 3]
-    assert list(model_ir.tensors["dead_internal"].shape_signature) == [1, 1, 1, 3]
+    assert _shape_signature(model_ir.tensors["input"]) == [-1, -1, -1, 3]
+    assert _shape_signature(model_ir.tensors["q_out"]) == [-1, -1, -1, 3]
+    assert _shape_signature(model_ir.tensors["dead_internal"]) == [1, 1, 1, 3]
 
 
 def test_flatbuffer_direct_sanitize_static_shape_signature_fixes_stale_batch_dynamic_without_lineage() -> None:
-    model_ir = ModelIR(name="sanitize_stale_batch_dynamic_without_lineage_test")
+    model_ir = ModelIR("sanitize_stale_batch_dynamic_without_lineage_test")
     model_ir.inputs = ["a", "b"]
     model_ir.outputs = []
 
@@ -14912,11 +14928,11 @@ def test_flatbuffer_direct_sanitize_static_shape_signature_fixes_stale_batch_dyn
     stats = _sanitize_static_shape_signature_consistency(model_ir)
     assert int(stats["sanitized_static_shape_signature_consistency"]) >= 1
     assert int(stats["preserved_dynamic_leading_axis_shape_signature"]) == 0
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 4420, 2]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 4420, 2]
 
 
 def test_flatbuffer_direct_sanitize_static_shape_signature_preserves_topk_dynamic_extent_lineage() -> None:
-    model_ir = ModelIR(name="sanitize_topk_dynamic_extent_lineage_test")
+    model_ir = ModelIR("sanitize_topk_dynamic_extent_lineage_test")
     model_ir.inputs = ["x", "k"]
     model_ir.outputs = ["flat_indices"]
 
@@ -14979,12 +14995,12 @@ def test_flatbuffer_direct_sanitize_static_shape_signature_preserves_topk_dynami
         + int(stats["preserved_dynamic_lineage_shape_signature"])
     )
     assert preserved_total >= 1
-    assert list(model_ir.tensors["topk_indices"].shape_signature) == [1, -1]
-    assert list(model_ir.tensors["flat_indices"].shape_signature) == [-1]
+    assert _shape_signature(model_ir.tensors["topk_indices"]) == [1, -1]
+    assert _shape_signature(model_ir.tensors["flat_indices"]) == [-1]
 
 
 def test_flatbuffer_direct_sanitize_squeeze_axes_repairs_non_singleton_dynamic_input() -> None:
-    model_ir = ModelIR(name="sanitize_squeeze_axes_dynamic_input_test")
+    model_ir = ModelIR("sanitize_squeeze_axes_dynamic_input_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -15012,14 +15028,14 @@ def test_flatbuffer_direct_sanitize_squeeze_axes_repairs_non_singleton_dynamic_i
     assert int(stats["sanitized_squeeze_axes_with_static_input_shapes"]) >= 0
     assert int(stats["repaired_squeeze_input_singleton_dims"]) == 1
     assert list(model_ir.tensors["x"].shape) == [1, 1, 8, 3]
-    assert list(model_ir.tensors["x"].shape_signature) == [1, 1, 8, 3]
+    assert _shape_signature(model_ir.tensors["x"]) == [1, 1, 8, 3]
     assert list(model_ir.tensors["y"].shape) == [1, 8, 3]
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 8, 3]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 8, 3]
     assert list(model_ir.operators[0].options.get("squeezeDims", [])) == [0]
 
 
 def test_flatbuffer_direct_sanitize_squeeze_axes_drops_const_invalid_axis() -> None:
-    model_ir = ModelIR(name="sanitize_squeeze_axes_const_input_test")
+    model_ir = ModelIR("sanitize_squeeze_axes_const_input_test")
     model_ir.inputs = []
     model_ir.outputs = ["y"]
     model_ir.tensors["x_const"] = TensorIR(
@@ -15051,11 +15067,11 @@ def test_flatbuffer_direct_sanitize_squeeze_axes_drops_const_invalid_axis() -> N
     assert list(model_ir.operators[0].options.get("squeezeDims", [])) == []
     assert list(model_ir.tensors["x_const"].shape) == [2, 3]
     assert list(model_ir.tensors["y"].shape) == [2, 3]
-    assert list(model_ir.tensors["y"].shape_signature) == [2, 3]
+    assert _shape_signature(model_ir.tensors["y"]) == [2, 3]
 
 
 def test_flatbuffer_direct_transpose_mul_add_const_rewrite_keeps_nhwc_consts_stable() -> None:
-    model_ir = ModelIR(name="transpose_mul_add_const_rewrite_idempotent_const_shape_test")
+    model_ir = ModelIR("transpose_mul_add_const_rewrite_idempotent_const_shape_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -15156,7 +15172,7 @@ def test_flatbuffer_direct_transpose_mul_add_const_rewrite_keeps_nhwc_consts_sta
 
 
 def test_flatbuffer_direct_transpose_mul_add_const_rewrite_does_not_mutate_on_partial_match() -> None:
-    model_ir = ModelIR(name="transpose_mul_add_const_partial_match_no_mutation_test")
+    model_ir = ModelIR("transpose_mul_add_const_partial_match_no_mutation_test")
     model_ir.inputs = ["x_nhwc", "residual_nchw"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -15249,7 +15265,7 @@ def test_flatbuffer_direct_transpose_mul_add_const_rewrite_does_not_mutate_on_pa
 
 
 def test_flatbuffer_direct_transpose_mul_posttranspose_add_nhwc_chain() -> None:
-    model_ir = ModelIR(name="transpose_mul_posttranspose_add_nhwc_chain_test")
+    model_ir = ModelIR("transpose_mul_posttranspose_add_nhwc_chain_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -15348,7 +15364,7 @@ def test_flatbuffer_direct_transpose_mul_posttranspose_add_nhwc_chain() -> None:
 
 
 def test_flatbuffer_direct_transpose_pad_mul_posttranspose_add_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pad_mul_posttranspose_add_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_pad_mul_posttranspose_add_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -15463,11 +15479,11 @@ def test_flatbuffer_direct_transpose_pad_mul_posttranspose_add_nhwc_chain_optimi
     )
     assert list(model_ir.tensors["mul_scale"].shape) == [1, 1, 1, 18]
     assert list(model_ir.tensors["mul_out_nhwc"].shape) == [1, 24, 12, 18]
-    assert list(model_ir.tensors["mul_out_nhwc"].shape_signature) == [1, 24, 12, 18]
+    assert _shape_signature(model_ir.tensors["mul_out_nhwc"]) == [1, 24, 12, 18]
 
 
 def test_flatbuffer_direct_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_elementwise_roundtrip_nhwc_nchw_fanout_chain_opt_test")
+    model_ir = ModelIR("transpose_elementwise_roundtrip_nhwc_nchw_fanout_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z0", "z1"]
 
@@ -15610,7 +15626,7 @@ def test_flatbuffer_direct_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chai
 
 
 def test_flatbuffer_direct_conv_output_transpose_nhwc_passthrough_chain_optimized() -> None:
-    model_ir = ModelIR(name="conv_output_transpose_nhwc_passthrough_opt_test")
+    model_ir = ModelIR("conv_output_transpose_nhwc_passthrough_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -15709,7 +15725,7 @@ def test_flatbuffer_direct_conv_output_transpose_nhwc_passthrough_chain_optimize
 
 
 def test_flatbuffer_direct_transpose_pre_add_mul_add_prelu_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_add_mul_add_prelu_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_pre_add_mul_add_prelu_nhwc_chain_opt_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc", "legacy_ref_nchw"]
     model_ir.outputs = ["z", "legacy_cat"]
     model_ir.tensors["a_nhwc"] = TensorIR(
@@ -15873,7 +15889,7 @@ def test_flatbuffer_direct_transpose_pre_add_mul_add_prelu_nhwc_chain_optimized(
 
 
 def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_logistic_muladd_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_logistic_muladd_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["skip_nhwc", "data_nhwc", "gate_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["skip_nhwc"] = TensorIR(
@@ -16001,7 +16017,7 @@ def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimize
 
 
 def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimized_with_legacy_users() -> None:
-    model_ir = ModelIR(name="transpose_logistic_muladd_prepost_nhwc_chain_opt_legacy_test")
+    model_ir = ModelIR("transpose_logistic_muladd_prepost_nhwc_chain_opt_legacy_test")
     model_ir.inputs = ["skip_nhwc", "data_nhwc", "gate_nhwc"]
     model_ir.outputs = ["z", "legacy_z"]
     model_ir.tensors["skip_nhwc"] = TensorIR(
@@ -16181,7 +16197,7 @@ def test_flatbuffer_direct_transpose_logistic_muladd_prepost_nhwc_chain_optimize
 
 
 def test_flatbuffer_direct_transpose_weighted_add_swish_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_weighted_add_swish_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_weighted_add_swish_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -16320,7 +16336,7 @@ def test_flatbuffer_direct_transpose_weighted_add_swish_prepost_nhwc_chain_optim
 
 
 def test_flatbuffer_direct_transpose_nested_weighted_add_swish_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_nested_weighted_add_swish_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_nested_weighted_add_swish_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc", "c_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -16428,7 +16444,7 @@ def test_flatbuffer_direct_transpose_nested_weighted_add_swish_prepost_nhwc_chai
 
 
 def test_flatbuffer_direct_transpose_pad_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pad_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_pad_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -16514,7 +16530,7 @@ def test_flatbuffer_direct_transpose_pad_prepost_nhwc_chain_optimized() -> None:
 
 
 def test_flatbuffer_direct_transpose_mirror_pad_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_mirror_pad_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_mirror_pad_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -16600,7 +16616,7 @@ def test_flatbuffer_direct_transpose_mirror_pad_prepost_nhwc_chain_optimized() -
 
 
 def test_flatbuffer_direct_transpose_unary_mirror_pad_prepost_nhwc_with_legacy_side_consumers() -> None:
-    model_ir = ModelIR(name="transpose_unary_mirror_pad_prepost_nhwc_side_consumer_opt_test")
+    model_ir = ModelIR("transpose_unary_mirror_pad_prepost_nhwc_side_consumer_opt_test")
     model_ir.inputs = ["x_nhwc", "skip_nchw"]
     model_ir.outputs = ["z", "mean_nchw", "side_out"]
 
@@ -16743,7 +16759,7 @@ def test_flatbuffer_direct_transpose_unary_mirror_pad_prepost_nhwc_with_legacy_s
 
 
 def test_flatbuffer_direct_transpose_unary_mirror_pad_prepost_nhwc_mean_reshape_side_consumer_no_adapter() -> None:
-    model_ir = ModelIR(name="transpose_unary_mirror_pad_prepost_nhwc_mean_side_opt_test")
+    model_ir = ModelIR("transpose_unary_mirror_pad_prepost_nhwc_mean_side_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z", "flat"]
 
@@ -16877,7 +16893,7 @@ def test_flatbuffer_direct_transpose_unary_mirror_pad_prepost_nhwc_mean_reshape_
 
 
 def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_bypass_adapter() -> None:
-    model_ir = ModelIR(name="transpose_norm_subgraph_pad_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_norm_subgraph_pad_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc", "skip_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -17026,7 +17042,7 @@ def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_b
 
 
 def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_shared_bypass_source() -> None:
-    model_ir = ModelIR(name="transpose_norm_subgraph_pad_prepost_nhwc_shared_bypass_source_test")
+    model_ir = ModelIR("transpose_norm_subgraph_pad_prepost_nhwc_shared_bypass_source_test")
     model_ir.inputs = ["x_nhwc", "skip_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -17184,7 +17200,7 @@ def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_s
 
 
 def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_external_nhwc_residual_source() -> None:
-    model_ir = ModelIR(name="transpose_norm_subgraph_pad_prepost_nhwc_external_nhwc_residual_test")
+    model_ir = ModelIR("transpose_norm_subgraph_pad_prepost_nhwc_external_nhwc_residual_test")
     model_ir.inputs = ["x_nhwc", "skip_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -17332,7 +17348,7 @@ def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_e
 
 
 def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_external_dynamic_channelwise_rank4() -> None:
-    model_ir = ModelIR(name="transpose_norm_subgraph_pad_prepost_nhwc_external_channelwise_rank4_opt_test")
+    model_ir = ModelIR("transpose_norm_subgraph_pad_prepost_nhwc_external_channelwise_rank4_opt_test")
     model_ir.inputs = ["x_nhwc", "gamma_vec", "bias_vec"]
     model_ir.outputs = ["z"]
 
@@ -17466,7 +17482,7 @@ def test_flatbuffer_direct_transpose_norm_subgraph_pad_prepost_nhwc_chain_with_e
 
 
 def test_flatbuffer_direct_transpose_instancenorm_mirror_pad_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_instancenorm_mirror_pad_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_instancenorm_mirror_pad_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -17675,7 +17691,7 @@ def test_flatbuffer_direct_transpose_instancenorm_mirror_pad_prepost_nhwc_chain_
 
 
 def test_flatbuffer_direct_transpose_instancenorm_posttranspose_bias_add_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_instancenorm_posttranspose_bias_add_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_instancenorm_posttranspose_bias_add_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc", "skip_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -17865,7 +17881,7 @@ def test_flatbuffer_direct_transpose_instancenorm_posttranspose_bias_add_nhwc_ch
 
 
 def test_flatbuffer_direct_transpose_flatten_globalnorm_pad_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_flatten_globalnorm_pad_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_flatten_globalnorm_pad_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -18135,7 +18151,7 @@ def test_flatbuffer_direct_transpose_flatten_globalnorm_pad_prepost_nhwc_chain_o
 
 
 def test_flatbuffer_direct_transpose_instancenorm_mirror_pad_prepost_nhwc_with_side_consumer() -> None:
-    model_ir = ModelIR(name="transpose_instancenorm_mirror_pad_prepost_nhwc_side_consumer_opt_test")
+    model_ir = ModelIR("transpose_instancenorm_mirror_pad_prepost_nhwc_side_consumer_opt_test")
     model_ir.inputs = ["x_nhwc", "skip_nchw"]
     model_ir.outputs = ["z", "side_out"]
 
@@ -18352,7 +18368,7 @@ def test_flatbuffer_direct_transpose_instancenorm_mirror_pad_prepost_nhwc_with_s
 
 
 def test_flatbuffer_direct_transpose_instancenorm_residual_add_pad_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_instancenorm_residual_add_pad_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_instancenorm_residual_add_pad_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc", "skip_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -18583,7 +18599,7 @@ def test_flatbuffer_direct_transpose_instancenorm_residual_add_pad_prepost_nhwc_
 
 
 def test_flatbuffer_direct_transpose_instancenorm_residual_add_single_post_adapter_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_instancenorm_residual_add_single_post_adapter_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_instancenorm_residual_add_single_post_adapter_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc", "res_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -18790,7 +18806,7 @@ def test_flatbuffer_direct_transpose_instancenorm_residual_add_single_post_adapt
 
 
 def test_flatbuffer_direct_transpose_dual_mul_concat_prepost_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_dual_mul_concat_prepost_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_dual_mul_concat_prepost_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc", "aux_nchw"]
     model_ir.outputs = ["z", "aux_out"]
 
@@ -18920,7 +18936,7 @@ def test_flatbuffer_direct_transpose_dual_mul_concat_prepost_nhwc_chain_optimize
 
 
 def test_flatbuffer_direct_transpose_instancenorm_residual_mul_concat_conv_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_instancenorm_residual_mul_concat_conv_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_instancenorm_residual_mul_concat_conv_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc", "res_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -19187,7 +19203,7 @@ def test_flatbuffer_direct_transpose_instancenorm_residual_mul_concat_conv_nhwc_
 
 
 def test_flatbuffer_direct_transpose_3d_leaky_logistic_muladd_ndhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_3d_leaky_logistic_muladd_ndhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_3d_leaky_logistic_muladd_ndhwc_chain_opt_test")
     model_ir.inputs = ["base_nhwc", "skip_ndhwc", "gate_ndhwc"]
     model_ir.outputs = ["y0", "y1"]
 
@@ -19363,7 +19379,7 @@ def test_flatbuffer_direct_transpose_3d_leaky_logistic_muladd_ndhwc_chain_optimi
 
 
 def test_flatbuffer_direct_transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_pre_unary_reshape_transpose_suffix_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -19453,7 +19469,7 @@ def test_flatbuffer_direct_transpose_pre_unary_reshape_transpose_suffix_nhwc_cha
 
 
 def test_flatbuffer_direct_transpose_reshape_transpose_to_expanddims_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_reshape_transpose_to_expanddims_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_reshape_transpose_to_expanddims_nhwc_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -19529,7 +19545,7 @@ def test_flatbuffer_direct_transpose_reshape_transpose_to_expanddims_nhwc_chain_
 
 
 def test_flatbuffer_direct_transpose_reshape_transpose_to_expanddims_nhwc_channel_tail_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_reshape_transpose_to_expanddims_nhwc_channel_tail_chain_opt_test")
+    model_ir = ModelIR("transpose_reshape_transpose_to_expanddims_nhwc_channel_tail_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -19605,7 +19621,7 @@ def test_flatbuffer_direct_transpose_reshape_transpose_to_expanddims_nhwc_channe
 
 
 def test_flatbuffer_direct_transpose_mul_add_const_prelu_prepost_terminal_optimized() -> None:
-    model_ir = ModelIR(name="transpose_mul_add_const_prelu_prepost_terminal_opt_test")
+    model_ir = ModelIR("transpose_mul_add_const_prelu_prepost_terminal_opt_test")
     model_ir.inputs = ["x_nhwc", "legacy_nchw"]
     model_ir.outputs = ["z", "legacy_cat"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -19739,7 +19755,7 @@ def test_flatbuffer_direct_transpose_mul_add_const_prelu_prepost_terminal_optimi
 
 
 def test_flatbuffer_direct_singleton_spatial_transpose_before_flatten_reshape_removed() -> None:
-    model_ir = ModelIR(name="singleton_spatial_transpose_flatten_test")
+    model_ir = ModelIR("singleton_spatial_transpose_flatten_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -19801,7 +19817,7 @@ def test_flatbuffer_direct_singleton_spatial_transpose_before_flatten_reshape_re
 
 
 def test_flatbuffer_direct_singleton_spatial_transpose_identity_reshape_flatten_removed() -> None:
-    model_ir = ModelIR(name="singleton_spatial_transpose_identity_reshape_flatten_test")
+    model_ir = ModelIR("singleton_spatial_transpose_identity_reshape_flatten_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -19884,7 +19900,7 @@ def test_flatbuffer_direct_singleton_spatial_transpose_identity_reshape_flatten_
 
 
 def test_flatbuffer_direct_sinet_concat_resize_affine_transpose_chain_optimized() -> None:
-    model_ir = ModelIR(name="sinet_concat_resize_affine_transpose_opt_test")
+    model_ir = ModelIR("sinet_concat_resize_affine_transpose_opt_test")
     model_ir.inputs = ["pre_nhwc", "b0_nhwc", "rz_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["pre_nhwc"] = TensorIR(
@@ -20043,7 +20059,7 @@ def test_flatbuffer_direct_sinet_concat_resize_affine_transpose_chain_optimized(
 
 
 def test_flatbuffer_direct_sinet_dual_resize_affine_transpose_chain_optimized() -> None:
-    model_ir = ModelIR(name="sinet_dual_resize_affine_transpose_opt_test")
+    model_ir = ModelIR("sinet_dual_resize_affine_transpose_opt_test")
     model_ir.inputs = ["pre_nhwc", "r0_nhwc", "r1_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -20213,7 +20229,7 @@ def test_flatbuffer_direct_sinet_dual_resize_affine_transpose_chain_optimized() 
 
 
 def test_flatbuffer_direct_transpose_pre_concat_nhwc_partial_match_does_not_mutate_swish_input() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_nhwc_partial_match_no_mutation_test")
+    model_ir = ModelIR("transpose_pre_concat_nhwc_partial_match_no_mutation_test")
     model_ir.inputs = ["x_nhwc", "residual_nchw"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -20302,7 +20318,7 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_partial_match_does_not_muta
     stats = _optimize_transpose_pre_concat_nhwc_chains(model_ir)
     assert stats["optimized_transpose_pre_concat_nhwc_chains"] == 0
     assert list(model_ir.tensors["swish_out"].shape) == [1, 384, 6, 6]
-    assert list(model_ir.tensors["swish_out"].shape_signature) == [1, 384, 6, 6]
+    assert _shape_signature(model_ir.tensors["swish_out"]) == [1, 384, 6, 6]
     assert [str(op.op_type) for op in model_ir.operators] == [
         "TRANSPOSE",
         "LOGISTIC",
@@ -20314,7 +20330,7 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_partial_match_does_not_muta
 
 
 def test_flatbuffer_direct_transpose_pre_concat_nhwc_relu_and_swish_inputs_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_nhwc_relu_swish_opt_test")
+    model_ir = ModelIR("transpose_pre_concat_nhwc_relu_swish_opt_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x0_nhwc"] = TensorIR(
@@ -20425,7 +20441,7 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_relu_and_swish_inputs_optim
 
 
 def test_flatbuffer_direct_transpose_pre_concat_ndhwc_unary_inputs_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_ndhwc_unary_opt_test")
+    model_ir = ModelIR("transpose_pre_concat_ndhwc_unary_opt_test")
     model_ir.inputs = ["x0_ndhwc", "x1_ndhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x0_ndhwc"] = TensorIR(
@@ -20522,7 +20538,7 @@ def test_flatbuffer_direct_transpose_pre_concat_ndhwc_unary_inputs_optimized() -
 
 
 def test_flatbuffer_direct_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_conv3d_leaky_mul_unsqueeze_ndhwc_opt_test")
+    model_ir = ModelIR("transpose_conv3d_leaky_mul_unsqueeze_ndhwc_opt_test")
     model_ir.inputs = ["sem_ndhwc", "conv_ndhwc"]
     model_ir.outputs = ["y"]
 
@@ -20697,7 +20713,7 @@ def test_flatbuffer_direct_transpose_conv3d_leaky_mul_unsqueeze_ndhwc_chain_opti
 
 
 def test_flatbuffer_direct_transpose_pre_concat_single_post_adapter_supports_relu_inputs() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_single_post_adapter_relu_test")
+    model_ir = ModelIR("transpose_pre_concat_single_post_adapter_relu_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x0_nhwc"] = TensorIR(
@@ -20798,7 +20814,7 @@ def test_flatbuffer_direct_transpose_pre_concat_single_post_adapter_supports_rel
 
 
 def test_flatbuffer_direct_transpose_pre_concat_single_post_adapter_supports_unary_after_singleton_reshape() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_single_post_adapter_unary_singleton_reshape_test")
+    model_ir = ModelIR("transpose_pre_concat_single_post_adapter_unary_singleton_reshape_test")
     model_ir.inputs = ["b0_nhwc", "b1_nhwc", "b2_nhwc"]
     model_ir.outputs = ["out_nchw"]
     model_ir.tensors["b0_nhwc"] = TensorIR(
@@ -20896,7 +20912,7 @@ def test_flatbuffer_direct_transpose_pre_concat_single_post_adapter_supports_una
 
 
 def test_flatbuffer_direct_transpose_split_mixed_pre_concat_single_post_adapter_optimized() -> None:
-    model_ir = ModelIR(name="transpose_split_mixed_pre_concat_single_post_adapter_test")
+    model_ir = ModelIR("transpose_split_mixed_pre_concat_single_post_adapter_test")
     model_ir.inputs = ["split_in_nchw", "b0_nhwc", "b1_nhwc", "b2_nhwc"]
     model_ir.outputs = ["out_nchw", "gate"]
     model_ir.tensors["split_axis"] = TensorIR(
@@ -21044,7 +21060,7 @@ def test_flatbuffer_direct_transpose_split_mixed_pre_concat_single_post_adapter_
 
 
 def test_flatbuffer_direct_transpose_relu_split_all_outputs_to_nhwc_chains_optimized() -> None:
-    model_ir = ModelIR(name="transpose_relu_split_all_outputs_to_nhwc_test")
+    model_ir = ModelIR("transpose_relu_split_all_outputs_to_nhwc_test")
     model_ir.inputs = ["src_nhwc"]
     model_ir.outputs = ["out0", "out1"]
     model_ir.tensors["to_nchw_perm"] = TensorIR(
@@ -21162,7 +21178,7 @@ def test_flatbuffer_direct_transpose_relu_split_all_outputs_to_nhwc_chains_optim
 
 
 def test_flatbuffer_direct_transpose_relu_split_conv_relu_concat_posttranspose_to_nhwc_chains_optimized() -> None:
-    model_ir = ModelIR(name="transpose_relu_split_conv_relu_concat_posttranspose_test")
+    model_ir = ModelIR("transpose_relu_split_conv_relu_concat_posttranspose_test")
     model_ir.inputs = ["src_nhwc"]
     model_ir.outputs = ["sink"]
     model_ir.tensors["to_nchw_perm"] = TensorIR(
@@ -21324,7 +21340,7 @@ def test_flatbuffer_direct_transpose_relu_split_conv_relu_concat_posttranspose_t
 
 
 def test_flatbuffer_direct_shufflenet_transpose_shuffle_chain_optimized() -> None:
-    model_ir = ModelIR(name="shufflenet_transpose_shuffle_chain_opt_test")
+    model_ir = ModelIR("shufflenet_transpose_shuffle_chain_opt_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["out_nchw"]
 
@@ -21529,7 +21545,7 @@ def test_flatbuffer_direct_shufflenet_transpose_shuffle_chain_optimized() -> Non
 
 
 def test_flatbuffer_direct_shufflenet_transpose_slice_shuffle_chain_optimized() -> None:
-    model_ir = ModelIR(name="shufflenet_transpose_slice_shuffle_chain_opt_test")
+    model_ir = ModelIR("shufflenet_transpose_slice_shuffle_chain_opt_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["out_nchw"]
 
@@ -21753,7 +21769,7 @@ def test_flatbuffer_direct_shufflenet_transpose_slice_shuffle_chain_optimized() 
 
 
 def test_flatbuffer_direct_transpose_slice_logistic_concat_reshape_tail_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_slice_logistic_concat_reshape_tail_nhwc_opt_test")
+    model_ir = ModelIR("transpose_slice_logistic_concat_reshape_tail_nhwc_opt_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc", "x2_nhwc", "x3_nhwc"]
     model_ir.outputs = ["out_nchw"]
 
@@ -21925,7 +21941,7 @@ def test_flatbuffer_direct_transpose_slice_logistic_concat_reshape_tail_nhwc_cha
 
 
 def test_flatbuffer_direct_transpose_cost_volume_scatter_ndhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_cost_volume_scatter_ndhwc_opt_test")
+    model_ir = ModelIR("transpose_cost_volume_scatter_ndhwc_opt_test")
     model_ir.inputs = ["desc0_nhwc", "desc1_nhwc"]
     model_ir.outputs = ["conv_out"]
 
@@ -22103,7 +22119,7 @@ def test_flatbuffer_direct_transpose_cost_volume_scatter_ndhwc_chain_optimized()
 
 
 def test_flatbuffer_direct_shufflenet_reshape_transpose_shuffle_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="shufflenet_reshape_transpose_shuffle_nhwc_opt_test")
+    model_ir = ModelIR("shufflenet_reshape_transpose_shuffle_nhwc_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y0", "y1"]
 
@@ -22230,7 +22246,7 @@ def test_flatbuffer_direct_shufflenet_reshape_transpose_shuffle_nhwc_chain_optim
 
 
 def test_flatbuffer_direct_nchw_channel_shuffle_reshape_transpose_reshape_to_gather_optimized() -> None:
-    model_ir = ModelIR(name="nchw_channel_shuffle_reshape_transpose_reshape_to_gather_opt_test")
+    model_ir = ModelIR("nchw_channel_shuffle_reshape_transpose_reshape_to_gather_opt_test")
     model_ir.inputs = ["x_nchw"]
     model_ir.outputs = ["y_nchw"]
 
@@ -22303,7 +22319,7 @@ def test_flatbuffer_direct_nchw_channel_shuffle_reshape_transpose_reshape_to_gat
 
 
 def test_flatbuffer_direct_transpose_gather_transpose_axis_remap_nhwc_optimized() -> None:
-    model_ir = ModelIR(name="transpose_gather_transpose_axis_remap_nhwc_opt_test")
+    model_ir = ModelIR("transpose_gather_transpose_axis_remap_nhwc_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
 
@@ -22380,7 +22396,7 @@ def test_flatbuffer_direct_transpose_gather_transpose_axis_remap_nhwc_optimized(
 
 
 def test_flatbuffer_direct_transpose_gather_transpose_axis_remap_nhwc_keeps_shared_pre_transpose() -> None:
-    model_ir = ModelIR(name="transpose_gather_transpose_axis_remap_nhwc_shared_pre_test")
+    model_ir = ModelIR("transpose_gather_transpose_axis_remap_nhwc_shared_pre_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc", "side_nchw"]
 
@@ -22465,7 +22481,7 @@ def test_flatbuffer_direct_transpose_gather_transpose_axis_remap_nhwc_keeps_shar
 
 
 def test_flatbuffer_direct_transpose_pre_add_nhwc_rewrites_gather_input_and_shared_mul_const() -> None:
-    model_ir = ModelIR(name="transpose_pre_add_nhwc_gather_shared_mul_const_test")
+    model_ir = ModelIR("transpose_pre_add_nhwc_gather_shared_mul_const_test")
     model_ir.inputs = ["x_nhwc", "y_nhwc"]
     model_ir.outputs = ["bn_out_nhwc"]
 
@@ -22629,7 +22645,7 @@ def test_flatbuffer_direct_transpose_pre_add_nhwc_rewrites_gather_input_and_shar
 
 
 def test_flatbuffer_direct_transpose_pre_add_nhwc_shared_concat_and_unary_input() -> None:
-    model_ir = ModelIR(name="transpose_pre_add_shared_concat_and_unary_test")
+    model_ir = ModelIR("transpose_pre_add_shared_concat_and_unary_test")
     model_ir.inputs = ["x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["legacy_cat"]
     model_ir.tensors["x0_nhwc"] = TensorIR(
@@ -22728,7 +22744,7 @@ def test_flatbuffer_direct_transpose_pre_add_nhwc_shared_concat_and_unary_input(
 
 
 def test_flatbuffer_direct_transpose_pre_add_nhwc_with_leakyrelu_inputs() -> None:
-    model_ir = ModelIR(name="transpose_pre_add_nhwc_with_leakyrelu_inputs_test")
+    model_ir = ModelIR("transpose_pre_add_nhwc_with_leakyrelu_inputs_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc"]
     model_ir.outputs = ["tail"]
     model_ir.tensors["a_nhwc"] = TensorIR(
@@ -22838,7 +22854,7 @@ def test_flatbuffer_direct_transpose_pre_add_nhwc_with_leakyrelu_inputs() -> Non
 
 
 def test_flatbuffer_direct_transpose_pre_add_nhwc_with_nested_add_const_affine() -> None:
-    model_ir = ModelIR(name="transpose_pre_add_nhwc_with_nested_add_const_affine_test")
+    model_ir = ModelIR("transpose_pre_add_nhwc_with_nested_add_const_affine_test")
     model_ir.inputs = ["main_nhwc", "skip_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["main_nhwc"] = TensorIR(
@@ -22976,7 +22992,7 @@ def test_flatbuffer_direct_transpose_pre_add_nhwc_with_nested_add_const_affine()
 
 
 def test_flatbuffer_direct_transpose_pre_concat_nhwc_shared_direct_and_nested_add_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_nhwc_shared_direct_nested_add_test")
+    model_ir = ModelIR("transpose_pre_concat_nhwc_shared_direct_nested_add_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc", "c_nhwc", "d_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["a_nhwc"] = TensorIR(
@@ -23119,7 +23135,7 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_shared_direct_and_nested_ad
 
 
 def test_flatbuffer_direct_transpose_pre_concat_nhwc_pad_input_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_nhwc_pad_input_opt_test")
+    model_ir = ModelIR("transpose_pre_concat_nhwc_pad_input_opt_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["a_nhwc"] = TensorIR(
@@ -23245,7 +23261,7 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_pad_input_optimized() -> No
 
 
 def test_flatbuffer_direct_transpose_pre_concat_nhwc_dequant_input_optimized() -> None:
-    model_ir = ModelIR(name="transpose_pre_concat_nhwc_dequant_input_opt_test")
+    model_ir = ModelIR("transpose_pre_concat_nhwc_dequant_input_opt_test")
     model_ir.inputs = ["a_q_nhwc", "b_q_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["a_q_nhwc"] = TensorIR(
@@ -23356,7 +23372,7 @@ def test_flatbuffer_direct_transpose_pre_concat_nhwc_dequant_input_optimized() -
 
 
 def test_flatbuffer_direct_transpose_axis3_const_concat_bridge_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_axis3_const_concat_bridge_nhwc_opt_test")
+    model_ir = ModelIR("transpose_axis3_const_concat_bridge_nhwc_opt_test")
     model_ir.inputs = ["stem_nhwc"]
     model_ir.outputs = ["y_nhwc", "mean_nchw"]
 
@@ -23487,7 +23503,7 @@ def test_flatbuffer_direct_transpose_axis3_const_concat_bridge_nhwc_chain_optimi
 
 
 def test_flatbuffer_direct_transpose_elementwise_concat_conv_nhwc_groups_optimized() -> None:
-    model_ir = ModelIR(name="transpose_elementwise_concat_conv_nhwc_groups_opt_test")
+    model_ir = ModelIR("transpose_elementwise_concat_conv_nhwc_groups_opt_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc", "c_nhwc"]
     model_ir.outputs = ["y0", "y1"]
     model_ir.tensors["a_nhwc"] = TensorIR(
@@ -23687,7 +23703,7 @@ def test_flatbuffer_direct_transpose_elementwise_concat_conv_nhwc_groups_optimiz
 
 
 def test_flatbuffer_direct_transpose_leakyrelu_concat_conv_nhwc_groups_optimized() -> None:
-    model_ir = ModelIR(name="transpose_leakyrelu_concat_conv_nhwc_groups_opt_test")
+    model_ir = ModelIR("transpose_leakyrelu_concat_conv_nhwc_groups_opt_test")
     model_ir.inputs = ["a_nhwc", "b_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["a_nhwc"] = TensorIR(
@@ -23810,7 +23826,7 @@ def test_flatbuffer_direct_transpose_leakyrelu_concat_conv_nhwc_groups_optimized
 
 
 def test_flatbuffer_direct_transpose_conv_attention_nhwc_propagation_optimized() -> None:
-    model_ir = ModelIR(name="transpose_conv_attention_nhwc_propagation_opt_test")
+    model_ir = ModelIR("transpose_conv_attention_nhwc_propagation_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -23985,7 +24001,7 @@ def test_flatbuffer_direct_transpose_conv_attention_nhwc_propagation_optimized()
 
 
 def test_flatbuffer_direct_transpose_conv_attention_hardsigmoid_nhwc_propagation_optimized() -> None:
-    model_ir = ModelIR(name="transpose_conv_attention_hardsigmoid_nhwc_propagation_opt_test")
+    model_ir = ModelIR("transpose_conv_attention_hardsigmoid_nhwc_propagation_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -24198,7 +24214,7 @@ def test_flatbuffer_direct_transpose_conv_attention_hardsigmoid_nhwc_propagation
 
 
 def test_flatbuffer_direct_transpose_conv_attention_hardswish_activation_nhwc_propagation_optimized() -> None:
-    model_ir = ModelIR(name="transpose_conv_attention_hardswish_activation_nhwc_propagation_opt_test")
+    model_ir = ModelIR("transpose_conv_attention_hardswish_activation_nhwc_propagation_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -24451,7 +24467,7 @@ def test_flatbuffer_direct_transpose_conv_attention_hardswish_activation_nhwc_pr
 
 
 def test_flatbuffer_direct_transpose_conv_hardswish_mean_conv_hardswish_mean_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_conv_hardswish_mean_conv_hardswish_mean_chain_opt_test")
+    model_ir = ModelIR("transpose_conv_hardswish_mean_conv_hardswish_mean_chain_opt_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -24676,7 +24692,7 @@ def test_flatbuffer_direct_transpose_conv_hardswish_mean_conv_hardswish_mean_cha
 
 
 def test_flatbuffer_direct_transpose_csp_attention_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_csp_attention_nhwc_chain_opt_test")
+    model_ir = ModelIR("transpose_csp_attention_nhwc_chain_opt_test")
     model_ir.inputs = ["short_nhwc", "main_nhwc", "point_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["short_nhwc"] = TensorIR(
@@ -24933,7 +24949,7 @@ def test_flatbuffer_direct_transpose_csp_attention_nhwc_chain_optimized() -> Non
 
 
 def test_flatbuffer_direct_transpose_csp_attention_nhwc_chain_without_main_add_optimized() -> None:
-    model_ir = ModelIR(name="transpose_csp_attention_nhwc_chain_no_add_opt_test")
+    model_ir = ModelIR("transpose_csp_attention_nhwc_chain_no_add_opt_test")
     model_ir.inputs = ["short_nhwc", "point_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["short_nhwc"] = TensorIR(
@@ -25168,7 +25184,7 @@ def test_flatbuffer_direct_transpose_csp_attention_nhwc_chain_without_main_add_o
 
 
 def test_flatbuffer_direct_hardsigmoid_mul_transpose_passthrough_with_legacy_fanout_keeps_adapter() -> None:
-    model_ir = ModelIR(name="hardsigmoid_mul_transpose_passthrough_legacy_fanout_test")
+    model_ir = ModelIR("hardsigmoid_mul_transpose_passthrough_legacy_fanout_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc", "m_nhwc"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -25314,7 +25330,7 @@ def test_flatbuffer_direct_hardsigmoid_mul_transpose_passthrough_with_legacy_fan
 
 
 def test_flatbuffer_direct_fold_conv_mul_add_affine_chain_single_path() -> None:
-    model_ir = ModelIR(name="fold_conv_mul_add_affine_single_path_test")
+    model_ir = ModelIR("fold_conv_mul_add_affine_single_path_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -25432,7 +25448,7 @@ def test_flatbuffer_direct_fold_conv_mul_add_affine_chain_single_path() -> None:
 
 
 def test_flatbuffer_direct_fold_conv_mul_add_affine_chain_skips_conv_fanout() -> None:
-    model_ir = ModelIR(name="fold_conv_mul_add_affine_conv_fanout_skip_test")
+    model_ir = ModelIR("fold_conv_mul_add_affine_conv_fanout_skip_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y", "branch"]
     model_ir.tensors["x"] = TensorIR(
@@ -25513,7 +25529,7 @@ def test_flatbuffer_direct_fold_conv_mul_add_affine_chain_skips_conv_fanout() ->
 
 
 def test_flatbuffer_direct_fold_conv_mul_affine_chain_single_path() -> None:
-    model_ir = ModelIR(name="fold_conv_mul_affine_single_path_test")
+    model_ir = ModelIR("fold_conv_mul_affine_single_path_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -25612,7 +25628,7 @@ def test_flatbuffer_direct_fold_conv_mul_affine_chain_single_path() -> None:
 
 
 def test_flatbuffer_direct_fold_conv_relu_mul_add_affine_chain_folds_mul_only() -> None:
-    model_ir = ModelIR(name="fold_conv_relu_mul_add_affine_mul_only_test")
+    model_ir = ModelIR("fold_conv_relu_mul_add_affine_mul_only_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -25715,7 +25731,7 @@ def test_flatbuffer_direct_fold_conv_relu_mul_add_affine_chain_folds_mul_only() 
 
 
 def test_flatbuffer_direct_fold_conv_relu_mul_affine_chain_skips_negative_scale() -> None:
-    model_ir = ModelIR(name="fold_conv_relu_mul_affine_negative_scale_skip_test")
+    model_ir = ModelIR("fold_conv_relu_mul_affine_negative_scale_skip_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -25781,7 +25797,7 @@ def test_flatbuffer_direct_fold_conv_relu_mul_affine_chain_skips_negative_scale(
 
 
 def test_flatbuffer_direct_fold_conv_add_affine_chain_single_path() -> None:
-    model_ir = ModelIR(name="fold_conv_add_affine_single_path_test")
+    model_ir = ModelIR("fold_conv_add_affine_single_path_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -25881,7 +25897,7 @@ def test_flatbuffer_direct_fold_conv_add_affine_chain_single_path() -> None:
 
 
 def test_flatbuffer_direct_fold_conv_add_affine_chain_skips_add_fanout() -> None:
-    model_ir = ModelIR(name="fold_conv_add_affine_add_fanout_skip_test")
+    model_ir = ModelIR("fold_conv_add_affine_add_fanout_skip_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y0", "y1"]
     model_ir.tensors["x"] = TensorIR(
@@ -25949,7 +25965,7 @@ def test_flatbuffer_direct_fold_conv_add_affine_chain_skips_add_fanout() -> None
 
 
 def test_flatbuffer_direct_fold_conv_add_affine_chain_skips_leading_channel_coeff_shape() -> None:
-    model_ir = ModelIR(name="fold_conv_add_affine_leading_channel_coeff_skip_test")
+    model_ir = ModelIR("fold_conv_add_affine_leading_channel_coeff_skip_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -26018,7 +26034,7 @@ def test_flatbuffer_direct_fold_conv_add_affine_chain_skips_leading_channel_coef
 
 
 def test_flatbuffer_direct_fold_conv_add_affine_chain_folds_relu6_muldiv_suffix() -> None:
-    model_ir = ModelIR(name="fold_conv_add_affine_relu6_muldiv_suffix_fold_test")
+    model_ir = ModelIR("fold_conv_add_affine_relu6_muldiv_suffix_fold_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -26115,7 +26131,7 @@ def test_flatbuffer_direct_fold_conv_add_affine_chain_folds_relu6_muldiv_suffix(
 
 
 def test_flatbuffer_direct_repair_channelwise_broadcast_constants_rotates_rank3_to_nhwc() -> None:
-    model_ir = ModelIR(name="repair_channelwise_rank3_to_nhwc_test")
+    model_ir = ModelIR("repair_channelwise_rank3_to_nhwc_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -26157,7 +26173,7 @@ def test_flatbuffer_direct_repair_channelwise_broadcast_constants_rotates_rank3_
 
 
 def test_flatbuffer_direct_repair_channelwise_broadcast_constants_keeps_nchw_rank3() -> None:
-    model_ir = ModelIR(name="repair_channelwise_rank3_keep_nchw_test")
+    model_ir = ModelIR("repair_channelwise_rank3_keep_nchw_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -26197,7 +26213,7 @@ def test_flatbuffer_direct_repair_channelwise_broadcast_constants_keeps_nchw_ran
 
 
 def test_flatbuffer_direct_repair_channelwise_broadcast_constants_uses_logical_layout_on_ambiguous_rank4() -> None:
-    model_ir = ModelIR(name="repair_channelwise_rank4_ambiguous_logical_layout_test")
+    model_ir = ModelIR("repair_channelwise_rank4_ambiguous_logical_layout_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -26241,7 +26257,7 @@ def test_flatbuffer_direct_repair_channelwise_broadcast_constants_uses_logical_l
 
 
 def test_flatbuffer_direct_fold_conv_add_affine_chain_folds_fused_add_activation() -> None:
-    model_ir = ModelIR(name="fold_conv_add_affine_fused_add_activation_fold_test")
+    model_ir = ModelIR("fold_conv_add_affine_fused_add_activation_fold_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -26325,7 +26341,7 @@ def test_flatbuffer_direct_fold_conv_add_affine_chain_folds_fused_add_activation
 
 
 def test_flatbuffer_direct_asin_transpose_passthrough_chain() -> None:
-    model_ir = ModelIR(name="asin_transpose_passthrough_test")
+    model_ir = ModelIR("asin_transpose_passthrough_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -26395,7 +26411,7 @@ def test_flatbuffer_direct_asin_transpose_passthrough_chain() -> None:
 
 
 def test_flatbuffer_direct_erf_transpose_passthrough_chain() -> None:
-    model_ir = ModelIR(name="erf_transpose_passthrough_test")
+    model_ir = ModelIR("erf_transpose_passthrough_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -26496,7 +26512,7 @@ def test_flatbuffer_direct_erf_transpose_passthrough_chain() -> None:
 
 
 def test_flatbuffer_direct_transpose_mean_prepost_nhwc_passthrough_chain() -> None:
-    model_ir = ModelIR(name="transpose_mean_prepost_nhwc_passthrough_test")
+    model_ir = ModelIR("transpose_mean_prepost_nhwc_passthrough_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -26563,7 +26579,7 @@ def test_flatbuffer_direct_transpose_mean_prepost_nhwc_passthrough_chain() -> No
 
 
 def test_flatbuffer_direct_transpose_mean_prepost_nhwc_passthrough_keeps_pre_on_fanout() -> None:
-    model_ir = ModelIR(name="transpose_mean_prepost_nhwc_pre_fanout_keep_pre_test")
+    model_ir = ModelIR("transpose_mean_prepost_nhwc_pre_fanout_keep_pre_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc", "side_nchw"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -26630,7 +26646,7 @@ def test_flatbuffer_direct_transpose_mean_prepost_nhwc_passthrough_keeps_pre_on_
 
 
 def test_flatbuffer_direct_mixed_mean_reducemax_concat_mirrorpad_nhwc_chain() -> None:
-    model_ir = ModelIR(name="mixed_mean_reducemax_concat_mirrorpad_nhwc_test")
+    model_ir = ModelIR("mixed_mean_reducemax_concat_mirrorpad_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
     for name, shape in [
@@ -26748,7 +26764,7 @@ def test_flatbuffer_direct_mixed_mean_reducemax_concat_mirrorpad_nhwc_chain() ->
 
 
 def test_flatbuffer_direct_transpose_pre_unary_mean_terminal_nhwc_chain() -> None:
-    model_ir = ModelIR(name="transpose_pre_unary_mean_terminal_nhwc_test")
+    model_ir = ModelIR("transpose_pre_unary_mean_terminal_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -26828,7 +26844,7 @@ def test_flatbuffer_direct_transpose_pre_unary_mean_terminal_nhwc_chain() -> Non
 
 
 def test_flatbuffer_direct_transpose_pre_mean_terminal_nhwc_chain_without_keepdims_option() -> None:
-    model_ir = ModelIR(name="transpose_pre_mean_terminal_nhwc_missing_keepdims_test")
+    model_ir = ModelIR("transpose_pre_mean_terminal_nhwc_missing_keepdims_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -26899,7 +26915,7 @@ def test_flatbuffer_direct_transpose_pre_mean_terminal_nhwc_chain_without_keepdi
 
 
 def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain() -> None:
-    model_ir = ModelIR(name="transpose_se_conv_mul_prepost_nhwc_test")
+    model_ir = ModelIR("transpose_se_conv_mul_prepost_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -26981,7 +26997,7 @@ def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain() -> None:
 
 
 def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain_with_squeeze_reshape_gate() -> None:
-    model_ir = ModelIR(name="transpose_se_conv_mul_prepost_nhwc_squeeze_reshape_gate_test")
+    model_ir = ModelIR("transpose_se_conv_mul_prepost_nhwc_squeeze_reshape_gate_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -27081,7 +27097,7 @@ def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain_with_squeeze
 
 
 def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain_with_affine_gate() -> None:
-    model_ir = ModelIR(name="transpose_se_conv_mul_prepost_nhwc_affine_gate_test")
+    model_ir = ModelIR("transpose_se_conv_mul_prepost_nhwc_affine_gate_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -27175,7 +27191,7 @@ def test_flatbuffer_direct_transpose_se_conv_mul_prepost_nhwc_chain_with_affine_
 
 
 def test_flatbuffer_direct_batchmatmul_affine_transpose_input_chains() -> None:
-    model_ir = ModelIR(name="batchmatmul_affine_transpose_inputs_test")
+    model_ir = ModelIR("batchmatmul_affine_transpose_inputs_test")
     model_ir.inputs = ["lhs_nhwc", "rhs_nhwc"]
     model_ir.outputs = ["bmm_out"]
 
@@ -27251,7 +27267,7 @@ def test_flatbuffer_direct_batchmatmul_affine_transpose_input_chains() -> None:
 
 
 def test_flatbuffer_direct_batchmatmul_reshape_se_nhwc_chains() -> None:
-    model_ir = ModelIR(name="batchmatmul_reshape_se_nhwc_chain_test")
+    model_ir = ModelIR("batchmatmul_reshape_se_nhwc_chain_test")
     model_ir.inputs = ["lhs_mat", "rhs_mat"]
     model_ir.outputs = ["z"]
 
@@ -27338,7 +27354,7 @@ def test_flatbuffer_direct_batchmatmul_reshape_se_nhwc_chains() -> None:
 
 
 def test_flatbuffer_direct_transpose_se_fc_mul_prepost_nhwc_chain() -> None:
-    model_ir = ModelIR(name="transpose_se_fc_mul_prepost_nhwc_test")
+    model_ir = ModelIR("transpose_se_fc_mul_prepost_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -27460,7 +27476,7 @@ def test_flatbuffer_direct_transpose_se_fc_mul_prepost_nhwc_chain() -> None:
 
 
 def test_flatbuffer_direct_transpose_se_fc_mul_prepost_nhwc_chain_without_pool_pretranspose() -> None:
-    model_ir = ModelIR(name="transpose_se_fc_mul_prepost_nhwc_no_pool_pretranspose_test")
+    model_ir = ModelIR("transpose_se_fc_mul_prepost_nhwc_no_pool_pretranspose_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -27554,7 +27570,7 @@ def test_flatbuffer_direct_transpose_se_fc_mul_prepost_nhwc_chain_without_pool_p
 
 
 def test_flatbuffer_direct_transpose_se_fc_mul_prepost_nhwc_chain_with_mean_and_post_relu0to1() -> None:
-    model_ir = ModelIR(name="transpose_se_fc_mul_prepost_nhwc_mean_relu0to1_test")
+    model_ir = ModelIR("transpose_se_fc_mul_prepost_nhwc_mean_relu0to1_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -27668,7 +27684,7 @@ def test_flatbuffer_direct_transpose_se_fc_mul_prepost_nhwc_chain_with_mean_and_
 
 
 def test_flatbuffer_direct_safe_transpose_reduction_lite_removes_transpose_quantize_transpose_chain() -> None:
-    model_ir = ModelIR(name="safe_transpose_reduction_lite_tqt_chain_test")
+    model_ir = ModelIR("safe_transpose_reduction_lite_tqt_chain_test")
     model_ir.inputs = ["input"]
     model_ir.outputs = ["output"]
 
@@ -27768,7 +27784,7 @@ def test_flatbuffer_direct_safe_transpose_reduction_lite_removes_transpose_quant
 
 
 def test_flatbuffer_direct_singleton_channel_layout_transpose_rewritten_to_reshape() -> None:
-    model_ir = ModelIR(name="singleton_channel_transpose_to_reshape_test")
+    model_ir = ModelIR("singleton_channel_transpose_to_reshape_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nchw"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -27811,7 +27827,7 @@ def test_flatbuffer_direct_singleton_channel_layout_transpose_rewritten_to_resha
 
 
 def test_flatbuffer_direct_singleton_spatial_layout_transpose_rewritten_to_reshape() -> None:
-    model_ir = ModelIR(name="singleton_spatial_transpose_to_reshape_test")
+    model_ir = ModelIR("singleton_spatial_transpose_to_reshape_test")
     model_ir.inputs = ["x_nhwc", "y_nchw"]
     model_ir.outputs = ["x_nchw", "y_nhwc"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -27867,7 +27883,7 @@ def test_flatbuffer_direct_singleton_spatial_layout_transpose_rewritten_to_resha
 
 
 def test_flatbuffer_direct_singleton_moved_axis_transpose_rewritten_to_reshape() -> None:
-    model_ir = ModelIR(name="singleton_moved_axis_transpose_to_reshape_test")
+    model_ir = ModelIR("singleton_moved_axis_transpose_to_reshape_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -27901,7 +27917,7 @@ def test_flatbuffer_direct_singleton_moved_axis_transpose_rewritten_to_reshape()
 
 
 def test_flatbuffer_direct_dynamic_batch_singleton_reshape_transpose_collapses_to_single_reshape() -> None:
-    model_ir = ModelIR(name="dynamic_batch_singleton_reshape_transpose_collapse_test")
+    model_ir = ModelIR("dynamic_batch_singleton_reshape_transpose_collapse_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -27963,7 +27979,7 @@ def test_flatbuffer_direct_dynamic_batch_singleton_reshape_transpose_collapses_t
 
 
 def test_flatbuffer_direct_non_singleton_order_change_transpose_not_rewritten_to_reshape() -> None:
-    model_ir = ModelIR(name="non_singleton_order_change_transpose_test")
+    model_ir = ModelIR("non_singleton_order_change_transpose_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -27996,7 +28012,7 @@ def test_flatbuffer_direct_non_singleton_order_change_transpose_not_rewritten_to
 
 
 def test_flatbuffer_direct_singleton_layout_reshape_unary_passthrough_rewritten() -> None:
-    model_ir = ModelIR(name="singleton_layout_reshape_unary_passthrough_test")
+    model_ir = ModelIR("singleton_layout_reshape_unary_passthrough_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -28069,7 +28085,7 @@ def test_flatbuffer_direct_singleton_layout_reshape_unary_passthrough_rewritten(
 
 
 def test_flatbuffer_direct_squeeze_reshape_identity_chains_removed() -> None:
-    model_ir = ModelIR(name="squeeze_reshape_identity_chains_test")
+    model_ir = ModelIR("squeeze_reshape_identity_chains_test")
     model_ir.inputs = ["mean_out"]
     model_ir.outputs = ["conv_out"]
     model_ir.tensors["mean_out"] = TensorIR(
@@ -28150,7 +28166,7 @@ def test_flatbuffer_direct_squeeze_reshape_identity_chains_removed() -> None:
 
 
 def test_flatbuffer_direct_consecutive_inverse_singleton_layout_reshapes_removed() -> None:
-    model_ir = ModelIR(name="consecutive_inverse_singleton_layout_reshapes_test")
+    model_ir = ModelIR("consecutive_inverse_singleton_layout_reshapes_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -28207,7 +28223,7 @@ def test_flatbuffer_direct_consecutive_inverse_singleton_layout_reshapes_removed
 
 
 def test_flatbuffer_direct_consecutive_reshape_passthrough_chains_removed() -> None:
-    model_ir = ModelIR(name="consecutive_reshape_passthrough_test")
+    model_ir = ModelIR("consecutive_reshape_passthrough_test")
     model_ir.inputs = ["x0", "x1"]
     model_ir.outputs = ["y0", "y1"]
 
@@ -28264,7 +28280,7 @@ def test_flatbuffer_direct_consecutive_reshape_passthrough_chains_removed() -> N
 
 
 def test_flatbuffer_direct_consecutive_reshape_passthrough_chains_fanout_bypass() -> None:
-    model_ir = ModelIR(name="consecutive_reshape_passthrough_fanout_test")
+    model_ir = ModelIR("consecutive_reshape_passthrough_fanout_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["z", "y"]
 
@@ -28336,7 +28352,7 @@ def test_flatbuffer_direct_consecutive_reshape_passthrough_chains_fanout_bypass(
 
 
 def test_flatbuffer_direct_consecutive_reshape_passthrough_chains_removed_after_static_minus_one_resolution() -> None:
-    model_ir = ModelIR(name="consecutive_reshape_passthrough_static_minus_one_test")
+    model_ir = ModelIR("consecutive_reshape_passthrough_static_minus_one_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
 
@@ -28397,7 +28413,7 @@ def test_flatbuffer_direct_consecutive_reshape_passthrough_chains_removed_after_
 
 
 def test_flatbuffer_direct_flatten_concat_expanddims_to_nhwc_concat_rewritten() -> None:
-    model_ir = ModelIR(name="flatten_concat_expanddims_to_nhwc_concat_test")
+    model_ir = ModelIR("flatten_concat_expanddims_to_nhwc_concat_test")
     model_ir.inputs = ["a4d", "b2d"]
     model_ir.outputs = ["z4d"]
     model_ir.tensors["a4d"] = TensorIR(
@@ -28463,7 +28479,7 @@ def test_flatbuffer_direct_flatten_concat_expanddims_to_nhwc_concat_rewritten() 
 
 
 def test_flatbuffer_direct_non_singleton_channel_transpose_kept() -> None:
-    model_ir = ModelIR(name="non_singleton_channel_transpose_kept_test")
+    model_ir = ModelIR("non_singleton_channel_transpose_kept_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["x_nchw"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -28496,7 +28512,7 @@ def test_flatbuffer_direct_non_singleton_channel_transpose_kept() -> None:
 
 
 def test_flatbuffer_direct_singleton_channel_dynamic_signature_transpose_kept() -> None:
-    model_ir = ModelIR(name="singleton_channel_dynamic_signature_transpose_kept_test")
+    model_ir = ModelIR("singleton_channel_dynamic_signature_transpose_kept_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["x_nchw"]
     model_ir.tensors["x_nhwc"] = TensorIR(
@@ -28529,7 +28545,7 @@ def test_flatbuffer_direct_singleton_channel_dynamic_signature_transpose_kept() 
 
 
 def test_flatbuffer_direct_singleton_reshape_concat_post_transpose_rewritten_to_nhwc() -> None:
-    model_ir = ModelIR(name="singleton_reshape_concat_post_transpose_to_nhwc_test")
+    model_ir = ModelIR("singleton_reshape_concat_post_transpose_to_nhwc_test")
     model_ir.inputs = ["split0_nhwc", "split1_nhwc", "split2_nhwc", "clip_nhwc"]
     model_ir.outputs = ["z"]
 
@@ -28626,7 +28642,7 @@ def test_flatbuffer_direct_singleton_reshape_concat_post_transpose_rewritten_to_
 
 
 def test_flatbuffer_direct_duplicate_transpose_fanout_deduplicates_shared_layout_adapter() -> None:
-    model_ir = ModelIR(name="duplicate_transpose_fanout_dedup_test")
+    model_ir = ModelIR("duplicate_transpose_fanout_dedup_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y0", "y1"]
     model_ir.tensors["x"] = TensorIR(
@@ -28684,7 +28700,7 @@ def test_flatbuffer_direct_duplicate_transpose_fanout_deduplicates_shared_layout
 
 
 def test_flatbuffer_direct_duplicate_reshape_fanout_deduplicates_shared_layout_adapter() -> None:
-    model_ir = ModelIR(name="duplicate_reshape_fanout_dedup_test")
+    model_ir = ModelIR("duplicate_reshape_fanout_dedup_test")
     model_ir.inputs = ["x_nchw"]
     model_ir.outputs = ["y0", "y1"]
     model_ir.tensors["x_nchw"] = TensorIR(
@@ -28744,7 +28760,7 @@ def test_flatbuffer_direct_duplicate_reshape_fanout_deduplicates_shared_layout_a
 
 
 def test_flatbuffer_direct_center_size_offset_terminal_transpose_optimization() -> None:
-    model_ir = ModelIR(name="center_size_offset_terminal_transpose_opt_test")
+    model_ir = ModelIR("center_size_offset_terminal_transpose_opt_test")
     model_ir.inputs = ["center_nhwc", "size_nhwc", "offset_nhwc"]
     model_ir.outputs = ["center_flat", "gather_size", "gather_offset"]
     model_ir.tensors["center_nhwc"] = TensorIR(
@@ -29036,7 +29052,7 @@ def test_flatbuffer_direct_qlinear_global_average_pool_lowering() -> None:
     y = model_ir.tensors.get("y")
     assert y is not None
     assert list(y.shape) == [1, 1, 1, 2]
-    assert list(y.shape_signature) == [1, 1, 1, 2]
+    assert _shape_signature(y) == [1, 1, 1, 2]
 
 
 def test_flatbuffer_direct_qlinear_concat_lowering() -> None:
@@ -29055,7 +29071,7 @@ def test_flatbuffer_direct_qlinear_concat_lowering() -> None:
     y = model_ir.tensors.get("y")
     assert y is not None
     assert list(y.shape) == [1, 2, 2, 2]
-    assert list(y.shape_signature) == [1, 2, 2, 2]
+    assert _shape_signature(y) == [1, 2, 2, 2]
 
 
 def test_flatbuffer_direct_elides_inverse_transpose_chain_at_generation() -> None:
@@ -29318,16 +29334,16 @@ def test_flatbuffer_direct_fused_conv_unknown_rank_io_materializes_rank4_shapes(
     assert len(list(output_tensor.shape)) == 4
     assert input_tensor.shape_signature is not None
     assert output_tensor.shape_signature is not None
-    assert len(list(input_tensor.shape_signature)) == 4
-    assert len(list(output_tensor.shape_signature)) == 4
-    assert int(input_tensor.shape_signature[1]) == 3
-    output_sig = [int(v) for v in list(output_tensor.shape_signature)]
+    assert len(_shape_signature(input_tensor)) == 4
+    assert len(_shape_signature(output_tensor)) == 4
+    assert int(_shape_signature(input_tensor)[1]) == 3
+    output_sig = [int(v) for v in _shape_signature(output_tensor)]
     output_shape = [int(v) for v in list(output_tensor.shape)]
     assert 4 in output_sig or 4 in output_shape
 
 
 def test_flatbuffer_direct_serialize_model_prunes_dead_ops() -> None:
-    model_ir = ModelIR(name="serialize_prune_test")
+    model_ir = ModelIR("serialize_prune_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3])
@@ -29367,7 +29383,7 @@ def test_flatbuffer_direct_serialize_model_prunes_dead_ops() -> None:
 
 
 def test_flatbuffer_direct_serialize_model_keeps_stateful_variable_side_effect_ops() -> None:
-    model_ir = ModelIR(name="serialize_stateful_keep_test")
+    model_ir = ModelIR("serialize_stateful_keep_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 1, 2])
@@ -29431,7 +29447,7 @@ def test_flatbuffer_direct_serialize_model_keeps_stateful_variable_side_effect_o
 
 
 def test_flatbuffer_direct_serialize_model_supports_one_hot() -> None:
-    model_ir = ModelIR(name="serialize_one_hot_test")
+    model_ir = ModelIR("serialize_one_hot_test")
     model_ir.inputs = ["indices"]
     model_ir.outputs = ["y"]
     model_ir.tensors["indices"] = TensorIR(name="indices", dtype="INT32", shape=[2])
@@ -29472,7 +29488,7 @@ def test_flatbuffer_direct_serialize_model_supports_one_hot() -> None:
 
 
 def test_flatbuffer_direct_serialize_model_supports_pow() -> None:
-    model_ir = ModelIR(name="serialize_pow_test")
+    model_ir = ModelIR("serialize_pow_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3])
@@ -29500,7 +29516,7 @@ def test_flatbuffer_direct_serialize_model_supports_pow() -> None:
 
 
 def test_flatbuffer_direct_serialize_model_supports_leaky_relu() -> None:
-    model_ir = ModelIR(name="serialize_leaky_relu_test")
+    model_ir = ModelIR("serialize_leaky_relu_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3])
@@ -29525,7 +29541,7 @@ def test_flatbuffer_direct_serialize_model_supports_leaky_relu() -> None:
 
 
 def test_flatbuffer_direct_serialize_model_supports_mirror_pad() -> None:
-    model_ir = ModelIR(name="serialize_mirror_pad_test")
+    model_ir = ModelIR("serialize_mirror_pad_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4])
@@ -29559,7 +29575,7 @@ def test_flatbuffer_direct_serialize_model_supports_mirror_pad() -> None:
 
 
 def test_flatbuffer_direct_serialize_model_supports_fill() -> None:
-    model_ir = ModelIR(name="serialize_fill_test")
+    model_ir = ModelIR("serialize_fill_test")
     model_ir.outputs = ["y"]
     model_ir.tensors["shape"] = TensorIR(
         name="shape",
@@ -29591,7 +29607,7 @@ def test_flatbuffer_direct_serialize_model_supports_fill() -> None:
 
 
 def test_flatbuffer_direct_serialize_model_sanitizes_negative_tensor_shape() -> None:
-    model_ir = ModelIR(name="serialize_negative_shape_sanitize_test")
+    model_ir = ModelIR("serialize_negative_shape_sanitize_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1], shape_signature=[-1])
@@ -29690,7 +29706,7 @@ def test_flatbuffer_direct_transpose_quantize_transpose_preserves_dynamic_batch_
     out_tensor = model_ir.tensors[out_name]
     assert out_tensor is not None
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == -1
+    assert int(_shape_signature(out_tensor)[0]) == -1
 
 
 def test_flatbuffer_direct_transpose_binary_fanout_chain_optimization() -> None:
@@ -29724,7 +29740,7 @@ def test_flatbuffer_direct_gather_singleton_const_indices_scalarized_for_rank_re
     gather_indices_tensor = model_ir.tensors[gather_indices_name]
     assert gather_indices_name != "indices"
     assert list(gather_indices_tensor.shape) == [1]
-    assert list(gather_indices_tensor.shape_signature) == [1]
+    assert _shape_signature(gather_indices_tensor) == [1]
 
     reshape_to_output_ops = [
         op
@@ -29751,7 +29767,7 @@ def test_flatbuffer_direct_gather_singleton_negative_const_indices_wrapped_befor
     gather_indices_tensor = model_ir.tensors[gather_indices_name]
     assert gather_indices_name != "indices"
     assert list(gather_indices_tensor.shape) == [1]
-    assert list(gather_indices_tensor.shape_signature) == [1]
+    assert _shape_signature(gather_indices_tensor) == [1]
     gather_indices = np.asarray(gather_indices_tensor.data, dtype=np.int64).reshape(-1)
     assert gather_indices.tolist() == [3]
 
@@ -29770,7 +29786,7 @@ def test_flatbuffer_direct_gather_runtime_scalar_indices_are_normalized_to_1d() 
     gather_indices_name = str(gather_op.inputs[1])
     gather_indices_tensor = model_ir.tensors[gather_indices_name]
     assert list(gather_indices_tensor.shape) == [1]
-    assert list(gather_indices_tensor.shape_signature) == [1]
+    assert _shape_signature(gather_indices_tensor) == [1]
 
     reshape_to_output_ops = [
         op
@@ -29817,7 +29833,7 @@ def test_flatbuffer_direct_gather_runtime_negative_indices_are_normalized_before
     gather_indices_tensor = model_ir.tensors[gather_indices_name]
     assert gather_indices_name != "indices_runtime"
     assert list(gather_indices_tensor.shape) == [2]
-    assert list(gather_indices_tensor.shape_signature) == [2]
+    assert _shape_signature(gather_indices_tensor) == [2]
 
     op_types = [str(op.op_type) for op in model_ir.operators]
     assert "LESS" in op_types
@@ -29884,7 +29900,7 @@ def test_flatbuffer_direct_flatten_unsqueeze_placeholder_shapes_are_inferred_fro
     )
 
     flatten_tensor = model_ir.tensors["flatten_out"]
-    assert list(flatten_tensor.shape_signature) == [-1, 8]
+    assert _shape_signature(flatten_tensor) == [-1, 8]
     flatten_reshape_op = next(
         op
         for op in model_ir.operators
@@ -29898,7 +29914,7 @@ def test_flatbuffer_direct_flatten_unsqueeze_placeholder_shapes_are_inferred_fro
     assert list(flatten_reshape_op.options.get("newShape", [])) == []
 
     unsqueeze_tensor = model_ir.tensors["y"]
-    assert list(unsqueeze_tensor.shape_signature) == [-1, 8, 1]
+    assert _shape_signature(unsqueeze_tensor) == [-1, 8, 1]
 
 
 def test_flatbuffer_direct_dynamic_reshape_allowzero_copy_dim0_preserves_shape_vector_rank() -> None:
@@ -29911,9 +29927,9 @@ def test_flatbuffer_direct_dynamic_reshape_allowzero_copy_dim0_preserves_shape_v
     )
 
     y_tensor = model_ir.tensors["y"]
-    assert len(list(y_tensor.shape_signature)) == 4
-    assert int(y_tensor.shape_signature[0]) == -1
-    assert all(int(v) == -1 for v in list(y_tensor.shape_signature))
+    assert len(_shape_signature(y_tensor)) == 4
+    assert int(_shape_signature(y_tensor)[0]) == -1
+    assert all(int(v) == -1 for v in _shape_signature(y_tensor))
     reshape_op = next(
         op
         for op in model_ir.operators
@@ -29923,7 +29939,7 @@ def test_flatbuffer_direct_dynamic_reshape_allowzero_copy_dim0_preserves_shape_v
     )
     shape_input_name = str(reshape_op.inputs[1])
     shape_input_tensor = model_ir.tensors[shape_input_name]
-    assert list(shape_input_tensor.shape_signature) == [4]
+    assert _shape_signature(shape_input_tensor) == [4]
 
 
 def test_flatbuffer_direct_slice_shape_outputs_preserve_empty_and_tail_lengths_for_concat() -> None:
@@ -29936,15 +29952,15 @@ def test_flatbuffer_direct_slice_shape_outputs_preserve_empty_and_tail_lengths_f
     )
 
     slice_empty_tensor = model_ir.tensors["slice_empty"]
-    assert list(slice_empty_tensor.shape_signature) == [0]
+    assert _shape_signature(slice_empty_tensor) == [0]
     assert list(slice_empty_tensor.shape) == [0]
 
     slice_tail_tensor = model_ir.tensors["slice_tail"]
-    assert list(slice_tail_tensor.shape_signature) == [3]
+    assert _shape_signature(slice_tail_tensor) == [3]
     assert list(slice_tail_tensor.shape) == [3]
 
     concat_tensor = model_ir.tensors["y"]
-    assert list(concat_tensor.shape_signature) == [4]
+    assert _shape_signature(concat_tensor) == [4]
     assert list(concat_tensor.shape) == [4]
 
 
@@ -29977,7 +29993,7 @@ def test_flatbuffer_direct_binary_broadcast_rhs_preserves_rank_for_matmul_path_s
 
     b_tensor = model_ir.tensors["b"]
     assert list(b_tensor.shape) == [1, 8, 1]
-    assert list(b_tensor.shape_signature) == [1, 8, 1]
+    assert _shape_signature(b_tensor) == [1, 8, 1]
 
     matmul_y_ops = [
         op
@@ -30032,7 +30048,7 @@ def test_flatbuffer_direct_gather_rank1_params_scalar_const_indices_not_scalariz
         gather_indices_name = str(gather_op.inputs[1])
         gather_indices_tensor = model_ir.tensors[gather_indices_name]
         assert list(gather_indices_tensor.shape) == [1]
-        assert list(gather_indices_tensor.shape_signature) == [1]
+        assert _shape_signature(gather_indices_tensor) == [1]
 
     concat_op = next(op for op in model_ir.operators if str(op.op_type) == "CONCATENATION")
     concat_input_shapes = [list(model_ir.tensors[str(input_name)].shape) for input_name in list(concat_op.inputs)]
@@ -30060,7 +30076,7 @@ def test_flatbuffer_direct_nms_scalar_const_inputs_do_not_emit_squeeze() -> None
     nms_valid_count_tensor = model_ir.tensors.get(nms_valid_count_name, None)
     assert nms_valid_count_tensor is not None
     assert list(nms_valid_count_tensor.shape) == []
-    assert list(nms_valid_count_tensor.shape_signature) == []
+    assert _shape_signature(nms_valid_count_tensor) == []
 
     reshape_from_valid_count_ops = [
         op
@@ -30133,7 +30149,7 @@ def test_flatbuffer_direct_multiclass_nms_without_onwa_matches_default_behavior(
 
     output_tensor = model_ir.tensors.get("selected_indices")
     assert output_tensor is not None
-    assert list(output_tensor.shape_signature) == [-1, 3]
+    assert _shape_signature(output_tensor) == [-1, 3]
 
 
 @pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
@@ -30178,7 +30194,7 @@ def test_flatbuffer_direct_conv2d_intermediate_preserves_dynamic_batch_signature
     out_name = conv_ops[0].outputs[0]
     out_tensor = model_ir.tensors[out_name]
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == -1
+    assert int(_shape_signature(out_tensor)[0]) == -1
 
 
 def test_flatbuffer_direct_conv_stride2_notset_symmetric_pad_uses_explicit_pad() -> None:
@@ -30224,7 +30240,7 @@ def test_flatbuffer_direct_maxpool2d_intermediate_preserves_dynamic_batch_signat
     out_name = maxpool_ops[0].outputs[0]
     out_tensor = model_ir.tensors[out_name]
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == -1
+    assert int(_shape_signature(out_tensor)[0]) == -1
 
 
 def test_flatbuffer_direct_averagepool1d_intermediate_preserves_dynamic_signature() -> None:
@@ -30241,18 +30257,18 @@ def test_flatbuffer_direct_averagepool1d_intermediate_preserves_dynamic_signatur
     avg_pool_outputs = [model_ir.tensors[str(op.outputs[0])] for op in avg_pool_ops if len(op.outputs) == 1]
     assert any(
         tensor.shape_signature is not None
-        and len(list(tensor.shape_signature)) == 4
-        and int(tensor.shape_signature[1]) == 1
-        and int(tensor.shape_signature[2]) == -1
+        and len(_shape_signature(tensor)) == 4
+        and int(_shape_signature(tensor)[1]) == 1
+        and int(_shape_signature(tensor)[2]) == -1
         for tensor in avg_pool_outputs
     )
 
     y_tensor = model_ir.tensors["y"]
     assert y_tensor.shape_signature is not None
-    assert len(list(y_tensor.shape_signature)) == 3
-    assert int(y_tensor.shape_signature[0]) == 1
-    assert int(y_tensor.shape_signature[1]) == 128
-    assert int(y_tensor.shape_signature[2]) == -1
+    assert len(_shape_signature(y_tensor)) == 3
+    assert int(_shape_signature(y_tensor)[0]) == 1
+    assert int(_shape_signature(y_tensor)[1]) == 128
+    assert int(_shape_signature(y_tensor)[2]) == -1
 
 
 def test_flatbuffer_direct_average_pool_exclude_pad_uses_divisor_correction() -> None:
@@ -30409,7 +30425,7 @@ def test_flatbuffer_direct_argmax_reducemax_int64_replaces_builtin_argmax() -> N
     assert op_types.count("REDUCE_MAX") == 2
     assert "CAST" in op_types
     assert str(model_ir.tensors["y"].dtype).upper() == "INT64"
-    assert list(model_ir.tensors["y"].shape_signature) == [2, 1, 4]
+    assert _shape_signature(model_ir.tensors["y"]) == [2, 1, 4]
 
 
 def test_flatbuffer_direct_argmax_reducemax_float32_replaces_builtin_argmax() -> None:
@@ -30426,7 +30442,7 @@ def test_flatbuffer_direct_argmax_reducemax_float32_replaces_builtin_argmax() ->
     assert "ARG_MAX" not in op_types
     assert op_types.count("REDUCE_MAX") == 2
     assert str(model_ir.tensors["y"].dtype).upper() == "FLOAT32"
-    assert list(model_ir.tensors["y"].shape_signature) == [2, 4]
+    assert _shape_signature(model_ir.tensors["y"]) == [2, 4]
 
 
 def test_flatbuffer_direct_argmax_fused_int64_restores_resize_shape() -> None:
@@ -30444,7 +30460,7 @@ def test_flatbuffer_direct_argmax_fused_int64_restores_resize_shape() -> None:
     assert op_types.count("RESIZE_NEAREST_NEIGHBOR") >= 2
     assert "CAST" in op_types
     assert str(model_ir.tensors["y"].dtype).upper() == "INT64"
-    assert list(model_ir.tensors["y"].shape_signature) == [1, 1, 8, 8]
+    assert _shape_signature(model_ir.tensors["y"]) == [1, 1, 8, 8]
 
 
 @pytest.mark.skipif(not _requires_flatbuffer_tools(), reason="flatbuffer_direct requires bundled schema artifacts")
@@ -30609,7 +30625,7 @@ def test_flatbuffer_direct_qlinear_conv2d_intermediate_preserves_dynamic_batch_s
     out_tensor = model_ir.tensors[out_name]
     assert out_tensor.quantization is not None
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == -1
+    assert int(_shape_signature(out_tensor)[0]) == -1
 
 
 def test_flatbuffer_direct_qlinear_conv_unknown_rank_placeholder_is_promoted_to_rank4() -> None:
@@ -30628,7 +30644,7 @@ def test_flatbuffer_direct_qlinear_conv_unknown_rank_placeholder_is_promoted_to_
     assert len(list(conv_out.shape)) == 4
     assert int(conv_out.shape[3]) == 4
     assert conv_out.shape_signature is not None
-    assert len(list(conv_out.shape_signature)) == 4
+    assert len(_shape_signature(conv_out)) == 4
 
 
 def test_flatbuffer_direct_qlinear_global_average_pool_intermediate_preserves_dynamic_batch_signature() -> None:
@@ -30644,11 +30660,11 @@ def test_flatbuffer_direct_qlinear_global_average_pool_intermediate_preserves_dy
     assert len(avg_pool_ops) == 1
     avg_tensor = model_ir.tensors[avg_pool_ops[0].outputs[0]]
     assert avg_tensor.shape_signature is not None
-    assert int(avg_tensor.shape_signature[0]) == -1
+    assert int(_shape_signature(avg_tensor)[0]) == -1
 
     y_tensor = model_ir.tensors["y"]
     assert y_tensor.shape_signature is not None
-    assert int(y_tensor.shape_signature[0]) == -1
+    assert int(_shape_signature(y_tensor)[0]) == -1
 
 
 def test_flatbuffer_direct_transpose_qlinear_global_average_pool_bridge_optimization() -> None:
@@ -30727,7 +30743,7 @@ def test_flatbuffer_direct_qlinear_concat_conv_layout_propagation() -> None:
 
 
 def test_flatbuffer_direct_qlinear_concat_conv_layout_propagation_with_concat_post_transpose() -> None:
-    model_ir = ModelIR(name="qlinear_concat_conv_layout_with_concat_post_transpose_test")
+    model_ir = ModelIR("qlinear_concat_conv_layout_with_concat_post_transpose_test")
     model_ir.inputs = ["a_q_nhwc", "b_q_nhwc"]
     model_ir.outputs = ["y0", "pool_out"]
 
@@ -30844,7 +30860,7 @@ def test_flatbuffer_direct_qlinear_concat_conv_layout_propagation_with_concat_po
     cat_q_tensor = model_ir.tensors["cat_q"]
     assert list(cat_f_tensor.shape) == [1, 3, 5, 4]
     assert list(cat_q_tensor.shape) == [1, 3, 5, 4]
-    assert list(cat_q_tensor.shape_signature) == [1, 3, 5, 4]
+    assert _shape_signature(cat_q_tensor) == [1, 3, 5, 4]
 
 
 def test_flatbuffer_direct_fuse_add_relu_activation_chain() -> None:
@@ -30886,7 +30902,7 @@ def test_flatbuffer_direct_fuse_add_relu_after_transpose_pre_add_rewrite() -> No
 
 
 def test_flatbuffer_direct_fuse_conv_relu_n1_to_1_activation_chain() -> None:
-    model_ir = ModelIR(name="fuse_conv_relu_n1_to_1_activation_chain_test")
+    model_ir = ModelIR("fuse_conv_relu_n1_to_1_activation_chain_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 8, 8, 3], shape_signature=[1, 8, 8, 3])
@@ -30935,7 +30951,7 @@ def test_flatbuffer_direct_fuse_conv_relu_n1_to_1_activation_chain() -> None:
 
 
 def test_flatbuffer_direct_fuse_depthwise_conv_relu_n1_to_1_activation_chain() -> None:
-    model_ir = ModelIR(name="fuse_depthwise_conv_relu_n1_to_1_activation_chain_test")
+    model_ir = ModelIR("fuse_depthwise_conv_relu_n1_to_1_activation_chain_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["z"]
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 8, 8, 4], shape_signature=[1, 8, 8, 4])
@@ -31081,7 +31097,7 @@ def test_flatbuffer_direct_lstm_forward_builtin_lowering() -> None:
     y_tensor = model_ir.tensors.get("y")
     assert y_tensor is not None
     assert list(y_tensor.shape) == [3, 1, 1, 2]
-    assert list(y_tensor.shape_signature) == [3, 1, 1, 2]
+    assert _shape_signature(y_tensor) == [3, 1, 1, 2]
 
 
 def test_flatbuffer_direct_lstm_reverse_builtin_lowering() -> None:
@@ -31103,7 +31119,7 @@ def test_flatbuffer_direct_lstm_reverse_builtin_lowering() -> None:
     y_tensor = model_ir.tensors.get("y")
     assert y_tensor is not None
     assert list(y_tensor.shape) == [3, 1, 1, 2]
-    assert list(y_tensor.shape_signature) == [3, 1, 1, 2]
+    assert _shape_signature(y_tensor) == [3, 1, 1, 2]
 
 
 def test_flatbuffer_direct_lstm_forward_state_io_builtin_lowering() -> None:
@@ -31332,7 +31348,7 @@ def test_flatbuffer_direct_div_shape_chain_elides_redundant_int64_to_int32_cast(
         user_indices = [int(v) for v in consumers.get(out_name, [])]
         if len(user_indices) != 1:
             continue
-            user_op = operators[int(user_indices[0])]
+        user_op = operators[int(user_indices[0])]
         if str(user_op.op_type) == "CAST":
             user_out_dtype = str(user_op.options.get("outDataType", "")).upper()
             assert user_out_dtype != "INT32"
@@ -31434,7 +31450,7 @@ def test_flatbuffer_direct_consecutive_variable_const_mul_chain_is_folded_after_
 
 
 def test_flatbuffer_direct_constant_input_cast_is_embedded_into_output_tensor() -> None:
-    model_ir = ModelIR(name="const_cast_embed_test")
+    model_ir = ModelIR("const_cast_embed_test")
     model_ir.outputs = ["y"]
     model_ir.tensors["x_const"] = TensorIR(
         name="x_const",
@@ -31823,7 +31839,7 @@ def test_flatbuffer_direct_transpose_swish_transpose_optimization_no_layout_fall
 
 
 def test_flatbuffer_direct_maximum_minimum_chain_rewrites_to_relu_0_to_1() -> None:
-    model_ir = ModelIR(name="maximum_minimum_relu0to1_opt_test")
+    model_ir = ModelIR("maximum_minimum_relu0to1_opt_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -31874,7 +31890,7 @@ def test_flatbuffer_direct_maximum_minimum_chain_rewrites_to_relu_0_to_1() -> No
 
 
 def test_flatbuffer_direct_maximum_with_zero_input2_rewrites_to_relu() -> None:
-    model_ir = ModelIR(name="maximum_input2_zero_relu_opt_test")
+    model_ir = ModelIR("maximum_input2_zero_relu_opt_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -31910,7 +31926,7 @@ def test_flatbuffer_direct_maximum_with_zero_input2_rewrites_to_relu() -> None:
 
 
 def test_flatbuffer_direct_maximum_with_zero_input1_is_not_rewritten() -> None:
-    model_ir = ModelIR(name="maximum_input1_zero_no_relu_opt_test")
+    model_ir = ModelIR("maximum_input1_zero_no_relu_opt_test")
     model_ir.inputs = ["x"]
     model_ir.outputs = ["y"]
     model_ir.tensors["x"] = TensorIR(
@@ -32000,7 +32016,7 @@ def test_flatbuffer_direct_transpose_prelu_transpose_optimization() -> None:
 
 
 def test_flatbuffer_direct_terminal_transpose_prelu_reshape_batchmatmul_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="terminal_transpose_prelu_reshape_batchmatmul_nhwc_test")
+    model_ir = ModelIR("terminal_transpose_prelu_reshape_batchmatmul_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y"]
 
@@ -32125,11 +32141,11 @@ def test_flatbuffer_direct_terminal_transpose_prelu_reshape_batchmatmul_nhwc_cha
 
     prelu_out_tensor = model_ir.tensors["prelu_out"]
     assert list(prelu_out_tensor.shape) == [n, h, w, c]
-    assert list(prelu_out_tensor.shape_signature) == [n, h, w, c]
+    assert _shape_signature(prelu_out_tensor) == [n, h, w, c]
 
 
 def test_flatbuffer_direct_transpose_squeeze_gelu_expanddims_transpose_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_squeeze_gelu_expanddims_transpose_nhwc_test")
+    model_ir = ModelIR("transpose_squeeze_gelu_expanddims_transpose_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
 
@@ -32237,7 +32253,7 @@ def test_flatbuffer_direct_transpose_squeeze_gelu_expanddims_transpose_nhwc_chai
 
 
 def test_flatbuffer_direct_transpose_squeeze_gelu_expanddims_transpose_nhwc_fanout_bypass_optimized() -> None:
-    model_ir = ModelIR(name="transpose_squeeze_gelu_expanddims_transpose_nhwc_fanout_test")
+    model_ir = ModelIR("transpose_squeeze_gelu_expanddims_transpose_nhwc_fanout_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["u3_add", "y_nhwc_relu"]
 
@@ -32390,7 +32406,7 @@ def test_flatbuffer_direct_transpose_squeeze_gelu_expanddims_transpose_nhwc_fano
 
 
 def test_flatbuffer_direct_transpose_squeeze_instancenorm_unary_expanddims_transpose_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="transpose_squeeze_instancenorm_unary_expanddims_transpose_nhwc_test")
+    model_ir = ModelIR("transpose_squeeze_instancenorm_unary_expanddims_transpose_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_relu"]
 
@@ -32632,7 +32648,7 @@ def test_flatbuffer_direct_transpose_squeeze_instancenorm_unary_expanddims_trans
 
 
 def test_flatbuffer_direct_tencoder_add_expand_transpose_conv_nhwc_chain_optimized() -> None:
-    model_ir = ModelIR(name="tencoder_add_expand_transpose_conv_nhwc_test")
+    model_ir = ModelIR("tencoder_add_expand_transpose_conv_nhwc_test")
     model_ir.inputs = ["lhs4", "rhs4"]
     model_ir.outputs = ["conv_out"]
 
@@ -32879,7 +32895,7 @@ def test_flatbuffer_direct_tencoder_add_expand_transpose_conv_nhwc_chain_optimiz
 
 
 def test_flatbuffer_direct_tencoder_add_expand_transpose_conv_nhwc_chain_multi_consumer_bridge() -> None:
-    model_ir = ModelIR(name="tencoder_add_expand_transpose_conv_nhwc_multi_consumer_test")
+    model_ir = ModelIR("tencoder_add_expand_transpose_conv_nhwc_multi_consumer_test")
     model_ir.inputs = ["lhs4", "rhs4"]
     model_ir.outputs = ["conv_out", "extra_out"]
 
@@ -33133,7 +33149,7 @@ def test_flatbuffer_direct_tencoder_add_expand_transpose_conv_nhwc_chain_multi_c
 
 
 def test_flatbuffer_direct_tencoder_add_expand_transpose_conv_nhwc_chain_legacy_rank3_lhs() -> None:
-    model_ir = ModelIR(name="tencoder_add_expand_transpose_conv_nhwc_legacy_rank3_lhs_test")
+    model_ir = ModelIR("tencoder_add_expand_transpose_conv_nhwc_legacy_rank3_lhs_test")
     model_ir.inputs = ["lhs_nwc", "rhs4"]
     model_ir.outputs = ["conv_out"]
 
@@ -33371,7 +33387,7 @@ def test_flatbuffer_direct_tencoder_add_expand_transpose_conv_nhwc_chain_legacy_
 
 
 def test_flatbuffer_direct_transpose_unary_transpose_reshape_expanddims_transpose_nhwc_chain() -> None:
-    model_ir = ModelIR(name="transpose_unary_transpose_reshape_expanddims_transpose_nhwc_test")
+    model_ir = ModelIR("transpose_unary_transpose_reshape_expanddims_transpose_nhwc_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["conv_out"]
 
@@ -33468,7 +33484,7 @@ def test_flatbuffer_direct_transpose_unary_transpose_reshape_expanddims_transpos
 
 
 def test_flatbuffer_direct_transpose_unary_transpose_reshape_expanddims_transpose_nhwc_chain_fanout_bridge() -> None:
-    model_ir = ModelIR(name="transpose_unary_transpose_reshape_expanddims_transpose_nhwc_fanout_test")
+    model_ir = ModelIR("transpose_unary_transpose_reshape_expanddims_transpose_nhwc_fanout_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["conv_out", "extra_out"]
 
@@ -33581,7 +33597,7 @@ def test_flatbuffer_direct_transpose_unary_transpose_reshape_expanddims_transpos
 
 
 def test_flatbuffer_direct_attention_qkv_gather_reshape_transpose_hoist() -> None:
-    model_ir = ModelIR(name="attention_qkv_gather_reshape_transpose_hoist_test")
+    model_ir = ModelIR("attention_qkv_gather_reshape_transpose_hoist_test")
     model_ir.inputs = ["src"]
     model_ir.outputs = ["z0", "z1", "z2"]
 
@@ -33713,7 +33729,7 @@ def test_flatbuffer_direct_attention_qkv_gather_reshape_transpose_hoist() -> Non
 
 
 def test_flatbuffer_direct_attention_qkv_slice_replace_gather_reshape() -> None:
-    model_ir = ModelIR(name="attention_qkv_slice_replace_test")
+    model_ir = ModelIR("attention_qkv_slice_replace_test")
     model_ir.inputs = ["src"]
     model_ir.outputs = ["z0", "z1", "z2"]
 
@@ -33844,7 +33860,7 @@ def test_flatbuffer_direct_attention_qkv_slice_replace_gather_reshape() -> None:
 
 
 def test_flatbuffer_direct_attention_qkv_slice_to_split() -> None:
-    model_ir = ModelIR(name="attention_qkv_slice_to_split_test")
+    model_ir = ModelIR("attention_qkv_slice_to_split_test")
     model_ir.inputs = ["src"]
     model_ir.outputs = ["z0", "z1", "z2"]
 
@@ -33926,7 +33942,7 @@ def test_flatbuffer_direct_attention_qkv_slice_to_split() -> None:
 
 
 def test_flatbuffer_direct_attention_qkv_shared_pretranspose_slice_nchw() -> None:
-    model_ir = ModelIR(name="attention_qkv_shared_pretranspose_slice_nchw_test")
+    model_ir = ModelIR("attention_qkv_shared_pretranspose_slice_nchw_test")
     model_ir.inputs = ["src"]
     model_ir.outputs = ["out"]
 
@@ -34136,7 +34152,7 @@ def test_flatbuffer_direct_attention_qkv_shared_pretranspose_slice_nchw() -> Non
 
 
 def test_flatbuffer_direct_attention_qkv_weighted_sum_bridge_to_nhwc() -> None:
-    model_ir = ModelIR(name="attention_qkv_weighted_sum_bridge_to_nhwc_test")
+    model_ir = ModelIR("attention_qkv_weighted_sum_bridge_to_nhwc_test")
     model_ir.inputs = ["k_nhwc", "q_in_nchw", "relu_in_nhwc"]
     model_ir.outputs = ["final_out"]
 
@@ -34282,7 +34298,7 @@ def test_flatbuffer_direct_attention_qkv_weighted_sum_bridge_to_nhwc() -> None:
 
 
 def test_flatbuffer_direct_attention_kv_slice_to_split_pipeline() -> None:
-    model_ir = ModelIR(name="attention_kv_slice_to_split_pipeline_test")
+    model_ir = ModelIR("attention_kv_slice_to_split_pipeline_test")
     model_ir.inputs = ["src"]
     model_ir.outputs = ["z0", "z1"]
 
@@ -36871,6 +36887,8 @@ def _make_if_nms_guard_direct_model(*, nested_if: bool = True, offset_slice: boo
         helper.make_node("ReduceMax", ["boxes"], ["max_coordinate"], name="IfElseReduceMax", keepdims=0),
         helper.make_node("Cast", ["idxs"], ["idxs_f"], name="IfElseCast", to=TensorProto.FLOAT),
     ]
+    nested_then_graph: onnx.GraphProto | None = None
+    nested_else_graph: onnx.GraphProto | None = None
     if nested_if:
         eq_lhs = numpy_helper.from_array(np.asarray([1], dtype=np.int64), name="eq_lhs")
         eq_rhs = numpy_helper.from_array(np.asarray([1], dtype=np.int64), name="eq_rhs")
@@ -36955,6 +36973,8 @@ def _make_if_nms_guard_direct_model(*, nested_if: bool = True, offset_slice: boo
         ]
     )
     if nested_if:
+        assert nested_then_graph is not None
+        assert nested_else_graph is not None
         else_nodes.append(
             helper.make_node(
                 "If",
@@ -36985,6 +37005,8 @@ def _make_if_nms_guard_direct_model(*, nested_if: bool = True, offset_slice: boo
         nms_gather_index,
     ]
     if nested_if:
+        assert eq_lhs is not None
+        assert eq_rhs is not None
         else_initializers.extend([eq_lhs, eq_rhs])
     else:
         else_initializers.append(squeeze_axes)
@@ -37665,8 +37687,8 @@ def test_flatbuffer_direct_if_p1_lowers_to_builtin_ops_without_custom() -> None:
     assert "SLICE" in op_types
     out_tensor = model_ir.tensors["If_p1_output"]
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == -1
-    assert int(out_tensor.shape_signature[1]) == 100
+    assert int(_shape_signature(out_tensor)[0]) == -1
+    assert int(_shape_signature(out_tensor)[1]) == 100
 
 
 def test_flatbuffer_direct_if_p2_lowers_to_builtin_ops_without_custom() -> None:
@@ -37680,8 +37702,8 @@ def test_flatbuffer_direct_if_p2_lowers_to_builtin_ops_without_custom() -> None:
     assert "SLICE" in op_types
     out_tensor = model_ir.tensors["If_p2_output"]
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == -1
-    assert int(out_tensor.shape_signature[1]) == 100
+    assert int(_shape_signature(out_tensor)[0]) == -1
+    assert int(_shape_signature(out_tensor)[1]) == 100
 
 
 def test_flatbuffer_direct_if_p3_lowers_to_builtin_ops_without_custom() -> None:
@@ -37697,7 +37719,7 @@ def test_flatbuffer_direct_if_p3_lowers_to_builtin_ops_without_custom() -> None:
     assert any(op in op_types for op in {"SELECT", "MUL"})
     out_tensor = model_ir.tensors["If_p3_output"]
     assert out_tensor.shape_signature is not None
-    assert int(out_tensor.shape_signature[0]) == 100
+    assert int(_shape_signature(out_tensor)[0]) == 100
 
 
 def test_flatbuffer_direct_if_multi_output_nested_lowers_to_builtin_ops_without_custom() -> None:
@@ -37759,7 +37781,7 @@ def test_flatbuffer_direct_if_const_true_selects_branch_without_generic_mux() ->
     assert all(str(op.op_type) not in {"SELECT", "SELECT_V2"} for op in model_ir.operators)
     out_tensor = model_ir.tensors["if_const_y"]
     assert out_tensor.shape_signature is not None
-    assert [int(v) for v in list(out_tensor.shape_signature)] == [-1]
+    assert [int(v) for v in _shape_signature(out_tensor)] == [-1]
 
 
 def test_flatbuffer_direct_if_branch_lstm_optional_input_lowers_to_builtin_ops_without_custom() -> None:
@@ -37774,9 +37796,9 @@ def test_flatbuffer_direct_if_branch_lstm_optional_input_lowers_to_builtin_ops_w
     out_tensor = model_ir.tensors["if_lstm_out"]
     assert out_tensor.shape_signature is not None
     assert len(out_tensor.shape_signature) == 3
-    assert int(out_tensor.shape_signature[0]) == 1
-    assert int(out_tensor.shape_signature[1]) == 1
-    assert int(out_tensor.shape_signature[2]) == 2
+    assert int(_shape_signature(out_tensor)[0]) == 1
+    assert int(_shape_signature(out_tensor)[1]) == 1
+    assert int(_shape_signature(out_tensor)[2]) == 2
 
 
 def test_flatbuffer_direct_size_lowers_to_builtin_ops_without_custom() -> None:
@@ -38313,7 +38335,7 @@ def test_flatbuffer_direct_sinet_mid_residual_transpose_targets_are_folded() -> 
 
 
 def test_repair_mixed_singleton_nchw_inputs_for_nhwc_concat_inserts_local_reshape() -> None:
-    model_ir = ModelIR(name="mixed_singleton_concat_repair")
+    model_ir = ModelIR("mixed_singleton_concat_repair")
     model_ir.tensors["gate_nchw"] = TensorIR(
         name="gate_nchw",
         dtype="FLOAT32",
@@ -38369,7 +38391,7 @@ def test_repair_mixed_singleton_nchw_inputs_for_nhwc_concat_inserts_local_reshap
 
 
 def test_repair_rank4_binary_singleton_broadcast_layout_mismatch_inserts_transpose() -> None:
-    model_ir = ModelIR(name="singleton_binary_broadcast_repair")
+    model_ir = ModelIR("singleton_binary_broadcast_repair")
     model_ir.tensors["gate_nchw"] = TensorIR(
         name="gate_nchw",
         dtype="FLOAT32",
@@ -38416,7 +38438,7 @@ def test_repair_rank4_binary_singleton_broadcast_layout_mismatch_inserts_transpo
 
 
 def test_repair_rank4_binary_singleton_broadcast_layout_mismatch_skips_existing_broadcast() -> None:
-    model_ir = ModelIR(name="singleton_binary_broadcast_passthrough")
+    model_ir = ModelIR("singleton_binary_broadcast_passthrough")
     model_ir.tensors["bias_nchw"] = TensorIR(
         name="bias_nchw",
         dtype="FLOAT32",
@@ -38453,7 +38475,7 @@ def test_repair_rank4_binary_singleton_broadcast_layout_mismatch_skips_existing_
 
 
 def test_constant_input_average_pool_is_folded_into_div_denominator() -> None:
-    model_ir = ModelIR(name="constant_pool_div_fold")
+    model_ir = ModelIR("constant_pool_div_fold")
     model_ir.tensors["x"] = TensorIR(
         name="x",
         dtype="FLOAT32",
@@ -38517,7 +38539,7 @@ def test_constant_input_average_pool_is_folded_into_div_denominator() -> None:
 
 
 def test_constant_input_padv2_and_average_pool_are_folded_into_div_denominator() -> None:
-    model_ir = ModelIR(name="constant_pad_pool_div_fold")
+    model_ir = ModelIR("constant_pad_pool_div_fold")
     model_ir.tensors["x"] = TensorIR(
         name="x",
         dtype="FLOAT32",
@@ -38610,8 +38632,6 @@ def test_constant_input_padv2_and_average_pool_are_folded_into_div_denominator()
 
 def _make_wave1_unary_builtin_model() -> onnx.ModelProto:
     x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [2, 3])
-    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [2, 3])
-    y_thr = helper.make_tensor_value_info("y_thr", TensorProto.FLOAT, [2, 3])
     y_shrink = helper.make_tensor_value_info("y_shrink", TensorProto.FLOAT, [2, 3])
     y_inf = helper.make_tensor_value_info("y_inf", TensorProto.BOOL, [2, 3])
     y_nan = helper.make_tensor_value_info("y_nan", TensorProto.BOOL, [2, 3])
@@ -39327,7 +39347,7 @@ def test_flatbuffer_direct_reverse_sequence_and_scatter_builtin_parity() -> None
 
 
 def test_flatbuffer_direct_singleton_gate_conv_concat_nhwc_bridge_blocks() -> None:
-    model_ir = ModelIR(name="singleton_gate_conv_concat_nhwc_bridge_blocks_test")
+    model_ir = ModelIR("singleton_gate_conv_concat_nhwc_bridge_blocks_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
     model_ir.tensors["x_nhwc"] = TensorIR(name="x_nhwc", dtype="FLOAT32", shape=[1, 5, 7, 3], shape_signature=[1, 5, 7, 3])
@@ -39387,7 +39407,7 @@ def test_flatbuffer_direct_singleton_gate_conv_concat_nhwc_bridge_blocks() -> No
 
 
 def test_flatbuffer_direct_singleton_gate_conv_concat_nhwc_bridge_blocks_accepts_direct_singleton_aux() -> None:
-    model_ir = ModelIR(name="singleton_gate_conv_concat_direct_aux_test")
+    model_ir = ModelIR("singleton_gate_conv_concat_direct_aux_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y_nhwc"]
     model_ir.tensors["x_nhwc"] = TensorIR(name="x_nhwc", dtype="FLOAT32", shape=[1, 5, 7, 3], shape_signature=[1, 5, 7, 3])
@@ -39438,7 +39458,7 @@ def test_flatbuffer_direct_singleton_gate_conv_concat_nhwc_bridge_blocks_accepts
 
 
 def test_flatbuffer_direct_transpose_unary_split_concat_single_post_nchw() -> None:
-    model_ir = ModelIR(name="transpose_unary_split_concat_single_post_nchw_test")
+    model_ir = ModelIR("transpose_unary_split_concat_single_post_nchw_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["cat_nchw"]
     model_ir.tensors["x_nhwc"] = TensorIR(name="x_nhwc", dtype="FLOAT32", shape=[1, 5, 7, 2], shape_signature=[1, 5, 7, 2])
@@ -39469,7 +39489,9 @@ def test_flatbuffer_direct_transpose_unary_split_concat_single_post_nchw() -> No
     assert stats["optimized_transpose_unary_split_concat_single_post_nchw"] == 1
     assert not any(str(op.op_type) == "TRANSPOSE" and list(op.outputs) == ["x_nchw"] for op in model_ir.operators)
     split_op = next(op for op in model_ir.operators if str(op.op_type) == "SPLIT")
-    assert np.array_equal(model_ir.tensors[str(split_op.inputs[0])].data, np.asarray([3], dtype=np.int32))
+    split_axis_data = model_ir.tensors[str(split_op.inputs[0])].data
+    assert split_axis_data is not None
+    assert np.array_equal(np.asarray(split_axis_data), np.asarray([3], dtype=np.int32))
     concat_op = next(op for op in model_ir.operators if str(op.op_type) == "CONCATENATION")
     assert int(concat_op.options.get("axis", -1)) == 3
     assert [str(v) for v in list(concat_op.inputs)] == ["clip3_nhwc", "u0", "u1"]
@@ -39477,7 +39499,7 @@ def test_flatbuffer_direct_transpose_unary_split_concat_single_post_nchw() -> No
 
 
 def test_flatbuffer_direct_transpose_binary_split_channelwise_tail_to_single_post_nchw() -> None:
-    model_ir = ModelIR(name="transpose_binary_split_channelwise_tail_test")
+    model_ir = ModelIR("transpose_binary_split_channelwise_tail_test")
     model_ir.inputs = ["x_nhwc", "gate_nhwc", "rgb_nhwc"]
     model_ir.outputs = ["y_nchw"]
     model_ir.tensors["x_nhwc"] = TensorIR(name="x_nhwc", dtype="FLOAT32", shape=[1, 5, 7, 3], shape_signature=[1, 5, 7, 3])
@@ -39514,7 +39536,7 @@ def test_flatbuffer_direct_transpose_binary_split_channelwise_tail_to_single_pos
 
 
 def test_flatbuffer_direct_transpose_gather_transpose_nhwc_channel_fanout() -> None:
-    model_ir = ModelIR(name="transpose_gather_transpose_nhwc_channel_fanout_test")
+    model_ir = ModelIR("transpose_gather_transpose_nhwc_channel_fanout_test")
     model_ir.inputs = ["x_nhwc"]
     model_ir.outputs = ["y0_relu", "y1_relu"]
     model_ir.tensors["x_nhwc"] = TensorIR(name="x_nhwc", dtype="FLOAT32", shape=[1, 5, 7, 4], shape_signature=[1, 5, 7, 4])
@@ -39573,7 +39595,7 @@ def test_flatbuffer_direct_transpose_gather_transpose_nhwc_channel_fanout() -> N
 
 
 def test_flatbuffer_direct_sinet_shuffle_residual_mul_posttranspose_tail_chains() -> None:
-    model_ir = ModelIR(name="sinet_shuffle_residual_mul_posttranspose_tail_test")
+    model_ir = ModelIR("sinet_shuffle_residual_mul_posttranspose_tail_test")
     model_ir.inputs = ["a_nhwc", "x0_nhwc", "x1_nhwc"]
     model_ir.outputs = ["y_nhwc", "aux_relu"]
     model_ir.tensors["a_nhwc"] = TensorIR(name="a_nhwc", dtype="FLOAT32", shape=[1, 5, 7, 2], shape_signature=[1, 5, 7, 2])

--- a/tests/test_tflite_builder_direct.py
+++ b/tests/test_tflite_builder_direct.py
@@ -169,7 +169,7 @@ from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _repair_rank4_channelwise_broadcast_constants_to_runtime_layout,
     lower_onnx_to_ir,
 )
-from onnx2tf.utils.common_functions import check_model_has_external_data
+from onnx2tf.utils.onnx_litert_runtime import check_model_has_external_data
 from onnx2tf.tflite_builder.model_writer import serialize_model
 from onnx2tf.tflite_builder.preprocess import (
     configure_pseudo_ops_wave1_targets,
@@ -190,6 +190,24 @@ def _save_model(tmpdir: str, name: str, model: onnx.ModelProto) -> str:
     model_path = os.path.join(tmpdir, f"{name}.onnx")
     onnx.save(model, model_path)
     return model_path
+
+
+def _write_x_calibration_data(
+    tmpdir: str,
+    name: str,
+    values: np.ndarray | None = None,
+) -> list[list[Any]]:
+    if values is None:
+        values = np.asarray(
+            [
+                [0.0, 1.0, 2.0, 3.0],
+                [4.0, 5.0, 6.0, 7.0],
+            ],
+            dtype=np.float32,
+        )
+    path = os.path.join(tmpdir, f"{name}.npy")
+    np.save(path, np.asarray(values, dtype=np.float32))
+    return [["x", path, np.asarray(0.0, dtype=np.float32), np.asarray(1.0, dtype=np.float32)]]
 
 
 def _convert(
@@ -35183,6 +35201,7 @@ def test_flatbuffer_direct_integration_quant_eval_coverage_smoke() -> None:
             "flatbuffer_direct",
             output_dynamic_range_quantized_tflite=True,
             output_integer_quantized_tflite=True,
+            custom_input_op_name_np_data_path=_write_x_calibration_data(tmpdir, "gemm_integ_calib"),
             eval_with_onnx=True,
             eval_num_samples=2,
             eval_target_tflite="full_integer_quant",
@@ -35389,6 +35408,7 @@ def test_flatbuffer_direct_integer_quantized_smoke() -> None:
             quant_type="per-channel",
             input_quant_dtype="int8",
             output_quant_dtype="int8",
+            custom_input_op_name_np_data_path=_write_x_calibration_data(tmpdir, "gemm_iq_calib"),
         )
 
         integer_tflite = os.path.join(out_dir, "gemm_iq_integer_quant.tflite")
@@ -35461,6 +35481,7 @@ def test_flatbuffer_direct_integer_quantized_reduce_compatibility() -> None:
             "flatbuffer_direct",
             output_integer_quantized_tflite=True,
             quant_type="per-channel",
+            custom_input_op_name_np_data_path=_write_x_calibration_data(tmpdir, "gemm_reduce_iq_calib"),
         )
         tflite_path = os.path.join(out_dir, "gemm_reduce_iq_integer_quant.tflite")
         assert os.path.isfile(tflite_path)
@@ -35562,6 +35583,7 @@ def test_flatbuffer_direct_accuracy_report_quant_dequant_mode() -> None:
             out_dir,
             "flatbuffer_direct",
             output_integer_quantized_tflite=True,
+            custom_input_op_name_np_data_path=_write_x_calibration_data(tmpdir, "gemm_eval_q_calib"),
             eval_with_onnx=True,
             eval_num_samples=3,
             eval_target_tflite="full_integer_quant",
@@ -35645,6 +35667,7 @@ def test_flatbuffer_direct_accuracy_report_fail_on_threshold() -> None:
                 out_dir,
                 "flatbuffer_direct",
                 output_integer_quantized_tflite=True,
+                custom_input_op_name_np_data_path=_write_x_calibration_data(tmpdir, "gemm_eval_fail_calib"),
                 eval_with_onnx=True,
                 eval_num_samples=2,
                 eval_target_tflite="full_integer_quant",


### PR DESCRIPTION
### 1. Content and background

This PR fixes and hardens `flatbuffer_direct` integer quantization behavior.

Related context:
- Issue #941: numpy scalar tensor buffer serialization caused invalid handling for scalar constant buffers.
- Issue #942: `flatbuffer_direct` integer quantization previously used fixed / pseudo I/O qparams and could emit artifacts that were not strict full-integer quantized models.

The changes make `flatbuffer_direct` strict integer quantization calibration-based, validate generated quantized TFLite files with LiteRT, and expand strict quantized operator coverage.

### 2. Summary of corrections

- Fix numpy scalar tensor buffer serialization.
- Require calibration data for `flatbuffer_direct` strict integer quantization and collect tensor ranges using LiteRT Interpreter.
- Replace fixed integer I/O qparams with calibration-derived qparams, while preserving TFLite fixed qparams for `SOFTMAX`, `LOGISTIC`, and `TANH`.
- Hard fail unsupported or invalid strict integer quantization instead of emitting misleading `full_integer_quant` artifacts.
- Add calibration reporting for strict integer quantization.
- Expand strict full-integer operator coverage, including forwarding/layout ops, reduce ops, activation ops, `PRELU`, and `TRANSPOSE_CONV`.
- Avoid unnecessary `tf_keras -> tensorflow.compat.v2` import chain in `test_tflite_builder_direct.py`.
- Resolve Ruff/Pylance/Pyright diagnostics in `test_tflite_builder_direct.py`.

### 3. Before/After (If there is an operating log that can be used as a reference)

Before:
- `flatbuffer_direct -oiqt` could use fixed qparams such as `uint8 scale=1/255, zero_point=128`.
- Some quantized outputs could be written even when strict full-integer validation was not guaranteed.
- `test_tflite_builder_direct.py` imported `common_functions` only for external-data detection, which could trigger `tf_keras` import and fail when `tensorflow.compat` was unavailable.

After:
- `flatbuffer_direct -oiqt` requires representative calibration data and writes strict quantized artifacts only after LiteRT allocation validation succeeds.
- Calibration-derived qparams are used for graph/internal tensors, with fixed TFLite-spec qparams only for relevant activations.
- Additional strict integer quantized ops are covered and tested.
- `test_tflite_builder_direct.py` no longer triggers the `tf_keras` import chain for `check_model_has_external_data`.

Validation performed:

```text
pytest -q tests/test_strict_integer_quantization.py tests/test_tensor_buffer_builder.py tests/test_tflite_builder_direct.py::test_flatbuffer_direct_integer_quantized_smoke
ruff check tests/test_tflite_builder_direct.py tests/test_strict_integer_quantization.py onnx2tf/tflite_builder/quantization.py
npx --yes pyright tests/test_strict_integer_quantization.py tests/test_tflite_builder_direct.py
```

### 4. Issue number (only if there is a related issue)

#941
#942
