### PR TITLE
Improve flatbuffer_direct strict int8 quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,7 +928,7 @@ Optional:
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  ghcr.io/pinto0309/onnx2tf:2.5.1
+  ghcr.io/pinto0309/onnx2tf:2.5.2
 
   or
 
@@ -937,7 +937,7 @@ Optional:
   docker run --rm -it \
   -v `pwd`:/workdir \
   -w /workdir \
-  docker.io/pinto0309/onnx2tf:2.5.1
+  docker.io/pinto0309/onnx2tf:2.5.2
   or
 
   # Direct execution in Docker
@@ -946,7 +946,7 @@ Optional:
   docker run --rm \
   --user $(id -u):$(id -g) \
   -v $(pwd):/work \
-  docker.io/pinto0309/onnx2tf:2.5.1 \
+  docker.io/pinto0309/onnx2tf:2.5.2 \
   onnx2tf -i /work/densenet-12.onnx -o /work/saved_model
 
   or

--- a/onnx2tf/__init__.py
+++ b/onnx2tf/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 
 def _load_impl():

--- a/onnx2tf/onnx2tf.py
+++ b/onnx2tf/onnx2tf.py
@@ -6142,11 +6142,13 @@ def convert(
                 raise RuntimeError(
                     'flatbuffer_direct full integer quantization was requested but no output was generated.'
                 )
-            if 'integer_quant_with_int16_act_tflite_path' not in direct_outputs:
+            int16_act_skipped = bool(direct_outputs.get('int16_activation_quantization_skipped', False))
+            int16_act_skip_reasons = direct_outputs.get('int16_activation_quantization_skip_reasons', [])
+            if 'integer_quant_with_int16_act_tflite_path' not in direct_outputs and not int16_act_skipped:
                 raise RuntimeError(
                     'flatbuffer_direct integer quantization with int16 activations was requested but no output was generated.'
                 )
-            if 'full_integer_quant_with_int16_act_tflite_path' not in direct_outputs:
+            if 'full_integer_quant_with_int16_act_tflite_path' not in direct_outputs and not int16_act_skipped:
                 raise RuntimeError(
                     'flatbuffer_direct full integer quantization with int16 activations was requested but no output was generated.'
                 )
@@ -6162,18 +6164,26 @@ def convert(
                     f'({direct_outputs["full_integer_quant_tflite_path"]})'
                 )
             )
