### PR TITLE
Document unsupported flatbuffer_direct edge cases

### DIFF
--- a/docs/baselines/flatbuffer_direct_active_tier0_4.json
+++ b/docs/baselines/flatbuffer_direct_active_tier0_4.json
@@ -480,8 +480,8 @@
       "tier": 0,
       "model": "inverse_11.onnx",
       "baseline_classification": "missing_tflite_report",
-      "baseline_reason": "missing_tflite_report",
-      "error_signature_sha256": "2ddafacaad52dc057613699a3760e632fd4e9b92f73028238cd8943aa9e4966a"
+      "baseline_reason": "unsupported_exact_inverse_matrix_size_224",
+      "error_signature_sha256": "c1bdaa58f8b1dda9b86c24ce66f509320a6201e08f6ebfd35b4ecb058109d885"
     },
     {
       "tier": 0,
@@ -692,8 +692,8 @@
       "tier": 0,
       "model": "string_normalizer_11.onnx",
       "baseline_classification": "missing_tflite_report",
-      "baseline_reason": "missing_tflite_report",
-      "error_signature_sha256": "603ca474b8eee210cb3bb2df39bb20791becc95c66d60a1ec68e1a8a2744c109"
+      "baseline_reason": "unsupported_stock_tflite_string_normalizer",
+      "error_signature_sha256": "2623d1f687770e4aade4749af32963fca446f80b3dd131e7061bcb13ae225722"
     },
     {
       "tier": 0,

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -103,6 +103,27 @@ lexically captured tensors that do not exist in the serialized ONNX, including
 all four LSTM weight/bias captures. It cannot provide an ONNX reference result
 for an accuracy-preserving promotion.
 
+`inverse_11.onnx` also remains an active non-pass, with the normalized reason
+`unsupported_exact_inverse_matrix_size_224`. Stock TFLite has matrix-diagonal
+and batch-matmul operators but no matrix solve/inverse operator. The model asks
+for three 224x224 inverses after bilinear upsampling. With the fixed evaluation
+seed, the matrices have condition numbers from approximately `8.0e9` to
+`9.2e10`, and ONNX Runtime produces magnitudes up to approximately `8.3e7`.
+Even a float64 NumPy inverse rounded to float32 differs from the ONNX Runtime
+reference by `1.7e7` to `1.2e8`, so substituting a different approximate
+algorithm cannot satisfy the required `1e-1` absolute-error limit. The existing
+custom-op fallback is retained; no inaccurate builtin approximation is emitted.
+
+`string_normalizer_11.onnx` remains an active non-pass with the normalized
+reason `unsupported_stock_tflite_string_normalizer`. It requires runtime string
+case conversion, locale-aware comparison, and stopword filtering. Stock TFLite
+supports string tensors and hash tables but has no string normalization,
+case-folding, tokenization, or filtering builtin, so the existing
+`ONNX_STRINGNORMALIZER` custom fallback is the only semantics-preserving
+artifact. The reference model additionally requests the `en_US` locale, which
+is not installed in the core validation environment. No locale package or
+string-processing dependency is added by this project.
+
 ### Recorded Tier 0 baseline
 
 The recursive Tier 0 corpus at commit `c4f3b7a` contains 190 models. Its

--- a/tests/test_flatbuffer_direct_bulk_runner.py
+++ b/tests/test_flatbuffer_direct_bulk_runner.py
@@ -965,6 +965,33 @@ def test_managed_regression_profile_includes_all_tier_zero_to_four_models() -> N
     assert profile["model_options"]["silero_vad.onnx"] == {
         "keep_shape_absolutely_input_names": ["input", "state", "sr"],
     }
+    profile_payload = json.loads(profile_path.read_text(encoding="utf-8"))
+    inverse_entry = next(
+        entry
+        for entry in profile_payload["models"]
+        if entry["model"] == "inverse_11.onnx"
+    )
+    assert inverse_entry["baseline_classification"] == "missing_tflite_report"
+    assert inverse_entry["baseline_reason"] == (
+        "unsupported_exact_inverse_matrix_size_224"
+    )
+    assert inverse_entry["error_signature_sha256"] == (
+        "c1bdaa58f8b1dda9b86c24ce66f509320a6201e08f6ebfd35b4ecb058109d885"
+    )
+    string_normalizer_entry = next(
+        entry
+        for entry in profile_payload["models"]
+        if entry["model"] == "string_normalizer_11.onnx"
+    )
+    assert string_normalizer_entry["baseline_classification"] == (
+        "missing_tflite_report"
+    )
+    assert string_normalizer_entry["baseline_reason"] == (
+        "unsupported_stock_tflite_string_normalizer"
+    )
+    assert string_normalizer_entry["error_signature_sha256"] == (
+        "2623d1f687770e4aade4749af32963fca446f80b3dd131e7061bcb13ae225722"
+    )
     assert profile["model_options"]["tiny_decoder_11.onnx"] == {
         "shape_hints": [
             "tokens:1,1",


### PR DESCRIPTION
## Summary

This pull request records two precisely investigated Tier 0 limitations in the flatbuffer_direct regression baseline. It replaces ambiguous missing-report reasons with stable, semantics-based classifications and adds regression assertions that prevent those classifications from drifting silently.

This is a focused follow-up to the already merged flatbuffer refactoring work. It does not begin the remaining implementation tasks and does not change runtime conversion behavior, public APIs, dependencies, artifact formats, or CLI defaults.

## Improvements

### Exact matrix inverse classification

- Reclassifies inverse_11.onnx as unsupported_exact_inverse_matrix_size_224 while preserving its active non-pass status.
- Documents that stock TFLite provides matrix diagonal and batch matrix multiplication operators, but no matrix solve or inverse builtin.
- Records that the model requires three 224 by 224 matrix inverses after bilinear upsampling.
- Captures the numerical feasibility investigation: fixed-seed matrices have condition numbers of approximately 8.0e9 through 9.2e10, and ONNX Runtime output magnitudes reach approximately 8.3e7.
- Records that even a NumPy float64 inverse rounded to float32 differs from the ONNX Runtime reference by approximately 1.7e7 through 1.2e8. Therefore, replacing the operation with a different approximate algorithm cannot satisfy the required maximum absolute error of 1e-1.
- Explicitly retains the existing custom-op fallback instead of emitting an inaccurate builtin approximation.

### StringNormalizer classification

- Reclassifies string_normalizer_11.onnx as unsupported_stock_tflite_string_normalizer while preserving its active non-pass status.
- Documents the required semantics: runtime string case conversion, locale-aware comparison, and stopword filtering.
- Records that stock TFLite supports string tensors and hash tables but does not provide a builtin for string normalization, case folding, tokenization, or filtering.
- Explicitly retains the ONNX_STRINGNORMALIZER custom fallback as the only semantics-preserving artifact available within the current dependency constraints.
- Documents the validation-environment constraint that the model requests the en_US locale, which is unavailable, and confirms that no locale package or string-processing dependency is added.

### Baseline and regression hardening

- Updates the normalized error signature hashes for both newly classified cases.
- Adds characterization assertions for each model's classification, reason, and SHA-256 signature in the managed Tier 0-4 profile test.
- Keeps both models visible as active non-passes rather than excluding or silently skipping them.

## Compatibility and scope

- No new package is introduced.
- No TensorFlow dependency or import path is added.
- No converter implementation, exporter behavior, public API, CLI option, output filename, report schema, or exit behavior is changed.
- No unfinished Goal implementation work is included in this pull request.

## Validation

- uv run pytest -q tests/test_flatbuffer_direct_bulk_runner.py::test_managed_regression_profile_includes_all_tier_zero_to_four_models
  - Result: 1 passed
- git diff --check
  - Result: passed