-            info(
-                Color.GREEN(
-                    f'INT8 Quantization with int16 activations tflite output complete! '
-                    f'({direct_outputs["integer_quant_with_int16_act_tflite_path"]})'
+            if int16_act_skipped:
+                info(
+                    Color.YELLOW(
+                        'INT8 Quantization with int16 activations skipped. '
+                        f'Reason: {"; ".join(str(v) for v in int16_act_skip_reasons)}'
+                    )
                 )
-            )
-            info(
-                Color.GREEN(
-                    f'Full INT8 Quantization with int16 activations tflite output complete! '
-                    f'({direct_outputs["full_integer_quant_with_int16_act_tflite_path"]})'
+            else:
+                info(
+                    Color.GREEN(
+                        f'INT8 Quantization with int16 activations tflite output complete! '
+                        f'({direct_outputs["integer_quant_with_int16_act_tflite_path"]})'
+                    )
                 )
-            )
+                info(
+                    Color.GREEN(
+                        f'Full INT8 Quantization with int16 activations tflite output complete! '
+                        f'({direct_outputs["full_integer_quant_with_int16_act_tflite_path"]})'
+                    )
+                )
         if copy_onnx_input_output_names_to_tflite:
             info(
                 'Input/Output tensor names are directly written from ONNX graph in flatbuffer_direct backend.'
@@ -7385,11 +7395,13 @@ def convert(
                         raise RuntimeError(
                             'flatbuffer_direct full integer quantization was requested but no output was generated.'
                         )
-                    if 'integer_quant_with_int16_act_tflite_path' not in direct_outputs:
+                    int16_act_skipped = bool(direct_outputs.get('int16_activation_quantization_skipped', False))
+                    int16_act_skip_reasons = direct_outputs.get('int16_activation_quantization_skip_reasons', [])
+                    if 'integer_quant_with_int16_act_tflite_path' not in direct_outputs and not int16_act_skipped:
                         raise RuntimeError(
                             'flatbuffer_direct integer quantization with int16 activations was requested but no output was generated.'
                         )
-                    if 'full_integer_quant_with_int16_act_tflite_path' not in direct_outputs:
+                    if 'full_integer_quant_with_int16_act_tflite_path' not in direct_outputs and not int16_act_skipped:
                         raise RuntimeError(
                             'flatbuffer_direct full integer quantization with int16 activations was requested but no output was generated.'
                         )
@@ -7405,18 +7417,26 @@ def convert(
                             f'({direct_outputs["full_integer_quant_tflite_path"]})'
                         )
                     )
-                    info(
-                        Color.GREEN(
-                            f'INT8 Quantization with int16 activations tflite output complete! '
-                            f'({direct_outputs["integer_quant_with_int16_act_tflite_path"]})'
+                    if int16_act_skipped:
+                        info(
+                            Color.YELLOW(
+                                'INT8 Quantization with int16 activations skipped. '
+                                f'Reason: {"; ".join(str(v) for v in int16_act_skip_reasons)}'
+                            )
                         )
-                    )
-                    info(
-                        Color.GREEN(
-                            f'Full INT8 Quantization with int16 activations tflite output complete! '
-                            f'({direct_outputs["full_integer_quant_with_int16_act_tflite_path"]})'
+                    else:
+                        info(
+                            Color.GREEN(
+                                f'INT8 Quantization with int16 activations tflite output complete! '
+                                f'({direct_outputs["integer_quant_with_int16_act_tflite_path"]})'
+                            )
                         )
-                    )
+                        info(
+                            Color.GREEN(
+                                f'Full INT8 Quantization with int16 activations tflite output complete! '
+                                f'({direct_outputs["full_integer_quant_with_int16_act_tflite_path"]})'
+                            )
+                        )
                 if copy_onnx_input_output_names_to_tflite:
                     info(
                         'Input/Output tensor names are directly written from ONNX graph in flatbuffer_direct backend.'

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -33,6 +33,7 @@ from onnx2tf.tflite_builder.quantization import (
     build_integer_quantized_with_int16_act_model_ir,
     collect_calibration_ranges_from_tflite,
     load_calibration_samples,
+    strict_int16_activation_skip_reasons,
 )
 from onnx2tf.tflite_builder.preprocess import (
     configure_pseudo_ops_wave1_targets,
@@ -1100,6 +1101,9 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
 
         integer_quant_path = None
         full_integer_quant_path = None
+        integer_quant_with_int16_act_path = None
+        full_integer_quant_with_int16_act_path = None
+        int16_activation_skip_reasons: List[str] = []
         if output_integer_quantized_tflite:
             _set_export_progress_desc("write integer quant tflite")
             integer_result = build_integer_quantized_model_ir(
@@ -1171,76 +1175,100 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
             )
             _advance_export_progress()
 
-            _set_export_progress_desc("write integer quant int16-act tflite")
-            integer_quant_with_int16_act_model_ir = build_integer_quantized_with_int16_act_model_ir(
-                model_ir,
-                quant_type=str(quant_type),
-                calibration_method=quant_controls["calibration_method"],
-                calibration_percentile=quant_controls["calibration_percentile"],
-                min_numel=quant_controls["min_numel"],
-                min_abs_max=quant_controls["min_abs_max"],
-                scale_floor=quant_controls["scale_floor"],
-                calibration_ranges=calibration_ranges,
-            )
-            integer_quant_with_int16_act_path = os.path.join(
-                output_folder_path,
-                f"{output_file_name}_integer_quant_with_int16_act.tflite",
-            )
-            integer_quant_int16_write_timing: Dict[str, Any] = {}
-            _write_validated_quantized_model_file(
-                model_ir=integer_quant_with_int16_act_model_ir,
-                output_tflite_path=integer_quant_with_int16_act_path,
-                timing=integer_quant_int16_write_timing,
-            )
-            write_timing_report["integer_quant_with_int16_act"] = integer_quant_int16_write_timing
-            _progress_write(
-                message=_format_write_timing_line(
-                    stage="integer_quant_with_int16_act",
+            int16_activation_skip_reasons = strict_int16_activation_skip_reasons(model_ir)
+            if len(int16_activation_skip_reasons) > 0:
+                calibration_report["variants"]["integer_quant_with_int16_act"] = {
+                    "skipped": True,
+                    "skip_reasons": list(int16_activation_skip_reasons),
+                }
+                calibration_report["variants"]["full_integer_quant_with_int16_act"] = {
+                    "skipped": True,
+                    "skip_reasons": list(int16_activation_skip_reasons),
+                }
+                _progress_write(
+                    message=(
+                        "integer_quant_with_int16_act skipped. "
+                        + " ".join(int16_activation_skip_reasons)
+                    ),
+                    enabled=bool(flatbuffer_direct_show_progress),
+                )
+                _advance_export_progress()
+                _progress_write(
+                    message=(
+                        "full_integer_quant_with_int16_act skipped. "
+                        + " ".join(int16_activation_skip_reasons)
+                    ),
+                    enabled=bool(flatbuffer_direct_show_progress),
+                )
+                _advance_export_progress()
+            else:
+                _set_export_progress_desc("write integer quant int16-act tflite")
+                integer_quant_with_int16_act_model_ir = build_integer_quantized_with_int16_act_model_ir(
+                    model_ir,
+                    quant_type=str(quant_type),
+                    calibration_method=quant_controls["calibration_method"],
+                    calibration_percentile=quant_controls["calibration_percentile"],
+                    min_numel=quant_controls["min_numel"],
+                    min_abs_max=quant_controls["min_abs_max"],
+                    scale_floor=quant_controls["scale_floor"],
+                    calibration_ranges=calibration_ranges,
+                )
+                integer_quant_with_int16_act_path = os.path.join(
+                    output_folder_path,
+                    f"{output_file_name}_integer_quant_with_int16_act.tflite",
+                )
+                integer_quant_int16_write_timing: Dict[str, Any] = {}
+                _write_validated_quantized_model_file(
+                    model_ir=integer_quant_with_int16_act_model_ir,
+                    output_tflite_path=integer_quant_with_int16_act_path,
                     timing=integer_quant_int16_write_timing,
-                ),
-                enabled=bool(flatbuffer_direct_show_progress),
-            )
-            _advance_export_progress()
+                )
+                write_timing_report["integer_quant_with_int16_act"] = integer_quant_int16_write_timing
+                _progress_write(
+                    message=_format_write_timing_line(
+                        stage="integer_quant_with_int16_act",
+                        timing=integer_quant_int16_write_timing,
+                    ),
+                    enabled=bool(flatbuffer_direct_show_progress),
+                )
+                _advance_export_progress()
 
-            _set_export_progress_desc("write full integer quant int16-act tflite")
-            full_integer_quant_with_int16_act_model_ir = build_full_integer_quantized_with_int16_act_model_ir(
-                model_ir,
-                quant_type=str(quant_type),
-                calibration_method=quant_controls["calibration_method"],
-                calibration_percentile=quant_controls["calibration_percentile"],
-                min_numel=quant_controls["min_numel"],
-                min_abs_max=quant_controls["min_abs_max"],
-                scale_floor=quant_controls["scale_floor"],
-                calibration_ranges=calibration_ranges,
-            )
-            full_integer_quant_with_int16_act_path = os.path.join(
-                output_folder_path,
-                f"{output_file_name}_full_integer_quant_with_int16_act.tflite",
-            )
-            full_integer_quant_int16_write_timing: Dict[str, Any] = {}
-            _write_validated_quantized_model_file(
-                model_ir=full_integer_quant_with_int16_act_model_ir,
-                output_tflite_path=full_integer_quant_with_int16_act_path,
-                timing=full_integer_quant_int16_write_timing,
-            )
-            write_timing_report["full_integer_quant_with_int16_act"] = full_integer_quant_int16_write_timing
-            _progress_write(
-                message=_format_write_timing_line(
-                    stage="full_integer_quant_with_int16_act",
+                _set_export_progress_desc("write full integer quant int16-act tflite")
+                full_integer_quant_with_int16_act_model_ir = build_full_integer_quantized_with_int16_act_model_ir(
+                    model_ir,
+                    quant_type=str(quant_type),
+                    calibration_method=quant_controls["calibration_method"],
+                    calibration_percentile=quant_controls["calibration_percentile"],
+                    min_numel=quant_controls["min_numel"],
+                    min_abs_max=quant_controls["min_abs_max"],
+                    scale_floor=quant_controls["scale_floor"],
+                    calibration_ranges=calibration_ranges,
+                )
+                full_integer_quant_with_int16_act_path = os.path.join(
+                    output_folder_path,
+                    f"{output_file_name}_full_integer_quant_with_int16_act.tflite",
+                )
+                full_integer_quant_int16_write_timing: Dict[str, Any] = {}
+                _write_validated_quantized_model_file(
+                    model_ir=full_integer_quant_with_int16_act_model_ir,
+                    output_tflite_path=full_integer_quant_with_int16_act_path,
                     timing=full_integer_quant_int16_write_timing,
-                ),
-                enabled=bool(flatbuffer_direct_show_progress),
-            )
-            _advance_export_progress()
+                )
+                write_timing_report["full_integer_quant_with_int16_act"] = full_integer_quant_int16_write_timing
+                _progress_write(
+                    message=_format_write_timing_line(
+                        stage="full_integer_quant_with_int16_act",
+                        timing=full_integer_quant_int16_write_timing,
+                    ),
+                    enabled=bool(flatbuffer_direct_show_progress),
+                )
+                _advance_export_progress()
             calibration_report_path = os.path.join(
                 output_folder_path,
                 f"{output_file_name}_strict_integer_quant_calibration_report.json",
             )
             with open(calibration_report_path, "w", encoding="utf-8") as f:
                 json.dump(calibration_report, f, indent=2)
-        else:
-            integer_quant_with_int16_act_path = None
-            full_integer_quant_with_int16_act_path = None
 
         if output_weights:
             _set_export_progress_desc("export float32 weights")
@@ -1349,6 +1377,9 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         outputs["integer_quant_with_int16_act_tflite_path"] = integer_quant_with_int16_act_path
     if full_integer_quant_with_int16_act_path is not None:
         outputs["full_integer_quant_with_int16_act_tflite_path"] = full_integer_quant_with_int16_act_path
+    if len(int16_activation_skip_reasons) > 0:
+        outputs["int16_activation_quantization_skipped"] = True
+        outputs["int16_activation_quantization_skip_reasons"] = list(int16_activation_skip_reasons)
     if calibration_report_path is not None:
         outputs["strict_integer_quant_calibration_report_path"] = calibration_report_path
     if split_plan_report_path is not None:

--- a/onnx2tf/tflite_builder/quantization.py
+++ b/onnx2tf/tflite_builder/quantization.py
@@ -46,8 +46,13 @@ _STRICT_FULL_INTEGER_SUPPORTED_OPS = {
     "DIV",
     "MAXIMUM",
     "MINIMUM",
+    "LESS",
+    "LOGICAL_NOT",
+    "WHERE",
+    "SHAPE",
     "SELECT",
     "SELECT_V2",
+    "CAST",
     "CONCATENATION",
     "RESHAPE",
     "TRANSPOSE",
@@ -57,6 +62,7 @@ _STRICT_FULL_INTEGER_SUPPORTED_OPS = {
     "STRIDED_SLICE",
     "SPLIT",
     "GATHER",
+    "GATHER_ND",
     "TILE",
     "SPACE_TO_DEPTH",
     "DEPTH_TO_SPACE",
@@ -70,6 +76,7 @@ _STRICT_FULL_INTEGER_SUPPORTED_OPS = {
     "MAX_POOL_2D",
     "ABS",
     "NEG",
+    "EXP",
     "RELU",
     "RELU6",
     "RELU_N1_TO_1",
@@ -81,6 +88,9 @@ _STRICT_FULL_INTEGER_SUPPORTED_OPS = {
     "LOGISTIC",
     "RESIZE_NEAREST_NEIGHBOR",
     "RESIZE_BILINEAR",
+    "SCATTER_ND",
+    "TOPK_V2",
+    "ARG_MAX",
     "CONV_2D",
     "DEPTHWISE_CONV_2D",
     "TRANSPOSE_CONV",
@@ -95,21 +105,30 @@ _STRICT_FULL_INTEGER_PASSTHROUGH_OPS = {
     "EXPAND_DIMS",
 }
 
-_STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES: Dict[str, Optional[Set[int]]] = {
-    "CONCATENATION": None,
-    "MEAN": {0},
-    "AVERAGE_POOL_2D": {0},
-    "MAX_POOL_2D": {0},
-    "SLICE": {0},
-    "STRIDED_SLICE": {0},
-    "SPLIT": {1},
-    "GATHER": {0},
-    "TILE": {0},
-    "SPACE_TO_DEPTH": {0},
-    "DEPTH_TO_SPACE": {0},
-    "PAD": {0},
-    "SELECT": {1, 2},
-    "SELECT_V2": {1, 2},
+_STRICT_FULL_INTEGER_SAME_QPARAM_INDICES: Dict[
+    str,
+    Tuple[Optional[Set[int]], Optional[Set[int]]],
+] = {
+    "CONCATENATION": (None, None),
+    "MEAN": ({0}, None),
+    "AVERAGE_POOL_2D": ({0}, None),
+    "MAX_POOL_2D": ({0}, None),
+    "SLICE": ({0}, None),
+    "STRIDED_SLICE": ({0}, None),
+    "SPLIT": ({1}, None),
+    "GATHER": ({0}, None),
+    "GATHER_ND": ({0}, {0}),
+    "TILE": ({0}, None),
+    "SPACE_TO_DEPTH": ({0}, None),
+    "DEPTH_TO_SPACE": ({0}, None),
+    "PAD": ({0}, None),
+    "SCATTER_ND": ({1}, {0}),
+    "SELECT": ({1, 2}, None),
+    "SELECT_V2": ({1, 2}, None),
+}
+
+_STRICT_FULL_INTEGER_INT16_ACT_UNSUPPORTED_OPS = {
+    "SCATTER_ND": "LiteRT SCATTER_ND does not support INT16 updates.",
 }
 
 
@@ -119,6 +138,22 @@ class _QuantizationControls(TypedDict):
     min_numel: int
     min_abs_max: float
     scale_floor: float
+
+
+def strict_int16_activation_skip_reasons(model_ir: ModelIR) -> List[str]:
+    reasons: List[str] = []
+    seen: Set[str] = set()
+    for op_idx, op in enumerate(model_ir.operators):
+        op_type = str(op.op_type)
+        reason = _STRICT_FULL_INTEGER_INT16_ACT_UNSUPPORTED_OPS.get(op_type, None)
+        if reason is None:
+            continue
+        key = f"{op_type}:{reason}"
+        if key in seen:
+            continue
+        seen.add(key)
+        reasons.append(f"index={op_idx} op_type={op_type}: {reason}")
+    return reasons
 
 
 def _clone_model_ir(model_ir: ModelIR) -> ModelIR:
@@ -715,18 +750,70 @@ def _elide_identity_operators(model_ir: ModelIR) -> None:
 
 
 def _same_qparam_tensor_names_for_op(op: OperatorIR) -> List[str]:
-    input_indices = _STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES.get(str(op.op_type), None)
+    policy = _STRICT_FULL_INTEGER_SAME_QPARAM_INDICES.get(str(op.op_type), None)
+    if policy is None:
+        return []
+    input_indices, output_indices = policy
     names: List[str] = []
-    if input_indices is None and str(op.op_type) in _STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES:
+    if input_indices is None:
         names.extend(str(v) for v in op.inputs if str(v) != "")
-    elif input_indices is not None:
+    else:
         names.extend(
             str(input_name)
             for idx, input_name in enumerate(op.inputs)
             if int(idx) in input_indices and str(input_name) != ""
         )
-    names.extend(str(v) for v in op.outputs if str(v) != "")
+    if output_indices is None:
+        names.extend(str(v) for v in op.outputs if str(v) != "")
+    else:
+        names.extend(
+            str(output_name)
+            for idx, output_name in enumerate(op.outputs)
+            if int(idx) in output_indices and str(output_name) != ""
+        )
     return names
+
+
+def _derive_same_qparams_from_available_tensor(
+    *,
+    model_ir: ModelIR,
+    tensor_names: Iterable[str],
+    calibration_ranges: Dict[str, TensorCalibrationRange],
+    dtype: str,
+    scale_floor: float,
+) -> Optional[QuantParamIR]:
+    names = [str(name) for name in tensor_names if str(name) != ""]
+    dtype_u = str(dtype).upper()
+    for tensor_name in names:
+        tensor = model_ir.tensors.get(str(tensor_name), None)
+        if tensor is None:
+            continue
+        if tensor.dtype == dtype_u and isinstance(tensor.quantization, QuantParamIR):
+            return _clone_quant_param(tensor.quantization)
+    for tensor_name in names:
+        if tensor_name not in calibration_ranges:
+            continue
+        rng = calibration_ranges[tensor_name]
+        return activation_qparams_from_range(
+            min_value=float(rng.min_value),
+            max_value=float(rng.max_value),
+            dtype=dtype_u,
+            scale_floor=float(scale_floor),
+        )
+    for tensor_name in names:
+        tensor = model_ir.tensors.get(str(tensor_name), None)
+        if tensor is None or tensor.dtype != "FLOAT32" or not isinstance(tensor.data, np.ndarray):
+            continue
+        data = np.asarray(tensor.data, dtype=np.float32)
+        if data.size == 0:
+            continue
+        return activation_qparams_from_range(
+            min_value=float(np.min(data)),
+            max_value=float(np.max(data)),
+            dtype=dtype_u,
+            scale_floor=float(scale_floor),
+        )
+    return None
 
 
 def _is_float_activation_tensor(
@@ -1412,15 +1499,38 @@ def _build_strict_full_integer_model_ir(
                         "qparams": _quant_param_to_report(out_tensor.quantization),
                     }
                 else:
-                    _ensure_activation_quantized(
-                        model_ir=clone,
-                        tensor_name=str(output_name),
-                        calibration_ranges=calibration_ranges,
-                        dtype=activation_dtype(str(output_name)),
-                        scale_floor=float(controls["scale_floor"]),
-                        report=report,
-                        fixed_qparams=output_fixed,
+                    same_qparam_names = (
+                        _same_qparam_tensor_names_for_op(op)
+                        if op_type in _STRICT_FULL_INTEGER_SAME_QPARAM_INDICES
+                        else []
                     )
+                    fallback_qparams = None
+                    if output_fixed is None and str(output_name) not in calibration_ranges:
+                        fallback_qparams = _derive_same_qparams_from_available_tensor(
+                            model_ir=clone,
+                            tensor_names=same_qparam_names or [str(v) for v in op.inputs],
+                            calibration_ranges=calibration_ranges,
+                            dtype=activation_dtype(str(output_name)),
+                            scale_floor=float(controls["scale_floor"]),
+                        )
+                    if fallback_qparams is not None and same_qparam_names:
+                        _force_same_qparams(
+                            model_ir=clone,
+                            tensor_names=same_qparam_names,
+                            qparams=fallback_qparams,
+                            dtype=activation_dtype(str(output_name)),
+                            report=report,
+                        )
+                    else:
+                        _ensure_activation_quantized(
+                            model_ir=clone,
+                            tensor_name=str(output_name),
+                            calibration_ranges=calibration_ranges,
+                            dtype=activation_dtype(str(output_name)),
+                            scale_floor=float(controls["scale_floor"]),
+                            report=report,
+                            fixed_qparams=output_fixed or fallback_qparams,
+                        )
 
         if op_type in {"FULLY_CONNECTED", "CONV_2D", "DEPTHWISE_CONV_2D", "BATCH_MATMUL", "TRANSPOSE_CONV"}:
             activation_input_idx = 2 if op_type == "TRANSPOSE_CONV" else 0
@@ -1452,19 +1562,21 @@ def _build_strict_full_integer_model_ir(
                         weight_qparams=weight_qparams,
                         report=report,
                     )
-        elif op_type in _STRICT_FULL_INTEGER_SAME_QPARAM_INPUT_INDICES and len(op.outputs) > 0:
+        elif op_type in _STRICT_FULL_INTEGER_SAME_QPARAM_INDICES and len(op.outputs) > 0:
             out_tensor = clone.tensors[str(op.outputs[0])]
             if not isinstance(out_tensor.quantization, QuantParamIR):
-                raise StrictFullIntegerQuantizationError(
-                    f"{op_type} output tensor is missing qparams: {op.outputs[0]}"
+                if out_tensor.dtype == "FLOAT32":
+                    raise StrictFullIntegerQuantizationError(
+                        f"{op_type} output tensor is missing qparams: {op.outputs[0]}"
+                    )
+            else:
+                _force_same_qparams(
+                    model_ir=clone,
+                    tensor_names=_same_qparam_tensor_names_for_op(op),
+                    qparams=out_tensor.quantization,
+                    dtype=out_tensor.dtype,
+                    report=report,
                 )
-            _force_same_qparams(
-                model_ir=clone,
-                tensor_names=_same_qparam_tensor_names_for_op(op),
-                qparams=out_tensor.quantization,
-                dtype=out_tensor.dtype,
-                report=report,
-            )
         else:
             for input_name in list(op.inputs):
                 tensor = clone.tensors.get(str(input_name), None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "onnx2tf"
-version = "2.5.1"
+version = "2.5.2"
 description = "A tool for converting ONNX files to LiteRT/TFLite/TensorFlow, PyTorch native code (nn.Module), TorchScript (.pt), state_dict (.pt), Exported Program (.pt2), and Dynamo ONNX. It also supports direct conversion from LiteRT to PyTorch."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_strict_integer_quantization.py
+++ b/tests/test_strict_integer_quantization.py
@@ -13,6 +13,7 @@ from onnx2tf.tflite_builder.quantization import (
     build_full_integer_quantized_model_ir,
     fixed_activation_qparams_for_op,
     load_calibration_samples,
+    strict_int16_activation_skip_reasons,
 )
 from onnx2tf.tflite_builder.schema_loader import load_schema_module
 
@@ -40,6 +41,21 @@ def _assert_litert_allocates(model_ir: ModelIR) -> None:
         )
         interpreter = Interpreter(model_path=tflite_path)
         interpreter.allocate_tensors()
+
+
+def _quantize_input_array(values: np.ndarray, detail: dict) -> np.ndarray:
+    scale, zero_point = detail["quantization"]
+    dtype = np.dtype(detail["dtype"])
+    if dtype == np.dtype(np.int8):
+        qmin, qmax = -128, 127
+    elif dtype == np.dtype(np.uint8):
+        qmin, qmax = 0, 255
+    elif dtype == np.dtype(np.int16):
+        qmin, qmax = -32768, 32767
+    else:
+        raise AssertionError(f"Unexpected quantized input dtype: {dtype}")
+    quantized = np.round(np.asarray(values, dtype=np.float32) / float(scale)) + int(zero_point)
+    return np.clip(quantized, qmin, qmax).astype(dtype)
 
 
 def test_activation_qparams_from_range_uint8_uses_calibrated_range() -> None:
@@ -136,7 +152,7 @@ def test_strict_full_integer_builder_rejects_unsupported_float_op() -> None:
     model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 3])
     model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1, 3])
     model_ir.operators = [
-        OperatorIR(op_type="EXP", inputs=["x"], outputs=["y"]),
+        OperatorIR(op_type="SIN", inputs=["x"], outputs=["y"]),
     ]
 
     with pytest.raises(StrictFullIntegerQuantizationError, match="Unsupported op"):
@@ -454,6 +470,7 @@ def _make_shape_op_model(op_type: str) -> ModelIR:
         "MAXIMUM",
         "MINIMUM",
         "DIV",
+        "EXP",
         "PRELU",
     ],
 )
@@ -546,4 +563,284 @@ def test_additional_resize_ops_allocate_as_strict_full_integer(op_type: str) -> 
         calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
     )
 
+    _assert_litert_allocates(quantized)
+
+
+def test_gather_nd_keeps_indices_int32_and_aligns_data_qparams() -> None:
+    model_ir = ModelIR(name="gather_nd_quantized")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[2, 3], shape_signature=[2, 3])
+    model_ir.tensors["idx"] = TensorIR(
+        name="idx",
+        dtype="INT32",
+        shape=[2, 1],
+        shape_signature=[2, 1],
+        data=np.asarray([[0], [1]], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[2, 3], shape_signature=[2, 3])
+    model_ir.operators = [OperatorIR(op_type="GATHER_ND", inputs=["x", "idx"], outputs=["y"])]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    assert quantized.tensors["idx"].dtype == "INT32"
+    assert quantized.tensors["idx"].quantization is None
+    assert quantized.tensors["x"].dtype == "INT8"
+    assert quantized.tensors["y"].dtype == "INT8"
+    assert quantized.tensors["x"].quantization is not None
+    assert quantized.tensors["y"].quantization is not None
+    assert quantized.tensors["x"].quantization.scale == quantized.tensors["y"].quantization.scale
+    assert quantized.tensors["x"].quantization.zero_point == quantized.tensors["y"].quantization.zero_point
+    _assert_litert_allocates(quantized)
+
+
+def test_scatter_nd_keeps_indices_shape_int32_and_aligns_update_qparams() -> None:
+    model_ir = ModelIR(name="scatter_nd_quantized")
+    model_ir.inputs = ["updates"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["idx"] = TensorIR(
+        name="idx",
+        dtype="INT32",
+        shape=[2, 1],
+        shape_signature=[2, 1],
+        data=np.asarray([[0], [2]], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["updates"] = TensorIR(
+        name="updates",
+        dtype="FLOAT32",
+        shape=[2],
+        shape_signature=[2],
+    )
+    model_ir.tensors["shape"] = TensorIR(
+        name="shape",
+        dtype="INT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([4], dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[4], shape_signature=[4])
+    model_ir.operators = [OperatorIR(op_type="SCATTER_ND", inputs=["idx", "updates", "shape"], outputs=["y"])]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges=_calibration_ranges_for_float_activations(model_ir),
+    )
+
+    assert quantized.tensors["idx"].dtype == "INT32"
+    assert quantized.tensors["shape"].dtype == "INT32"
+    assert quantized.tensors["idx"].quantization is None
+    assert quantized.tensors["shape"].quantization is None
+    assert quantized.tensors["updates"].dtype == "INT8"
+    assert quantized.tensors["y"].dtype == "INT8"
+    assert quantized.tensors["updates"].quantization is not None
+    assert quantized.tensors["y"].quantization is not None
+    assert quantized.tensors["updates"].quantization.scale == quantized.tensors["y"].quantization.scale
+    assert quantized.tensors["updates"].quantization.zero_point == quantized.tensors["y"].quantization.zero_point
+    _assert_litert_allocates(quantized)
+
+
+def test_scatter_nd_reports_int16_activation_skip_reason() -> None:
+    model_ir = ModelIR(name="scatter_nd_int16_skip")
+    model_ir.tensors["idx"] = TensorIR(
+        name="idx",
+        dtype="INT32",
+        shape=[1, 1],
+        data=np.asarray([[0]], dtype=np.int32),
+    )
+    model_ir.tensors["updates"] = TensorIR(name="updates", dtype="FLOAT32", shape=[1])
+    model_ir.tensors["shape"] = TensorIR(
+        name="shape",
+        dtype="INT32",
+        shape=[1],
+        data=np.asarray([1], dtype=np.int32),
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="FLOAT32", shape=[1])
+    model_ir.operators = [OperatorIR(op_type="SCATTER_ND", inputs=["idx", "updates", "shape"], outputs=["y"])]
+
+    reasons = strict_int16_activation_skip_reasons(model_ir)
+
+    assert len(reasons) == 1
+    assert "SCATTER_ND" in reasons[0]
+    assert "INT16 updates" in reasons[0]
+
+
+def test_topk_v2_quantizes_values_and_keeps_indices_int32() -> None:
+    model_ir = ModelIR(name="topk_v2_quantized")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["values", "indices"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["k"] = TensorIR(
+        name="k",
+        dtype="INT32",
+        shape=[],
+        shape_signature=[],
+        data=np.asarray(2, dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["values"] = TensorIR(
+        name="values",
+        dtype="FLOAT32",
+        shape=[1, 2],
+        shape_signature=[1, 2],
+    )
+    model_ir.tensors["indices"] = TensorIR(
+        name="indices",
+        dtype="INT32",
+        shape=[1, 2],
+        shape_signature=[1, 2],
+    )
+    model_ir.operators = [OperatorIR(op_type="TOPK_V2", inputs=["x", "k"], outputs=["values", "indices"])]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges={
+            "x": TensorCalibrationRange(-1.0, 1.0, 1),
+            "values": TensorCalibrationRange(-1.0, 1.0, 1),
+        },
+    )
+
+    assert quantized.tensors["x"].dtype == "INT8"
+    assert quantized.tensors["values"].dtype == "INT8"
+    assert quantized.tensors["k"].dtype == "INT32"
+    assert quantized.tensors["indices"].dtype == "INT32"
+    assert quantized.tensors["indices"].quantization is None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema = load_schema_module(output_folder_path=tmpdir)
+        tflite_path = os.path.join(tmpdir, "topk_v2_quantized.tflite")
+        write_model_file(schema_tflite=schema, model_ir=quantized, output_tflite_path=tflite_path, timing={})
+        interpreter = Interpreter(model_path=tflite_path)
+        interpreter.allocate_tensors()
+        input_detail = interpreter.get_input_details()[0]
+        interpreter.set_tensor(
+            int(input_detail["index"]),
+            _quantize_input_array(np.asarray([[0.1, 0.8, -0.2, 0.5]], dtype=np.float32), input_detail),
+        )
+        interpreter.invoke()
+        indices_detail = next(
+            detail
+            for detail in interpreter.get_output_details()
+            if np.dtype(detail["dtype"]) == np.dtype(np.int32)
+        )
+        indices = interpreter.get_tensor(int(indices_detail["index"]))
+
+    np.testing.assert_array_equal(indices, np.asarray([[1, 3]], dtype=np.int32))
+
+
+def test_arg_max_quantizes_data_and_keeps_axis_output_integer() -> None:
+    model_ir = ModelIR(name="arg_max_quantized")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[1, 4], shape_signature=[1, 4])
+    model_ir.tensors["axis"] = TensorIR(
+        name="axis",
+        dtype="INT32",
+        shape=[],
+        shape_signature=[],
+        data=np.asarray(1, dtype=np.int32),
+        is_variable=False,
+    )
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="INT64", shape=[1], shape_signature=[1])
+    model_ir.operators = [
+        OperatorIR(op_type="ARG_MAX", inputs=["x", "axis"], outputs=["y"], options={"outputType": "INT64"})
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges={"x": TensorCalibrationRange(-1.0, 1.0, 1)},
+    )
+
+    assert quantized.tensors["x"].dtype == "INT8"
+    assert quantized.tensors["axis"].dtype == "INT32"
+    assert quantized.tensors["y"].dtype == "INT64"
+    assert quantized.tensors["axis"].quantization is None
+    assert quantized.tensors["y"].quantization is None
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema = load_schema_module(output_folder_path=tmpdir)
+        tflite_path = os.path.join(tmpdir, "arg_max_quantized.tflite")
+        write_model_file(schema_tflite=schema, model_ir=quantized, output_tflite_path=tflite_path, timing={})
+        interpreter = Interpreter(model_path=tflite_path)
+        interpreter.allocate_tensors()
+        input_detail = interpreter.get_input_details()[0]
+        interpreter.set_tensor(
+            int(input_detail["index"]),
+            _quantize_input_array(np.asarray([[0.1, 0.9, -0.2, 0.5]], dtype=np.float32), input_detail),
+        )
+        interpreter.invoke()
+        output_detail = interpreter.get_output_details()[0]
+        output = interpreter.get_tensor(int(output_detail["index"]))
+
+    np.testing.assert_array_equal(output, np.asarray([1], dtype=np.int64))
+
+
+def test_logical_where_and_shape_keep_non_activation_outputs() -> None:
+    model_ir = ModelIR(name="logical_where_shape_quantized")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["where_out", "shape_out"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="FLOAT32", shape=[4], shape_signature=[4])
+    model_ir.tensors["threshold"] = TensorIR(
+        name="threshold",
+        dtype="FLOAT32",
+        shape=[1],
+        shape_signature=[1],
+        data=np.asarray([0.5], dtype=np.float32),
+        is_variable=False,
+    )
+    model_ir.tensors["less"] = TensorIR(name="less", dtype="BOOL", shape=[4], shape_signature=[4])
+    model_ir.tensors["not_out"] = TensorIR(name="not_out", dtype="BOOL", shape=[4], shape_signature=[4])
+    model_ir.tensors["where_out"] = TensorIR(name="where_out", dtype="INT64", shape=[-1, 1], shape_signature=[-1, 1])
+    model_ir.tensors["shape_out"] = TensorIR(name="shape_out", dtype="INT32", shape=[1], shape_signature=[1])
+    model_ir.operators = [
+        OperatorIR(op_type="LESS", inputs=["x", "threshold"], outputs=["less"]),
+        OperatorIR(op_type="LOGICAL_NOT", inputs=["less"], outputs=["not_out"]),
+        OperatorIR(op_type="WHERE", inputs=["not_out"], outputs=["where_out"]),
+        OperatorIR(op_type="SHAPE", inputs=["x"], outputs=["shape_out"], options={"outType": "INT32"}),
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges={"x": TensorCalibrationRange(-1.0, 1.0, 1)},
+    )
+
+    assert quantized.tensors["x"].dtype == "INT8"
+    assert quantized.tensors["threshold"].dtype == "INT8"
+    assert quantized.tensors["less"].dtype == "BOOL"
+    assert quantized.tensors["not_out"].dtype == "BOOL"
+    assert quantized.tensors["where_out"].dtype == "INT64"
+    assert quantized.tensors["shape_out"].dtype == "INT32"
+    assert quantized.tensors["where_out"].quantization is None
+    assert quantized.tensors["shape_out"].quantization is None
+    _assert_litert_allocates(quantized)
+
+
+def test_cast_integer_output_remains_unquantized() -> None:
+    model_ir = ModelIR(name="cast_integer_quantized")
+    model_ir.inputs = ["x"]
+    model_ir.outputs = ["y"]
+    model_ir.tensors["x"] = TensorIR(name="x", dtype="INT64", shape=[3], shape_signature=[3])
+    model_ir.tensors["y"] = TensorIR(name="y", dtype="INT32", shape=[3], shape_signature=[3])
+    model_ir.operators = [
+        OperatorIR(
+            op_type="CAST",
+            inputs=["x"],
+            outputs=["y"],
+            options={"inDataType": "INT64", "outDataType": "INT32"},
+        )
+    ]
+
+    quantized = build_full_integer_quantized_model_ir(
+        model_ir,
+        calibration_ranges={"unused": TensorCalibrationRange(0.0, 1.0, 1)},
+    )
+
+    assert quantized.tensors["x"].dtype == "INT64"
+    assert quantized.tensors["y"].dtype == "INT32"
+    assert quantized.tensors["y"].quantization is None
     _assert_litert_allocates(quantized)


### PR DESCRIPTION
### 1. Content and background

This PR improves `flatbuffer_direct` strict integer quantization so more mixed-dtype and detection-postprocess-adjacent graphs can be converted without producing invalid full-integer artifacts. It also keeps the int8 and full-int8 outputs available when optional int16-activation variants are not supported by LiteRT kernels.

### 2. Summary of corrections

- Added strict full-integer quantization support for additional ops including `GATHER_ND`, `SCATTER_ND`, `TOPK_V2`, `ARG_MAX`, `EXP`, `CAST`, `LESS`, `LOGICAL_NOT`, `WHERE`, and `SHAPE`.
- Extended same-qparams policy handling so mixed input/output ops only quantize activation/value tensors and leave index, axis, shape, condition, and integer outputs unquantized.
- Added fallback qparam derivation from existing qparams, calibration ranges, or float constants when calibration cannot observe an output tensor.
- Added explicit skip reporting for int16-activation variants when a model contains `SCATTER_ND`, because LiteRT does not support INT16 updates for that kernel. The int8 and full-int8 variants still validate and are emitted.
- Added unit/integration coverage for the newly supported mixed-dtype ops and int16-activation skip reporting.
- Bumped package/docker references from 2.5.1 to 2.5.2.

### 3. Before/After (If there is an operating log that can be used as a reference)

Before:

- Pre-NMS YOLOX conversion could write int8 artifacts, then fail the overall `-oiqt` command when `*_integer_quant_with_int16_act.tflite` validation reached `SCATTER_ND`:
  `Updates of type 'INT16' are not supported by scatter_nd.`

After:

- `python -m onnx2tf -i /tmp/onnx2tf_yolox_quant/yolox_nano_ti_lite_26p1_41p8_pre_nms.onnx -o /tmp/onnx2tf_yolox_quant/pre_nms_quant_out_after_skip -oiqt -cind images calib_data_416x416_n200.npy "[[[[0.0,0.0,0.0]]]]" "[[[[1.0,1.0,1.0]]]]"` completed successfully.
- Generated and validated:
  - `yolox_nano_ti_lite_26p1_41p8_pre_nms_integer_quant.tflite`
  - `yolox_nano_ti_lite_26p1_41p8_pre_nms_full_integer_quant.tflite`
- The int16-activation variants are now explicitly skipped with the reason:
  `SCATTER_ND: LiteRT SCATTER_ND does not support INT16 updates.`

Validation run locally:

- `pytest -q tests/test_strict_integer_quantization.py tests/test_tensor_buffer_builder.py tests/test_tflite_builder_direct.py::test_flatbuffer_direct_integer_quantized_smoke`
- `ruff check onnx2tf/tflite_builder/quantization.py onnx2tf/tflite_builder/__init__.py tests/test_strict_integer_quantization.py tests/test_tflite_builder_direct.py`
- `npx --yes pyright onnx2tf/tflite_builder/quantization.py onnx2tf/tflite_builder/__init__.py tests/test_strict_integer_quantization.py tests/test_tflite_builder_direct.py`
- `python -m py_compile onnx2tf/onnx2tf.py onnx2tf/tflite_builder/__init__.py onnx2tf/tflite_builder/quantization.py tests/test_strict_integer_quantization.py`

### 4. Issue number (only if there is a related issue)

Related issue: #929

```bash
onnx2tf \
-i yolox_nano_ti_lite_26p1_41p8_pre_nms.onnx \
-coion \
-oiqt \
-cind "images" "./calib_data_416x416_n200.npy" "[[[[0.485,0.456,0.406]]]]" "[[[[0.229,0.224,0.225]]]]"

onnx2tf \
-i yolox_nano_ti_lite_26p1_41p8_pre_nms.onnx \
-coion \
-oiqt \
-qt per-tensor \
-cind "images" "./calib_data_416x416_n200.npy" "[[[[0.485,0.456,0.406]]]]" "[[[[0.229,0.224,0.225]]]]"
```

- [yolox_nano_ti_lite_26p1_41p8_pre_nms.onnx.zip](https://github.com/user-attachments/files/29849894/yolox_nano_ti_lite_26p1_41p8_pre_nms.onnx.zip)
- [yolox_nano_ti_lite_26p1_41p8_pre_nms_integer_quant.tflite.zip](https://github.com/user-attachments/files/29849872/yolox_nano_ti_lite_26p1_41p8_pre_nms_integer_quant.tflite.zip)

