### PR TITLE
Refactor flatbuffer_direct request, lowering, and pass-state boundaries

### DIFF
--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -84,6 +84,12 @@ The preceding mixed-attention runner is intentionally excluded because a
 legacy dequantize/HardSigmoid/quantize mutator separates it from the pair. The
 scope ends before the following raw convolution-affine fold.
 
+Immediately after that fold, the axis-3 constant-Concat, Dequantize/Concat/
+Quantize, LayerNorm-statistics, and generic transpose-cleanup runners share a
+third late scope. All four implementations mutate through the differential
+index. The scope ends before the conditional legacy elementwise-roundtrip
+optimizer.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -2107,6 +2107,12 @@ static shapes, and removes stale NHWC evidence for that output. The source line
 is not rewritten, so the exporter does not mark the file changed solely for
 this propagation; the updated evidence is consumed by the subsequent
 Softmax/ReduceMax and Pool decisions.
+Successful aligned-binary, Resize, and Pool rewrites record literal output
+shapes through one policy-owned cache helper. It accepts only a literal
+`target_shape=[...]` or the exact trailing aligned-shape form and leaves the
+existing cache untouched for dynamic or unparseable expressions. The exporter
+still invokes the update immediately after each rewrite, so every later rule in
+the ordered scan observes the same shape evidence as before extraction.
 The NHWC AveragePool-to-binary bridge repair and its channel-last spatial-pool
 restoration wrapper use the same owner. AveragePool, binary-anchor, and multiply
 target shapes are normalized as one chain only when NHWC producer and consumer

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -37,6 +37,14 @@ object is referenced only as the input to `ConversionRequest.from_kwargs`.
 This keeps legacy keys and default values intact while preventing later
 enhancements from bypassing normalization and reintroducing raw option
 propagation.
+SavedModel- and PyTorch-specific preparation options use a second requested-
+exporter control resolver in `artifact_preparation.py`. It does not read output
+paths, persistence, native PyTorch timeout, shape hints, or test data unless
+the corresponding artifact is requested. The custom input data option is read
+only for integer calibration or PyTorch-derived artifacts. Consequently, an
+invalid unused PyTorch timeout cannot fail a TFLite-only conversion, while a
+requested artifact retains the existing default paths, coercions, and error
+behavior.
 
 A pass has a stable ID, phase, priority, maximum iteration count, and explicit
 `changed` result. Repeating passes must use a graph fingerprint so a cycle

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -2083,6 +2083,15 @@ required. Channel mismatches, channel-last Resize, mixed-layout operand names,
 and already-channel-first shapes remain no-ops. The exporter applies returned
 layout evidence before its existing Resize rule, preserving the established
 general-repair → downstream-fallback → Resize ordering.
+Channel-first Resize repair now has two explicit policy stages. The general
+`_repair_cf_resize_target_shape` decision remains first; when it does not
+rewrite the statement, the exact input/BN-evidence fallback may normalize the
+target and publish CF evidence for the following Pool and aligned-constant
+rules. Immediate direct and reshaped BN statements share policy-owned parsers,
+and a registered BN constant channel count is preferred when present but is
+not required for the legacy input-evidence fallback. Explicit NHWC input and
+already-channel-first target shapes remain no-ops, preserving the established
+Resize-to-Pool scan behavior.
 The NHWC AveragePool-to-binary bridge repair and its channel-last spatial-pool
 restoration wrapper use the same owner. AveragePool, binary-anchor, and multiply
 target shapes are normalized as one chain only when NHWC producer and consumer

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -74,6 +74,12 @@ for compatibility with external mutations that bypass these APIs.
 source passed into `LoweringContext`. This preserves the pre-session safety
 contract used by inverse-transpose elision, including repeated uses of one
 input, without rebuilding a second ONNX edge-count map.
+Lowering-time logical and physical layout changes use
+`LoweringContext.set_tensor_layout()`. The method updates the tensor metadata
+and the Session-owned `LayoutState` together, so the first post-lowering pass
+receives current layout evidence without relying on that pass to hide stale
+state through a full resynchronization. Op-family builders must not assign
+`TensorIR.logical_layout` or `TensorIR.physical_layout` directly.
 Lineage-aware graph mutation helpers accept an optional ModelIR index and
 update it atomically.
 `operator_indices_for_types()` returns a sorted, deduplicated union for

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -30,6 +30,10 @@ TensorFlow- and Torch-free artifact policy only when the corresponding
 CLI values or environment variables, while requested values retain the legacy
 conversion and default semantics. The resolved quantization mapping is
 immutable and raw option dictionaries do not propagate into builders.
+The same guarded quantization mapping owns `quant_type`, input quant dtype, and
+output quant dtype. Their legacy `per-channel`/`int8` defaults are materialized
+without reading the request when no quantized output is selected; requested
+dynamic-range or integer artifacts receive the original explicit values.
 The direct export boundary constructs `ConversionRequest` once. Every option
 read after that boundary, including unsupported-quantization validation, uses
 the request's immutable mapping or typed `ArtifactPlan`; the original `kwargs`

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -97,6 +97,11 @@ other four scopes end before their next legacy mutator. Four separate repeated
 unary-passthrough/unary-fan-out/binary-fan-out sequences likewise share one
 scope per occurrence.
 
+Four repeated boundary-input BatchMatMul followed by leading-input unary
+passthrough pairs share one scope per occurrence. Each scope is limited to the
+two adjacent registered runners; the legacy layout transforms before and after
+each occurrence remain hard boundaries.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -61,6 +61,16 @@ data belongs to one session, is removed on first consumption, and is cleared
 on rollback, so it cannot leak across conversions or survive restored graph
 objects.
 
+`ModelIRPassStateScope` is the explicit reuse boundary for adjacent registered
+pass groups that have no raw ModelIR mutation between them. It is lazy, so a
+sequence whose model-only preflights all fail still constructs no graph index.
+The first matching group constructs one `ModelIRPassState`; later groups reuse
+its differentially maintained `ModelIRGraphIndex` and `LayoutState`. A scope
+rejects a different ModelIR or LayoutState identity and must end before any
+legacy/raw mutator. The repeated Mean/LayerNorm/terminal-Mean/SE/Conv-attention
+cluster is the first production consumer, preserving its original runner order
+while replacing up to seven identical index constructions with one.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -2074,6 +2074,15 @@ consumer agree on one rank-four shape and the current shape is the exact H/W
 swap. The rule keeps its positional scalar grammar and uses the shared aligned
 and Softmax statement decoders; their remaining consumers are policy-local, so
 the exporter does not import them.
+The subsequent aligned-binary fallback is policy-owned as a separate decision.
+It preserves the narrower generated-statement grammar and runs only when the
+general binary alignment repair made no change. Two channel-first operand names
+are not sufficient by themselves: an immediate matching BN constant operation,
+direct return, or channel-first Resize with matching channel evidence is also
+required. Channel mismatches, channel-last Resize, mixed-layout operand names,
+and already-channel-first shapes remain no-ops. The exporter applies returned
+layout evidence before its existing Resize rule, preserving the established
+general-repair → downstream-fallback → Resize ordering.
 The NHWC AveragePool-to-binary bridge repair and its channel-last spatial-pool
 restoration wrapper use the same owner. AveragePool, binary-anchor, and multiply
 target shapes are normalized as one chain only when NHWC producer and consumer

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -2118,6 +2118,13 @@ restoration wrapper use the same owner. AveragePool, binary-anchor, and multiply
 target shapes are normalized as one chain only when NHWC producer and consumer
 evidence agree; otherwise the repair remains a no-op. Constant-pad axis repair
 and reshape-to-permute replacement reuse the shared parser and layout context.
+On a successful bridge rewrite, the same policy decision now publishes all
+four affected names as NHWC, removes their stale CF evidence, and records their
+legacy normalized state shape. The state shape is deliberately recomputed from
+the pre-rewrite Pool shape after the layout-set update, matching the old
+exporter-side sequence rather than silently switching the cache to the rendered
+rewrite target. The exporter retains only the changed flag and immediate Pool
+reparse required by the following ordered decisions.
 Channel-first binary alignment repair is co-located with that context as well.
 It normalizes only rank-four targets backed by CF operands or CF consumer
 evidence, preserves already normalized targets, and leaves explicit binary

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -79,6 +79,11 @@ Each occurrence now constructs at most one index instead of as many as eight.
 Later isolated calls remain standalone because the scope must not cross the
 legacy ModelIR mutators surrounding them.
 
+The late NDHWC-gate/cost-volume-scatter pair uses a separate two-runner scope.
+The preceding mixed-attention runner is intentionally excluded because a
+legacy dequantize/HardSigmoid/quantize mutator separates it from the pair. The
+scope ends before the following raw convolution-affine fold.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -71,6 +71,14 @@ legacy/raw mutator. The repeated Mean/LayerNorm/terminal-Mean/SE/Conv-attention
 cluster is the first production consumer, preserving its original runner order
 while replacing up to seven identical index constructions with one.
 
+The repeated mixed-attention/elementwise-gate/Pad/dual-postconv-gate/NDHWC-
+gate/cost-volume-scatter/Add-Concat-suffix/dual-Mul-Concat sequence is the
+second production consumer. Four occurrences retain all eight runners and one
+occurrence retains the original seven-runner suffix without mixed attention.
+Each occurrence now constructs at most one index instead of as many as eight.
+Later isolated calls remain standalone because the scope must not cross the
+legacy ModelIR mutators surrounding them.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -2092,6 +2092,14 @@ and a registered BN constant channel count is preferred when present but is
 not required for the legacy input-evidence fallback. Explicit NHWC input and
 already-channel-first target shapes remain no-ops, preserving the established
 Resize-to-Pool scan behavior.
+The two aligned BatchNorm-constant forms are handled by one policy decision
+after Resize, Pool, and Concat evidence has been applied. A direct constant is
+reshaped only when its registered channel count matches the generated target;
+an already-reshaped constant retains the legacy normalization based on its
+explicit reshape channel. Both forms require a CF-like input and a generated
+BatchNorm attribute name. Their exact direct/reshaped statement grammars are
+shared with the preceding Resize evidence rule, and the repaired output is
+published as CF evidence for later normalization decisions.
 The NHWC AveragePool-to-binary bridge repair and its channel-last spatial-pool
 restoration wrapper use the same owner. AveragePool, binary-anchor, and multiply
 target shapes are normalized as one chain only when NHWC producer and consumer

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -90,6 +90,13 @@ third late scope. All four implementations mutate through the differential
 index. The scope ends before the conditional legacy elementwise-roundtrip
 optimizer.
 
+Five repeated two-way/NHWC/NCHW channel-shuffle plus Gather-axis sequences
+share one scope per occurrence. The final occurrence preserves its contiguous
+generic transpose and unary fan-out suffix inside the same scope, while the
+other four scopes end before their next legacy mutator. Four separate repeated
+unary-passthrough/unary-fan-out/binary-fan-out sequences likewise share one
+scope per occurrence.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -2100,6 +2100,13 @@ explicit reshape channel. Both forms require a CF-like input and a generated
 BatchNorm attribute name. Their exact direct/reshaped statement grammars are
 shared with the preceding Resize evidence rule, and the repaired output is
 published as CF evidence for later normalization decisions.
+Local-response-normalization output propagation is policy-owned as a state-only
+decision. It preserves the generated parser grammar, marks an output CF only
+when the input has exact dynamic or suffix evidence, copies only rank-four
+static shapes, and removes stale NHWC evidence for that output. The source line
+is not rewritten, so the exporter does not mark the file changed solely for
+this propagation; the updated evidence is consumed by the subsequent
+Softmax/ReduceMax and Pool decisions.
 The NHWC AveragePool-to-binary bridge repair and its channel-last spatial-pool
 restoration wrapper use the same owner. AveragePool, binary-anchor, and multiply
 target shapes are normalized as one chain only when NHWC producer and consumer

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -30,6 +30,13 @@ TensorFlow- and Torch-free artifact policy only when the corresponding
 CLI values or environment variables, while requested values retain the legacy
 conversion and default semantics. The resolved quantization mapping is
 immutable and raw option dictionaries do not propagate into builders.
+The direct export boundary constructs `ConversionRequest` once. Every option
+read after that boundary, including unsupported-quantization validation, uses
+the request's immutable mapping or typed `ArtifactPlan`; the original `kwargs`
+object is referenced only as the input to `ConversionRequest.from_kwargs`.
+This keeps legacy keys and default values intact while preventing later
+enhancements from bypassing normalization and reintroducing raw option
+propagation.
 
 A pass has a stable ID, phase, priority, maximum iteration count, and explicit
 `changed` result. Repeating passes must use a graph fingerprint so a cycle

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -70,6 +70,10 @@ positions and is shifted together with all edge indices on insertion/removal,
 so bounded passes can enumerate only relevant operator families instead of
 rescanning the full ModelIR operator list. A full `refresh()` is retained only
 for compatibility with external mutations that bypass these APIs.
+`ConversionSession.tensor_consumer_count` is also the sole consumer-count
+source passed into `LoweringContext`. This preserves the pre-session safety
+contract used by inverse-transpose elision, including repeated uses of one
+input, without rebuilding a second ONNX edge-count map.
 Lineage-aware graph mutation helpers accept an optional ModelIR index and
 update it atomically.
 `operator_indices_for_types()` returns a sorted, deduplicated union for

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -102,6 +102,10 @@ passthrough pairs share one scope per occurrence. Each scope is limited to the
 two adjacent registered runners; the legacy layout transforms before and after
 each occurrence remain hard boundaries.
 
+Three repeated strict channel-slice-merge followed by Pad/Mul cleanup pairs
+share one scope per occurrence. The three-spec channel-slice group and the
+single-spec Pad/Mul group keep their original order and diagnostic grouping.
+
 `GraphIndex` and `ModelIRGraphIndex` provide differential mutation contracts.
 ONNX rewriters notify node input/output updates and node registration/removal;
 ModelIR rewriters can replace inputs/outputs or insert/remove operators while

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -80,6 +80,14 @@ and the Session-owned `LayoutState` together, so the first post-lowering pass
 receives current layout evidence without relying on that pass to hide stale
 state through a full resynchronization. Op-family builders must not assign
 `TensorIR.logical_layout` or `TensorIR.physical_layout` directly.
+`LoweringContext.add_operator()` and `remove_operator()` likewise own the
+lowering-time operator list and maintain differential IR producer and consumer
+maps. Inverse-Transpose generation uses the ONNX `GraphIndex` count for an ONNX
+edge and the current IR count plus the pending use for a synthetic edge. It may
+therefore remove an exclusive producer without rescanning the partial graph,
+while retaining that producer when a previously emitted side branch still
+consumes its synthetic output. Op-family builders must not mutate
+`model_ir.operators` directly.
 Lineage-aware graph mutation helpers accept an optional ModelIR index and
 update it atomically.
 `operator_indices_for_types()` returns a sorted, deduplicated union for

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,14 +7,13 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit audits the later mixed-attention/NDHWC/cost-
-volume sequence. A raw dequantize/HardSigmoid/quantize mutator separates mixed
-attention from the other runners, so mixed attention intentionally remains
-standalone. Only the contiguous NDHWC-gate and cost-volume-scatter runners now
-share a separate lazy `ModelIRPassStateScope`, which ends before the following
-raw convolution-affine fold. A synthetic model whose two model-only preflights
-match proves that three diagnostic events construct one graph index without
-crossing either raw boundary.
+The latest implementation unit shares one lazy `ModelIRPassStateScope` across
+the late axis-3 constant-Concat, Dequantize/Concat/Quantize, LayerNorm-
+statistics, and generic transpose-cleanup runners. The scope starts after the
+raw convolution-affine fold and ends before the conditional legacy
+elementwise-roundtrip optimizer. A synthetic model whose four model-only
+preflights match proves that five diagnostic events construct one graph index
+without crossing either raw boundary.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -36,7 +35,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains fifteen coherent continuations:
+The current `fb-refactor5` work contains sixteen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -69,8 +68,10 @@ The current `fb-refactor5` work contains fifteen coherent continuations:
   Mean/attention registered-pass cluster;
 - `514fc683` applies the same bounded reuse contract to the repeated mixed-
   attention through dual-Mul/Concat registered-pass cluster;
-- the current checkpoint shares state only across the separately audited late
-  NDHWC-gate/cost-volume-scatter pair.
+- `9b32c680` shares state only across the separately audited late NDHWC-gate/
+  cost-volume-scatter pair;
+- the current checkpoint shares state across the following four registered
+  Concat, LayerNorm, and transpose-cleanup runners.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -88,7 +89,11 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
+- `onnx2tf/tflite_builder/passes/axis3_const_concat_layout.py`;
+- `onnx2tf/tflite_builder/passes/dequant_concat_quantize_layout.py`;
+- `onnx2tf/tflite_builder/passes/layout_transpose.py`;
 - `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
+- `tests/test_flatbuffer_direct_core.py`;
 - `tests/test_flatbuffer_direct_pass_efficiency.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
@@ -195,6 +200,12 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   NDHWC is a hard boundary. A new scope is therefore constructed only for the
   immediately adjacent NDHWC and cost-volume runners, and ends before the raw
   convolution-affine optimizer. Both runners preserve standalone behavior.
+- After that convolution-affine boundary, axis-3 constant-Concat,
+  Dequantize/Concat/Quantize, LayerNorm-statistics, and generic transpose
+  cleanup form one independently audited four-runner scope. Each runner either
+  already accepted a scope or now exposes the same optional
+  standalone-compatible argument; the scope ends before the conditional raw
+  elementwise-roundtrip optimizer.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -393,17 +404,39 @@ build flags `[true, true, false]`: both events in the first two-spec runner
 belong to the one state-building group, and the second runner reuses that
 state. The architecture test fixes both raw boundaries and proves that mixed
 attention receives no shared scope.
+A focused late-Concat cluster checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_pass_efficiency.py::test_late_concat_layout_cluster_reuses_one_pass_state \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_late_concat_layout_cluster_reuses_one_pass_state_scope \
+  tests/test_flatbuffer_direct_axis3_const_concat_layout.py \
+  tests/test_flatbuffer_direct_dequant_concat_quantize_layout.py \
+  tests/test_flatbuffer_direct_layernorm_layout.py \
+  tests/test_flatbuffer_direct_layout_transpose.py
+
+74 passed
+```
+
+The synthetic runtime fixture records one graph-index refresh and build flags
+`[true, false, false, false, false]`. The architecture test fixes the four-
+runner order and both raw boundaries. The core layout-handoff monkeypatch now
+accepts and forwards the runner's optional scope without changing its original
+pre-pass layout assertions.
 A broader single-process selection of
 `test_flatbuffer_direct_core.py`, `test_flatbuffer_direct_pass_efficiency.py`,
 and the complete `test_flatbuffer_direct_architecture.py` passed with
-`141 passed` after adding the late-pair checks.
+`143 passed` after adding the late-Concat cluster checks.
 
-All changed pass modules and tests pass Ruff. The lowerer passes Ruff with only
-its pre-existing `F401` and `F841` findings scoped out. Every changed Python
-file passes `python -m py_compile`, and `git diff --check` passes. The
-immediately preceding DepthToSpace, Pool, dynamic-Pool, simple-alias, and
-aligned-scalar checkpoints passed their focused synthetic and ownership
-selections.
+The changed axis-3/dequant pass modules and tests pass Ruff normally.
+`layout_transpose.py` passes with its one pre-existing `F841` finding scoped
+out, and the lowerer passes with its pre-existing `F401` and `F841` findings
+scoped out. Every changed Python file passes `python -m py_compile`, and
+`git diff --check` passes. The immediately preceding DepthToSpace, Pool,
+dynamic-Pool, simple-alias, and aligned-scalar checkpoints passed their focused
+synthetic and ownership selections.
 
 ## Failing tests and known issues
 

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,12 +7,12 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit moves the input/BN-evidence channel-first
-Resize fallback out of `_apply_fast_precanonicalize_repairs` and into the
-Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The orchestrator is
-372 lines at this checkpoint, down from 482 lines at Goal resumption, 1,025
-lines at the beginning of the previous continuation, and 1,608 lines before
-the broader fast-precanonicalize extraction.
+The latest implementation unit moves the direct and reshaped aligned
+BatchNorm-constant repairs out of `_apply_fast_precanonicalize_repairs` and
+into the Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The
+orchestrator is 316 lines at this checkpoint, down from 482 lines at Goal
+resumption, 1,025 lines at the beginning of the previous continuation, and
+1,608 lines before the broader fast-precanonicalize extraction.
 
 ## Completed work
 
@@ -31,15 +31,17 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains two coherent continuations:
+The current `fb-refactor5` work contains three coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
   statement supplies matching BN, direct-return, or channel-first Resize
   evidence;
-- the current checkpoint centralizes the following Resize fallback, including
+- `008e4ad0` centralizes the following Resize fallback, including
   exact direct and reshaped BN-constant parsing, preferred-channel selection,
-  input-layout guards, and CF evidence propagation.
+  input-layout guards, and CF evidence propagation;
+- the current checkpoint centralizes the aligned BatchNorm-constant rewrite
+  itself while preserving the different direct and already-reshaped guards.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -91,6 +93,12 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 - Explicit NHWC Resize inputs and already-channel-first target shapes remain
   no-ops. BN evidence refines the preferred channel count but is not a
   prerequisite for the legacy CF-input repair.
+- Direct aligned BatchNorm constants require a registered channel count that
+  matches the generated target channel before a reshape is introduced.
+  Already-reshaped constants intentionally retain the older, narrower rule:
+  their explicit reshape channel drives normalization without requiring a
+  registered-buffer channel lookup. Both forms still require CF input and a
+  BatchNorm-derived attribute name.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -100,7 +108,8 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 
 ## Tests executed
 
-The resumed downstream-binary and Resize-evidence checkpoints passed:
+The resumed downstream-binary, Resize-evidence, and aligned-BatchNorm
+checkpoints passed:
 
 ```text
 env -u PYTHONPATH -u LD_LIBRARY_PATH \
@@ -109,7 +118,7 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
   tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py \
   tests/test_flatbuffer_direct_architecture.py
 
-121 passed
+122 passed
 ```
 
 Seven pre/post-extraction characterization cases also preserve the exact
@@ -117,6 +126,9 @@ orchestrator output for matching BN, direct return, channel-first Resize,
 channel mismatch, channel-last Resize, mixed operands, and an already-CF shape.
 Five additional pre/post-extraction cases preserve direct BN, reshaped BN,
 no-BN fallback, NHWC-input no-op, and already-CF Resize behavior.
+Seven aligned-BatchNorm cases preserve direct rewrite, non-BN no-op, channel
+mismatch no-op, NHWC-input no-op, reshaped rewrite, already-CF behavior, and
+reshaped non-BN no-op.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -142,9 +154,8 @@ ownership selections.
 ## Unfinished work
 
 The full Goal is not complete. The fast-precanonicalize orchestrator still has
-372 lines. Its largest remaining in-loop blocks are:
+316 lines. Its remaining in-loop logic is primarily:
 
-- 32 and 26 lines: reshaped and direct aligned BN-constant repair;
 - smaller Pool state-update glue and local-response-normalization shape repair.
 
 The broader fixed-pipeline, exporter, artifact-matrix, optional TensorFlow,
@@ -155,12 +166,12 @@ remains subject to the original refactor plan and its verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Inspect the 32-line reshaped and 26-line direct aligned BN-constant repairs
-   in `_apply_fast_precanonicalize_repairs`.
-3. Characterize input/constant channel agreement, layout propagation, and
-   no-op cases before moving their exact decisions to the policy owner.
-4. Preserve their current ordering after Resize/Pool evidence and before the
-   subsequent Softmax and local-response-normalization decisions.
+2. Inspect local-response-normalization layout propagation and the remaining
+   Pool state-update glue in `_apply_fast_precanonicalize_repairs`.
+3. Characterize exact CF/NHWC and static-shape propagation behavior before
+   moving another bounded decision to the policy owner.
+4. Preserve the current ordering after aligned BatchNorm repair and before
+   Softmax/ReduceMax normalization.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -8,11 +8,11 @@ currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
 The latest implementation unit shares one lazy `ModelIRPassStateScope` across
-each of four repeated boundary-input BatchMatMul/input-unary runner pairs. The
-scope contains only those two adjacent registered runners and ends before the
-next legacy layout optimizer. A synthetic fixture whose two model-only
-preflights match proves that four diagnostic events construct one graph index
-without changing runner order or standalone behavior.
+each of three repeated strict channel-slice-merge/Pad-Mul runner pairs. The
+scope contains only the adjacent three-spec channel-slice and single-spec Pad-
+Mul groups. A synthetic fixture whose two model-only preflights match proves
+that four diagnostic events construct one graph index without changing runner
+order, diagnostic grouping, or standalone behavior.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -34,7 +34,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains eighteen coherent continuations:
+The current `fb-refactor5` work contains nineteen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -73,8 +73,10 @@ The current `fb-refactor5` work contains eighteen coherent continuations:
   LayerNorm, and transpose-cleanup runners;
 - `969d5e26` shares state across the repeated channel-shuffle/Gather-axis and
   unary fan-out runner clusters;
-- the current checkpoint shares state across four repeated boundary-input
-  BatchMatMul/input-unary runner pairs.
+- `251edc58` shares state across four repeated boundary-input BatchMatMul/input-
+  unary runner pairs;
+- the current checkpoint shares state across three repeated channel-slice-
+  merge/Pad-Mul pairs.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -92,8 +94,8 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/passes/boundary_input_chains.py`;
-- `onnx2tf/tflite_builder/passes/input_passthrough_layout.py`;
+- `onnx2tf/tflite_builder/passes/channel_slice_layout.py`;
+- `onnx2tf/tflite_builder/passes/pad_layout.py`;
 - `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
 - `tests/test_flatbuffer_direct_pass_efficiency.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
@@ -220,6 +222,10 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   No scope crosses the legacy transformations surrounding any occurrence.
   Their two stale `_build_tensor_consumer_map` imports are removed; neither
   module constructs an ad hoc consumer map for these runners.
+- Three repeated channel-slice-merge/Pad-Mul pairs now use a two-group helper-
+  owned scope. Both runners retain optional standalone-compatible scope
+  arguments, and the scope ends before the legacy optimizer following each
+  pair.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -484,10 +490,30 @@ The runtime fixture records one graph-index refresh and build flags
 `[true, false, false, false]`; the latter three events belong to the reused
 three-spec input-unary group. The architecture gate fixes the two-runner order
 and all four helper invocations.
+A focused channel-slice/Pad-Mul checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_pass_efficiency.py::test_channel_slice_pad_mul_pair_reuses_one_pass_state \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_channel_slice_pad_mul_pair_reuses_pass_state_scope \
+  tests/test_flatbuffer_direct_architecture.py::test_ordered_model_ir_runner_calls_record_session_diagnostics \
+  tests/test_flatbuffer_direct_pad_layout.py \
+  tests/test_tflite_builder_direct.py \
+  -k 'channel_slice or transpose_pad_mul_posttranspose or channel_slice_pad_mul_pair or ordered_model_ir_runner or lowerer_channel_slice'
+
+8 passed, 754 deselected
+```
+
+The runtime fixture records one graph-index refresh and build flags
+`[true, true, true, false]`: the first three events belong to the one state-
+building channel-slice group, and Pad-Mul reuses that state. The architecture
+gate fixes the two-group order and all three helper invocations.
 A broader single-process selection of
 `test_flatbuffer_direct_core.py`, `test_flatbuffer_direct_pass_efficiency.py`,
 and the complete `test_flatbuffer_direct_architecture.py` passed with
-`148 passed` after adding the boundary-input pair checks.
+`150 passed` after adding the channel-slice/Pad-Mul checks.
 
 The changed pass modules and tests pass Ruff normally. The lowerer passes with
 its pre-existing `F401` and `F841` findings scoped out. Every changed Python
@@ -529,9 +555,9 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the remaining small repeated registered-runner pairs, beginning with
-   channel-slice-merge/Pad-Mul, while treating every surrounding legacy helper
-   as a hard boundary.
+2. Audit the remaining repeated singleton/duplicate/consecutive-reshape runner
+   sequences while treating every surrounding legacy helper as a hard
+   boundary.
 3. Add a focused production-boundary characterization before sharing another
    scope, and preserve exact diagnostics and rule order. Never carry a scope
    across a legacy helper or introduce a blanket refresh.

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,10 +7,10 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit centralizes the repeated post-rewrite literal
-static-shape cache update for aligned binary, Resize, and Pool statements in
-the Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The orchestrator
-remains 308 lines at this checkpoint, down from 482 lines at Goal
+The latest implementation unit co-locates successful NHWC AveragePool bridge
+layout-set and static-shape state application with its existing Torch-free
+policy rewrite. The orchestrator is 294 lines at this checkpoint, down from
+482 lines at Goal
 resumption, 1,025 lines at the beginning of the previous continuation, and
 1,608 lines before the broader fast-precanonicalize extraction.
 
@@ -31,7 +31,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains five coherent continuations:
+The current `fb-refactor5` work contains six coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -44,8 +44,10 @@ The current `fb-refactor5` work contains five coherent continuations:
   preserving the different direct and already-reshaped guards;
 - `91a0a52d` centralizes LRN output evidence propagation without changing or
   broadening the generated source grammar;
-- the current checkpoint centralizes literal static-shape recording while
-  retaining each update at its original point in the ordered scan.
+- `b00774a7` centralizes literal static-shape recording while retaining each
+  update at its original point in the ordered scan;
+- the current checkpoint makes the NHWC AveragePool bridge own the CF/NHWC and
+  static-shape state resulting from its rewrite.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -111,6 +113,11 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   exact trailing aligned shape. Dynamic and unparseable expressions do not
   replace existing cache entries, and binary/Resize/Pool callers still update
   the shared context immediately after their successful rewrite.
+- The NHWC AveragePool bridge keeps its returned-name contract, but successful
+  calls now update the layout sets and all four affected static-shape entries
+  internally. To preserve behavior, the cached state shape is still recomputed
+  from the pre-rewrite Pool shape after the layout sets change; it is not
+  replaced by the rendered rewrite target.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -120,8 +127,8 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 
 ## Tests executed
 
-The resumed downstream-binary, Resize-evidence, aligned-BatchNorm, LRN, and
-static-shape-cache checkpoints passed:
+The resumed downstream-binary, Resize-evidence, aligned-BatchNorm, LRN,
+static-shape-cache, and NHWC-bridge checkpoints passed:
 
 ```text
 env -u PYTHONPATH -u LD_LIBRARY_PATH \
@@ -146,6 +153,8 @@ and static-shape state, Pool/LRN interaction, architecture ownership, and the
 existing generated-source integration case.
 The cache checkpoint passed four focused cases covering aligned binary,
 Resize/Pool, literal recording, parse-failure no-op, and architecture ownership.
+The bridge checkpoint adds positive state-set/cache assertions and a no-op
+state-preservation case to the existing whole-chain normalization test.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -171,11 +180,9 @@ ownership selections.
 ## Unfinished work
 
 The full Goal is not complete. The fast-precanonicalize orchestrator still has
-308 lines. Its remaining body is primarily the intended ordered helper
-orchestration. Remaining state-update glue includes:
-
-- applying NHWC AveragePool bridge layout/shape results before subsequent Pool
-  decisions.
+294 lines. Its remaining body is primarily the intended ordered helper
+orchestration, source-line replacement, changed-flag handling, and the explicit
+short-circuit boundaries required by the extracted policy decisions.
 
 The broader fixed-pipeline, exporter, artifact-matrix, optional TensorFlow,
 PyTorch/TorchScript/Dynamo/ExportedProgram, and full Tier regression work also
@@ -185,12 +192,14 @@ remains subject to the original refactor plan and its verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Inspect NHWC AveragePool-to-binary bridge state application in
-   `_apply_fast_precanonicalize_repairs`.
-3. Characterize the returned-name, CF/NHWC-set, normalized-shape, and no-op
-   behavior before co-locating the state update with its policy rewrite.
-4. Preserve the immediate reparse of the rewritten Pool statement before the
-   following Pool layout decisions.
+2. Audit the remaining 294-line orchestrator for decision logic rather than
+   orchestration glue; do not move the explicit ordered sequencing merely to
+   reduce line count.
+3. If no bounded decision remains, select the next unfinished fixed-pipeline or
+   exporter contract task from the broader Goal instead of introducing a large
+   mechanical wrapper.
+4. Preserve the existing changed flags, line refreshes, and explicit
+   short-circuits while making that selection.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,15 +7,14 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit extends the lazy `ModelIRPassStateScope` to the
-next audited registered-pass sequence. Four repeated production clusters now
-share one differential index across mixed attention, elementwise gates, Pad,
-dual post-convolution gates, NDHWC gates, cost-volume ScatterND, Add/Concat
-suffixes, and dual-Mul/Concat. A fifth occurrence shares the same seven-runner
-suffix while retaining its original omission of mixed attention. All later
-isolated calls remain outside this scope. A synthetic model whose model-only
-preflights match every runner proves that 15 diagnostic events construct one
-graph index without changing runner order.
+The latest implementation unit audits the later mixed-attention/NDHWC/cost-
+volume sequence. A raw dequantize/HardSigmoid/quantize mutator separates mixed
+attention from the other runners, so mixed attention intentionally remains
+standalone. Only the contiguous NDHWC-gate and cost-volume-scatter runners now
+share a separate lazy `ModelIRPassStateScope`, which ends before the following
+raw convolution-affine fold. A synthetic model whose two model-only preflights
+match proves that three diagnostic events construct one graph index without
+crossing either raw boundary.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -37,7 +36,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains fourteen coherent continuations:
+The current `fb-refactor5` work contains fifteen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -68,8 +67,10 @@ The current `fb-refactor5` work contains fourteen coherent continuations:
   inverse-Transpose fan-out with differential consumer counts;
 - `2a2968cc` lazily shares `ModelIRPassState` across the repeated
   Mean/attention registered-pass cluster;
-- the current checkpoint applies the same bounded reuse contract to the
-  repeated mixed-attention through dual-Mul/Concat registered-pass cluster.
+- `514fc683` applies the same bounded reuse contract to the repeated mixed-
+  attention through dual-Mul/Concat registered-pass cluster;
+- the current checkpoint shares state only across the separately audited late
+  NDHWC-gate/cost-volume-scatter pair.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -87,14 +88,6 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/passes/attention_layout.py`;
-- `onnx2tf/tflite_builder/passes/elementwise_gate_layout.py`;
-- `onnx2tf/tflite_builder/passes/pad_layout.py`;
-- `onnx2tf/tflite_builder/passes/dual_postconv_gate_layout.py`;
-- `onnx2tf/tflite_builder/passes/ndhwc_gate_layout.py`;
-- `onnx2tf/tflite_builder/passes/cost_volume_scatter_layout.py`;
-- `onnx2tf/tflite_builder/passes/add_concat_suffix_layout.py`;
-- `onnx2tf/tflite_builder/passes/dual_mul_concat_layout.py`;
 - `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
 - `tests/test_flatbuffer_direct_pass_efficiency.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
@@ -197,6 +190,11 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   standalone behavior through an optional `state_scope` argument, and the
   later isolated mixed-attention, Pad, NDHWC, cost-volume, and dual-Mul calls
   intentionally do not share this scope.
+- The late mixed-attention/NDHWC/cost-volume candidate is not one valid scope:
+  the raw dequantize/HardSigmoid/quantize optimizer between mixed attention and
+  NDHWC is a hard boundary. A new scope is therefore constructed only for the
+  immediately adjacent NDHWC and cost-volume runners, and ends before the raw
+  convolution-affine optimizer. Both runners preserve standalone behavior.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -375,10 +373,30 @@ The architecture checks fix the eight-runner order, five production helper
 invocations, and the single invocation that omits mixed attention. They also
 bring the global direct-runner count characterization up to date with both
 bounded helper extractions.
+A focused late-pair checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_pass_efficiency.py::test_late_ndhwc_cost_volume_pair_reuses_one_pass_state \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_late_ndhwc_cost_volume_pair_reuses_one_pass_state_scope \
+  tests/test_flatbuffer_direct_3d_gate_layout.py \
+  tests/test_flatbuffer_direct_conv3d_gate_layout.py \
+  tests/test_flatbuffer_direct_cost_volume_scatter_layout.py
+
+50 passed
+```
+
+The runtime characterization observes one graph-index refresh and diagnostic
+build flags `[true, true, false]`: both events in the first two-spec runner
+belong to the one state-building group, and the second runner reuses that
+state. The architecture test fixes both raw boundaries and proves that mixed
+attention receives no shared scope.
 A broader single-process selection of
 `test_flatbuffer_direct_core.py`, `test_flatbuffer_direct_pass_efficiency.py`,
 and the complete `test_flatbuffer_direct_architecture.py` passed with
-`139 passed`.
+`141 passed` after adding the late-pair checks.
 
 All changed pass modules and tests pass Ruff. The lowerer passes Ruff with only
 its pre-existing `F401` and `F841` findings scoped out. Every changed Python
@@ -420,12 +438,12 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the later contiguous mixed-attention/NDHWC-gate/cost-volume-scatter
-   triple as the next small reuse candidate. Confirm both surrounding legacy
-   boundaries before sharing state; leave the other isolated calls unchanged.
-3. Add a focused production-boundary characterization for that triple and
-   preserve exact diagnostics and rule order. Never carry a scope across a
-   legacy helper or introduce a blanket refresh.
+2. Audit the remaining post-lowering runner calls for another adjacent pair or
+   cluster. Treat every legacy helper between registered runners as a hard
+   boundary, even when the surrounding runner families are related.
+3. Add a focused production-boundary characterization before sharing another
+   scope, and preserve exact diagnostics and rule order. Never carry a scope
+   across a legacy helper or introduce a blanket refresh.
 4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing
    unless a new bounded decision is found.
 5. Run only the focused synthetic/ownership/static checks unless the user asks

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,13 +7,13 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit shares one lazy `ModelIRPassStateScope` across
-the late axis-3 constant-Concat, Dequantize/Concat/Quantize, LayerNorm-
-statistics, and generic transpose-cleanup runners. The scope starts after the
-raw convolution-affine fold and ends before the conditional legacy
-elementwise-roundtrip optimizer. A synthetic model whose four model-only
-preflights match proves that five diagnostic events construct one graph index
-without crossing either raw boundary.
+The latest implementation unit shares lazy `ModelIRPassStateScope` instances
+across two repeated families. Five channel-shuffle/Gather-axis clusters now
+reuse one index; the final occurrence includes its contiguous generic
+transpose and two unary fan-out runners in the same scope. Four separate unary-
+passthrough/fan-out clusters also reuse one index each. Synthetic fixtures prove
+one index build across seven-runner and three-runner forms while preserving all
+model-only preflights, diagnostics, and runner order.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -35,7 +35,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains sixteen coherent continuations:
+The current `fb-refactor5` work contains seventeen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -70,8 +70,10 @@ The current `fb-refactor5` work contains sixteen coherent continuations:
   attention through dual-Mul/Concat registered-pass cluster;
 - `9b32c680` shares state only across the separately audited late NDHWC-gate/
   cost-volume-scatter pair;
-- the current checkpoint shares state across the following four registered
-  Concat, LayerNorm, and transpose-cleanup runners.
+- `1aa636e3` shares state across the following four registered Concat,
+  LayerNorm, and transpose-cleanup runners;
+- the current checkpoint shares state across the repeated channel-shuffle/
+  Gather-axis and unary fan-out runner clusters.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -89,11 +91,9 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/passes/axis3_const_concat_layout.py`;
-- `onnx2tf/tflite_builder/passes/dequant_concat_quantize_layout.py`;
+- `onnx2tf/tflite_builder/passes/channel_shuffle.py`;
 - `onnx2tf/tflite_builder/passes/layout_transpose.py`;
 - `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
-- `tests/test_flatbuffer_direct_core.py`;
 - `tests/test_flatbuffer_direct_pass_efficiency.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
@@ -206,6 +206,13 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   already accepted a scope or now exposes the same optional
   standalone-compatible argument; the scope ends before the conditional raw
   elementwise-roundtrip optimizer.
+- Two repeated cluster families now have explicit helper-owned scopes. The
+  channel-shuffle helper preserves two-way, NHWC, NCHW, and Gather-axis order
+  at all five call sites; only its final invocation enables the already-
+  contiguous generic transpose and unary/binary fan-out suffix. The separate
+  unary helper preserves passthrough, unary fan-out, and unary/binary fan-out
+  order at four call sites. Every runner remains callable standalone through
+  an optional scope argument.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -425,16 +432,42 @@ The synthetic runtime fixture records one graph-index refresh and build flags
 runner order and both raw boundaries. The core layout-handoff monkeypatch now
 accepts and forwards the runner's optional scope without changing its original
 pre-pass layout assertions.
+A focused shuffle/unary cluster checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_pass_efficiency.py::test_shuffle_gather_cluster_reuses_one_pass_state \
+  tests/test_flatbuffer_direct_pass_efficiency.py::test_unary_fanout_cluster_reuses_one_pass_state \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_shuffle_and_unary_clusters_reuse_pass_state_scopes \
+  tests/test_flatbuffer_direct_architecture.py::test_ordered_model_ir_runner_calls_record_session_diagnostics \
+  tests/test_flatbuffer_direct_nhwc_channel_shuffle.py \
+  tests/test_flatbuffer_direct_nchw_channel_shuffle.py \
+  tests/test_flatbuffer_direct_layout_transpose.py \
+  tests/test_flatbuffer_direct_transpose_unary.py \
+  tests/test_flatbuffer_direct_transpose_unary_fanout.py \
+  tests/test_flatbuffer_direct_transpose_unary_binary_fanout.py \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_shufflenet_transpose_shuffle_chain_optimized
+
+29 passed
+```
+
+Both synthetic fixtures observe exactly one graph-index refresh. The seven-
+runner fixture records one `state_built: true` followed by six `false` events;
+the three-runner fixture records one `true` followed by two `false` events.
+The architecture gate fixes the two helper orders, five and four invocations,
+and the single extended channel-shuffle invocation.
 A broader single-process selection of
 `test_flatbuffer_direct_core.py`, `test_flatbuffer_direct_pass_efficiency.py`,
 and the complete `test_flatbuffer_direct_architecture.py` passed with
-`143 passed` after adding the late-Concat cluster checks.
+`146 passed` after adding the shuffle/unary cluster checks.
 
-The changed axis-3/dequant pass modules and tests pass Ruff normally.
-`layout_transpose.py` passes with its one pre-existing `F841` finding scoped
-out, and the lowerer passes with its pre-existing `F401` and `F841` findings
-scoped out. Every changed Python file passes `python -m py_compile`, and
-`git diff --check` passes. The immediately preceding DepthToSpace, Pool,
+The changed tests pass Ruff normally. `channel_shuffle.py` and
+`layout_transpose.py` pass with their two and one pre-existing `F841` findings
+scoped out, and the lowerer passes with its pre-existing `F401` and `F841`
+findings scoped out. Every changed Python file passes `python -m py_compile`,
+and `git diff --check` passes. The immediately preceding DepthToSpace, Pool,
 dynamic-Pool, simple-alias, and aligned-scalar checkpoints passed their focused
 synthetic and ownership selections.
 
@@ -471,9 +504,9 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the remaining post-lowering runner calls for another adjacent pair or
-   cluster. Treat every legacy helper between registered runners as a hard
-   boundary, even when the surrounding runner families are related.
+2. Audit the repeated boundary-input BatchMatMul/input-unary pairs as the next
+   small candidate. Treat every legacy helper before and after each pair as a
+   hard boundary.
 3. Add a focused production-boundary characterization before sharing another
    scope, and preserve exact diagnostics and rule order. Never carry a scope
    across a legacy helper or introduce a blanket refresh.

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,12 +7,13 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit co-locates successful NHWC AveragePool bridge
-layout-set and static-shape state application with its existing Torch-free
-policy rewrite. The orchestrator is 294 lines at this checkpoint, down from
-482 lines at Goal
-resumption, 1,025 lines at the beginning of the previous continuation, and
-1,608 lines before the broader fast-precanonicalize extraction.
+The latest implementation unit completes the immutable `ConversionRequest`
+read boundary inside the direct exporter. All 36 option reads now use
+`request.get`, artifact selection continues through `ArtifactPlan`, and the
+original `kwargs` object is referenced only when constructing the request.
+The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
+lines at Goal resumption, 1,025 lines at the beginning of the previous
+continuation, and 1,608 lines before the broader extraction.
 
 ## Completed work
 
@@ -31,7 +32,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains six coherent continuations:
+The current `fb-refactor5` work contains seven coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -46,8 +47,10 @@ The current `fb-refactor5` work contains six coherent continuations:
   broadening the generated source grammar;
 - `b00774a7` centralizes literal static-shape recording while retaining each
   update at its original point in the ordered scan;
-- the current checkpoint makes the NHWC AveragePool bridge own the CF/NHWC and
-  static-shape state resulting from its rewrite.
+- `95fbd0cb` makes the NHWC AveragePool bridge own the CF/NHWC and static-shape
+  state resulting from its rewrite;
+- the current checkpoint routes all direct-export option reads through the
+  normalized request and adds a structural boundary test.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -64,9 +67,7 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/pytorch_exporter.py`;
-- `onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py`;
-- `tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py`;
+- `onnx2tf/tflite_builder/__init__.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
@@ -118,6 +119,12 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   internally. To preserve behavior, the cached state shape is still recomputed
   from the pre-rewrite Pool shape after the layout sets change; it is not
   replaced by the rendered rewrite target.
+- `ConversionRequest.from_kwargs` is the direct exporter's only raw-kwargs
+  boundary. Quantization validation receives `request.options`, all 36
+  remaining optional reads use `request.get`, and typed artifact decisions
+  remain on `request.artifacts`. This is a source-routing change only; keys,
+  defaults, coercions, public return values, and downstream arguments are
+  unchanged.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -155,6 +162,20 @@ The cache checkpoint passed four focused cases covering aligned binary,
 Resize/Pool, literal recording, parse-failure no-op, and architecture ownership.
 The bridge checkpoint adds positive state-set/cache assertions and a no-op
 state-preservation case to the existing whole-chain normalization test.
+The request-boundary checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_core.py \
+  tests/test_flatbuffer_direct_architecture.py
+
+126 passed
+```
+
+Its AST gate proves zero `kwargs.get` calls and exactly one raw `kwargs` read,
+as the argument to `ConversionRequest.from_kwargs`.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -184,7 +205,8 @@ The full Goal is not complete. The fast-precanonicalize orchestrator still has
 orchestration, source-line replacement, changed-flag handling, and the explicit
 short-circuit boundaries required by the extracted policy decisions.
 
-The broader fixed-pipeline, exporter, artifact-matrix, optional TensorFlow,
+The broader fixed-pipeline, remaining artifact-plan coverage, artifact-matrix,
+optional TensorFlow,
 PyTorch/TorchScript/Dynamo/ExportedProgram, and full Tier regression work also
 remains subject to the original refactor plan and its verification gates.
 
@@ -192,14 +214,12 @@ remains subject to the original refactor plan and its verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the remaining 294-line orchestrator for decision logic rather than
-   orchestration glue; do not move the explicit ordered sequencing merely to
-   reduce line count.
-3. If no bounded decision remains, select the next unfinished fixed-pipeline or
-   exporter contract task from the broader Goal instead of introducing a large
-   mechanical wrapper.
-4. Preserve the existing changed flags, line refreshes, and explicit
-   short-circuits while making that selection.
+2. Audit `ArtifactPlan.from_options` and the direct exporter call sites for the
+   next bounded unrequested-artifact or compatibility-contract gap.
+3. Characterize existing defaults and legacy output keys before adding a typed
+   artifact field or moving another guard; do not infer a new public option.
+4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing
+   unless a new bounded decision is found.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,10 +7,10 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit moves the direct and reshaped aligned
-BatchNorm-constant repairs out of `_apply_fast_precanonicalize_repairs` and
-into the Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The
-orchestrator is 316 lines at this checkpoint, down from 482 lines at Goal
+The latest implementation unit moves channel-first local-response-normalization
+layout and static-shape propagation out of `_apply_fast_precanonicalize_repairs`
+and into the Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The
+orchestrator is 308 lines at this checkpoint, down from 482 lines at Goal
 resumption, 1,025 lines at the beginning of the previous continuation, and
 1,608 lines before the broader fast-precanonicalize extraction.
 
@@ -31,7 +31,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains three coherent continuations:
+The current `fb-refactor5` work contains four coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -40,8 +40,10 @@ The current `fb-refactor5` work contains three coherent continuations:
 - `008e4ad0` centralizes the following Resize fallback, including
   exact direct and reshaped BN-constant parsing, preferred-channel selection,
   input-layout guards, and CF evidence propagation;
-- the current checkpoint centralizes the aligned BatchNorm-constant rewrite
-  itself while preserving the different direct and already-reshaped guards.
+- `80d1d6a5` centralizes the aligned BatchNorm-constant rewrite itself while
+  preserving the different direct and already-reshaped guards;
+- the current checkpoint centralizes LRN output evidence propagation without
+  changing or broadening the generated source grammar.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -99,6 +101,10 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   their explicit reshape channel drives normalization without requiring a
   registered-buffer channel lookup. Both forms still require CF input and a
   BatchNorm-derived attribute name.
+- LRN output propagation is state-only: exact CF input evidence adds the output
+  to the CF set, removes stale NHWC evidence, and copies only a known rank-four
+  static input shape. It does not mark the source file changed or rewrite the
+  LRN statement.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -108,7 +114,7 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 
 ## Tests executed
 
-The resumed downstream-binary, Resize-evidence, and aligned-BatchNorm
+The resumed downstream-binary, Resize-evidence, aligned-BatchNorm, and LRN
 checkpoints passed:
 
 ```text
@@ -118,7 +124,7 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
   tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py \
   tests/test_flatbuffer_direct_architecture.py
 
-122 passed
+123 passed
 ```
 
 Seven pre/post-extraction characterization cases also preserve the exact
@@ -129,6 +135,9 @@ no-BN fallback, NHWC-input no-op, and already-CF Resize behavior.
 Seven aligned-BatchNorm cases preserve direct rewrite, non-BN no-op, channel
 mismatch no-op, NHWC-input no-op, reshaped rewrite, already-CF behavior, and
 reshaped non-BN no-op.
+The LRN checkpoint additionally passed a four-test selection covering CF/NHWC
+and static-shape state, Pool/LRN interaction, architecture ownership, and the
+existing generated-source integration case.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -154,9 +163,13 @@ ownership selections.
 ## Unfinished work
 
 The full Goal is not complete. The fast-precanonicalize orchestrator still has
-316 lines. Its remaining in-loop logic is primarily:
+308 lines. Its remaining body is primarily the intended ordered helper
+orchestration. Repeated state-update glue still includes:
 
-- smaller Pool state-update glue and local-response-normalization shape repair.
+- parsing repaired binary, Resize, and Pool target shapes back into the shared
+  static-shape context;
+- applying NHWC AveragePool bridge layout/shape results before subsequent Pool
+  decisions.
 
 The broader fixed-pipeline, exporter, artifact-matrix, optional TensorFlow,
 PyTorch/TorchScript/Dynamo/ExportedProgram, and full Tier regression work also
@@ -166,12 +179,12 @@ remains subject to the original refactor plan and its verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Inspect local-response-normalization layout propagation and the remaining
-   Pool state-update glue in `_apply_fast_precanonicalize_repairs`.
-3. Characterize exact CF/NHWC and static-shape propagation behavior before
-   moving another bounded decision to the policy owner.
-4. Preserve the current ordering after aligned BatchNorm repair and before
-   Softmax/ReduceMax normalization.
+2. Inspect the repeated repaired-target static-shape updates for binary,
+   Resize, and Pool statements in `_apply_fast_precanonicalize_repairs`.
+3. Characterize parse-failure/no-op behavior before replacing them with one
+   bounded state helper, without moving the ordered orchestration itself.
+4. Preserve updates immediately after each successful rewrite so later rules
+   in the same scan see identical shape evidence.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,10 +7,10 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit moves SavedModel/PyTorch-specific preparation
-settings into a requested-exporter resolver. Unrequested output paths,
-persistence, PyTorch timeout, shape hints, and test data are no longer read;
-custom input data is read only for integer calibration or PyTorch artifacts.
+The latest implementation unit moves quantization type and input/output dtype
+selection into the existing requested quantization controls. A conversion
+without quantized artifacts no longer reads these options; requested outputs
+retain the legacy `per-channel`/`int8` defaults and explicit-value behavior.
 The immutable `ConversionRequest` remains the sole option source.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
@@ -33,7 +33,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains eight coherent continuations:
+The current `fb-refactor5` work contains nine coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -52,8 +52,10 @@ The current `fb-refactor5` work contains eight coherent continuations:
   state resulting from its rewrite;
 - `907c91fa` routes all direct-export option reads through the normalized
   request and adds a structural boundary test;
-- the current checkpoint adds request-aware optional exporter controls and
-  removes eager parsing of unrequested PyTorch settings.
+- `5848cc28` adds request-aware optional exporter controls and removes eager
+  parsing of unrequested PyTorch settings;
+- the current checkpoint makes quant type and input/output quant dtype part of
+  the guarded immutable quantization controls.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -134,6 +136,10 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   calibration are all unrequested. Requested output paths, persistence,
   timeout conversion, shape/test data, and custom-input values preserve their
   existing defaults and dependencies.
+- Requested quantization controls now also own `quant_type`,
+  `input_quant_dtype`, and `output_quant_dtype`. The builder reads these values
+  only from the resolved immutable mapping; when quantization is unrequested it
+  uses the legacy local defaults without touching the corresponding options.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -201,6 +207,10 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
 Dedicated resolver tests use a mapping that raises on every `get` to prove
 unrequested settings are untouched, then verify requested and calibration-only
 values and timeout coercion.
+The same 145-test selection passed after adding requested-only quant type/dtype
+resolution. Focused assertions cover explicit values, the three legacy
+defaults, immutable mapping behavior, and absence of direct `request.get`
+calls for those keys.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,12 +7,12 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit moves the downstream-evidence aligned-binary
-fallback out of `_apply_fast_precanonicalize_repairs` and into the Torch-free
-`pytorch_fast_precanonicalize_policy.py` owner. The orchestrator is 421 lines at
-this checkpoint, down from 482 lines at Goal resumption, 1,025 lines at the
-beginning of the previous continuation, and 1,608 lines before the broader
-fast-precanonicalize extraction.
+The latest implementation unit moves the input/BN-evidence channel-first
+Resize fallback out of `_apply_fast_precanonicalize_repairs` and into the
+Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The orchestrator is
+372 lines at this checkpoint, down from 482 lines at Goal resumption, 1,025
+lines at the beginning of the previous continuation, and 1,608 lines before
+the broader fast-precanonicalize extraction.
 
 ## Completed work
 
@@ -31,10 +31,15 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` checkpoint centralizes the ordered fallback that
-repairs aligned binary shapes only when general binary repair made no change
-and the immediate next statement supplies matching BN, direct-return, or
-channel-first Resize evidence.
+The current `fb-refactor5` work contains two coherent continuations:
+
+- `3ac19b40` centralizes the ordered fallback that repairs aligned binary
+  shapes only when general binary repair made no change and the immediate next
+  statement supplies matching BN, direct-return, or channel-first Resize
+  evidence;
+- the current checkpoint centralizes the following Resize fallback, including
+  exact direct and reshaped BN-constant parsing, preferred-channel selection,
+  input-layout guards, and CF evidence propagation.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -78,6 +83,14 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   `_in` naming evidence. It additionally requires an immediate matching BN,
   direct return, or channel-first Resize; mismatched channels and mixed-layout
   names remain no-ops.
+- General Resize repair also remains first. The input/BN-evidence fallback runs
+  only afterward, uses an immediate matching direct or reshaped BN constant as
+  the preferred channel hint when available, and otherwise retains the legacy
+  input/source channel fallback. Its returned CF evidence remains visible to
+  Pool and later aligned-constant decisions in the same ordered scan.
+- Explicit NHWC Resize inputs and already-channel-first target shapes remain
+  no-ops. BN evidence refines the preferred channel count but is not a
+  prerequisite for the legacy CF-input repair.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -87,7 +100,7 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 
 ## Tests executed
 
-The resumed downstream-evidence checkpoint passed:
+The resumed downstream-binary and Resize-evidence checkpoints passed:
 
 ```text
 env -u PYTHONPATH -u LD_LIBRARY_PATH \
@@ -96,12 +109,14 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
   tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py \
   tests/test_flatbuffer_direct_architecture.py
 
-120 passed
+121 passed
 ```
 
 Seven pre/post-extraction characterization cases also preserve the exact
 orchestrator output for matching BN, direct return, channel-first Resize,
 channel mismatch, channel-last Resize, mixed operands, and an already-CF shape.
+Five additional pre/post-extraction cases preserve direct BN, reshaped BN,
+no-BN fallback, NHWC-input no-op, and already-CF Resize behavior.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -127,9 +142,8 @@ ownership selections.
 ## Unfinished work
 
 The full Goal is not complete. The fast-precanonicalize orchestrator still has
-421 lines. Its largest remaining in-loop blocks are:
+372 lines. Its largest remaining in-loop blocks are:
 
-- 65 lines: Resize shape repair selected by following BN constant evidence;
 - 32 and 26 lines: reshaped and direct aligned BN-constant repair;
 - smaller Pool state-update glue and local-response-normalization shape repair.
 
@@ -141,13 +155,12 @@ remains subject to the original refactor plan and its verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Inspect the 65-line Resize repair selected by following BN constant
-   evidence in `_apply_fast_precanonicalize_repairs`.
-3. Characterize direct and reshaped BN constant evidence, channel-count
-   agreement, and no-op cases before moving the exact decision to the policy
-   owner.
-4. Preserve the current ordering after downstream binary evidence and before
-   the later aligned BN-constant repairs.
+2. Inspect the 32-line reshaped and 26-line direct aligned BN-constant repairs
+   in `_apply_fast_precanonicalize_repairs`.
+3. Characterize input/constant channel agreement, layout propagation, and
+   no-op cases before moving their exact decisions to the policy owner.
+4. Preserve their current ordering after Resize/Pool evidence and before the
+   subsequent Softmax and local-response-normalization decisions.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,13 +7,12 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit shares lazy `ModelIRPassStateScope` instances
-across two repeated families. Five channel-shuffle/Gather-axis clusters now
-reuse one index; the final occurrence includes its contiguous generic
-transpose and two unary fan-out runners in the same scope. Four separate unary-
-passthrough/fan-out clusters also reuse one index each. Synthetic fixtures prove
-one index build across seven-runner and three-runner forms while preserving all
-model-only preflights, diagnostics, and runner order.
+The latest implementation unit shares one lazy `ModelIRPassStateScope` across
+each of four repeated boundary-input BatchMatMul/input-unary runner pairs. The
+scope contains only those two adjacent registered runners and ends before the
+next legacy layout optimizer. A synthetic fixture whose two model-only
+preflights match proves that four diagnostic events construct one graph index
+without changing runner order or standalone behavior.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -35,7 +34,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains seventeen coherent continuations:
+The current `fb-refactor5` work contains eighteen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -72,8 +71,10 @@ The current `fb-refactor5` work contains seventeen coherent continuations:
   cost-volume-scatter pair;
 - `1aa636e3` shares state across the following four registered Concat,
   LayerNorm, and transpose-cleanup runners;
-- the current checkpoint shares state across the repeated channel-shuffle/
-  Gather-axis and unary fan-out runner clusters.
+- `969d5e26` shares state across the repeated channel-shuffle/Gather-axis and
+  unary fan-out runner clusters;
+- the current checkpoint shares state across four repeated boundary-input
+  BatchMatMul/input-unary runner pairs.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -91,8 +92,8 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/passes/channel_shuffle.py`;
-- `onnx2tf/tflite_builder/passes/layout_transpose.py`;
+- `onnx2tf/tflite_builder/passes/boundary_input_chains.py`;
+- `onnx2tf/tflite_builder/passes/input_passthrough_layout.py`;
 - `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
 - `tests/test_flatbuffer_direct_pass_efficiency.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
@@ -213,6 +214,12 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   unary helper preserves passthrough, unary fan-out, and unary/binary fan-out
   order at four call sites. Every runner remains callable standalone through
   an optional scope argument.
+- Four repeated boundary-input BatchMatMul/input-unary pairs now use a small
+  helper-owned scope. The boundary BatchMatMul runner and the three-spec input-
+  unary runner expose the same optional standalone-compatible scope argument.
+  No scope crosses the legacy transformations surrounding any occurrence.
+  Their two stale `_build_tensor_consumer_map` imports are removed; neither
+  module constructs an ad hoc consumer map for these runners.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -458,18 +465,36 @@ runner fixture records one `state_built: true` followed by six `false` events;
 the three-runner fixture records one `true` followed by two `false` events.
 The architecture gate fixes the two helper orders, five and four invocations,
 and the single extended channel-shuffle invocation.
+A focused boundary-input pair checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_pass_efficiency.py::test_boundary_batchmatmul_unary_pair_reuses_one_pass_state \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_boundary_batchmatmul_unary_pair_reuses_pass_state_scope \
+  tests/test_flatbuffer_direct_architecture.py::test_ordered_model_ir_runner_calls_record_session_diagnostics \
+  tests/test_flatbuffer_direct_boundary_input_chains.py \
+  tests/test_flatbuffer_direct_input_passthrough_layout.py
+
+17 passed
+```
+
+The runtime fixture records one graph-index refresh and build flags
+`[true, false, false, false]`; the latter three events belong to the reused
+three-spec input-unary group. The architecture gate fixes the two-runner order
+and all four helper invocations.
 A broader single-process selection of
 `test_flatbuffer_direct_core.py`, `test_flatbuffer_direct_pass_efficiency.py`,
 and the complete `test_flatbuffer_direct_architecture.py` passed with
-`146 passed` after adding the shuffle/unary cluster checks.
+`148 passed` after adding the boundary-input pair checks.
 
-The changed tests pass Ruff normally. `channel_shuffle.py` and
-`layout_transpose.py` pass with their two and one pre-existing `F841` findings
-scoped out, and the lowerer passes with its pre-existing `F401` and `F841`
-findings scoped out. Every changed Python file passes `python -m py_compile`,
-and `git diff --check` passes. The immediately preceding DepthToSpace, Pool,
-dynamic-Pool, simple-alias, and aligned-scalar checkpoints passed their focused
-synthetic and ownership selections.
+The changed pass modules and tests pass Ruff normally. The lowerer passes with
+its pre-existing `F401` and `F841` findings scoped out. Every changed Python
+file passes `python -m py_compile`, and `git diff --check` passes. The
+immediately preceding DepthToSpace, Pool, dynamic-Pool, simple-alias, and
+aligned-scalar checkpoints passed their focused synthetic and ownership
+selections.
 
 ## Failing tests and known issues
 
@@ -504,9 +529,9 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the repeated boundary-input BatchMatMul/input-unary pairs as the next
-   small candidate. Treat every legacy helper before and after each pair as a
-   hard boundary.
+2. Audit the remaining small repeated registered-runner pairs, beginning with
+   channel-slice-merge/Pad-Mul, while treating every surrounding legacy helper
+   as a hard boundary.
 3. Add a focused production-boundary characterization before sharing another
    scope, and preserve exact diagnostics and rule order. Never carry a scope
    across a legacy helper or introduce a blanket refresh.

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,11 +7,11 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit moves quantization type and input/output dtype
-selection into the existing requested quantization controls. A conversion
-without quantized artifacts no longer reads these options; requested outputs
-retain the legacy `per-channel`/`int8` defaults and explicit-value behavior.
-The immutable `ConversionRequest` remains the sole option source.
+The latest implementation unit reconnects `LoweringContext` consumer counts to
+the authoritative `ConversionSession.graph_index`. The Session migration had
+removed the duplicate ONNX scan but left an empty dictionary at the lowering
+boundary; shared-edge inverse-transpose safety checks now receive the same
+counts as before the migration without adding a second scan.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -33,7 +33,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains nine coherent continuations:
+The current `fb-refactor5` work contains ten coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -54,8 +54,10 @@ The current `fb-refactor5` work contains nine coherent continuations:
   request and adds a structural boundary test;
 - `5848cc28` adds request-aware optional exporter controls and removes eager
   parsing of unrequested PyTorch settings;
-- the current checkpoint makes quant type and input/output quant dtype part of
-  the guarded immutable quantization controls.
+- `e3c03e3d` makes quant type and input/output quant dtype part of the guarded
+  immutable quantization controls;
+- the current checkpoint restores Session-owned consumer counts at the
+  `LoweringContext` boundary.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -72,9 +74,8 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/__init__.py`;
-- `onnx2tf/tflite_builder/artifact_preparation.py`;
-- `tests/test_flatbuffer_direct_artifact_preparation.py`;
+- `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
+- `tests/test_flatbuffer_direct_core.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
 
@@ -140,6 +141,10 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   `input_quant_dtype`, and `output_quant_dtype`. The builder reads these values
   only from the resolved immutable mapping; when quantization is unrequested it
   uses the legacy local defaults without touching the corresponding options.
+- `LoweringContext.tensor_consumer_count` is populated from
+  `ConversionSession.tensor_consumer_count`, not an empty compatibility
+  dictionary and not a new ONNX scan. This restores the original fan-out guard
+  used by inverse-transpose elision and preserves duplicate input occurrences.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -211,6 +216,22 @@ The same 145-test selection passed after adding requested-only quant type/dtype
 resolution. Focused assertions cover explicit values, the three legacy
 defaults, immutable mapping behavior, and absence of direct `request.get`
 calls for those keys.
+The Session consumer-count checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_core.py \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_transpose_quantize_transpose_optimization \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_transpose_quantize_transpose_fanout_optimization \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_transpose_quantize_transpose_preserves_dynamic_batch_signature
+
+32 passed
+```
+
+The core spy fixture uses one input in both Add and Identity and verifies the
+context receives counts `{"x": 2, "y": 1}` from the Session index.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -249,11 +270,10 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Continue auditing `ArtifactPlan.from_options` and the remaining direct
-   exporter call sites for the next bounded unrequested-artifact or
-   compatibility-contract gap.
-3. Characterize existing defaults and legacy output keys before adding a typed
-   artifact field or moving another guard; do not infer a new public option.
+2. Audit remaining `ConversionSession`/`LoweringContext` state handoffs for
+   another bounded empty-copy, duplicate-scan, or stale-index gap.
+3. Characterize the pre-session behavior and a focused fan-out/no-op boundary
+   before changing another handoff; do not introduce a second graph scan.
 4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing
    unless a new bounded decision is found.
 5. Run only the focused synthetic/ownership/static checks unless the user asks

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,13 +7,14 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit closes a lowering-time `LayoutState` handoff
-gap. Tensor creation already registered layout state, but seven subsequent
-layout mutations in shape-family lowerers changed `TensorIR` directly. A
-rank-three Resize probe demonstrated four logical-layout mismatches immediately
-before the first post-lowering pass. `LoweringContext.set_tensor_layout()` now
-updates tensor metadata and the Session-owned state together, and all direct
-op-builder layout assignments use that boundary.
+The latest implementation unit closes a lowering-time synthetic-consumer gap.
+Inverse-Transpose generation previously read only ONNX consumer counts and
+directly deleted its producer operator. A compact probe demonstrated that a
+synthetic bridge with an existing Identity side consumer lost its producer,
+while `ir_tensor_producers` retained the removed object. `LoweringContext` now
+maintains differential IR consumer counts, owns operator removal, and combines
+the ONNX or synthetic count appropriate to the edge without rescanning the
+partial graph.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -35,7 +36,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains eleven coherent continuations:
+The current `fb-refactor5` work contains twelve coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -60,8 +61,10 @@ The current `fb-refactor5` work contains eleven coherent continuations:
   immutable quantization controls;
 - `4f3d20b0` restores Session-owned consumer counts at the `LoweringContext`
   boundary;
-- the current checkpoint synchronizes lowering-time logical and physical
-  layout mutations with the Session before the first post-lowering pass.
+- `6e8a8486` synchronizes lowering-time logical and physical layout mutations
+  with the Session before the first post-lowering pass;
+- the current checkpoint centralizes lowering-time operator removal and protects
+  synthetic inverse-Transpose fan-out with differential consumer counts.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -80,8 +83,9 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 The final checkpoint changes:
 
 - `onnx2tf/tflite_builder/core/lowering_context.py`;
-- `onnx2tf/tflite_builder/op_builders/shape.py`;
+- `onnx2tf/tflite_builder/op_builders/shared.py`;
 - `tests/test_flatbuffer_direct_core.py`;
+- `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
 
@@ -157,6 +161,14 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   Shape-family edge-Pad passthroughs, integer-linear Resize casts, and rank-three
   Resize adapters no longer assign layout fields directly. This fixes observed
   pre-pass staleness without adding an eager ModelIR-wide synchronization.
+- `LoweringContext.add_operator()` increments a differential consumer count for
+  every emitted input occurrence. `remove_operator()` decrements those counts
+  and removes only producer entries owned by the removed object. The inverse
+  Transpose helper uses the authoritative ONNX count when present; otherwise it
+  adds the pending inverse use to the current synthetic IR count. An exclusive
+  pair is still elided, while a synthetic side consumer keeps its producer.
+  This replaces the only direct op-builder deletion and adds no partial-graph
+  scan.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -264,6 +276,25 @@ ModelIR mismatch. The focused edge-Pad and integer-linear Resize tests also
 serialize and execute their TFLite artifacts sequentially. The architecture
 gate rejects future direct logical/physical layout assignments anywhere below
 `op_builders`.
+The synthetic-consumer checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_core.py \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_elides_inverse_transpose_chain_at_generation \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_no_dead_operator_outputs_after_prune \
+  tests/test_flatbuffer_direct_architecture.py::test_op_builders_mutate_operator_list_only_through_lowering_context
+
+35 passed
+```
+
+The two direct context cases prove both sides of the contract: exclusive
+inverse Transposes remove their operator and differential indexes, while a
+synthetic bridge already consumed by an Identity retains its producer. The
+architecture gate rejects direct operator-list writes and mutating method calls
+from op builders.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -302,9 +333,9 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the remaining `ConversionSession`/`LoweringContext` handoffs for a
-   bounded stale constant, producer, or synthetic-consumer state gap; layout
-   field mutation is now centralized.
+2. Audit the remaining `ConversionSession`/`LoweringContext` constant ownership
+   and constant-fold updates for a bounded stale-map gap; layout, lowering-time
+   producer, and synthetic-consumer mutation are now centralized.
 3. Characterize pre-session behavior and a focused fan-out/no-op boundary
    before changing another handoff; do not introduce a second graph scan or a
    blanket post-lowering resynchronization.

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,13 +7,15 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit introduces a lazy `ModelIRPassStateScope` for
-adjacent registered pass groups. Six repeated production clusters now share one
-differential index across Mean, optional LayerNorm, terminal Mean, SE conv, SE
-FC, and optional Conv-attention runners. The scope ends before every raw legacy
-mutator. A characterization in which the first Mean runner builds state but
-does not rewrite and the second runner does rewrite proves that graph-index
-refreshes fall from two to one without changing pass order.
+The latest implementation unit extends the lazy `ModelIRPassStateScope` to the
+next audited registered-pass sequence. Four repeated production clusters now
+share one differential index across mixed attention, elementwise gates, Pad,
+dual post-convolution gates, NDHWC gates, cost-volume ScatterND, Add/Concat
+suffixes, and dual-Mul/Concat. A fifth occurrence shares the same seven-runner
+suffix while retaining its original omission of mixed attention. All later
+isolated calls remain outside this scope. A synthetic model whose model-only
+preflights match every runner proves that 15 diagnostic events construct one
+graph index without changing runner order.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -35,7 +37,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains thirteen coherent continuations:
+The current `fb-refactor5` work contains fourteen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -64,8 +66,10 @@ The current `fb-refactor5` work contains thirteen coherent continuations:
   with the Session before the first post-lowering pass;
 - `e7c1457d` centralizes lowering-time operator removal and protects synthetic
   inverse-Transpose fan-out with differential consumer counts;
-- the current checkpoint lazily shares `ModelIRPassState` across the repeated
-  Mean/attention registered-pass cluster.
+- `2a2968cc` lazily shares `ModelIRPassState` across the repeated
+  Mean/attention registered-pass cluster;
+- the current checkpoint applies the same bounded reuse contract to the
+  repeated mixed-attention through dual-Mul/Concat registered-pass cluster.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -74,8 +78,8 @@ result to the exporter. Exact generated-statement grammars remain rule-local or
 use the shared Torch-free parser owner.
 
 No dependency was added and no TensorFlow path was introduced. The latest
-checkpoint uses only compact synthetic Resize and Pad models; no Tier corpus or
-real-model conversion was run.
+checkpoint uses only synthetic ModelIR fixtures; no Tier corpus or real-model
+conversion was run.
 
 ## Current branch and changed files
 
@@ -83,15 +87,16 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/core/model_ir_pass_state.py`;
-- `onnx2tf/tflite_builder/core/__init__.py`;
-- `onnx2tf/tflite_builder/passes/mean_layout.py`;
-- `onnx2tf/tflite_builder/passes/layernorm_layout.py`;
-- `onnx2tf/tflite_builder/passes/terminal_mean_layout.py`;
-- `onnx2tf/tflite_builder/passes/se_layout.py`;
 - `onnx2tf/tflite_builder/passes/attention_layout.py`;
+- `onnx2tf/tflite_builder/passes/elementwise_gate_layout.py`;
+- `onnx2tf/tflite_builder/passes/pad_layout.py`;
+- `onnx2tf/tflite_builder/passes/dual_postconv_gate_layout.py`;
+- `onnx2tf/tflite_builder/passes/ndhwc_gate_layout.py`;
+- `onnx2tf/tflite_builder/passes/cost_volume_scatter_layout.py`;
+- `onnx2tf/tflite_builder/passes/add_concat_suffix_layout.py`;
+- `onnx2tf/tflite_builder/passes/dual_mul_concat_layout.py`;
 - `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
-- `tests/test_flatbuffer_direct_mean_layout.py`;
+- `tests/test_flatbuffer_direct_pass_efficiency.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
@@ -184,6 +189,14 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   index. All six production occurrences retain the exact order
   transpose-Mean, Mean/Mul/Add/Conv, optional LayerNorm, terminal Mean, SE conv,
   SE FC, and optional Conv attention.
+- The same scope contract covers only the five repeated gate-layout sequences
+  that were audited as contiguous registered runners. Four keep the exact
+  mixed-attention, elementwise-gate, Pad, dual-postconv-gate, NDHWC-gate,
+  cost-volume-scatter, Add/Concat-suffix, and dual-Mul/Concat order. The fifth
+  starts at elementwise-gate exactly as before. All eight runners retain
+  standalone behavior through an optional `state_scope` argument, and the
+  later isolated mixed-attention, Pad, NDHWC, cost-volume, and dual-Mul calls
+  intentionally do not share this scope.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -332,10 +345,47 @@ candidate Mean runners and a diagnostic build sequence of `[true, false]`.
 The all-preflight-miss case observes zero index refreshes and `[false, false]`.
 The architecture gate fixes all seven runner calls, their order, their shared
 scope keyword, and the six production cluster invocations.
-The exporter and policy pass `python -m py_compile`, and `git diff --check`
-passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
-simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
-ownership selections.
+The adjacent gate-pass reuse checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_elementwise_gate_layout.py \
+  tests/test_flatbuffer_direct_pad_layout.py \
+  tests/test_flatbuffer_direct_dual_postconv_gate_layout.py \
+  tests/test_flatbuffer_direct_3d_gate_layout.py \
+  tests/test_flatbuffer_direct_conv3d_gate_layout.py \
+  tests/test_flatbuffer_direct_cost_volume_scatter_layout.py \
+  tests/test_flatbuffer_direct_add_concat_suffix_layout.py \
+  tests/test_flatbuffer_direct_dual_mul_concat_layout.py \
+  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_mixed_mean_reducemax_concat_mirrorpad_nhwc_chain \
+  tests/test_flatbuffer_direct_pass_efficiency.py \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_gate_cluster_reuses_one_pass_state_scope \
+  tests/test_flatbuffer_direct_architecture.py::test_ordered_model_ir_runner_calls_record_session_diagnostics
+
+116 passed
+```
+
+The synthetic shared-scope fixture makes every runner's model-only preflight
+match but contains no deep rewrite candidate. It records one
+`ModelIRGraphIndex.refresh()` across all eight calls and 15 diagnostic events:
+the first reports `state_built: true`, and every later event reports `false`.
+The architecture checks fix the eight-runner order, five production helper
+invocations, and the single invocation that omits mixed attention. They also
+bring the global direct-runner count characterization up to date with both
+bounded helper extractions.
+A broader single-process selection of
+`test_flatbuffer_direct_core.py`, `test_flatbuffer_direct_pass_efficiency.py`,
+and the complete `test_flatbuffer_direct_architecture.py` passed with
+`139 passed`.
+
+All changed pass modules and tests pass Ruff. The lowerer passes Ruff with only
+its pre-existing `F401` and `F841` findings scoped out. Every changed Python
+file passes `python -m py_compile`, and `git diff --check` passes. The
+immediately preceding DepthToSpace, Pool, dynamic-Pool, simple-alias, and
+aligned-scalar checkpoints passed their focused synthetic and ownership
+selections.
 
 ## Failing tests and known issues
 
@@ -370,11 +420,11 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Apply the same scope only to the next contiguous registered-runner cluster
-   after proving that no raw ModelIR mutator occurs inside its lifetime. The
-   mixed-attention through dual-Mul/Concat block is the next candidate.
-3. Add a focused index-construction count and preserve exact diagnostics and
-   rule order before migrating that cluster. Never carry a scope across a
+2. Audit the later contiguous mixed-attention/NDHWC-gate/cost-volume-scatter
+   triple as the next small reuse candidate. Confirm both surrounding legacy
+   boundaries before sharing state; leave the other isolated calls unchanged.
+3. Add a focused production-boundary characterization for that triple and
+   preserve exact diagnostics and rule order. Never carry a scope across a
    legacy helper or introduce a blanket refresh.
 4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing
    unless a new bounded decision is found.

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,10 +7,11 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit completes the immutable `ConversionRequest`
-read boundary inside the direct exporter. All 36 option reads now use
-`request.get`, artifact selection continues through `ArtifactPlan`, and the
-original `kwargs` object is referenced only when constructing the request.
+The latest implementation unit moves SavedModel/PyTorch-specific preparation
+settings into a requested-exporter resolver. Unrequested output paths,
+persistence, PyTorch timeout, shape hints, and test data are no longer read;
+custom input data is read only for integer calibration or PyTorch artifacts.
+The immutable `ConversionRequest` remains the sole option source.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -32,7 +33,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains seven coherent continuations:
+The current `fb-refactor5` work contains eight coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -49,8 +50,10 @@ The current `fb-refactor5` work contains seven coherent continuations:
   update at its original point in the ordered scan;
 - `95fbd0cb` makes the NHWC AveragePool bridge own the CF/NHWC and static-shape
   state resulting from its rewrite;
-- the current checkpoint routes all direct-export option reads through the
-  normalized request and adds a structural boundary test.
+- `907c91fa` routes all direct-export option reads through the normalized
+  request and adds a structural boundary test;
+- the current checkpoint adds request-aware optional exporter controls and
+  removes eager parsing of unrequested PyTorch settings.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -68,7 +71,8 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 The final checkpoint changes:
 
 - `onnx2tf/tflite_builder/__init__.py`;
-- `tests/test_flatbuffer_direct_architecture.py`;
+- `onnx2tf/tflite_builder/artifact_preparation.py`;
+- `tests/test_flatbuffer_direct_artifact_preparation.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
 
@@ -120,11 +124,16 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   from the pre-rewrite Pool shape after the layout sets change; it is not
   replaced by the rendered rewrite target.
 - `ConversionRequest.from_kwargs` is the direct exporter's only raw-kwargs
-  boundary. Quantization validation receives `request.options`, all 36
-  remaining optional reads use `request.get`, and typed artifact decisions
-  remain on `request.artifacts`. This is a source-routing change only; keys,
-  defaults, coercions, public return values, and downstream arguments are
-  unchanged.
+  boundary. Quantization validation receives `request.options`, normal option
+  reads use `request.get`, and typed artifact decisions remain on
+  `request.artifacts`. Checkpoint `907c91fa` mechanically converted all 36
+  former raw reads without changing keys, defaults, coercions, public return
+  values, or downstream arguments.
+- `resolve_requested_exporter_controls` now owns seven artifact-specific
+  settings. It performs no option reads when SavedModel, PyTorch, and integer
+  calibration are all unrequested. Requested output paths, persistence,
+  timeout conversion, shape/test data, and custom-input values preserve their
+  existing defaults and dependencies.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -176,6 +185,22 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
 
 Its AST gate proves zero `kwargs.get` calls and exactly one raw `kwargs` read,
 as the argument to `ConversionRequest.from_kwargs`.
+The requested-exporter checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_artifact_preparation.py \
+  tests/test_flatbuffer_direct_core.py \
+  tests/test_flatbuffer_direct_architecture.py
+
+145 passed
+```
+
+Dedicated resolver tests use a mapping that raises on every `get` to prove
+unrequested settings are untouched, then verify requested and calibration-only
+values and timeout coercion.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -206,16 +231,17 @@ orchestration, source-line replacement, changed-flag handling, and the explicit
 short-circuit boundaries required by the extracted policy decisions.
 
 The broader fixed-pipeline, remaining artifact-plan coverage, artifact-matrix,
-optional TensorFlow,
-PyTorch/TorchScript/Dynamo/ExportedProgram, and full Tier regression work also
-remains subject to the original refactor plan and its verification gates.
+optional TensorFlow, PyTorch/TorchScript/Dynamo/ExportedProgram, and full Tier
+regression work also remains subject to the original refactor plan and its
+verification gates.
 
 ## Next work
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit `ArtifactPlan.from_options` and the direct exporter call sites for the
-   next bounded unrequested-artifact or compatibility-contract gap.
+2. Continue auditing `ArtifactPlan.from_options` and the remaining direct
+   exporter call sites for the next bounded unrequested-artifact or
+   compatibility-contract gap.
 3. Characterize existing defaults and legacy output keys before adding a typed
    artifact field or moving another guard; do not infer a new public option.
 4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -3,15 +3,17 @@
 ## Status
 
 The active branch is `fb-refactor5`, created from `main` after pull request
-`#949` merged the complete `fb-refactor4` checkpoint. The Goal is active again;
-subsequent work uses coherent commits and pushes without opening another pull
-request.
+`#949` merged the complete `fb-refactor4` checkpoint. Pull request `#950`
+currently tracks this branch. The Goal is active again; subsequent work uses
+coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit reconnects `LoweringContext` consumer counts to
-the authoritative `ConversionSession.graph_index`. The Session migration had
-removed the duplicate ONNX scan but left an empty dictionary at the lowering
-boundary; shared-edge inverse-transpose safety checks now receive the same
-counts as before the migration without adding a second scan.
+The latest implementation unit closes a lowering-time `LayoutState` handoff
+gap. Tensor creation already registered layout state, but seven subsequent
+layout mutations in shape-family lowerers changed `TensorIR` directly. A
+rank-three Resize probe demonstrated four logical-layout mismatches immediately
+before the first post-lowering pass. `LoweringContext.set_tensor_layout()` now
+updates tensor metadata and the Session-owned state together, and all direct
+op-builder layout assignments use that boundary.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -33,7 +35,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains ten coherent continuations:
+The current `fb-refactor5` work contains eleven coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -56,8 +58,10 @@ The current `fb-refactor5` work contains ten coherent continuations:
   parsing of unrequested PyTorch settings;
 - `e3c03e3d` makes quant type and input/output quant dtype part of the guarded
   immutable quantization controls;
-- the current checkpoint restores Session-owned consumer counts at the
-  `LoweringContext` boundary.
+- `4f3d20b0` restores Session-owned consumer counts at the `LoweringContext`
+  boundary;
+- the current checkpoint synchronizes lowering-time logical and physical
+  layout mutations with the Session before the first post-lowering pass.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -65,8 +69,9 @@ shared. Rules that formerly used `continue` return an explicit short-circuit
 result to the exporter. Exact generated-statement grammars remain rule-local or
 use the shared Torch-free parser owner.
 
-No dependency was added, no TensorFlow path was introduced, and no model
-conversion or inference was run during these checkpoints.
+No dependency was added and no TensorFlow path was introduced. The latest
+checkpoint uses only compact synthetic Resize and Pad models; no Tier corpus or
+real-model conversion was run.
 
 ## Current branch and changed files
 
@@ -74,7 +79,8 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
+- `onnx2tf/tflite_builder/core/lowering_context.py`;
+- `onnx2tf/tflite_builder/op_builders/shape.py`;
 - `tests/test_flatbuffer_direct_core.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
@@ -145,6 +151,12 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   `ConversionSession.tensor_consumer_count`, not an empty compatibility
   dictionary and not a new ONNX scan. This restores the original fan-out guard
   used by inverse-transpose elision and preserves duplicate input occurrences.
+- `LoweringContext.set_tensor_layout()` is the lowering-time layout mutation
+  boundary. It normalizes and writes `TensorIR` metadata and immediately
+  records the same logical/physical values in the Session-owned `LayoutState`.
+  Shape-family edge-Pad passthroughs, integer-linear Resize casts, and rank-three
+  Resize adapters no longer assign layout fields directly. This fixes observed
+  pre-pass staleness without adding an eager ModelIR-wide synchronization.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -232,6 +244,26 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
 
 The core spy fixture uses one input in both Add and Identity and verifies the
 context receives counts `{"x": 2, "y": 1}` from the Session index.
+The lowering-time layout checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_core.py \
+  tests/test_pad_edge_lowering.py \
+  tests/test_flatbuffer_direct_resize_integer_linear.py \
+  tests/test_flatbuffer_direct_architecture.py::test_op_builders_mutate_layout_only_through_lowering_context
+
+33 passed
+```
+
+The rank-three Resize regression hook inspects `LayoutState` before the first
+post-lowering pass and verifies that the NWC/NHWC adapter tensors have no
+ModelIR mismatch. The focused edge-Pad and integer-linear Resize tests also
+serialize and execute their TFLite artifacts sequentially. The architecture
+gate rejects future direct logical/physical layout assignments anywhere below
+`op_builders`.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -270,10 +302,12 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit remaining `ConversionSession`/`LoweringContext` state handoffs for
-   another bounded empty-copy, duplicate-scan, or stale-index gap.
-3. Characterize the pre-session behavior and a focused fan-out/no-op boundary
-   before changing another handoff; do not introduce a second graph scan.
+2. Audit the remaining `ConversionSession`/`LoweringContext` handoffs for a
+   bounded stale constant, producer, or synthetic-consumer state gap; layout
+   field mutation is now centralized.
+3. Characterize pre-session behavior and a focused fan-out/no-op boundary
+   before changing another handoff; do not introduce a second graph scan or a
+   blanket post-lowering resynchronization.
 4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing
    unless a new bounded decision is found.
 5. Run only the focused synthetic/ownership/static checks unless the user asks

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -1,20 +1,22 @@
-# `flatbuffer_direct` refactor pause checkpoint — 2026-07-14
+# `flatbuffer_direct` refactor continuation checkpoint — 2026-07-14
 
 ## Status
 
-The active branch is `fb-refactor4`. This checkpoint is intended to leave the
-branch committed, pushed, and clean so the Goal can be paused without carrying
-a partial source rewrite. No pull request was created.
+The active branch is `fb-refactor5`, created from `main` after pull request
+`#949` merged the complete `fb-refactor4` checkpoint. The Goal is active again;
+subsequent work uses coherent commits and pushes without opening another pull
+request.
 
-The latest implementation unit moves aligned scalar-binary shape
-reconciliation out of `_apply_fast_precanonicalize_repairs` and into the
-Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The orchestrator is
-482 lines at this checkpoint, down from 1,025 lines at the beginning of this
-continuation and 1,608 lines before the broader fast-precanonicalize extraction.
+The latest implementation unit moves the downstream-evidence aligned-binary
+fallback out of `_apply_fast_precanonicalize_repairs` and into the Torch-free
+`pytorch_fast_precanonicalize_policy.py` owner. The orchestrator is 421 lines at
+this checkpoint, down from 482 lines at Goal resumption, 1,025 lines at the
+beginning of the previous continuation, and 1,608 lines before the broader
+fast-precanonicalize extraction.
 
 ## Completed work
 
-Recent pushed checkpoints on `fb-refactor4` are:
+The merged `fb-refactor4` checkpoints included:
 
 - `062ddc4` — centralized DepthToSpace/Gather repair and the permuted-Conv
   statement decoder;
@@ -25,9 +27,14 @@ Recent pushed checkpoints on `fb-refactor4` are:
   aligned-rank4 decoder;
 - `e0bc280` — centralized simple-alias layout repair and moved all
   permuted-Conv decoder consumers into the policy owner;
-- the checkpoint carrying this document — centralizes aligned scalar-binary
+- `afb5bb5` — centralizes aligned scalar-binary
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
+
+The current `fb-refactor5` checkpoint centralizes the ordered fallback that
+repairs aligned binary shapes only when general binary repair made no change
+and the immediate next statement supplies matching BN, direct-return, or
+channel-first Resize evidence.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -40,7 +47,7 @@ conversion or inference was run during these checkpoints.
 
 ## Current branch and changed files
 
-Branch: `fb-refactor4`, tracking `origin/fb-refactor4`.
+Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
@@ -49,11 +56,10 @@ The final checkpoint changes:
 - `tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
-- `docs/flatbuffer_direct_handoff_2026-07-13.md`;
 - this handoff document.
 
 The expected handoff state after committing and pushing is an empty `git
-status --short` with local `fb-refactor4` equal to `origin/fb-refactor4`.
+status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 
 ## Important design decisions
 
@@ -65,6 +71,13 @@ status --short` with local `fb-refactor4` equal to `origin/fb-refactor4`.
   generated source unless the preserved rule already required a bounded scan.
 - Former loop `continue` behavior is represented explicitly in helper results;
   extraction must not silently allow later rules to run.
+- General binary repair remains first. The downstream-evidence fallback is
+  called only from its unchanged no-rewrite branch, and its returned CF
+  evidence is visible to the following Resize repair in the same scan.
+- The fallback deliberately retains its narrower positional grammar and legacy
+  `_in` naming evidence. It additionally requires an immediate matching BN,
+  direct return, or channel-first Resize; mismatched channels and mixed-layout
+  names remain no-ops.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -74,21 +87,25 @@ status --short` with local `fb-refactor4` equal to `origin/fb-refactor4`.
 
 ## Tests executed
 
-The final aligned scalar-binary checkpoint passed:
+The resumed downstream-evidence checkpoint passed:
 
 ```text
-uv run --no-sync pytest -q \
-  tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py::test_aligned_scalar_binary_shape_uses_neighbor_consensus \
-  tests/test_flatbuffer_direct_architecture.py::test_generated_pytorch_source_parsers_have_single_owner \
-  tests/test_flatbuffer_direct_architecture.py::test_generated_pytorch_fast_precanonicalize_policy_has_single_owner
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py \
+  tests/test_flatbuffer_direct_architecture.py
 
-3 passed
+120 passed
 ```
 
-The touched policy and tests pass scoped Ruff, the exporter and policy pass
-`python -m py_compile`, and `git diff --check` passes. The immediately preceding
-DepthToSpace, Pool, dynamic-Pool, and simple-alias checkpoints passed focused
-synthetic/ownership selections of 4, 2, 2, 4, and 3 tests respectively.
+Seven pre/post-extraction characterization cases also preserve the exact
+orchestrator output for matching BN, direct return, channel-first Resize,
+channel mismatch, channel-last Resize, mixed operands, and an already-CF shape.
+The exporter and policy pass `python -m py_compile`, and `git diff --check`
+passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
+simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
+ownership selections.
 
 ## Failing tests and known issues
 
@@ -110,10 +127,8 @@ synthetic/ownership selections of 4, 2, 2, 4, and 3 tests respectively.
 ## Unfinished work
 
 The full Goal is not complete. The fast-precanonicalize orchestrator still has
-482 lines. Its largest remaining in-loop blocks are:
+421 lines. Its largest remaining in-loop blocks are:
 
-- 71 lines: aligned binary repair selected by downstream BN, return, or Resize
-  evidence;
 - 65 lines: Resize shape repair selected by following BN constant evidence;
 - 32 and 26 lines: reshaped and direct aligned BN-constant repair;
 - smaller Pool state-update glue and local-response-normalization shape repair.
@@ -122,19 +137,18 @@ The broader fixed-pipeline, exporter, artifact-matrix, optional TensorFlow,
 PyTorch/TorchScript/Dynamo/ExportedProgram, and full Tier regression work also
 remains subject to the original refactor plan and its verification gates.
 
-## First work on resume
+## Next work
 
-1. Confirm `git status --short --branch` is clean and local `fb-refactor4`
-   matches `origin/fb-refactor4`.
-2. Inspect the 71-line aligned-binary downstream-evidence block in
-   `_apply_fast_precanonicalize_repairs`.
-3. Characterize its BN, direct-return, and Resize guards with one compact
-   synthetic policy fixture, then move the exact rule to the policy owner.
-4. Preserve the existing order: general binary alignment repair runs first;
-   the downstream-evidence fallback runs only when that repair made no change.
+1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
+   matches `origin/fb-refactor5`.
+2. Inspect the 65-line Resize repair selected by following BN constant
+   evidence in `_apply_fast_precanonicalize_repairs`.
+3. Characterize direct and reshaped BN constant evidence, channel-count
+   agreement, and no-op cases before moving the exact decision to the policy
+   owner.
+4. Preserve the current ordering after downstream binary evidence and before
+   the later aligned BN-constant repairs.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not
    create a pull request.
-
-Do not begin the remaining work before the Goal is explicitly resumed.

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,14 +7,13 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 currently tracks this branch. The Goal is active again; subsequent work uses
 coherent commits and pushes without opening an additional pull request.
 
-The latest implementation unit closes a lowering-time synthetic-consumer gap.
-Inverse-Transpose generation previously read only ONNX consumer counts and
-directly deleted its producer operator. A compact probe demonstrated that a
-synthetic bridge with an existing Identity side consumer lost its producer,
-while `ir_tensor_producers` retained the removed object. `LoweringContext` now
-maintains differential IR consumer counts, owns operator removal, and combines
-the ONNX or synthetic count appropriate to the edge without rescanning the
-partial graph.
+The latest implementation unit introduces a lazy `ModelIRPassStateScope` for
+adjacent registered pass groups. Six repeated production clusters now share one
+differential index across Mean, optional LayerNorm, terminal Mean, SE conv, SE
+FC, and optional Conv-attention runners. The scope ends before every raw legacy
+mutator. A characterization in which the first Mean runner builds state but
+does not rewrite and the second runner does rewrite proves that graph-index
+refreshes fall from two to one without changing pass order.
 The audited fast-precanonicalize orchestrator remains 294 lines, down from 482
 lines at Goal resumption, 1,025 lines at the beginning of the previous
 continuation, and 1,608 lines before the broader extraction.
@@ -36,7 +35,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains twelve coherent continuations:
+The current `fb-refactor5` work contains thirteen coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -63,8 +62,10 @@ The current `fb-refactor5` work contains twelve coherent continuations:
   boundary;
 - `6e8a8486` synchronizes lowering-time logical and physical layout mutations
   with the Session before the first post-lowering pass;
-- the current checkpoint centralizes lowering-time operator removal and protects
-  synthetic inverse-Transpose fan-out with differential consumer counts.
+- `e7c1457d` centralizes lowering-time operator removal and protects synthetic
+  inverse-Transpose fan-out with differential consumer counts;
+- the current checkpoint lazily shares `ModelIRPassState` across the repeated
+  Mean/attention registered-pass cluster.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -82,9 +83,15 @@ Branch: `fb-refactor5`, tracking `origin/fb-refactor5`.
 
 The final checkpoint changes:
 
-- `onnx2tf/tflite_builder/core/lowering_context.py`;
-- `onnx2tf/tflite_builder/op_builders/shared.py`;
-- `tests/test_flatbuffer_direct_core.py`;
+- `onnx2tf/tflite_builder/core/model_ir_pass_state.py`;
+- `onnx2tf/tflite_builder/core/__init__.py`;
+- `onnx2tf/tflite_builder/passes/mean_layout.py`;
+- `onnx2tf/tflite_builder/passes/layernorm_layout.py`;
+- `onnx2tf/tflite_builder/passes/terminal_mean_layout.py`;
+- `onnx2tf/tflite_builder/passes/se_layout.py`;
+- `onnx2tf/tflite_builder/passes/attention_layout.py`;
+- `onnx2tf/tflite_builder/lower_from_onnx2tf.py`;
+- `tests/test_flatbuffer_direct_mean_layout.py`;
 - `tests/test_flatbuffer_direct_architecture.py`;
 - `docs/flatbuffer_direct_architecture.md`;
 - this handoff document.
@@ -169,6 +176,14 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   pair is still elided, while a synthetic side consumer keeps its producer.
   This replaces the only direct op-builder deletion and adds no partial-graph
   scan.
+- `ModelIRPassStateScope` is lazy and identity-bound. A group with a successful
+  model-only preflight acquires the state; subsequent adjacent groups reuse it
+  and report `state_built: false`, so diagnostic `state_build_count` reflects
+  actual construction rather than pass invocation count. The scope is never
+  carried across legacy helpers that mutate ModelIR outside the differential
+  index. All six production occurrences retain the exact order
+  transpose-Mean, Mean/Mul/Add/Conv, optional LayerNorm, terminal Mean, SE conv,
+  SE FC, and optional Conv attention.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -295,6 +310,28 @@ inverse Transposes remove their operator and differential indexes, while a
 synthetic bridge already consumed by an Identity retains its producer. The
 architecture gate rejects direct operator-list writes and mutating method calls
 from op builders.
+The adjacent pass-state reuse checkpoint passed:
+
+```text
+env -u PYTHONPATH -u LD_LIBRARY_PATH \
+  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
+  uv run pytest -q \
+  tests/test_flatbuffer_direct_mean_layout.py \
+  tests/test_flatbuffer_direct_layernorm_layout.py \
+  tests/test_flatbuffer_direct_terminal_mean_layout.py \
+  tests/test_flatbuffer_direct_se_layout.py \
+  tests/test_flatbuffer_direct_core.py \
+  tests/test_flatbuffer_direct_pass_efficiency.py \
+  tests/test_flatbuffer_direct_architecture.py::test_lowerer_mean_attention_cluster_reuses_one_pass_state_scope
+
+65 passed
+```
+
+The focused reuse case observes one `ModelIRGraphIndex.refresh()` across two
+candidate Mean runners and a diagnostic build sequence of `[true, false]`.
+The all-preflight-miss case observes zero index refreshes and `[false, false]`.
+The architecture gate fixes all seven runner calls, their order, their shared
+scope keyword, and the six production cluster invocations.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -333,12 +370,12 @@ verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Audit the remaining `ConversionSession`/`LoweringContext` constant ownership
-   and constant-fold updates for a bounded stale-map gap; layout, lowering-time
-   producer, and synthetic-consumer mutation are now centralized.
-3. Characterize pre-session behavior and a focused fan-out/no-op boundary
-   before changing another handoff; do not introduce a second graph scan or a
-   blanket post-lowering resynchronization.
+2. Apply the same scope only to the next contiguous registered-runner cluster
+   after proving that no raw ModelIR mutator occurs inside its lifetime. The
+   mixed-attention through dual-Mul/Concat block is the next candidate.
+3. Add a focused index-construction count and preserve exact diagnostics and
+   rule order before migrating that cluster. Never carry a scope across a
+   legacy helper or introduce a blanket refresh.
 4. Keep the audited 294-line PyTorch source orchestrator as explicit sequencing
    unless a new bounded decision is found.
 5. Run only the focused synthetic/ownership/static checks unless the user asks

--- a/docs/flatbuffer_direct_handoff_2026-07-14.md
+++ b/docs/flatbuffer_direct_handoff_2026-07-14.md
@@ -7,10 +7,10 @@ The active branch is `fb-refactor5`, created from `main` after pull request
 subsequent work uses coherent commits and pushes without opening another pull
 request.
 
-The latest implementation unit moves channel-first local-response-normalization
-layout and static-shape propagation out of `_apply_fast_precanonicalize_repairs`
-and into the Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The
-orchestrator is 308 lines at this checkpoint, down from 482 lines at Goal
+The latest implementation unit centralizes the repeated post-rewrite literal
+static-shape cache update for aligned binary, Resize, and Pool statements in
+the Torch-free `pytorch_fast_precanonicalize_policy.py` owner. The orchestrator
+remains 308 lines at this checkpoint, down from 482 lines at Goal
 resumption, 1,025 lines at the beginning of the previous continuation, and
 1,608 lines before the broader fast-precanonicalize extraction.
 
@@ -31,7 +31,7 @@ The merged `fb-refactor4` checkpoints included:
   shape reconciliation and removes the now-unused aligned-rank4 and Softmax
   parser imports from the exporter.
 
-The current `fb-refactor5` work contains four coherent continuations:
+The current `fb-refactor5` work contains five coherent continuations:
 
 - `3ac19b40` centralizes the ordered fallback that repairs aligned binary
   shapes only when general binary repair made no change and the immediate next
@@ -42,8 +42,10 @@ The current `fb-refactor5` work contains four coherent continuations:
   input-layout guards, and CF evidence propagation;
 - `80d1d6a5` centralizes the aligned BatchNorm-constant rewrite itself while
   preserving the different direct and already-reshaped guards;
-- the current checkpoint centralizes LRN output evidence propagation without
-  changing or broadening the generated source grammar.
+- `91a0a52d` centralizes LRN output evidence propagation without changing or
+  broadening the generated source grammar;
+- the current checkpoint centralizes literal static-shape recording while
+  retaining each update at its original point in the ordered scan.
 
 The extraction preserves the ordered source-rewrite behavior. Layout evidence
 continues to mutate only the per-run CF/NHWC sets; repair context maps remain
@@ -105,6 +107,10 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
   to the CF set, removes stale NHWC evidence, and copies only a known rank-four
   static input shape. It does not mark the source file changed or rewrite the
   LRN statement.
+- Rewritten-shape caching accepts only a literal `target_shape=[...]` or the
+  exact trailing aligned shape. Dynamic and unparseable expressions do not
+  replace existing cache entries, and binary/Resize/Pool callers still update
+  the shared context immediately after their successful rewrite.
 - Shared parsers preserve the exact old generated syntax when broadening would
   change rule eligibility. Parser ownership tests prevent duplicate exporter
   implementations and unused compatibility imports.
@@ -114,8 +120,8 @@ status --short` with local `fb-refactor5` equal to `origin/fb-refactor5`.
 
 ## Tests executed
 
-The resumed downstream-binary, Resize-evidence, aligned-BatchNorm, and LRN
-checkpoints passed:
+The resumed downstream-binary, Resize-evidence, aligned-BatchNorm, LRN, and
+static-shape-cache checkpoints passed:
 
 ```text
 env -u PYTHONPATH -u LD_LIBRARY_PATH \
@@ -124,7 +130,7 @@ env -u PYTHONPATH -u LD_LIBRARY_PATH \
   tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py \
   tests/test_flatbuffer_direct_architecture.py
 
-123 passed
+124 passed
 ```
 
 Seven pre/post-extraction characterization cases also preserve the exact
@@ -138,6 +144,8 @@ reshaped non-BN no-op.
 The LRN checkpoint additionally passed a four-test selection covering CF/NHWC
 and static-shape state, Pool/LRN interaction, architecture ownership, and the
 existing generated-source integration case.
+The cache checkpoint passed four focused cases covering aligned binary,
+Resize/Pool, literal recording, parse-failure no-op, and architecture ownership.
 The exporter and policy pass `python -m py_compile`, and `git diff --check`
 passes. The immediately preceding DepthToSpace, Pool, dynamic-Pool,
 simple-alias, and aligned-scalar checkpoints passed their focused synthetic and
@@ -164,10 +172,8 @@ ownership selections.
 
 The full Goal is not complete. The fast-precanonicalize orchestrator still has
 308 lines. Its remaining body is primarily the intended ordered helper
-orchestration. Repeated state-update glue still includes:
+orchestration. Remaining state-update glue includes:
 
-- parsing repaired binary, Resize, and Pool target shapes back into the shared
-  static-shape context;
 - applying NHWC AveragePool bridge layout/shape results before subsequent Pool
   decisions.
 
@@ -179,12 +185,12 @@ remains subject to the original refactor plan and its verification gates.
 
 1. Confirm `git status --short --branch` is clean and local `fb-refactor5`
    matches `origin/fb-refactor5`.
-2. Inspect the repeated repaired-target static-shape updates for binary,
-   Resize, and Pool statements in `_apply_fast_precanonicalize_repairs`.
-3. Characterize parse-failure/no-op behavior before replacing them with one
-   bounded state helper, without moving the ordered orchestration itself.
-4. Preserve updates immediately after each successful rewrite so later rules
-   in the same scan see identical shape evidence.
+2. Inspect NHWC AveragePool-to-binary bridge state application in
+   `_apply_fast_precanonicalize_repairs`.
+3. Characterize the returned-name, CF/NHWC-set, normalized-shape, and no-op
+   behavior before co-locating the state update with its policy rewrite.
+4. Preserve the immediate reparse of the rewritten Pool statement before the
+   following Pool layout decisions.
 5. Run only the focused synthetic/ownership/static checks unless the user asks
    for broader conversion validation. Use `uv`, run inference sequentially if
    any is explicitly requested, commit and push coherent units, and do not

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -243,15 +243,15 @@ def _set_reduced_precision_support_metadata(
 
 def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
     request = ConversionRequest.from_kwargs(kwargs)
-    _reject_unsupported_quantization(**kwargs)
+    _reject_unsupported_quantization(**request.options)
 
     output_folder_path = request.output_folder_path
     output_file_name = request.output_file_name
     onnx_graph = request.onnx_graph
     output_weights = request.artifacts.weights
-    quant_type = kwargs.get("quant_type", "per-channel")
-    input_quant_dtype = kwargs.get("input_quant_dtype", "int8")
-    output_quant_dtype = kwargs.get("output_quant_dtype", "int8")
+    quant_type = request.get("quant_type", "per-channel")
+    input_quant_dtype = request.get("input_quant_dtype", "int8")
+    output_quant_dtype = request.get("output_quant_dtype", "int8")
     output_dynamic_range_quantized_tflite = request.artifacts.dynamic_range_quantized_tflite
     output_integer_quantized_tflite = request.artifacts.integer_quantized_tflite
     output_saved_model_from_model_ir = request.artifacts.saved_model
@@ -276,13 +276,13 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         required_pytorch_feature = "flatbuffer_direct PyTorch package export"
     if required_pytorch_feature is not None:
         require_torch(required_pytorch_feature)
-    saved_model_output_folder_path = kwargs.get(
+    saved_model_output_folder_path = request.get(
         "saved_model_output_folder_path",
         None,
     )
     if saved_model_output_folder_path is None:
         saved_model_output_folder_path = output_folder_path
-    pytorch_output_folder_path = kwargs.get(
+    pytorch_output_folder_path = request.get(
         "pytorch_output_folder_path",
         None,
     )
@@ -292,59 +292,59 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
             f"{output_file_name}_pytorch",
         )
     persist_saved_model_output = bool(
-        kwargs.get(
+        request.get(
             "persist_saved_model_output",
             output_saved_model_from_model_ir,
         )
     )
     enable_accumulation_type_float16 = bool(
-        kwargs.get("enable_accumulation_type_float16", False)
+        request.get("enable_accumulation_type_float16", False)
     )
     force_split_manifest = request.artifacts.split_manifest
     split_plan_requested = bool(force_split_manifest)
     report_op_coverage = request.artifacts.op_coverage_report
-    custom_input_op_name_np_data_path = kwargs.get(
+    custom_input_op_name_np_data_path = request.get(
         "custom_input_op_name_np_data_path",
         None,
     )
-    shape_hints = kwargs.get("shape_hints", None)
-    test_data_nhwc_path = kwargs.get("test_data_nhwc_path", None)
+    shape_hints = request.get("shape_hints", None)
+    test_data_nhwc_path = request.get("test_data_nhwc_path", None)
     native_pytorch_generation_timeout_sec = int(
-        kwargs.get("native_pytorch_generation_timeout_sec", 0) or 0
+        request.get("native_pytorch_generation_timeout_sec", 0) or 0
     )
-    output_nms_with_argmax = bool(kwargs.get("output_nms_with_argmax", False))
-    switch_nms_version = str(kwargs.get("switch_nms_version", "v4")).strip().lower()
+    output_nms_with_argmax = bool(request.get("output_nms_with_argmax", False))
+    switch_nms_version = str(request.get("switch_nms_version", "v4")).strip().lower()
     if switch_nms_version not in {"v4", "v5"}:
         raise ValueError(
             "switch_nms_version must be 'v4' or 'v5'. "
             f"got: {switch_nms_version}"
         )
-    keep_ncw_or_nchw_or_ncdhw_input_names = kwargs.get(
+    keep_ncw_or_nchw_or_ncdhw_input_names = request.get(
         "keep_ncw_or_nchw_or_ncdhw_input_names",
         None,
     )
-    keep_nwc_or_nhwc_or_ndhwc_input_names = kwargs.get(
+    keep_nwc_or_nhwc_or_ndhwc_input_names = request.get(
         "keep_nwc_or_nhwc_or_ndhwc_input_names",
         None,
     )
-    keep_shape_absolutely_input_names = kwargs.get(
+    keep_shape_absolutely_input_names = request.get(
         "keep_shape_absolutely_input_names",
         None,
     )
     disable_group_convolution = bool(
-        kwargs.get("disable_group_convolution", False)
+        request.get("disable_group_convolution", False)
     )
     enable_batchmatmul_unfold = bool(
-        kwargs.get("enable_batchmatmul_unfold", False)
+        request.get("enable_batchmatmul_unfold", False)
     )
     enable_rnn_unroll = bool(
-        kwargs.get("enable_rnn_unroll", False)
+        request.get("enable_rnn_unroll", False)
     )
-    mvn_epsilon = float(kwargs.get("mvn_epsilon", 1e-10))
+    mvn_epsilon = float(request.get("mvn_epsilon", 1e-10))
     flatbuffer_direct_allow_custom_ops = bool(
-        kwargs.get("flatbuffer_direct_allow_custom_ops", False)
+        request.get("flatbuffer_direct_allow_custom_ops", False)
     )
-    custom_allowlist_raw = kwargs.get(
+    custom_allowlist_raw = request.get(
         "flatbuffer_direct_custom_op_allowlist",
         None,
     )
@@ -380,44 +380,44 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
     ) and quant_controls is None:
         raise RuntimeError("quantization artifact controls were not resolved")
     flatbuffer_direct_show_progress = bool(
-        kwargs.get("flatbuffer_direct_show_progress", True)
+        request.get("flatbuffer_direct_show_progress", True)
     )
     number_of_dimensions_after_flextranspose_compression = int(
-        kwargs.get("number_of_dimensions_after_flextranspose_compression", 6)
+        request.get("number_of_dimensions_after_flextranspose_compression", 6)
     )
     disable_suppression_flextranspose = bool(
-        kwargs.get("disable_suppression_flextranspose", False)
+        request.get("disable_suppression_flextranspose", False)
     )
     number_of_dimensions_after_flexstridedslice_compression = int(
-        kwargs.get("number_of_dimensions_after_flexstridedslice_compression", 5)
+        request.get("number_of_dimensions_after_flexstridedslice_compression", 5)
     )
     disable_suppression_flexstridedslice = bool(
-        kwargs.get("disable_suppression_flexstridedslice", False)
+        request.get("disable_suppression_flexstridedslice", False)
     )
     optimization_for_gpu_delegate = bool(
-        kwargs.get("optimization_for_gpu_delegate", False)
+        request.get("optimization_for_gpu_delegate", False)
     )
     replace_argmax_to_reducemax_and_indices_is_int64 = bool(
-        kwargs.get("replace_argmax_to_reducemax_and_indices_is_int64", False)
+        request.get("replace_argmax_to_reducemax_and_indices_is_int64", False)
     )
     replace_argmax_to_reducemax_and_indices_is_float32 = bool(
-        kwargs.get("replace_argmax_to_reducemax_and_indices_is_float32", False)
+        request.get("replace_argmax_to_reducemax_and_indices_is_float32", False)
     )
     replace_argmax_to_fused_argmax_and_indices_is_int64 = bool(
-        kwargs.get("replace_argmax_to_fused_argmax_and_indices_is_int64", False)
+        request.get("replace_argmax_to_fused_argmax_and_indices_is_int64", False)
     )
     replace_argmax_to_fused_argmax_and_indices_is_float32 = bool(
-        kwargs.get("replace_argmax_to_fused_argmax_and_indices_is_float32", False)
+        request.get("replace_argmax_to_fused_argmax_and_indices_is_float32", False)
     )
     fused_argmax_scale_ratio = float(
-        kwargs.get("fused_argmax_scale_ratio", 0.5)
+        request.get("fused_argmax_scale_ratio", 0.5)
     )
-    requested_pseudo_ops_raw = kwargs.get("replace_to_pseudo_operators", None)
-    input_names_to_interrupt_model_conversion = kwargs.get(
+    requested_pseudo_ops_raw = request.get("replace_to_pseudo_operators", None)
+    input_names_to_interrupt_model_conversion = request.get(
         "input_names_to_interrupt_model_conversion",
         None,
     )
-    output_names_to_interrupt_model_conversion = kwargs.get(
+    output_names_to_interrupt_model_conversion = request.get(
         "output_names_to_interrupt_model_conversion",
         None,
     )

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -250,9 +250,6 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
     output_file_name = request.output_file_name
     onnx_graph = request.onnx_graph
     output_weights = request.artifacts.weights
-    quant_type = request.get("quant_type", "per-channel")
-    input_quant_dtype = request.get("input_quant_dtype", "int8")
-    output_quant_dtype = request.get("output_quant_dtype", "int8")
     output_dynamic_range_quantized_tflite = request.artifacts.dynamic_range_quantized_tflite
     output_integer_quantized_tflite = request.artifacts.integer_quantized_tflite
     output_saved_model_from_model_ir = request.artifacts.saved_model
@@ -371,6 +368,21 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         or output_integer_quantized_tflite
     ) and quant_controls is None:
         raise RuntimeError("quantization artifact controls were not resolved")
+    quant_type = (
+        quant_controls["quant_type"]
+        if quant_controls is not None
+        else "per-channel"
+    )
+    input_quant_dtype = (
+        quant_controls["input_quant_dtype"]
+        if quant_controls is not None
+        else "int8"
+    )
+    output_quant_dtype = (
+        quant_controls["output_quant_dtype"]
+        if quant_controls is not None
+        else "int8"
+    )
     flatbuffer_direct_show_progress = bool(
         request.get("flatbuffer_direct_show_progress", True)
     )

--- a/onnx2tf/tflite_builder/__init__.py
+++ b/onnx2tf/tflite_builder/__init__.py
@@ -10,6 +10,7 @@ from onnx2tf.tflite_builder.artifact_metadata import (
 from onnx2tf.tflite_builder.artifact_preparation import (
     isolate_float32_model_ir_for_tflite_write,
     resolve_requested_artifact_controls,
+    resolve_requested_exporter_controls,
 )
 from onnx2tf.tflite_builder.core.contracts import ConversionRequest, ConversionResult
 from onnx2tf.tflite_builder.core.graph import ModelIRGraphIndex
@@ -276,41 +277,32 @@ def export_tflite_model_flatbuffer_direct(**kwargs: Any) -> Dict[str, Any]:
         required_pytorch_feature = "flatbuffer_direct PyTorch package export"
     if required_pytorch_feature is not None:
         require_torch(required_pytorch_feature)
-    saved_model_output_folder_path = request.get(
-        "saved_model_output_folder_path",
-        None,
+    exporter_controls = resolve_requested_exporter_controls(
+        request.options,
+        output_folder_path=output_folder_path,
+        output_file_name=output_file_name,
+        saved_model_requested=output_saved_model_from_model_ir,
+        pytorch_requested=output_pytorch_from_model_ir,
+        calibration_inputs_requested=output_integer_quantized_tflite,
     )
-    if saved_model_output_folder_path is None:
-        saved_model_output_folder_path = output_folder_path
-    pytorch_output_folder_path = request.get(
-        "pytorch_output_folder_path",
-        None,
+    saved_model_output_folder_path = (
+        exporter_controls.saved_model_output_folder_path
     )
-    if pytorch_output_folder_path is None:
-        pytorch_output_folder_path = os.path.join(
-            output_folder_path,
-            f"{output_file_name}_pytorch",
-        )
-    persist_saved_model_output = bool(
-        request.get(
-            "persist_saved_model_output",
-            output_saved_model_from_model_ir,
-        )
-    )
+    pytorch_output_folder_path = exporter_controls.pytorch_output_folder_path
+    persist_saved_model_output = exporter_controls.persist_saved_model_output
     enable_accumulation_type_float16 = bool(
         request.get("enable_accumulation_type_float16", False)
     )
     force_split_manifest = request.artifacts.split_manifest
     split_plan_requested = bool(force_split_manifest)
     report_op_coverage = request.artifacts.op_coverage_report
-    custom_input_op_name_np_data_path = request.get(
-        "custom_input_op_name_np_data_path",
-        None,
+    custom_input_op_name_np_data_path = (
+        exporter_controls.custom_input_op_name_np_data_path
     )
-    shape_hints = request.get("shape_hints", None)
-    test_data_nhwc_path = request.get("test_data_nhwc_path", None)
-    native_pytorch_generation_timeout_sec = int(
-        request.get("native_pytorch_generation_timeout_sec", 0) or 0
+    shape_hints = exporter_controls.shape_hints
+    test_data_nhwc_path = exporter_controls.test_data_nhwc_path
+    native_pytorch_generation_timeout_sec = (
+        exporter_controls.native_pytorch_generation_timeout_sec
     )
     output_nms_with_argmax = bool(request.get("output_nms_with_argmax", False))
     switch_nms_version = str(request.get("switch_nms_version", "v4")).strip().lower()

--- a/onnx2tf/tflite_builder/artifact_preparation.py
+++ b/onnx2tf/tflite_builder/artifact_preparation.py
@@ -108,7 +108,12 @@ def resolve_requested_artifact_controls(
 
     quantization: Optional[Mapping[str, Any]] = None
     if quantization_requested:
-        quantization = MappingProxyType(
+        quantization_values = {
+            "quant_type": options.get("quant_type", "per-channel"),
+            "input_quant_dtype": options.get("input_quant_dtype", "int8"),
+            "output_quant_dtype": options.get("output_quant_dtype", "int8"),
+        }
+        quantization_values.update(
             {
                 key: cast(
                     _option_or_environment(
@@ -123,6 +128,7 @@ def resolve_requested_artifact_controls(
                 )
             }
         )
+        quantization = MappingProxyType(quantization_values)
 
     return ArtifactExecutionControls(
         split_max_bytes=split_max_bytes,

--- a/onnx2tf/tflite_builder/artifact_preparation.py
+++ b/onnx2tf/tflite_builder/artifact_preparation.py
@@ -67,6 +67,17 @@ class ArtifactExecutionControls:
     quantization: Optional[Mapping[str, Any]]
 
 
+@dataclass(frozen=True)
+class RequestedExporterControls:
+    saved_model_output_folder_path: str
+    persist_saved_model_output: bool
+    pytorch_output_folder_path: str
+    native_pytorch_generation_timeout_sec: int
+    custom_input_op_name_np_data_path: Any
+    shape_hints: Any
+    test_data_nhwc_path: Any
+
+
 def resolve_requested_artifact_controls(
     options: Mapping[str, Any],
     *,
@@ -117,6 +128,69 @@ def resolve_requested_artifact_controls(
         split_max_bytes=split_max_bytes,
         split_target_bytes=split_target_bytes,
         quantization=quantization,
+    )
+
+
+def resolve_requested_exporter_controls(
+    options: Mapping[str, Any],
+    *,
+    output_folder_path: str,
+    output_file_name: str,
+    saved_model_requested: bool,
+    pytorch_requested: bool,
+    calibration_inputs_requested: bool,
+) -> RequestedExporterControls:
+    saved_model_output_folder_path = str(output_folder_path)
+    pytorch_output_folder_path = os.path.join(
+        str(output_folder_path),
+        f"{output_file_name}_pytorch",
+    )
+    persist_saved_model_output = False
+    native_pytorch_generation_timeout_sec = 0
+    custom_input_op_name_np_data_path = None
+    shape_hints = None
+    test_data_nhwc_path = None
+
+    if saved_model_requested:
+        saved_model_output_option = options.get(
+            "saved_model_output_folder_path",
+            None,
+        )
+        if saved_model_output_option is not None:
+            saved_model_output_folder_path = saved_model_output_option
+    if pytorch_requested:
+        pytorch_output_option = options.get(
+            "pytorch_output_folder_path",
+            None,
+        )
+        if pytorch_output_option is not None:
+            pytorch_output_folder_path = pytorch_output_option
+    if saved_model_requested:
+        persist_saved_model_output = bool(
+            options.get("persist_saved_model_output", True)
+        )
+    if calibration_inputs_requested or pytorch_requested:
+        custom_input_op_name_np_data_path = options.get(
+            "custom_input_op_name_np_data_path",
+            None,
+        )
+    if pytorch_requested:
+        shape_hints = options.get("shape_hints", None)
+        test_data_nhwc_path = options.get("test_data_nhwc_path", None)
+        native_pytorch_generation_timeout_sec = int(
+            options.get("native_pytorch_generation_timeout_sec", 0) or 0
+        )
+
+    return RequestedExporterControls(
+        saved_model_output_folder_path=saved_model_output_folder_path,
+        persist_saved_model_output=persist_saved_model_output,
+        pytorch_output_folder_path=pytorch_output_folder_path,
+        native_pytorch_generation_timeout_sec=(
+            native_pytorch_generation_timeout_sec
+        ),
+        custom_input_op_name_np_data_path=custom_input_op_name_np_data_path,
+        shape_hints=shape_hints,
+        test_data_nhwc_path=test_data_nhwc_path,
     )
 
 

--- a/onnx2tf/tflite_builder/core/__init__.py
+++ b/onnx2tf/tflite_builder/core/__init__.py
@@ -16,6 +16,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
     summarize_model_ir_pass_diagnostics,
 )
@@ -55,6 +56,7 @@ __all__ = [
     "ModelIRGraphIndex",
     "ModelIRPreflightResult",
     "ModelIRPassState",
+    "ModelIRPassStateScope",
     "run_model_ir_pass_group",
     "summarize_model_ir_pass_diagnostics",
     "ModelIRInvariantError",

--- a/onnx2tf/tflite_builder/core/lowering_context.py
+++ b/onnx2tf/tflite_builder/core/lowering_context.py
@@ -116,6 +116,7 @@ class LoweringContext:
         }
         self._serial = 0
         self.ir_tensor_producers: Dict[str, OperatorIR] = {}
+        self.ir_tensor_consumer_count: Dict[str, int] = {}
         self.onnx_tensor_consumers: Dict[str, List[Any]] = (
             session.graph_index.consumers if session is not None else {}
         )
@@ -267,6 +268,46 @@ class LoweringContext:
 
     def add_operator(self, op: OperatorIR) -> None:
         self.model_ir.operators.append(op)
+        for input_name in op.inputs:
+            name = str(input_name)
+            if name:
+                self.ir_tensor_consumer_count[name] = int(
+                    self.ir_tensor_consumer_count.get(name, 0) + 1
+                )
         for output_name in op.outputs:
             if str(output_name):
                 self.ir_tensor_producers[str(output_name)] = op
+
+    def remove_operator(self, operator_index: int) -> OperatorIR:
+        """Remove one lowering-time operator and update differential indexes."""
+
+        op = self.model_ir.operators.pop(int(operator_index))
+        for input_name in op.inputs:
+            name = str(input_name)
+            if not name:
+                continue
+            remaining = int(self.ir_tensor_consumer_count.get(name, 0) - 1)
+            if remaining > 0:
+                self.ir_tensor_consumer_count[name] = remaining
+            else:
+                self.ir_tensor_consumer_count.pop(name, None)
+        for output_name in op.outputs:
+            name = str(output_name)
+            if self.ir_tensor_producers.get(name) is op:
+                self.ir_tensor_producers.pop(name, None)
+        return op
+
+    def effective_tensor_consumer_count(
+        self,
+        name: str,
+        *,
+        include_pending_synthetic_consumer: bool = False,
+    ) -> int:
+        """Return ONNX fan-out or the current differential synthetic fan-out."""
+
+        tensor_name = str(name)
+        if tensor_name in self.tensor_consumer_count:
+            return int(self.tensor_consumer_count[tensor_name])
+        return int(self.ir_tensor_consumer_count.get(tensor_name, 0)) + int(
+            bool(include_pending_synthetic_consumer)
+        )

--- a/onnx2tf/tflite_builder/core/lowering_context.py
+++ b/onnx2tf/tflite_builder/core/lowering_context.py
@@ -8,7 +8,13 @@ from onnx2tf.tflite_builder.core.session import ConversionSession
 from onnx2tf.tflite_builder.core.shape_resolution import (
     shape_hint_only_adds_singleton_or_dynamic_axes,
 )
-from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR, normalize_onnx_shape
+from onnx2tf.tflite_builder.ir import (
+    ModelIR,
+    OperatorIR,
+    TensorIR,
+    normalize_logical_layout,
+    normalize_onnx_shape,
+)
 from onnx2tf.tflite_builder.tensor_buffer_builder import tflite_dtype_from_numpy
 
 
@@ -157,6 +163,27 @@ class LoweringContext:
             logical=tensor.logical_layout,
             physical=tensor.physical_layout,
         )
+
+    def set_tensor_layout(
+        self,
+        name: str,
+        *,
+        logical: Optional[str] = None,
+        physical: Optional[str] = None,
+    ) -> None:
+        """Update tensor layout metadata and the Session-owned layout state."""
+
+        tensor_name = str(name)
+        if tensor_name not in self.model_ir.tensors:
+            raise KeyError(
+                f"Tensor layout cannot be updated before creation: {tensor_name}"
+            )
+        tensor = self.model_ir.tensors[tensor_name]
+        if logical is not None:
+            tensor.logical_layout = normalize_logical_layout(logical)
+        if physical is not None:
+            tensor.physical_layout = normalize_logical_layout(physical)
+        self._record_layout(tensor_name)
 
     def ensure_tensor(
         self,

--- a/onnx2tf/tflite_builder/core/model_ir_pass_state.py
+++ b/onnx2tf/tflite_builder/core/model_ir_pass_state.py
@@ -250,6 +250,37 @@ class ModelIRPreflightResult:
     operators_visited: int
 
 
+@dataclass
+class ModelIRPassStateScope:
+    """Lazily share pass state across adjacent groups with no raw mutation."""
+
+    model_ir: ModelIR
+    layout_state: Optional[LayoutState] = None
+    _state: Optional[ModelIRPassState] = field(
+        init=False,
+        default=None,
+        repr=False,
+    )
+
+    def acquire(
+        self,
+        *,
+        model_ir: ModelIR,
+        layout_state: Optional[LayoutState],
+    ) -> Tuple[ModelIRPassState, bool]:
+        if model_ir is not self.model_ir:
+            raise ValueError("ModelIRPassStateScope cannot cross ModelIR instances")
+        if layout_state is not self.layout_state:
+            raise ValueError("ModelIRPassStateScope cannot cross LayoutState instances")
+        if self._state is None:
+            self._state = ModelIRPassState(
+                self.model_ir,
+                layout_state=self.layout_state,
+            )
+            return self._state, True
+        return self._state, False
+
+
 def preflight_any_operator(
     model_ir: ModelIR,
     predicate: Callable[[OperatorIR], bool],
@@ -356,6 +387,7 @@ def run_model_ir_pass_group(
     layout_state: Optional[LayoutState] = None,
     default_details: Optional[Mapping[str, Any]] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
     preflight: Optional[
         Callable[[ModelIR], bool | ModelIRPreflightResult]
     ] = None,
@@ -431,8 +463,14 @@ def run_model_ir_pass_group(
             for spec in manager.ordered_specs()
         ]
     else:
-        state_built = True
-        state = ModelIRPassState(model_ir, layout_state=layout_state)
+        if state_scope is None:
+            state = ModelIRPassState(model_ir, layout_state=layout_state)
+            state_built = True
+        else:
+            state, state_built = state_scope.acquire(
+                model_ir=model_ir,
+                layout_state=layout_state,
+            )
         try:
             results = manager.run(state)
         except PassInvariantError as error:

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -50106,6 +50106,24 @@ def lower_onnx_to_ir(
             state_scope=state_scope,
         )
 
+    def _run_boundary_batchmatmul_unary_layout_pass_cluster() -> None:
+        state_scope = ModelIRPassStateScope(
+            model_ir,
+            layout_state=session.layout_state,
+        )
+        run_boundary_input_batchmatmul_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_input_unary_passthrough_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+
     _set_post_progress_desc("outputs")
 
     # Outputs
@@ -50184,16 +50202,7 @@ def lower_onnx_to_ir(
             diagnostics=session.diagnostics,
         )
         _optimize_transpose_quant_dequant_bridges(model_ir)
-        run_boundary_input_batchmatmul_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_input_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_boundary_batchmatmul_unary_layout_pass_cluster()
         _optimize_transpose_elementwise_roundtrip_nchw_nhwc_chains(model_ir)
         _optimize_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chains(model_ir)
         run_hard_activation_passthrough_cleanup(
@@ -50297,16 +50306,7 @@ def lower_onnx_to_ir(
         )
         # Binary bridge rewrites can introduce new transpose-(q|dq)-transpose patterns.
         _optimize_transpose_quant_dequant_bridges(model_ir)
-        run_boundary_input_batchmatmul_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_input_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_boundary_batchmatmul_unary_layout_pass_cluster()
         _optimize_transpose_elementwise_roundtrip_nchw_nhwc_chains(model_ir)
         _optimize_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chains(model_ir)
         run_hard_activation_passthrough_cleanup(
@@ -50413,16 +50413,7 @@ def lower_onnx_to_ir(
         _optimize_concat_pre_quantize_dequantize(model_ir)
         _optimize_transpose_mean_maxpool_concat_conv_chains(model_ir)
         _optimize_transpose_quant_dequant_bridges(model_ir)
-        run_boundary_input_batchmatmul_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_input_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_boundary_batchmatmul_unary_layout_pass_cluster()
         _optimize_transpose_elementwise_roundtrip_nchw_nhwc_chains(model_ir)
         _optimize_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chains(model_ir)
         run_hard_activation_passthrough_cleanup(
@@ -50584,16 +50575,7 @@ def lower_onnx_to_ir(
         _optimize_concat_pre_quantize_dequantize(model_ir)
         _optimize_transpose_mean_maxpool_concat_conv_chains(model_ir)
         _optimize_transpose_quant_dequant_bridges(model_ir)
-        run_boundary_input_batchmatmul_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_input_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_boundary_batchmatmul_unary_layout_pass_cluster()
         _optimize_transpose_elementwise_roundtrip_nchw_nhwc_chains(model_ir)
         _optimize_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chains(model_ir)
         run_hard_activation_passthrough_cleanup(

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -51181,25 +51181,33 @@ def lower_onnx_to_ir(
         model_ir,
         enable_conv_add_only_fold=True,
     )
+    late_concat_layout_state_scope = ModelIRPassStateScope(
+        model_ir,
+        layout_state=session.layout_state,
+    )
     run_axis3_const_concat_layout_cleanup(
         model_ir,
         layout_state=session.layout_state,
         diagnostics=session.diagnostics,
+        state_scope=late_concat_layout_state_scope,
     )
     run_dequant_concat_quantize_layout_cleanup(
         model_ir,
         layout_state=session.layout_state,
         diagnostics=session.diagnostics,
+        state_scope=late_concat_layout_state_scope,
     )
     run_layernorm_statistics_layout_cleanup(
         model_ir,
         layout_state=session.layout_state,
         diagnostics=session.diagnostics,
+        state_scope=late_concat_layout_state_scope,
     )
     run_layout_transpose_cleanup(
         model_ir,
         layout_state=session.layout_state,
         diagnostics=session.diagnostics,
+        state_scope=late_concat_layout_state_scope,
     )
     if optimize_layout_transpose_chains:
         _optimize_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chains(model_ir)

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -50030,6 +50030,82 @@ def lower_onnx_to_ir(
             state_scope=state_scope,
         )
 
+    def _run_channel_shuffle_gather_layout_pass_cluster(
+        *,
+        include_post_gather_cleanup: bool = False,
+    ) -> None:
+        state_scope = ModelIRPassStateScope(
+            model_ir,
+            layout_state=session.layout_state,
+        )
+        run_two_way_channel_shuffle_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_nhwc_channel_shuffle_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_nchw_channel_shuffle_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_transpose_gather_axis_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        if include_post_gather_cleanup:
+            run_layout_transpose_cleanup(
+                model_ir,
+                layout_state=session.layout_state,
+                diagnostics=session.diagnostics,
+                state_scope=state_scope,
+            )
+            run_transpose_unary_fanout_bridge_cleanup(
+                model_ir,
+                layout_state=session.layout_state,
+                diagnostics=session.diagnostics,
+                state_scope=state_scope,
+            )
+            run_transpose_unary_binary_fanout_bridge_cleanup(
+                model_ir,
+                layout_state=session.layout_state,
+                diagnostics=session.diagnostics,
+                state_scope=state_scope,
+            )
+
+    def _run_transpose_unary_fanout_layout_pass_cluster() -> None:
+        state_scope = ModelIRPassStateScope(
+            model_ir,
+            layout_state=session.layout_state,
+        )
+        run_transpose_unary_passthrough_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_transpose_unary_fanout_bridge_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_transpose_unary_binary_fanout_bridge_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+
     _set_post_progress_desc("outputs")
 
     # Outputs
@@ -50150,26 +50226,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_split_mixed_pre_concat_to_single_post_adapter_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
-        run_two_way_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nhwc_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nchw_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_gather_axis_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_channel_shuffle_gather_layout_pass_cluster()
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
@@ -50200,21 +50257,7 @@ def lower_onnx_to_ir(
         _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
-        run_transpose_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_binary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_transpose_unary_fanout_layout_pass_cluster()
         _optimize_transpose_dequant_relu_quantize_bridges(model_ir)
         _optimize_transpose_dequant_hardsigmoid_quantize_bridges(model_ir)
         run_trailing_output_transpose_cleanup(
@@ -50296,26 +50339,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_split_mixed_pre_concat_to_single_post_adapter_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
-        run_two_way_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nhwc_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nchw_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_gather_axis_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_channel_shuffle_gather_layout_pass_cluster()
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
@@ -50346,21 +50370,7 @@ def lower_onnx_to_ir(
         _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
-        run_transpose_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_binary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_transpose_unary_fanout_layout_pass_cluster()
         _optimize_transpose_dequant_relu_quantize_bridges(model_ir)
         _optimize_transpose_dequant_hardsigmoid_quantize_bridges(model_ir)
         run_trailing_output_transpose_cleanup(
@@ -50445,26 +50455,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_split_mixed_pre_concat_to_single_post_adapter_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
-        run_two_way_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nhwc_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nchw_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_gather_axis_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_channel_shuffle_gather_layout_pass_cluster()
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mulconst_reshape_transpose_suffix_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_reshape_transpose_suffix_nhwc_chains(model_ir)
@@ -50501,21 +50492,7 @@ def lower_onnx_to_ir(
         _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
-        run_transpose_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_binary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_transpose_unary_fanout_layout_pass_cluster()
         _optimize_transpose_dequant_relu_quantize_bridges(model_ir)
         _optimize_transpose_dequant_hardsigmoid_quantize_bridges(model_ir)
         run_trailing_output_transpose_cleanup(
@@ -50649,26 +50626,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_split_mixed_pre_concat_to_single_post_adapter_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
-        run_two_way_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nhwc_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nchw_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_gather_axis_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_channel_shuffle_gather_layout_pass_cluster()
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mul_add_prelu_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mul_add_transpose_fanout_nhwc_chains(model_ir)
@@ -50681,21 +50639,7 @@ def lower_onnx_to_ir(
         _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
-        run_transpose_unary_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_binary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_transpose_unary_fanout_layout_pass_cluster()
         _optimize_transpose_dequant_relu_quantize_bridges(model_ir)
         _optimize_transpose_dequant_hardsigmoid_quantize_bridges(model_ir)
         run_trailing_output_transpose_cleanup(
@@ -50736,40 +50680,8 @@ def lower_onnx_to_ir(
         _optimize_transpose_split_mixed_pre_concat_to_single_post_adapter_nhwc_chains(model_ir)
         _optimize_transpose_input_chains_pre_concat_to_single_post_adapter(model_ir)
         _optimize_transpose_slice_logistic_concat_reshape_tail_nhwc_chains(model_ir)
-        run_two_way_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nhwc_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_nchw_channel_shuffle_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_gather_axis_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_layout_transpose_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_transpose_unary_binary_fanout_bridge_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
+        _run_channel_shuffle_gather_layout_pass_cluster(
+            include_post_gather_cleanup=True,
         )
         _optimize_transpose_pre_add_nhwc_chains(model_ir)
         _optimize_transpose_pre_add_mul_add_prelu_nhwc_chains(model_ir)

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -49972,6 +49972,64 @@ def lower_onnx_to_ir(
                 state_scope=state_scope,
             )
 
+    def _run_gate_layout_pass_cluster(
+        *,
+        include_mixed_attention: bool = True,
+    ) -> None:
+        state_scope = ModelIRPassStateScope(
+            model_ir,
+            layout_state=session.layout_state,
+        )
+        if include_mixed_attention:
+            run_mixed_attention_layout_cleanup(
+                model_ir,
+                layout_state=session.layout_state,
+                diagnostics=session.diagnostics,
+                state_scope=state_scope,
+            )
+        run_elementwise_gate_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_pad_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_dual_postconv_gate_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_ndhwc_gate_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_cost_volume_scatter_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_add_concat_suffix_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_dual_mul_concat_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+
     _set_post_progress_desc("outputs")
 
     # Outputs
@@ -50139,46 +50197,7 @@ def lower_onnx_to_ir(
         _run_mean_attention_layout_pass_cluster(include_layernorm=True)
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
-        run_mixed_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_elementwise_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_pad_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_postconv_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_ndhwc_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_cost_volume_scatter_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_add_concat_suffix_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_mul_concat_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
         run_transpose_unary_passthrough_cleanup(
@@ -50324,46 +50343,7 @@ def lower_onnx_to_ir(
         _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
-        run_mixed_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_elementwise_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_pad_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_postconv_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_ndhwc_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_cost_volume_scatter_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_add_concat_suffix_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_mul_concat_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
         run_transpose_unary_passthrough_cleanup(
@@ -50518,46 +50498,7 @@ def lower_onnx_to_ir(
         _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
-        run_mixed_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_elementwise_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_pad_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_postconv_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_ndhwc_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_cost_volume_scatter_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_add_concat_suffix_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_mul_concat_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
         run_transpose_unary_passthrough_cleanup(
@@ -50737,46 +50678,7 @@ def lower_onnx_to_ir(
         _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
-        run_mixed_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_elementwise_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_pad_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_postconv_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_ndhwc_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_cost_volume_scatter_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_add_concat_suffix_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_mul_concat_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_gate_layout_pass_cluster()
         _optimize_transposeconv_output_nhwc_passthrough_chains(model_ir)
         _optimize_transposeconv_output_channel1_terminal_transpose_chains(model_ir)
         run_transpose_unary_passthrough_cleanup(
@@ -50877,41 +50779,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
         _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
-        run_elementwise_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_pad_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_postconv_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_ndhwc_gate_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_cost_volume_scatter_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_add_concat_suffix_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_dual_mul_concat_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_gate_layout_pass_cluster(include_mixed_attention=False)
         for _ in range(2):
             rewritten_instnorm = int(
                 _optimize_transpose_instancenorm_prepost_nhwc_chains(model_ir).get(

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -50124,6 +50124,24 @@ def lower_onnx_to_ir(
             state_scope=state_scope,
         )
 
+    def _run_channel_slice_pad_mul_layout_pass_cluster() -> None:
+        state_scope = ModelIRPassStateScope(
+            model_ir,
+            layout_state=session.layout_state,
+        )
+        run_channel_slice_merge_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_pad_mul_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+
     _set_post_progress_desc("outputs")
 
     # Outputs
@@ -50773,16 +50791,7 @@ def lower_onnx_to_ir(
         model_ir,
         layout_state=session.layout_state,
     )
-    run_channel_slice_merge_layout_cleanup(
-        model_ir,
-        layout_state=session.layout_state,
-        diagnostics=session.diagnostics,
-    )
-    run_pad_mul_layout_cleanup(
-        model_ir,
-        layout_state=session.layout_state,
-        diagnostics=session.diagnostics,
-    )
+    _run_channel_slice_pad_mul_layout_pass_cluster()
     _optimize_transpose_mul_posttranspose_add_nhwc_chains(model_ir)
     _optimize_concat_mul_add_transpose_nhwc_bridge_chains(model_ir)
     _optimize_concat_mul_add_transpose_add_nhwc_bridge_chains(model_ir)
@@ -51150,16 +51159,7 @@ def lower_onnx_to_ir(
     )
     _optimize_internal_transpose_channel_slice_nhwc_propagation_chains(model_ir)
     _optimize_transpose_channel_slice_muladd_nhwc_bridge_chains(model_ir)
-    run_channel_slice_merge_layout_cleanup(
-        model_ir,
-        layout_state=session.layout_state,
-        diagnostics=session.diagnostics,
-    )
-    run_pad_mul_layout_cleanup(
-        model_ir,
-        layout_state=session.layout_state,
-        diagnostics=session.diagnostics,
-    )
+    _run_channel_slice_pad_mul_layout_pass_cluster()
     _optimize_transpose_mul_posttranspose_add_nhwc_chains(model_ir)
     _optimize_concat_mul_add_transpose_nhwc_bridge_chains(model_ir)
     _optimize_concat_mul_add_transpose_add_nhwc_bridge_chains(model_ir)
@@ -51373,16 +51373,7 @@ def lower_onnx_to_ir(
     _optimize_transpose_binary_split_channelwise_tail_to_single_post_nchw(model_ir)
     _sanitize_probable_nhwc_axis_sensitive_ops(model_ir)
     _optimize_transpose_pre_add_nhwc_chains(model_ir)
-    run_channel_slice_merge_layout_cleanup(
-        model_ir,
-        layout_state=session.layout_state,
-        diagnostics=session.diagnostics,
-    )
-    run_pad_mul_layout_cleanup(
-        model_ir,
-        layout_state=session.layout_state,
-        diagnostics=session.diagnostics,
-    )
+    _run_channel_slice_pad_mul_layout_pass_cluster()
     _optimize_transpose_mul_posttranspose_add_nhwc_chains(model_ir)
     _optimize_transpose_stridedslice_pad_concat_mul_add_posttranspose_nhwc_chains(model_ir)
     # Strict slice/merge cleanup above can recreate simple affine bridge tails:

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -17,6 +17,7 @@ from onnx2tf.tflite_builder.core.lowering_context import LoweringContext
 from onnx2tf.tflite_builder.core.graph import ModelIRGraphIndex
 from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.node import NodeView as _NodeWrap
+from onnx2tf.tflite_builder.core.model_ir_pass_state import ModelIRPassStateScope
 from onnx2tf.tflite_builder.core.model_ir_utils import (
     _append_tensor_lineage_event,
     _broadcast_static_shapes,
@@ -49917,6 +49918,60 @@ def lower_onnx_to_ir(
         post_progress_bar.update(1)
         post_progress_step = int(post_progress_step + 1)
 
+    def _run_mean_attention_layout_pass_cluster(
+        *,
+        include_layernorm: bool = False,
+        include_conv_attention: bool = True,
+    ) -> None:
+        state_scope = ModelIRPassStateScope(
+            model_ir,
+            layout_state=session.layout_state,
+        )
+        run_transpose_mean_passthrough_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_mean_mul_add_conv_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        if include_layernorm:
+            run_layernorm_statistics_layout_cleanup(
+                model_ir,
+                layout_state=session.layout_state,
+                diagnostics=session.diagnostics,
+                state_scope=state_scope,
+            )
+        run_terminal_mean_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_se_conv_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        run_se_fc_layout_cleanup(
+            model_ir,
+            layout_state=session.layout_state,
+            diagnostics=session.diagnostics,
+            state_scope=state_scope,
+        )
+        if include_conv_attention:
+            run_conv_attention_layout_cleanup(
+                model_ir,
+                layout_state=session.layout_state,
+                diagnostics=session.diagnostics,
+                state_scope=state_scope,
+            )
+
     _set_post_progress_desc("outputs")
 
     # Outputs
@@ -50081,41 +50136,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_mul_add_transpose_fanout_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
-        run_transpose_mean_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_mean_mul_add_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_layernorm_statistics_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_terminal_mean_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_fc_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_conv_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_mean_attention_layout_pass_cluster(include_layernorm=True)
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         run_mixed_attention_layout_cleanup(
@@ -50300,36 +50321,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_mul_add_transpose_fanout_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
-        run_transpose_mean_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_mean_mul_add_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_terminal_mean_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_fc_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_conv_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         run_mixed_attention_layout_cleanup(
@@ -50523,36 +50515,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_mul_add_transpose_fanout_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
-        run_transpose_mean_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_mean_mul_add_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_terminal_mean_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_fc_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_conv_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         run_mixed_attention_layout_cleanup(
@@ -50771,36 +50734,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_mul_add_transpose_fanout_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
-        run_transpose_mean_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_mean_mul_add_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_terminal_mean_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_fc_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_conv_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         _optimize_sinet_mix_attention_double_logistic_nhwc_chains(model_ir)
         run_mixed_attention_layout_cleanup(
@@ -50941,36 +50875,7 @@ def lower_onnx_to_ir(
         _optimize_transpose_mul_add_const_prepost_nhwc_chains(model_ir)
         _optimize_transpose_pre_unary_mul_add_transpose_fanout_nhwc_chains(model_ir)
         _optimize_transpose_mean_mul_add_const_prepost_nhwc_chains(model_ir)
-        run_transpose_mean_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_mean_mul_add_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_terminal_mean_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_fc_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_conv_attention_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
+        _run_mean_attention_layout_pass_cluster()
         _optimize_transpose_sa_pa_mirrorpad_nhwc_propagation_chains(model_ir)
         run_elementwise_gate_layout_cleanup(
             model_ir,
@@ -51181,30 +51086,8 @@ def lower_onnx_to_ir(
     if optimize_layout_transpose_chains:
         # Boundary/layout recovery can still recreate NCHW wrappers around MEAN.
         # Run dedicated NHWC passthrough once more in the terminal stage.
-        run_transpose_mean_passthrough_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_mean_mul_add_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_terminal_mean_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_conv_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
-        )
-        run_se_fc_layout_cleanup(
-            model_ir,
-            layout_state=session.layout_state,
-            diagnostics=session.diagnostics,
+        _run_mean_attention_layout_pass_cluster(
+            include_conv_attention=False,
         )
         _optimize_batchmatmul_affine_transpose_input_chains(model_ir)
         _optimize_batchmatmul_reshape_se_nhwc_chains(model_ir)

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -51161,15 +51161,21 @@ def lower_onnx_to_ir(
         diagnostics=session.diagnostics,
     )
     _optimize_transpose_dequant_hardsigmoid_quantize_bridges(model_ir)
+    late_ndhwc_cost_volume_state_scope = ModelIRPassStateScope(
+        model_ir,
+        layout_state=session.layout_state,
+    )
     run_ndhwc_gate_layout_cleanup(
         model_ir,
         layout_state=session.layout_state,
         diagnostics=session.diagnostics,
+        state_scope=late_ndhwc_cost_volume_state_scope,
     )
     run_cost_volume_scatter_layout_cleanup(
         model_ir,
         layout_state=session.layout_state,
         diagnostics=session.diagnostics,
+        state_scope=late_ndhwc_cost_volume_state_scope,
     )
     _optimize_fold_conv_mul_add_affine_chains(
         model_ir,

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -49619,7 +49619,6 @@ def lower_onnx_to_ir(
     for ini in onnx_graph.graph.initializer:
         constants[ini.name] = np.asarray(numpy_helper.to_array(ini))
     # Producer/consumer information is built once by ConversionSession below.
-    tensor_consumer_count: Dict[str, int] = {}
     graph_output_names = [str(o.name) for o in onnx_graph.graph.output]
 
     model_ir = ModelIR(name=output_file_name)
@@ -49668,7 +49667,7 @@ def lower_onnx_to_ir(
         allow_custom_ops=allow_custom_ops,
         custom_op_allowlist=custom_op_allowlist,
         disable_group_convolution=disable_group_convolution,
-        tensor_consumer_count=tensor_consumer_count,
+        tensor_consumer_count=session.tensor_consumer_count,
         graph_output_names=graph_output_names,
         output_nms_with_argmax=output_nms_with_argmax,
         switch_nms_version=switch_nms_version,

--- a/onnx2tf/tflite_builder/op_builders/shape.py
+++ b/onnx2tf/tflite_builder/op_builders/shape.py
@@ -5229,8 +5229,11 @@ def _add_edge_pad_ops(
         source_tensor = ctx.model_ir.tensors[source_name]
         tensor = ctx.model_ir.tensors[name]
         tensor.shape_signature = [int(value) for value in shape_signature]
-        tensor.logical_layout = str(source_tensor.logical_layout)
-        tensor.physical_layout = str(source_tensor.physical_layout)
+        ctx.set_tensor_layout(
+            name,
+            logical=str(source_tensor.logical_layout),
+            physical=str(source_tensor.physical_layout),
+        )
         if source_tensor.quantization is not None:
             tensor.quantization = _clone_quantization(source_tensor.quantization)
         return name
@@ -7365,7 +7368,10 @@ def _add_resize_builtin_with_integer_linear_compatibility(
         if input_tensor.shape_signature is not None
         else [int(v) for v in list(input_tensor.shape)]
     )
-    input_float_tensor.logical_layout = input_tensor.logical_layout
+    ctx.set_tensor_layout(
+        input_float_name,
+        logical=input_tensor.logical_layout,
+    )
     ctx.add_operator(
         OperatorIR(
             op_type="CAST",
@@ -7389,7 +7395,10 @@ def _add_resize_builtin_with_integer_linear_compatibility(
         if output_tensor.shape_signature is not None
         else [int(v) for v in list(output_tensor.shape)]
     )
-    output_float_tensor.logical_layout = output_tensor.logical_layout
+    ctx.set_tensor_layout(
+        output_float_name,
+        logical=output_tensor.logical_layout,
+    )
     ctx.add_operator(
         OperatorIR(
             op_type=tflite_op,
@@ -10041,7 +10050,7 @@ def build_resize_op(node: Any, ctx: Any) -> None:
             x_quant = ctx.model_ir.tensors[input_name].quantization
             if x_quant is not None:
                 x_nwc_tensor.quantization = _clone_quantization(x_quant)
-            x_nwc_tensor.logical_layout = "NWC"
+            ctx.set_tensor_layout(x_nwc_name, logical="NWC")
             rank3_work_name = make_transpose(
                 ctx,
                 input_name,
@@ -10072,7 +10081,7 @@ def build_resize_op(node: Any, ctx: Any) -> None:
         )
         x_nhwc_tensor = ctx.model_ir.tensors[x_nhwc]
         x_nhwc_tensor.shape_signature = [int(v) for v in list(nhwc_input_signature)]
-        x_nhwc_tensor.logical_layout = "NHWC"
+        ctx.set_tensor_layout(x_nhwc, logical="NHWC")
         x_quant = ctx.model_ir.tensors[input_name].quantization
         if x_quant is not None:
             x_nhwc_tensor.quantization = _clone_quantization(x_quant)
@@ -10090,7 +10099,7 @@ def build_resize_op(node: Any, ctx: Any) -> None:
         )
         y_nhwc_tensor = ctx.model_ir.tensors[y_nhwc]
         y_nhwc_tensor.shape_signature = [int(v) for v in list(nhwc_output_signature)]
-        y_nhwc_tensor.logical_layout = "NHWC"
+        ctx.set_tensor_layout(y_nhwc, logical="NHWC")
         y_quant = ctx.model_ir.tensors[output_name].quantization
         if y_quant is not None:
             y_nhwc_tensor.quantization = _clone_quantization(y_quant)
@@ -10178,7 +10187,7 @@ def build_resize_op(node: Any, ctx: Any) -> None:
             )
             y_nwc_tensor = ctx.model_ir.tensors[y_nwc_name]
             y_nwc_tensor.shape_signature = [int(v) for v in list(output_rank3_signature_nwc)]
-            y_nwc_tensor.logical_layout = "NWC"
+            ctx.set_tensor_layout(y_nwc_name, logical="NWC")
             y_quant = ctx.model_ir.tensors[output_name].quantization
             if y_quant is not None:
                 y_nwc_tensor.quantization = _clone_quantization(y_quant)

--- a/onnx2tf/tflite_builder/op_builders/shared.py
+++ b/onnx2tf/tflite_builder/op_builders/shared.py
@@ -539,15 +539,20 @@ def make_transpose(
                 prev_input_shape = list(ctx.get_tensor_shape(prev_input_name))
                 output_shape = list(ctx.get_tensor_shape(output_name))
                 if prev_input_shape == output_shape:
-                    consumer_count = int(ctx.tensor_consumer_count.get(str(input_name), 0))
+                    consumer_count = int(
+                        ctx.effective_tensor_consumer_count(
+                            str(input_name),
+                            include_pending_synthetic_consumer=True,
+                        )
+                    )
                     if (
                         consumer_count <= 1
                         and str(input_name) not in set(ctx.graph_output_names)
                         and producer_idx is not None
                     ):
-                        # input_name is an ONNX edge consumed only by this transpose.
+                        # The ONNX or synthetic edge is exclusive to this inverse use.
                         # Remove the previous transpose as well to avoid leaving dead ops.
-                        del ctx.model_ir.operators[int(producer_idx)]
+                        ctx.remove_operator(int(producer_idx))
                     return prev_input_name
 
     input_shape = [int(v) for v in list(ctx.get_tensor_shape(input_name))]

--- a/onnx2tf/tflite_builder/passes/add_concat_suffix_layout.py
+++ b/onnx2tf/tflite_builder/passes/add_concat_suffix_layout.py
@@ -10,6 +10,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPassState,
     ModelIRPreflightResult,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -428,6 +429,7 @@ def run_add_concat_suffix_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate a validated Add/Concat constant-suffix island to NHWC."""
 
@@ -464,6 +466,7 @@ def run_add_concat_suffix_layout_cleanup(
         layout_state=layout_state,
         default_details={stats_key: 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/attention_layout.py
+++ b/onnx2tf/tflite_builder/passes/attention_layout.py
@@ -281,6 +281,7 @@ def run_mixed_attention_layout_cleanup(
     *,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run the mixed reduction/MirrorPad rewrite as an ordered layout pass."""
 
@@ -332,6 +333,7 @@ def run_mixed_attention_layout_cleanup(
             "optimized_mixed_mean_reducemax_concat_mirrorpad_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/attention_layout.py
+++ b/onnx2tf/tflite_builder/passes/attention_layout.py
@@ -10,6 +10,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     preflight_required_op_types,
     run_model_ir_pass_group,
 )
@@ -3436,6 +3437,7 @@ def run_conv_attention_layout_cleanup(
     *,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run generic Conv-attention NHWC propagation transactionally."""
 
@@ -3487,6 +3489,7 @@ def run_conv_attention_layout_cleanup(
             "optimized_transpose_conv_attention_nhwc_propagation_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/axis3_const_concat_layout.py
+++ b/onnx2tf/tflite_builder/passes/axis3_const_concat_layout.py
@@ -10,6 +10,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPassState,
     ModelIRPreflightResult,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -422,6 +423,7 @@ def run_axis3_const_concat_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate a validated axis-3 constant-Concat island to NHWC."""
 
@@ -460,6 +462,7 @@ def run_axis3_const_concat_layout_cleanup(
         layout_state=layout_state,
         default_details={stats_key: 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/boundary_input_chains.py
+++ b/onnx2tf/tflite_builder/passes/boundary_input_chains.py
@@ -9,10 +9,10 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
-    _build_tensor_consumer_map,
     _permute_tensor_metadata_if_rank_matches,
     _prune_unused_tensors,
     _read_const_ints_from_tensor,
@@ -491,6 +491,7 @@ def run_boundary_input_batchmatmul_cleanup(
     *,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run boundary BatchMatMul adapter removal as an ordered layout pass."""
 
@@ -553,6 +554,7 @@ def run_boundary_input_batchmatmul_cleanup(
             "rewritten_boundary_input_transpose_batchmatmul_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/channel_shuffle.py
+++ b/onnx2tf/tflite_builder/passes/channel_shuffle.py
@@ -21,6 +21,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -684,6 +685,7 @@ def run_two_way_channel_shuffle_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Canonicalize guarded two-way channel-shuffle branch/Concat graphs."""
 
@@ -810,6 +812,7 @@ def run_two_way_channel_shuffle_cleanup(
         layout_state=layout_state,
         default_details={"optimized_shufflenet_transpose_shuffle_chains": 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -1086,6 +1089,7 @@ def run_nhwc_channel_shuffle_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Canonicalize strict ShuffleNet NHWC channel shuffle to Gather."""
 
@@ -1271,6 +1275,7 @@ def run_nhwc_channel_shuffle_cleanup(
             "optimized_shufflenet_reshape_transpose_shuffle_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -1612,6 +1617,7 @@ def run_nchw_channel_shuffle_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Canonicalize strict static NCHW channel shuffle to Gather."""
 
@@ -1745,6 +1751,7 @@ def run_nchw_channel_shuffle_cleanup(
             "optimized_nchw_channel_shuffle_reshape_transpose_reshape_to_gather": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/channel_slice_layout.py
+++ b/onnx2tf/tflite_builder/passes/channel_slice_layout.py
@@ -9,6 +9,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -2721,6 +2722,7 @@ def run_channel_slice_merge_layout_cleanup(
     include_posttranspose_merge: bool = True,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run the adjacent strict channel-slice merge rewrites in legacy order."""
 
@@ -3048,6 +3050,7 @@ def run_channel_slice_merge_layout_cleanup(
         layout_state=layout_state,
         default_details=default_details,
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/cost_volume_scatter_layout.py
+++ b/onnx2tf/tflite_builder/passes/cost_volume_scatter_layout.py
@@ -10,6 +10,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPassState,
     ModelIRPreflightResult,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -739,6 +740,7 @@ def run_cost_volume_scatter_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate a validated cost-volume ScatterND island to NHWC/NDHWC."""
 
@@ -775,6 +777,7 @@ def run_cost_volume_scatter_layout_cleanup(
         layout_state=layout_state,
         default_details={stats_key: 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/dequant_concat_quantize_layout.py
+++ b/onnx2tf/tflite_builder/passes/dequant_concat_quantize_layout.py
@@ -8,6 +8,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPassState,
     ModelIRPreflightResult,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -332,6 +333,7 @@ def run_dequant_concat_quantize_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate a validated Dequantize/Concat/Quantize island to NHWC."""
 
@@ -372,6 +374,7 @@ def run_dequant_concat_quantize_layout_cleanup(
         layout_state=layout_state,
         default_details={stats_key: 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/dual_mul_concat_layout.py
+++ b/onnx2tf/tflite_builder/passes/dual_mul_concat_layout.py
@@ -10,6 +10,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPassState,
     ModelIRPreflightResult,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -407,6 +408,7 @@ def run_dual_mul_concat_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate a validated dual-Mul/Concat island to NHWC."""
 
@@ -443,6 +445,7 @@ def run_dual_mul_concat_layout_cleanup(
         layout_state=layout_state,
         default_details={stats_key: 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/dual_postconv_gate_layout.py
+++ b/onnx2tf/tflite_builder/passes/dual_postconv_gate_layout.py
@@ -16,6 +16,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -894,6 +895,7 @@ def run_dual_postconv_gate_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NHWC through guarded complementary-gate output branches."""
 
@@ -956,6 +958,7 @@ def run_dual_postconv_gate_layout_cleanup(
         layout_state=layout_state,
         default_details=defaults,
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/elementwise_gate_layout.py
+++ b/onnx2tf/tflite_builder/passes/elementwise_gate_layout.py
@@ -23,6 +23,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -1611,6 +1612,7 @@ def run_elementwise_gate_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Run ordered rank-four elementwise gate layout propagation."""
 
@@ -1687,6 +1689,7 @@ def run_elementwise_gate_layout_cleanup(
         layout_state=layout_state,
         default_details=defaults,
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/input_passthrough_layout.py
+++ b/onnx2tf/tflite_builder/passes/input_passthrough_layout.py
@@ -9,10 +9,10 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
-    _build_tensor_consumer_map,
     _clone_quantization,
     _invert_perm,
     _is_per_tensor_quantization,
@@ -1135,6 +1135,7 @@ def run_input_unary_passthrough_cleanup(
     *,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run the repeated leading-input, Asin, and Erf passthrough sequence."""
 
@@ -1269,6 +1270,7 @@ def run_input_unary_passthrough_cleanup(
             "rewritten_erf_transpose_passthrough_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/layernorm_layout.py
+++ b/onnx2tf/tflite_builder/passes/layernorm_layout.py
@@ -16,6 +16,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -619,6 +620,7 @@ def run_layernorm_statistics_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NHWC through guarded LayerNorm statistics branches."""
 
@@ -694,6 +696,7 @@ def run_layernorm_statistics_layout_cleanup(
             "optimized_layernorm_stats_via_existing_post_transpose_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/layout_transpose.py
+++ b/onnx2tf/tflite_builder/passes/layout_transpose.py
@@ -25,6 +25,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -484,6 +485,7 @@ def run_layout_transpose_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Run identity, inverse, fan-out, and composed Transpose cleanup."""
 
@@ -561,6 +563,7 @@ def run_layout_transpose_cleanup(
         layout_state=layout_state,
         default_details=default_details,
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/layout_transpose.py
+++ b/onnx2tf/tflite_builder/passes/layout_transpose.py
@@ -726,6 +726,7 @@ def run_transpose_unary_passthrough_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Run strict NHWC/NCHW unary Transpose passthrough cleanup."""
 
@@ -810,6 +811,7 @@ def run_transpose_unary_passthrough_cleanup(
         layout_state=layout_state,
         default_details={"rewritten_transpose_unary_passthrough_chains": 0},
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -986,6 +988,7 @@ def run_transpose_unary_fanout_bridge_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Run inverse-post Transpose cleanup around unary fan-out branches."""
 
@@ -1094,6 +1097,7 @@ def run_transpose_unary_fanout_bridge_cleanup(
             "rewritten_transpose_unary_fanout_inverse_post_bridges": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -1427,6 +1431,7 @@ def run_transpose_unary_binary_fanout_bridge_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Run strict Transpose/unary/binary inverse-post fan-out cleanup."""
 
@@ -1658,6 +1663,7 @@ def run_transpose_unary_binary_fanout_bridge_cleanup(
             "rewritten_transpose_unary_binary_full_post_fanout_bridges": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -2482,6 +2488,7 @@ def run_transpose_gather_axis_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Run strict NHWC Transpose/Gather axis remapping."""
 
@@ -2555,6 +2562,7 @@ def run_transpose_gather_axis_cleanup(
         layout_state=layout_state,
         default_details=default_details,
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/mean_layout.py
+++ b/onnx2tf/tflite_builder/passes/mean_layout.py
@@ -20,6 +20,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -381,6 +382,7 @@ def run_transpose_mean_passthrough_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Collapse guarded NHWC/NCHW round-trips around keep-dims Mean."""
 
@@ -487,6 +489,7 @@ def run_transpose_mean_passthrough_cleanup(
             "optimized_transpose_mean_prepost_nhwc_passthrough_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -497,6 +500,7 @@ def run_mean_mul_add_conv_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NHWC through a guarded Mean/Mul/Add/Conv branch."""
 
@@ -653,6 +657,7 @@ def run_mean_mul_add_conv_layout_cleanup(
             "optimized_transpose_mean_mul_reshape_add_conv_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/ndhwc_gate_layout.py
+++ b/onnx2tf/tflite_builder/passes/ndhwc_gate_layout.py
@@ -18,6 +18,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -944,6 +945,7 @@ def run_ndhwc_gate_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NDHWC through a guarded LeakyRelu/Logistic gate block."""
 
@@ -1006,6 +1008,7 @@ def run_ndhwc_gate_layout_cleanup(
         layout_state=layout_state,
         default_details=defaults,
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/pad_layout.py
+++ b/onnx2tf/tflite_builder/passes/pad_layout.py
@@ -9,6 +9,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.model_ir_utils import (
@@ -2057,6 +2058,7 @@ def run_pad_layout_cleanup(
     include_norm: bool = True,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run the contiguous Pad layout propagation family in fixed order."""
 
@@ -2253,6 +2255,7 @@ def run_pad_layout_cleanup(
             "optimized_transpose_norm_subgraph_pad_prepost_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/pad_layout.py
+++ b/onnx2tf/tflite_builder/passes/pad_layout.py
@@ -1049,6 +1049,7 @@ def run_pad_mul_layout_cleanup(
     *,
     layout_state: Optional[LayoutState] = None,
     diagnostics: Optional[List[Dict[str, Any]]] = None,
+    state_scope: Optional[ModelIRPassStateScope] = None,
 ) -> Dict[str, int]:
     """Run the strict Pad/Mul/PostTranspose/Add rewrite as an ordered pass."""
 
@@ -1252,6 +1253,7 @@ def run_pad_mul_layout_cleanup(
             "optimized_transpose_pad_mul_posttranspose_add_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/se_layout.py
+++ b/onnx2tf/tflite_builder/passes/se_layout.py
@@ -22,6 +22,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -538,6 +539,7 @@ def run_se_conv_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NHWC through guarded convolutional SE gates."""
 
@@ -743,6 +745,7 @@ def run_se_conv_layout_cleanup(
             "optimized_transpose_se_conv_mul_prepost_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}
@@ -1759,6 +1762,7 @@ def run_se_fc_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NHWC through guarded dense or 1x1-convolution SE gates."""
     gate_head_unary = {
@@ -1962,6 +1966,7 @@ def run_se_fc_layout_cleanup(
             "optimized_transpose_se_fc_mul_prepost_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/passes/terminal_mean_layout.py
+++ b/onnx2tf/tflite_builder/passes/terminal_mean_layout.py
@@ -15,6 +15,7 @@ from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -296,6 +297,7 @@ def run_terminal_mean_layout_cleanup(
     *,
     layout_state: LayoutState | None = None,
     diagnostics: List[Dict[str, Any]] | None = None,
+    state_scope: ModelIRPassStateScope | None = None,
 ) -> Dict[str, int]:
     """Propagate NHWC through a guarded unary/Mean/Reshape suffix."""
     unary_passthrough_ops = {
@@ -479,6 +481,7 @@ def run_terminal_mean_layout_cleanup(
             "optimized_transpose_pre_unary_mean_terminal_nhwc_chains": 0,
         },
         diagnostics=diagnostics,
+        state_scope=state_scope,
         preflight=_preflight,
     )
     return {str(key): int(value) for key, value in details.items()}

--- a/onnx2tf/tflite_builder/pytorch_exporter.py
+++ b/onnx2tf/tflite_builder/pytorch_exporter.py
@@ -150,6 +150,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_terminal_classifier_tail_layout,
     _propagate_cf_local_response_norm_output,
     _propagate_cf_prelu_output,
+    _record_rewritten_static_shape,
     _restore_channel_last_spatial_pool_chains,
 )
 from onnx2tf.tflite_builder.pytorch_fusion_policy import (
@@ -7362,11 +7363,11 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 lines[index] = rewritten_binary_line
                 if binary_lhs is not None:
                     cf_like_names.add(binary_lhs)
-                    binary_shape_match = re.search(r"\[(?P<shape>[0-9, ]+)\]\)$", rewritten_binary_line)
-                    if binary_shape_match is not None:
-                        repair_context.static_shapes[binary_lhs] = _parse_int_list_literal(
-                            str(binary_shape_match.group("shape"))
-                        )
+                    _record_rewritten_static_shape(
+                        rewritten_binary_line,
+                        binary_lhs,
+                        repair_context,
+                    )
                 changed = True
                 line = rewritten_binary_line
             else:
@@ -7399,11 +7400,11 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 lines[index] = rewritten_resize_line
                 if resize_lhs is not None:
                     cf_like_names.add(resize_lhs)
-                    resize_shape_match = re.search(r"target_shape=\[(?P<shape>[0-9, ]+)\]", rewritten_resize_line)
-                    if resize_shape_match is not None:
-                        repair_context.static_shapes[resize_lhs] = _parse_int_list_literal(
-                            str(resize_shape_match.group("shape"))
-                        )
+                    _record_rewritten_static_shape(
+                        rewritten_resize_line,
+                        resize_lhs,
+                        repair_context,
+                    )
                 changed = True
                 line = rewritten_resize_line
                 apply_resize_match = _parse_apply_resize_assign(line)
@@ -7479,11 +7480,11 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 lines[index] = rewritten_pool_line
                 if pool_lhs is not None:
                     cf_like_names.add(pool_lhs)
-                    pool_shape_match = re.search(r"target_shape=\[(?P<shape>[0-9, ]+)\]", rewritten_pool_line)
-                    if pool_shape_match is not None:
-                        repair_context.static_shapes[pool_lhs] = _parse_int_list_literal(
-                            str(pool_shape_match.group("shape"))
-                        )
+                    _record_rewritten_static_shape(
+                        rewritten_pool_line,
+                        pool_lhs,
+                        repair_context,
+                    )
                 changed = True
                 line = rewritten_pool_line
                 apply_pool2d_assign = _parse_apply_pool2d_assign_with_shape(line)

--- a/onnx2tf/tflite_builder/pytorch_exporter.py
+++ b/onnx2tf/tflite_builder/pytorch_exporter.py
@@ -130,6 +130,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_aligned_scalar_binary_shape_at,
     _repair_cf_pool_target_shape,
     _repair_cf_pool_neighbor_layout_at,
+    _repair_cf_resize_from_input_and_bn_evidence,
     _repair_cf_resize_target_shape,
     _repair_cf_reduce_max_axis,
     _repair_cf_softmax_axis,
@@ -7411,69 +7412,20 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 line = rewritten_resize_line
                 apply_resize_match = _parse_apply_resize_assign(line)
         if apply_resize_match is not None:
-            resize_indent, resize_lhs_name, input_name, out_h, out_w, resize_method, current_shape, resize_align_corners, resize_half_pixel_centers, _ = apply_resize_match
-            next_aligned_bn_match = None
-            if index + 1 < len(lines):
-                next_aligned_bn_match = aligned_bn_const_re.match(lines[index + 1])
-                if next_aligned_bn_match is None:
-                    next_aligned_bn_match = aligned_bn_const_reshaped_re.match(lines[index + 1])
-            next_bn_channel_count = None
-            if (
-                next_aligned_bn_match is not None
-                and str(next_aligned_bn_match.group("input")) == resize_lhs_name
-            ):
-                next_bn_channel_count = repair_context.const_channel_counts.get(
-                    str(next_aligned_bn_match.group("const_attr")),
-                    None,
+            evidence_resize_line, evidence_resize_lhs = (
+                _repair_cf_resize_from_input_and_bn_evidence(
+                    line,
+                    index,
+                    lines,
+                    cf_like_names,
+                    nhwc_like_names,
+                    repair_context,
                 )
-            if (
-                _fast_precanonicalize_rank4_layout_hint(
-                    current_shape,
-                    preferred_channel_count=_fast_precanonicalize_preferred_channel_count(
-                        input_name,
-                        cf_like_names,
-                        nhwc_like_names,
-                        repair_context,
-                        shape_hint=current_shape,
-                    ),
-                ) != "cf"
-                and (
-                    input_name in cf_like_names
-                    or input_name.endswith("_cf")
-                    or input_name.endswith("_out_cf")
-                )
-            ):
-                preferred_channel_count = next_bn_channel_count
-                if preferred_channel_count is None:
-                    preferred_channel_count = _fast_precanonicalize_preferred_channel_count(
-                        resize_lhs_name,
-                        cf_like_names,
-                        nhwc_like_names,
-                        repair_context,
-                        shape_hint=current_shape,
-                    )
-                if preferred_channel_count is None:
-                    preferred_channel_count = _fast_precanonicalize_preferred_channel_count(
-                        input_name,
-                        cf_like_names,
-                        nhwc_like_names,
-                        repair_context,
-                        shape_hint=current_shape,
-                    )
-                normalized_shape = _normalize_cf_rank4_shape(
-                    current_shape,
-                    preferred_channel_count=preferred_channel_count,
-                    out_hw=(out_h, out_w),
-                )
-                lines[index] = (
-                    f"{resize_indent}{resize_lhs_name} = _apply_resize("
-                    f"{input_name}, [{out_h}, {out_w}], "
-                    f"method='{resize_method}', "
-                    f"target_shape={repr(normalized_shape)}, "
-                    f"align_corners={resize_align_corners}, "
-                    f"half_pixel_centers={resize_half_pixel_centers}, channel_last=False)"
-                )
-                cf_like_names.add(resize_lhs_name)
+            )
+            if evidence_resize_line is not None:
+                lines[index] = evidence_resize_line
+                if evidence_resize_lhs is not None:
+                    cf_like_names.add(evidence_resize_lhs)
                 changed = True
         apply_pool2d_assign = _parse_apply_pool2d_assign_with_shape(line)
         if apply_pool2d_assign is not None:

--- a/onnx2tf/tflite_builder/pytorch_exporter.py
+++ b/onnx2tf/tflite_builder/pytorch_exporter.py
@@ -128,6 +128,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_binary_alignment_layout,
     _repair_binary_alignment_from_downstream_evidence,
     _repair_aligned_scalar_binary_shape_at,
+    _repair_aligned_bn_constant_layout,
     _repair_cf_pool_target_shape,
     _repair_cf_pool_neighbor_layout_at,
     _repair_cf_resize_from_input_and_bn_evidence,
@@ -7312,12 +7313,6 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
     changed = False
     cf_like_names: set[str] = set(repair_context.cf_like_names)
     nhwc_like_names: set[str] = set(repair_context.nhwc_like_names)
-    aligned_bn_const_re = re.compile(
-        r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*_align_tensor_to_target_shape\(torch\.(?P<op>mul|add)\((?P<input>[A-Za-z0-9_]+), self\.(?P<const_attr>[A-Za-z0-9_]+)\), \[(?P<n>\d+), (?P<h>\d+), (?P<w>\d+), (?P<c>\d+)\]\)$"
-    )
-    aligned_bn_const_reshaped_re = re.compile(
-        r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*_align_tensor_to_target_shape\(torch\.(?P<op>mul|add)\((?P<input>[A-Za-z0-9_]+), torch\.reshape\(self\.(?P<const_attr>[A-Za-z0-9_]+), \[1, (?P<reshape_c>\d+), 1, 1\]\)\), \[(?P<n>\d+), (?P<c0>\d+), (?P<h>\d+), (?P<w>\d+)\]\)$"
-    )
     for index, line in enumerate(lines[:-1]):
         repaired_alias_layout, repaired_alias_line = _repair_simple_alias_layout_at(
             index,
@@ -7533,66 +7528,16 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 cf_like_names.add(concat_lhs)
             changed = True
             line = rewritten_concat_line
-        aligned_bn_const_match = aligned_bn_const_re.match(line)
-        if aligned_bn_const_match is not None:
-            input_name = str(aligned_bn_const_match.group("input"))
-            const_attr = str(aligned_bn_const_match.group("const_attr"))
-            channel_count = repair_context.const_channel_counts.get(const_attr)
-            if (
-                (
-                    input_name in cf_like_names
-                    or input_name.endswith("_cf")
-                    or input_name.endswith("_out_cf")
-                )
-                and (
-                    "BatchNormalization" in const_attr
-                    or "batch_normalization" in const_attr
-                )
-                and channel_count is not None
-                and int(aligned_bn_const_match.group("c")) == channel_count
-            ):
-                lines[index] = (
-                    f"{aligned_bn_const_match.group('indent')}{aligned_bn_const_match.group('lhs')} = "
-                    f"_align_tensor_to_target_shape(torch.{aligned_bn_const_match.group('op')}("
-                    f"{input_name}, torch.reshape(self.{const_attr}, [1, {aligned_bn_const_match.group('c')}, 1, 1])), "
-                    f"[{aligned_bn_const_match.group('n')}, {aligned_bn_const_match.group('c')}, "
-                    f"{aligned_bn_const_match.group('h')}, {aligned_bn_const_match.group('w')}])"
-                )
-                cf_like_names.add(str(aligned_bn_const_match.group("lhs")))
-                changed = True
-        aligned_bn_const_reshaped_match = aligned_bn_const_reshaped_re.match(line)
-        if aligned_bn_const_reshaped_match is not None:
-            input_name = str(aligned_bn_const_reshaped_match.group("input"))
-            const_attr = str(aligned_bn_const_reshaped_match.group("const_attr"))
-            reshape_channel_count = int(aligned_bn_const_reshaped_match.group("reshape_c"))
-            if (
-                (
-                    input_name in cf_like_names
-                    or input_name.endswith("_cf")
-                    or input_name.endswith("_out_cf")
-                )
-                and (
-                    "BatchNormalization" in const_attr
-                    or "batch_normalization" in const_attr
-                )
-            ):
-                normalized_shape = _normalize_cf_rank4_shape(
-                    [
-                        int(aligned_bn_const_reshaped_match.group("n")),
-                        int(aligned_bn_const_reshaped_match.group("c0")),
-                        int(aligned_bn_const_reshaped_match.group("h")),
-                        int(aligned_bn_const_reshaped_match.group("w")),
-                    ],
-                    preferred_channel_count=reshape_channel_count,
-                )
-                lines[index] = (
-                    f"{aligned_bn_const_reshaped_match.group('indent')}{aligned_bn_const_reshaped_match.group('lhs')} = "
-                    f"_align_tensor_to_target_shape(torch.{aligned_bn_const_reshaped_match.group('op')}("
-                    f"{input_name}, torch.reshape(self.{const_attr}, [1, {reshape_channel_count}, 1, 1])), "
-                    f"{repr(normalized_shape)})"
-                )
-                cf_like_names.add(str(aligned_bn_const_reshaped_match.group("lhs")))
-                changed = True
+        rewritten_bn_line, bn_lhs = _repair_aligned_bn_constant_layout(
+            line,
+            cf_like_names,
+            repair_context,
+        )
+        if rewritten_bn_line is not None:
+            lines[index] = rewritten_bn_line
+            if bn_lhs is not None:
+                cf_like_names.add(bn_lhs)
+            changed = True
         local_response_norm_assign = _parse_local_response_norm_assign(line)
         if local_response_norm_assign is not None:
             input_name = str(local_response_norm_assign[2])

--- a/onnx2tf/tflite_builder/pytorch_exporter.py
+++ b/onnx2tf/tflite_builder/pytorch_exporter.py
@@ -148,6 +148,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_split_axis_from_consumers,
     _repair_singleton_reshape_cf_binary_at,
     _repair_terminal_classifier_tail_layout,
+    _propagate_cf_local_response_norm_output,
     _propagate_cf_prelu_output,
     _restore_channel_last_spatial_pool_chains,
 )
@@ -7538,20 +7539,12 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
             if bn_lhs is not None:
                 cf_like_names.add(bn_lhs)
             changed = True
-        local_response_norm_assign = _parse_local_response_norm_assign(line)
-        if local_response_norm_assign is not None:
-            input_name = str(local_response_norm_assign[2])
-            if (
-                input_name in cf_like_names
-                or input_name.endswith("_cf")
-                or input_name.endswith("_out_cf")
-            ):
-                lhs_name = str(local_response_norm_assign[1])
-                cf_like_names.add(lhs_name)
-                static_input_shape = repair_context.static_shapes.get(input_name, None)
-                if static_input_shape is not None and len(static_input_shape) == 4:
-                    repair_context.static_shapes[lhs_name] = [int(v) for v in list(static_input_shape)]
-                nhwc_like_names.discard(lhs_name)
+        _propagate_cf_local_response_norm_output(
+            line,
+            cf_like_names,
+            nhwc_like_names,
+            repair_context,
+        )
         rewritten_softmax_line, softmax_lhs = _repair_cf_softmax_axis(
             line,
             cf_like_names,

--- a/onnx2tf/tflite_builder/pytorch_exporter.py
+++ b/onnx2tf/tflite_builder/pytorch_exporter.py
@@ -126,6 +126,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _has_immediate_rank4_permute_source,
     _infer_unique_channel_count_from_rank4_shape,
     _repair_binary_alignment_layout,
+    _repair_binary_alignment_from_downstream_evidence,
     _repair_aligned_scalar_binary_shape_at,
     _repair_cf_pool_target_shape,
     _repair_cf_pool_neighbor_layout_at,
@@ -7316,9 +7317,6 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
     aligned_bn_const_reshaped_re = re.compile(
         r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*_align_tensor_to_target_shape\(torch\.(?P<op>mul|add)\((?P<input>[A-Za-z0-9_]+), torch\.reshape\(self\.(?P<const_attr>[A-Za-z0-9_]+), \[1, (?P<reshape_c>\d+), 1, 1\]\)\), \[(?P<n>\d+), (?P<c0>\d+), (?P<h>\d+), (?P<w>\d+)\]\)$"
     )
-    aligned_binary_re = re.compile(
-        r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*_align_tensor_to_target_shape\(torch\.(?P<op>mul|add|sub|div|minimum|maximum)\((?P<a>[A-Za-z0-9_]+), (?P<b>[A-Za-z0-9_]+)\), \[(?P<n>\d+), (?P<h>\d+), (?P<w>\d+), (?P<c>\d+)\]\)$"
-    )
     for index, line in enumerate(lines[:-1]):
         repaired_alias_layout, repaired_alias_line = _repair_simple_alias_layout_at(
             index,
@@ -7353,9 +7351,8 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
         ):
             changed = True
             line = lines[index]
-        aligned_binary_match = aligned_binary_re.match(line)
         aligned_binary_assign = _parse_aligned_binary_assign_with_shape(line)
-        if aligned_binary_match is not None or aligned_binary_assign is not None:
+        if aligned_binary_assign is not None:
             rewritten_binary_line, binary_lhs = _repair_binary_alignment_layout(
                 line,
                 index,
@@ -7375,79 +7372,22 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                         )
                 changed = True
                 line = rewritten_binary_line
-                aligned_binary_match = None
-                aligned_binary_assign = None
-        if aligned_binary_match is not None:
-            arg_a = str(aligned_binary_match.group("a"))
-            arg_b = str(aligned_binary_match.group("b"))
-            next_aligned_bn_match = aligned_bn_const_re.match(lines[index + 1])
-            next_return_value = _parse_simple_return_identifier(lines[index + 1])
-            next_resize_match = _parse_apply_resize_assign(lines[index + 1])
-            current_shape_hint = _fast_precanonicalize_rank4_layout_hint(
-                [
-                    int(aligned_binary_match.group("n")),
-                    int(aligned_binary_match.group("h")),
-                    int(aligned_binary_match.group("w")),
-                    int(aligned_binary_match.group("c")),
-                ],
-                preferred_channel_count=_fast_precanonicalize_preferred_channel_count(
-                    arg_a,
-                    cf_like_names,
-                    nhwc_like_names,
-                    repair_context,
-                    shape_hint=[
-                        int(aligned_binary_match.group("n")),
-                        int(aligned_binary_match.group("h")),
-                        int(aligned_binary_match.group("w")),
-                        int(aligned_binary_match.group("c")),
-                    ],
-                ),
-            )
-            operands_are_cf_like = (
-                (
-                    arg_a in cf_like_names
-                    or arg_a.endswith("_cf")
-                    or arg_a.endswith("_out_cf")
-                    or (arg_a.endswith("_in") and not arg_a.endswith("_in_nhwc"))
-                )
-                and (
-                    arg_b in cf_like_names
-                    or arg_b.endswith("_cf")
-                    or arg_b.endswith("_out_cf")
-                    or (arg_b.endswith("_in") and not arg_b.endswith("_in_nhwc"))
-                )
-            )
-            if (
-                current_shape_hint != "cf"
-                and
-                operands_are_cf_like
-                and (
-                    (
-                        next_aligned_bn_match is not None
-                        and str(next_aligned_bn_match.group("input")) == str(aligned_binary_match.group("lhs"))
-                        and int(next_aligned_bn_match.group("c")) == int(aligned_binary_match.group("c"))
-                    )
-                    or (
-                        next_return_value is not None
-                        and str(next_return_value) == str(aligned_binary_match.group("lhs"))
-                    )
-                    or (
-                        next_resize_match is not None
-                        and str(next_resize_match[2]) == str(aligned_binary_match.group("lhs"))
-                        and not bool(next_resize_match[9])
-                        and int(next_resize_match[6][3]) == int(aligned_binary_match.group("c"))
+            else:
+                downstream_binary_line, downstream_binary_lhs = (
+                    _repair_binary_alignment_from_downstream_evidence(
+                        line,
+                        index,
+                        lines,
+                        cf_like_names,
+                        nhwc_like_names,
+                        repair_context,
                     )
                 )
-            ):
-                lines[index] = (
-                    f"{aligned_binary_match.group('indent')}{aligned_binary_match.group('lhs')} = "
-                    f"_align_tensor_to_target_shape(torch.{aligned_binary_match.group('op')}("
-                    f"{arg_a}, {arg_b}), "
-                    f"[{aligned_binary_match.group('n')}, {aligned_binary_match.group('c')}, "
-                    f"{aligned_binary_match.group('h')}, {aligned_binary_match.group('w')}])"
-                )
-                cf_like_names.add(str(aligned_binary_match.group("lhs")))
-                changed = True
+                if downstream_binary_line is not None:
+                    lines[index] = downstream_binary_line
+                    if downstream_binary_lhs is not None:
+                        cf_like_names.add(downstream_binary_lhs)
+                    changed = True
         apply_resize_match = _parse_apply_resize_assign(line)
         if apply_resize_match is not None:
             rewritten_resize_line, resize_lhs = _repair_cf_resize_target_shape(

--- a/onnx2tf/tflite_builder/pytorch_exporter.py
+++ b/onnx2tf/tflite_builder/pytorch_exporter.py
@@ -7426,7 +7426,7 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 changed = True
         apply_pool2d_assign = _parse_apply_pool2d_assign_with_shape(line)
         if apply_pool2d_assign is not None:
-            repaired_nhwc_avg_pool_bridge, nhwc_bridge_names = _repair_nhwc_average_pool_binary_bridge(
+            repaired_nhwc_avg_pool_bridge, _nhwc_bridge_names = _repair_nhwc_average_pool_binary_bridge(
                 index,
                 lines,
                 cf_like_names,
@@ -7434,20 +7434,6 @@ def _apply_fast_precanonicalize_repairs(package_path: Path) -> None:
                 repair_context,
             )
             if repaired_nhwc_avg_pool_bridge:
-                nhwc_like_names.update(nhwc_bridge_names)
-                cf_like_names.difference_update(nhwc_bridge_names)
-                normalized_bridge_shape = _normalize_nhwc_rank4_shape(
-                    apply_pool2d_assign[4],
-                    preferred_channel_count=_fast_precanonicalize_preferred_channel_count(
-                        str(apply_pool2d_assign[1]),
-                        cf_like_names,
-                        nhwc_like_names,
-                        repair_context,
-                        shape_hint=apply_pool2d_assign[4],
-                    ),
-                )
-                for updated_name in nhwc_bridge_names:
-                    repair_context.static_shapes[updated_name] = list(normalized_bridge_shape)
                 changed = True
                 line = lines[index]
                 apply_pool2d_assign = _parse_apply_pool2d_assign_with_shape(line)

--- a/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
+++ b/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
@@ -2385,6 +2385,33 @@ def _repair_cf_reduce_max_axis(
     return rewritten, lhs_name
 
 
+def _propagate_cf_local_response_norm_output(
+    line: str,
+    dynamic_cf_like_names: Set[str],
+    dynamic_nhwc_like_names: Set[str],
+    context: _FastPrecanonicalizeRepairContext,
+) -> bool:
+    local_response_norm_assign = _parse_local_response_norm_assign(line)
+    if local_response_norm_assign is None:
+        return False
+    input_name = str(local_response_norm_assign[2])
+    input_is_cf_like = (
+        input_name in dynamic_cf_like_names
+        or input_name.endswith("_cf")
+        or input_name.endswith("_out_cf")
+    )
+    if not input_is_cf_like:
+        return False
+
+    lhs_name = str(local_response_norm_assign[1])
+    dynamic_cf_like_names.add(lhs_name)
+    static_input_shape = context.static_shapes.get(input_name, None)
+    if static_input_shape is not None and len(static_input_shape) == 4:
+        context.static_shapes[lhs_name] = [int(v) for v in list(static_input_shape)]
+    dynamic_nhwc_like_names.discard(lhs_name)
+    return True
+
+
 def _propagate_cf_prelu_output(
     line: str,
     dynamic_cf_like_names: Set[str],

--- a/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
+++ b/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
@@ -109,6 +109,12 @@ _RESHAPED_ALIGNED_BN_CONST_RE = re.compile(
     r"\[1, (?P<reshape_c>\d+), 1, 1\]\)\), "
     r"\[(?P<n>\d+), (?P<c0>\d+), (?P<h>\d+), (?P<w>\d+)\]\)$"
 )
+_REWRITTEN_TARGET_SHAPE_RE = re.compile(
+    r"target_shape=\[(?P<shape>[0-9, ]+)\]"
+)
+_REWRITTEN_TRAILING_SHAPE_RE = re.compile(
+    r"\[(?P<shape>[0-9, ]+)\]\)$"
+)
 
 
 def _convert_nhwc_pad_to_nchw_pad_values(pad_values: Sequence[int]) -> List[int] | None:
@@ -416,6 +422,22 @@ def _build_fast_precanonicalize_repair_context(
         module_output_producers=module_output_producers,
         module_input_consumers=module_input_consumers,
     )
+
+
+def _record_rewritten_static_shape(
+    line: str,
+    lhs_name: str,
+    context: _FastPrecanonicalizeRepairContext,
+) -> bool:
+    shape_match = _REWRITTEN_TARGET_SHAPE_RE.search(line)
+    if shape_match is None:
+        shape_match = _REWRITTEN_TRAILING_SHAPE_RE.search(line)
+    if shape_match is None:
+        return False
+    context.static_shapes[str(lhs_name)] = _parse_int_list_literal(
+        str(shape_match.group("shape"))
+    )
+    return True
 
 
 def _fast_precanonicalize_resolve_alias(

--- a/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
+++ b/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
@@ -28,6 +28,7 @@ from onnx2tf.tflite_builder.pytorch_source_parser import (
     _parse_rank4_shape_literal,
     _parse_reduce_max_assign,
     _parse_simple_assignment_line,
+    _parse_simple_return_identifier,
     _parse_tensor_split_assign,
     _parse_torch_cat_inputs_and_dim,
     _parse_torch_permute_assign,
@@ -86,6 +87,19 @@ _ALIGNED_SCALAR_BINARY_RE = re.compile(
     r"(?P<scalar>[-+]?(?:[0-9]*\.[0-9]+|[0-9]+(?:\.[0-9]*)?)"
     r"(?:[eE][-+]?\d+)?)\), "
     r"\[(?P<n>\d+), (?P<d1>\d+), (?P<d2>\d+), (?P<d3>\d+)\]\)$"
+)
+_DOWNSTREAM_EVIDENCE_ALIGNED_BINARY_RE = re.compile(
+    r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*"
+    r"_align_tensor_to_target_shape\("
+    r"torch\.(?P<op>mul|add|sub|div|minimum|maximum)\("
+    r"(?P<a>[A-Za-z0-9_]+), (?P<b>[A-Za-z0-9_]+)\), "
+    r"\[(?P<n>\d+), (?P<h>\d+), (?P<w>\d+), (?P<c>\d+)\]\)$"
+)
+_DOWNSTREAM_EVIDENCE_ALIGNED_BN_RE = re.compile(
+    r"^\s*[A-Za-z0-9_]+\s*=\s*_align_tensor_to_target_shape\("
+    r"torch\.(?:mul|add)\((?P<input>[A-Za-z0-9_]+), "
+    r"self\.[A-Za-z0-9_]+\), "
+    r"\[\d+, \d+, \d+, (?P<c>\d+)\]\)$"
 )
 
 
@@ -1808,6 +1822,80 @@ def _repair_binary_alignment_layout(
     )
     if rewritten == line:
         return None, lhs_name
+    return rewritten, lhs_name
+
+
+def _repair_binary_alignment_from_downstream_evidence(
+    line: str,
+    index: int,
+    lines: Sequence[str],
+    dynamic_cf_like_names: Set[str],
+    dynamic_nhwc_like_names: Set[str],
+    context: _FastPrecanonicalizeRepairContext,
+) -> Tuple[str | None, str | None]:
+    aligned_binary_match = _DOWNSTREAM_EVIDENCE_ALIGNED_BINARY_RE.match(line)
+    if aligned_binary_match is None or index + 1 >= len(lines):
+        return None, None
+
+    arg_a = str(aligned_binary_match.group("a"))
+    arg_b = str(aligned_binary_match.group("b"))
+    current_shape = [
+        int(aligned_binary_match.group("n")),
+        int(aligned_binary_match.group("h")),
+        int(aligned_binary_match.group("w")),
+        int(aligned_binary_match.group("c")),
+    ]
+    current_shape_hint = _fast_precanonicalize_rank4_layout_hint(
+        current_shape,
+        preferred_channel_count=_fast_precanonicalize_preferred_channel_count(
+            arg_a,
+            dynamic_cf_like_names,
+            dynamic_nhwc_like_names,
+            context,
+            shape_hint=current_shape,
+        ),
+    )
+    operands_are_cf_like = all(
+        name in dynamic_cf_like_names
+        or name.endswith("_cf")
+        or name.endswith("_out_cf")
+        or (name.endswith("_in") and not name.endswith("_in_nhwc"))
+        for name in (arg_a, arg_b)
+    )
+    if current_shape_hint == "cf" or not operands_are_cf_like:
+        return None, None
+
+    next_line = str(lines[index + 1])
+    lhs_name = str(aligned_binary_match.group("lhs"))
+    next_aligned_bn_match = _DOWNSTREAM_EVIDENCE_ALIGNED_BN_RE.match(next_line)
+    next_return_value = _parse_simple_return_identifier(next_line)
+    next_resize_match = _parse_apply_resize_assign(next_line)
+    has_downstream_cf_evidence = (
+        (
+            next_aligned_bn_match is not None
+            and str(next_aligned_bn_match.group("input")) == lhs_name
+            and int(next_aligned_bn_match.group("c"))
+            == int(aligned_binary_match.group("c"))
+        )
+        or (next_return_value is not None and str(next_return_value) == lhs_name)
+        or (
+            next_resize_match is not None
+            and str(next_resize_match[2]) == lhs_name
+            and not bool(next_resize_match[9])
+            and int(next_resize_match[6][3])
+            == int(aligned_binary_match.group("c"))
+        )
+    )
+    if not has_downstream_cf_evidence:
+        return None, None
+
+    rewritten = (
+        f"{aligned_binary_match.group('indent')}{lhs_name} = "
+        f"_align_tensor_to_target_shape("
+        f"torch.{aligned_binary_match.group('op')}({arg_a}, {arg_b}), "
+        f"[{aligned_binary_match.group('n')}, {aligned_binary_match.group('c')}, "
+        f"{aligned_binary_match.group('h')}, {aligned_binary_match.group('w')}])"
+    )
     return rewritten, lhs_name
 
 

--- a/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
+++ b/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
@@ -1124,6 +1124,80 @@ def _repair_cf_resize_from_input_and_bn_evidence(
     return rewritten, resize_lhs_name
 
 
+def _repair_aligned_bn_constant_layout(
+    line: str,
+    dynamic_cf_like_names: Set[str],
+    context: _FastPrecanonicalizeRepairContext,
+) -> Tuple[str | None, str | None]:
+    direct_match = _DIRECT_ALIGNED_BN_CONST_RE.match(line)
+    if direct_match is not None:
+        input_name = str(direct_match.group("input"))
+        const_attr = str(direct_match.group("const_attr"))
+        channel_count = context.const_channel_counts.get(const_attr)
+        input_is_cf_like = (
+            input_name in dynamic_cf_like_names
+            or input_name.endswith("_cf")
+            or input_name.endswith("_out_cf")
+        )
+        const_is_bn = (
+            "BatchNormalization" in const_attr
+            or "batch_normalization" in const_attr
+        )
+        if (
+            not input_is_cf_like
+            or not const_is_bn
+            or channel_count is None
+            or int(direct_match.group("c")) != channel_count
+        ):
+            return None, None
+        lhs_name = str(direct_match.group("lhs"))
+        rewritten = (
+            f"{direct_match.group('indent')}{lhs_name} = "
+            f"_align_tensor_to_target_shape(torch.{direct_match.group('op')}("
+            f"{input_name}, torch.reshape(self.{const_attr}, "
+            f"[1, {direct_match.group('c')}, 1, 1])), "
+            f"[{direct_match.group('n')}, {direct_match.group('c')}, "
+            f"{direct_match.group('h')}, {direct_match.group('w')}])"
+        )
+        return rewritten, lhs_name
+
+    reshaped_match = _RESHAPED_ALIGNED_BN_CONST_RE.match(line)
+    if reshaped_match is None:
+        return None, None
+    input_name = str(reshaped_match.group("input"))
+    const_attr = str(reshaped_match.group("const_attr"))
+    input_is_cf_like = (
+        input_name in dynamic_cf_like_names
+        or input_name.endswith("_cf")
+        or input_name.endswith("_out_cf")
+    )
+    const_is_bn = (
+        "BatchNormalization" in const_attr
+        or "batch_normalization" in const_attr
+    )
+    if not input_is_cf_like or not const_is_bn:
+        return None, None
+
+    reshape_channel_count = int(reshaped_match.group("reshape_c"))
+    normalized_shape = _normalize_cf_rank4_shape(
+        [
+            int(reshaped_match.group("n")),
+            int(reshaped_match.group("c0")),
+            int(reshaped_match.group("h")),
+            int(reshaped_match.group("w")),
+        ],
+        preferred_channel_count=reshape_channel_count,
+    )
+    lhs_name = str(reshaped_match.group("lhs"))
+    rewritten = (
+        f"{reshaped_match.group('indent')}{lhs_name} = "
+        f"_align_tensor_to_target_shape(torch.{reshaped_match.group('op')}("
+        f"{input_name}, torch.reshape(self.{const_attr}, "
+        f"[1, {reshape_channel_count}, 1, 1])), {repr(normalized_shape)})"
+    )
+    return rewritten, lhs_name
+
+
 def _repair_cf_pool_target_shape(
     line: str,
     index: int,

--- a/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
+++ b/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
@@ -1879,6 +1879,20 @@ def _repair_nhwc_average_pool_binary_bridge(
     updated_names: Set[str] = set()
     if changed:
         updated_names.update({str(pool_lhs_name), str(lhs0), str(lhs1), str(mul_lhs)})
+        dynamic_nhwc_like_names.update(updated_names)
+        dynamic_cf_like_names.difference_update(updated_names)
+        state_shape = _normalize_nhwc_rank4_shape(
+            pool_shape,
+            preferred_channel_count=_fast_precanonicalize_preferred_channel_count(
+                str(pool_lhs_name),
+                dynamic_cf_like_names,
+                dynamic_nhwc_like_names,
+                context,
+                shape_hint=pool_shape,
+            ),
+        )
+        for updated_name in updated_names:
+            context.static_shapes[updated_name] = list(state_shape)
     return changed, updated_names
 
 

--- a/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
+++ b/onnx2tf/tflite_builder/pytorch_fast_precanonicalize_policy.py
@@ -95,11 +95,19 @@ _DOWNSTREAM_EVIDENCE_ALIGNED_BINARY_RE = re.compile(
     r"(?P<a>[A-Za-z0-9_]+), (?P<b>[A-Za-z0-9_]+)\), "
     r"\[(?P<n>\d+), (?P<h>\d+), (?P<w>\d+), (?P<c>\d+)\]\)$"
 )
-_DOWNSTREAM_EVIDENCE_ALIGNED_BN_RE = re.compile(
-    r"^\s*[A-Za-z0-9_]+\s*=\s*_align_tensor_to_target_shape\("
-    r"torch\.(?:mul|add)\((?P<input>[A-Za-z0-9_]+), "
-    r"self\.[A-Za-z0-9_]+\), "
-    r"\[\d+, \d+, \d+, (?P<c>\d+)\]\)$"
+_DIRECT_ALIGNED_BN_CONST_RE = re.compile(
+    r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*"
+    r"_align_tensor_to_target_shape\(torch\.(?P<op>mul|add)\("
+    r"(?P<input>[A-Za-z0-9_]+), self\.(?P<const_attr>[A-Za-z0-9_]+)\), "
+    r"\[(?P<n>\d+), (?P<h>\d+), (?P<w>\d+), (?P<c>\d+)\]\)$"
+)
+_RESHAPED_ALIGNED_BN_CONST_RE = re.compile(
+    r"^(?P<indent>\s*)(?P<lhs>[A-Za-z0-9_]+)\s*=\s*"
+    r"_align_tensor_to_target_shape\(torch\.(?P<op>mul|add)\("
+    r"(?P<input>[A-Za-z0-9_]+), torch\.reshape\("
+    r"self\.(?P<const_attr>[A-Za-z0-9_]+), "
+    r"\[1, (?P<reshape_c>\d+), 1, 1\]\)\), "
+    r"\[(?P<n>\d+), (?P<c0>\d+), (?P<h>\d+), (?P<w>\d+)\]\)$"
 )
 
 
@@ -1026,6 +1034,96 @@ def _repair_cf_resize_target_shape(
     return rewritten, lhs_name
 
 
+def _repair_cf_resize_from_input_and_bn_evidence(
+    line: str,
+    index: int,
+    lines: Sequence[str],
+    dynamic_cf_like_names: Set[str],
+    dynamic_nhwc_like_names: Set[str],
+    context: _FastPrecanonicalizeRepairContext,
+) -> Tuple[str | None, str | None]:
+    apply_resize_match = _parse_apply_resize_assign(line)
+    if apply_resize_match is None:
+        return None, None
+    (
+        resize_indent,
+        resize_lhs_name,
+        input_name,
+        out_h,
+        out_w,
+        resize_method,
+        current_shape,
+        resize_align_corners,
+        resize_half_pixel_centers,
+        _,
+    ) = apply_resize_match
+
+    next_aligned_bn_match = None
+    if index + 1 < len(lines):
+        next_line = str(lines[index + 1])
+        next_aligned_bn_match = _DIRECT_ALIGNED_BN_CONST_RE.match(next_line)
+        if next_aligned_bn_match is None:
+            next_aligned_bn_match = _RESHAPED_ALIGNED_BN_CONST_RE.match(next_line)
+    next_bn_channel_count = None
+    if (
+        next_aligned_bn_match is not None
+        and str(next_aligned_bn_match.group("input")) == resize_lhs_name
+    ):
+        next_bn_channel_count = context.const_channel_counts.get(
+            str(next_aligned_bn_match.group("const_attr")),
+            None,
+        )
+
+    current_shape_hint = _fast_precanonicalize_rank4_layout_hint(
+        current_shape,
+        preferred_channel_count=_fast_precanonicalize_preferred_channel_count(
+            input_name,
+            dynamic_cf_like_names,
+            dynamic_nhwc_like_names,
+            context,
+            shape_hint=current_shape,
+        ),
+    )
+    input_is_cf_like = (
+        input_name in dynamic_cf_like_names
+        or input_name.endswith("_cf")
+        or input_name.endswith("_out_cf")
+    )
+    if current_shape_hint == "cf" or not input_is_cf_like:
+        return None, None
+
+    preferred_channel_count = next_bn_channel_count
+    if preferred_channel_count is None:
+        preferred_channel_count = _fast_precanonicalize_preferred_channel_count(
+            resize_lhs_name,
+            dynamic_cf_like_names,
+            dynamic_nhwc_like_names,
+            context,
+            shape_hint=current_shape,
+        )
+    if preferred_channel_count is None:
+        preferred_channel_count = _fast_precanonicalize_preferred_channel_count(
+            input_name,
+            dynamic_cf_like_names,
+            dynamic_nhwc_like_names,
+            context,
+            shape_hint=current_shape,
+        )
+    normalized_shape = _normalize_cf_rank4_shape(
+        current_shape,
+        preferred_channel_count=preferred_channel_count,
+        out_hw=(out_h, out_w),
+    )
+    rewritten = (
+        f"{resize_indent}{resize_lhs_name} = _apply_resize("
+        f"{input_name}, [{out_h}, {out_w}], "
+        f"method='{resize_method}', target_shape={repr(normalized_shape)}, "
+        f"align_corners={resize_align_corners}, "
+        f"half_pixel_centers={resize_half_pixel_centers}, channel_last=False)"
+    )
+    return rewritten, resize_lhs_name
+
+
 def _repair_cf_pool_target_shape(
     line: str,
     index: int,
@@ -1867,7 +1965,7 @@ def _repair_binary_alignment_from_downstream_evidence(
 
     next_line = str(lines[index + 1])
     lhs_name = str(aligned_binary_match.group("lhs"))
-    next_aligned_bn_match = _DOWNSTREAM_EVIDENCE_ALIGNED_BN_RE.match(next_line)
+    next_aligned_bn_match = _DIRECT_ALIGNED_BN_CONST_RE.match(next_line)
     next_return_value = _parse_simple_return_identifier(next_line)
     next_resize_match = _parse_apply_resize_assign(next_line)
     has_downstream_cf_evidence = (

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -4905,6 +4905,7 @@ def test_generated_pytorch_fast_precanonicalize_policy_has_single_owner() -> Non
         "_repair_aligned_scalar_binary_shape_at",
         "_repair_cf_pool_target_shape",
         "_repair_cf_pool_neighbor_layout_at",
+        "_repair_cf_resize_from_input_and_bn_evidence",
         "_repair_cf_gather_slice_at",
         "_repair_cf_reduce_max_axis",
         "_repair_cf_resize_target_shape",

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -178,6 +178,45 @@ def test_op_builders_mutate_layout_only_through_lowering_context() -> None:
     assert offenders == []
 
 
+def test_op_builders_mutate_operator_list_only_through_lowering_context() -> None:
+    op_builders_root = REPO_ROOT / "onnx2tf" / "tflite_builder" / "op_builders"
+    mutating_methods = {"append", "extend", "insert", "pop", "remove", "clear"}
+    offenders: list[str] = []
+
+    def _is_context_operator_list(node: ast.AST) -> bool:
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "operators"
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "model_ir"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "ctx"
+        )
+
+    for path in op_builders_root.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            is_mutating_call = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in mutating_methods
+                and _is_context_operator_list(node.func.value)
+            )
+            is_direct_store = (
+                isinstance(node, (ast.Attribute, ast.Subscript))
+                and isinstance(node.ctx, (ast.Store, ast.Del))
+                and _is_context_operator_list(
+                    node if isinstance(node, ast.Attribute) else node.value
+                )
+            )
+            if is_mutating_call or is_direct_store:
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno}"
+                )
+
+    assert offenders == []
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -273,6 +273,74 @@ def test_lowerer_mean_attention_cluster_reuses_one_pass_state_scope() -> None:
     assert len(helper_invocations) == 6
 
 
+def test_lowerer_gate_cluster_reuses_one_pass_state_scope() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+    helper = next(
+        node
+        for node in lowerer.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_run_gate_layout_pass_cluster"
+    )
+    expected_order = [
+        "run_mixed_attention_layout_cleanup",
+        "run_elementwise_gate_layout_cleanup",
+        "run_pad_layout_cleanup",
+        "run_dual_postconv_gate_layout_cleanup",
+        "run_ndhwc_gate_layout_cleanup",
+        "run_cost_volume_scatter_layout_cleanup",
+        "run_add_concat_suffix_layout_cleanup",
+        "run_dual_mul_concat_layout_cleanup",
+    ]
+    calls = {
+        node.func.id: node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in expected_order
+    }
+
+    assert [
+        call.func.id
+        for call in sorted(calls.values(), key=lambda candidate: candidate.lineno)
+    ] == expected_order
+    for name in expected_order:
+        scope_keyword = next(
+            keyword
+            for keyword in calls[name].keywords
+            if keyword.arg == "state_scope"
+        )
+        assert isinstance(scope_keyword.value, ast.Name)
+        assert scope_keyword.value.id == "state_scope"
+
+    helper_invocations = [
+        node
+        for node in ast.walk(lowerer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_run_gate_layout_pass_cluster"
+    ]
+    assert len(helper_invocations) == 5
+    omitted_mixed_attention = [
+        call
+        for call in helper_invocations
+        if any(
+            keyword.arg == "include_mixed_attention"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is False
+            for keyword in call.keywords
+        )
+    ]
+    assert len(omitted_mixed_attention) == 1
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (
@@ -2125,7 +2193,7 @@ def test_cost_volume_scatter_layout_rewrite_has_single_owner() -> None:
         and isinstance(call.func, ast.Name)
         and call.func.id == "run_cost_volume_scatter_layout_cleanup"
     ]
-    assert len(runner_calls) == 6
+    assert len(runner_calls) == 2
 
 
 def test_add_concat_suffix_layout_rewrite_has_single_owner() -> None:
@@ -2198,7 +2266,7 @@ def test_add_concat_suffix_layout_rewrite_has_single_owner() -> None:
         and isinstance(call.func, ast.Name)
         and call.func.id == "run_add_concat_suffix_layout_cleanup"
     ]
-    assert len(runner_calls) == 5
+    assert len(runner_calls) == 1
 
 
 def test_dual_mul_concat_layout_rewrite_has_single_owner() -> None:
@@ -2271,7 +2339,7 @@ def test_dual_mul_concat_layout_rewrite_has_single_owner() -> None:
         and isinstance(call.func, ast.Name)
         and call.func.id == "run_dual_mul_concat_layout_cleanup"
     ]
-    assert len(runner_calls) == 6
+    assert len(runner_calls) == 2
 
 
 def test_axis3_const_concat_layout_rewrite_has_single_owner() -> None:
@@ -2717,7 +2785,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
     ]
 
     assert {call.func.id for call in calls if isinstance(call.func, ast.Name)} == runner_names
-    assert len(calls) == 255
+    assert len(calls) == 195
     for call in calls:
         diagnostics_keywords = [
             keyword for keyword in call.keywords if keyword.arg == "diagnostics"
@@ -2958,7 +3026,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_transpose_mean_passthrough_cleanup"
     ]
-    assert len(transpose_mean_calls) == 6
+    assert len(transpose_mean_calls) == 1
 
     mean_mul_add_conv_calls = [
         call
@@ -2966,7 +3034,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_mean_mul_add_conv_layout_cleanup"
     ]
-    assert len(mean_mul_add_conv_calls) == 7
+    assert len(mean_mul_add_conv_calls) == 2
 
     layernorm_statistics_calls = [
         call
@@ -2982,7 +3050,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_terminal_mean_layout_cleanup"
     ]
-    assert len(terminal_mean_calls) == 6
+    assert len(terminal_mean_calls) == 1
 
     se_conv_calls = [
         call
@@ -2990,7 +3058,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_se_conv_layout_cleanup"
     ]
-    assert len(se_conv_calls) == 6
+    assert len(se_conv_calls) == 1
 
     se_fc_calls = [
         call
@@ -2998,7 +3066,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_se_fc_layout_cleanup"
     ]
-    assert len(se_fc_calls) == 9
+    assert len(se_fc_calls) == 4
 
     elementwise_gate_calls = [
         call
@@ -3006,7 +3074,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_elementwise_gate_layout_cleanup"
     ]
-    assert len(elementwise_gate_calls) == 5
+    assert len(elementwise_gate_calls) == 1
 
     multi_branch_gate_calls = [
         call
@@ -3022,7 +3090,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_dual_postconv_gate_layout_cleanup"
     ]
-    assert len(dual_postconv_gate_calls) == 5
+    assert len(dual_postconv_gate_calls) == 1
 
     ndhwc_gate_calls = [
         call
@@ -3030,7 +3098,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_ndhwc_gate_layout_cleanup"
     ]
-    assert len(ndhwc_gate_calls) == 6
+    assert len(ndhwc_gate_calls) == 2
 
     cost_volume_scatter_calls = [
         call
@@ -3038,7 +3106,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_cost_volume_scatter_layout_cleanup"
     ]
-    assert len(cost_volume_scatter_calls) == 6
+    assert len(cost_volume_scatter_calls) == 2
 
     add_concat_suffix_calls = [
         call
@@ -3046,7 +3114,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_add_concat_suffix_layout_cleanup"
     ]
-    assert len(add_concat_suffix_calls) == 5
+    assert len(add_concat_suffix_calls) == 1
 
     dual_mul_concat_calls = [
         call
@@ -3054,7 +3122,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_dual_mul_concat_layout_cleanup"
     ]
-    assert len(dual_mul_concat_calls) == 6
+    assert len(dual_mul_concat_calls) == 2
 
 
 def test_cast_cleanup_rewrites_have_single_owner() -> None:

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -341,6 +341,61 @@ def test_lowerer_gate_cluster_reuses_one_pass_state_scope() -> None:
     assert len(omitted_mixed_attention) == 1
 
 
+def test_lowerer_late_ndhwc_cost_volume_pair_reuses_one_pass_state_scope() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+
+    assignment_index = next(
+        index
+        for index, statement in enumerate(lowerer.body)
+        if isinstance(statement, ast.Assign)
+        and len(statement.targets) == 1
+        and isinstance(statement.targets[0], ast.Name)
+        and statement.targets[0].id == "late_ndhwc_cost_volume_state_scope"
+    )
+    assignment = lowerer.body[assignment_index]
+    assert isinstance(assignment, ast.Assign)
+    assert isinstance(assignment.value, ast.Call)
+    assert isinstance(assignment.value.func, ast.Name)
+    assert assignment.value.func.id == "ModelIRPassStateScope"
+
+    def _statement_call(statement: ast.stmt) -> ast.Call:
+        assert isinstance(statement, ast.Expr)
+        assert isinstance(statement.value, ast.Call)
+        assert isinstance(statement.value.func, ast.Name)
+        return statement.value
+
+    mixed_call = _statement_call(lowerer.body[assignment_index - 2])
+    raw_boundary_call = _statement_call(lowerer.body[assignment_index - 1])
+    ndhwc_call = _statement_call(lowerer.body[assignment_index + 1])
+    cost_volume_call = _statement_call(lowerer.body[assignment_index + 2])
+    next_raw_boundary_call = _statement_call(lowerer.body[assignment_index + 3])
+
+    assert mixed_call.func.id == "run_mixed_attention_layout_cleanup"
+    assert all(keyword.arg != "state_scope" for keyword in mixed_call.keywords)
+    assert (
+        raw_boundary_call.func.id
+        == "_optimize_transpose_dequant_hardsigmoid_quantize_bridges"
+    )
+    assert ndhwc_call.func.id == "run_ndhwc_gate_layout_cleanup"
+    assert cost_volume_call.func.id == "run_cost_volume_scatter_layout_cleanup"
+    assert next_raw_boundary_call.func.id == "_optimize_fold_conv_mul_add_affine_chains"
+
+    for call in [ndhwc_call, cost_volume_call]:
+        scope_keyword = next(
+            keyword for keyword in call.keywords if keyword.arg == "state_scope"
+        )
+        assert isinstance(scope_keyword.value, ast.Name)
+        assert scope_keyword.value.id == "late_ndhwc_cost_volume_state_scope"
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -4901,6 +4901,7 @@ def test_generated_pytorch_fast_precanonicalize_policy_has_single_owner() -> Non
         "_has_immediate_rank4_permute_source",
         "_infer_unique_channel_count_from_rank4_shape",
         "_repair_binary_alignment_layout",
+        "_repair_binary_alignment_from_downstream_evidence",
         "_repair_aligned_scalar_binary_shape_at",
         "_repair_cf_pool_target_shape",
         "_repair_cf_pool_neighbor_layout_at",
@@ -4949,6 +4950,13 @@ def test_generated_pytorch_fast_precanonicalize_policy_has_single_owner() -> Non
             "module_output_producers",
             "registered_buffer_shapes",
         }
+    )
+    orchestrator_source = ast.get_source_segment(exporter_source, orchestrator)
+    assert orchestrator_source is not None
+    assert orchestrator_source.index("_repair_binary_alignment_layout(") < (
+        orchestrator_source.index(
+            "_repair_binary_alignment_from_downstream_evidence("
+        )
     )
 
 

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -4925,6 +4925,7 @@ def test_generated_pytorch_fast_precanonicalize_policy_has_single_owner() -> Non
         "_repair_terminal_classifier_tail_layout",
         "_propagate_cf_local_response_norm_output",
         "_propagate_cf_prelu_output",
+        "_record_rewritten_static_shape",
         "_restore_channel_last_spatial_pool_chains",
     ):
         assert function_name in policy_functions

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -4903,6 +4903,7 @@ def test_generated_pytorch_fast_precanonicalize_policy_has_single_owner() -> Non
         "_repair_binary_alignment_layout",
         "_repair_binary_alignment_from_downstream_evidence",
         "_repair_aligned_scalar_binary_shape_at",
+        "_repair_aligned_bn_constant_layout",
         "_repair_cf_pool_target_shape",
         "_repair_cf_pool_neighbor_layout_at",
         "_repair_cf_resize_from_input_and_bn_evidence",

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -217,6 +217,62 @@ def test_op_builders_mutate_operator_list_only_through_lowering_context() -> Non
     assert offenders == []
 
 
+def test_lowerer_mean_attention_cluster_reuses_one_pass_state_scope() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+    helper = next(
+        node
+        for node in lowerer.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_run_mean_attention_layout_pass_cluster"
+    )
+    expected_order = [
+        "run_transpose_mean_passthrough_cleanup",
+        "run_mean_mul_add_conv_layout_cleanup",
+        "run_layernorm_statistics_layout_cleanup",
+        "run_terminal_mean_layout_cleanup",
+        "run_se_conv_layout_cleanup",
+        "run_se_fc_layout_cleanup",
+        "run_conv_attention_layout_cleanup",
+    ]
+    calls = {
+        node.func.id: node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in expected_order
+    }
+
+    assert [
+        call.func.id
+        for call in sorted(calls.values(), key=lambda candidate: candidate.lineno)
+    ] == expected_order
+    for name in expected_order:
+        scope_keyword = next(
+            keyword
+            for keyword in calls[name].keywords
+            if keyword.arg == "state_scope"
+        )
+        assert isinstance(scope_keyword.value, ast.Name)
+        assert scope_keyword.value.id == "state_scope"
+
+    helper_invocations = [
+        node
+        for node in ast.walk(lowerer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_run_mean_attention_layout_pass_cluster"
+    ]
+    assert len(helper_invocations) == 6
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -4923,6 +4923,7 @@ def test_generated_pytorch_fast_precanonicalize_policy_has_single_owner() -> Non
         "_repair_singleton_reshape_cf_binary_at",
         "_repair_split_axis_from_consumers",
         "_repair_terminal_classifier_tail_layout",
+        "_propagate_cf_local_response_norm_output",
         "_propagate_cf_prelu_output",
         "_restore_channel_last_spatial_pool_chains",
     ):

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -457,6 +457,96 @@ def test_lowerer_late_concat_layout_cluster_reuses_one_pass_state_scope() -> Non
     )
 
 
+def test_lowerer_shuffle_and_unary_clusters_reuse_pass_state_scopes() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+
+    def _assert_helper(
+        helper_name: str,
+        expected_order: list[str],
+    ) -> None:
+        helper = next(
+            node
+            for node in lowerer.body
+            if isinstance(node, ast.FunctionDef) and node.name == helper_name
+        )
+        calls = {
+            node.func.id: node
+            for node in ast.walk(helper)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in expected_order
+        }
+        assert [
+            call.func.id
+            for call in sorted(calls.values(), key=lambda candidate: candidate.lineno)
+        ] == expected_order
+        for name in expected_order:
+            scope_keyword = next(
+                keyword
+                for keyword in calls[name].keywords
+                if keyword.arg == "state_scope"
+            )
+            assert isinstance(scope_keyword.value, ast.Name)
+            assert scope_keyword.value.id == "state_scope"
+
+    channel_helper_name = "_run_channel_shuffle_gather_layout_pass_cluster"
+    _assert_helper(
+        channel_helper_name,
+        [
+            "run_two_way_channel_shuffle_cleanup",
+            "run_nhwc_channel_shuffle_cleanup",
+            "run_nchw_channel_shuffle_cleanup",
+            "run_transpose_gather_axis_cleanup",
+            "run_layout_transpose_cleanup",
+            "run_transpose_unary_fanout_bridge_cleanup",
+            "run_transpose_unary_binary_fanout_bridge_cleanup",
+        ],
+    )
+    channel_invocations = [
+        node
+        for node in ast.walk(lowerer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == channel_helper_name
+    ]
+    assert len(channel_invocations) == 5
+    assert sum(
+        any(
+            keyword.arg == "include_post_gather_cleanup"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in call.keywords
+        )
+        for call in channel_invocations
+    ) == 1
+
+    unary_helper_name = "_run_transpose_unary_fanout_layout_pass_cluster"
+    _assert_helper(
+        unary_helper_name,
+        [
+            "run_transpose_unary_passthrough_cleanup",
+            "run_transpose_unary_fanout_bridge_cleanup",
+            "run_transpose_unary_binary_fanout_bridge_cleanup",
+        ],
+    )
+    unary_invocations = [
+        node
+        for node in ast.walk(lowerer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == unary_helper_name
+    ]
+    assert len(unary_invocations) == 4
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (
@@ -2901,7 +2991,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
     ]
 
     assert {call.func.id for call in calls if isinstance(call.func, ast.Name)} == runner_names
-    assert len(calls) == 195
+    assert len(calls) == 170
     for call in calls:
         diagnostics_keywords = [
             keyword for keyword in call.keywords if keyword.arg == "diagnostics"
@@ -3062,7 +3152,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_transpose_gather_axis_cleanup"
     ]
-    assert len(transpose_gather_axis_calls) == 8
+    assert len(transpose_gather_axis_calls) == 4
 
     transpose_gather_channel_fanout_calls = [
         call
@@ -3078,7 +3168,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_transpose_unary_passthrough_cleanup"
     ]
-    assert len(transpose_unary_calls) == 6
+    assert len(transpose_unary_calls) == 3
 
     transpose_unary_fanout_calls = [
         call
@@ -3086,7 +3176,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_transpose_unary_fanout_bridge_cleanup"
     ]
-    assert len(transpose_unary_fanout_calls) == 7
+    assert len(transpose_unary_fanout_calls) == 4
 
     transpose_unary_binary_fanout_calls = [
         call
@@ -3094,7 +3184,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_transpose_unary_binary_fanout_bridge_cleanup"
     ]
-    assert len(transpose_unary_binary_fanout_calls) == 6
+    assert len(transpose_unary_binary_fanout_calls) == 3
 
     trailing_output_transpose_calls = [
         call
@@ -3110,7 +3200,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_nchw_channel_shuffle_cleanup"
     ]
-    assert len(nchw_channel_shuffle_calls) == 6
+    assert len(nchw_channel_shuffle_calls) == 2
 
     nhwc_channel_shuffle_calls = [
         call
@@ -3118,7 +3208,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_nhwc_channel_shuffle_cleanup"
     ]
-    assert len(nhwc_channel_shuffle_calls) == 5
+    assert len(nhwc_channel_shuffle_calls) == 1
 
     two_way_channel_shuffle_calls = [
         call
@@ -3126,7 +3216,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_two_way_channel_shuffle_cleanup"
     ]
-    assert len(two_way_channel_shuffle_calls) == 5
+    assert len(two_way_channel_shuffle_calls) == 1
 
     stale_nchw_channel_shuffle_calls = [
         call

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -396,6 +396,67 @@ def test_lowerer_late_ndhwc_cost_volume_pair_reuses_one_pass_state_scope() -> No
         assert scope_keyword.value.id == "late_ndhwc_cost_volume_state_scope"
 
 
+def test_lowerer_late_concat_layout_cluster_reuses_one_pass_state_scope() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+
+    assignment_index = next(
+        index
+        for index, statement in enumerate(lowerer.body)
+        if isinstance(statement, ast.Assign)
+        and len(statement.targets) == 1
+        and isinstance(statement.targets[0], ast.Name)
+        and statement.targets[0].id == "late_concat_layout_state_scope"
+    )
+    assignment = lowerer.body[assignment_index]
+    assert isinstance(assignment, ast.Assign)
+    assert isinstance(assignment.value, ast.Call)
+    assert isinstance(assignment.value.func, ast.Name)
+    assert assignment.value.func.id == "ModelIRPassStateScope"
+
+    def _statement_call(statement: ast.stmt) -> ast.Call:
+        assert isinstance(statement, ast.Expr)
+        assert isinstance(statement.value, ast.Call)
+        assert isinstance(statement.value.func, ast.Name)
+        return statement.value
+
+    previous_raw_boundary = _statement_call(lowerer.body[assignment_index - 1])
+    assert previous_raw_boundary.func.id == "_optimize_fold_conv_mul_add_affine_chains"
+
+    expected_order = [
+        "run_axis3_const_concat_layout_cleanup",
+        "run_dequant_concat_quantize_layout_cleanup",
+        "run_layernorm_statistics_layout_cleanup",
+        "run_layout_transpose_cleanup",
+    ]
+    runner_calls = [
+        _statement_call(lowerer.body[assignment_index + offset])
+        for offset in range(1, 5)
+    ]
+    assert [call.func.id for call in runner_calls] == expected_order
+    for call in runner_calls:
+        scope_keyword = next(
+            keyword for keyword in call.keywords if keyword.arg == "state_scope"
+        )
+        assert isinstance(scope_keyword.value, ast.Name)
+        assert scope_keyword.value.id == "late_concat_layout_state_scope"
+
+    next_boundary = lowerer.body[assignment_index + 5]
+    assert isinstance(next_boundary, ast.If)
+    next_raw_boundary = _statement_call(next_boundary.body[0])
+    assert (
+        next_raw_boundary.func.id
+        == "_optimize_transpose_elementwise_roundtrip_nhwc_nchw_fanout_chains"
+    )
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -547,6 +547,57 @@ def test_lowerer_shuffle_and_unary_clusters_reuse_pass_state_scopes() -> None:
     assert len(unary_invocations) == 4
 
 
+def test_lowerer_boundary_batchmatmul_unary_pair_reuses_pass_state_scope() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+    helper_name = "_run_boundary_batchmatmul_unary_layout_pass_cluster"
+    helper = next(
+        node
+        for node in lowerer.body
+        if isinstance(node, ast.FunctionDef) and node.name == helper_name
+    )
+    expected_order = [
+        "run_boundary_input_batchmatmul_cleanup",
+        "run_input_unary_passthrough_cleanup",
+    ]
+    calls = {
+        node.func.id: node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in expected_order
+    }
+
+    assert [
+        call.func.id
+        for call in sorted(calls.values(), key=lambda candidate: candidate.lineno)
+    ] == expected_order
+    for name in expected_order:
+        scope_keyword = next(
+            keyword
+            for keyword in calls[name].keywords
+            if keyword.arg == "state_scope"
+        )
+        assert isinstance(scope_keyword.value, ast.Name)
+        assert scope_keyword.value.id == "state_scope"
+
+    helper_invocations = [
+        node
+        for node in ast.walk(lowerer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == helper_name
+    ]
+    assert len(helper_invocations) == 4
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (
@@ -2991,7 +3042,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
     ]
 
     assert {call.func.id for call in calls if isinstance(call.func, ast.Name)} == runner_names
-    assert len(calls) == 170
+    assert len(calls) == 164
     for call in calls:
         diagnostics_keywords = [
             keyword for keyword in call.keywords if keyword.arg == "diagnostics"
@@ -3048,7 +3099,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_boundary_input_batchmatmul_cleanup"
     ]
-    assert len(boundary_batchmatmul_calls) == 4
+    assert len(boundary_batchmatmul_calls) == 1
 
     pad_mul_calls = [
         call

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -160,6 +160,24 @@ def test_flatbuffer_direct_core_has_no_tensorflow_imports() -> None:
     assert offenders == []
 
 
+def test_op_builders_mutate_layout_only_through_lowering_context() -> None:
+    op_builders_root = REPO_ROOT / "onnx2tf" / "tflite_builder" / "op_builders"
+    offenders: list[str] = []
+    for path in op_builders_root.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.ctx, ast.Store)
+                and node.attr in {"logical_layout", "physical_layout"}
+            ):
+                offenders.append(
+                    f"{path.relative_to(REPO_ROOT)}:{node.lineno}:{node.attr}"
+                )
+
+    assert offenders == []
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -217,6 +217,58 @@ def test_custom_op_artifact_metadata_has_single_scan_owner() -> None:
     assert "custom_op_nodes_seen" not in builder_source
 
 
+def test_direct_export_reads_options_only_from_normalized_request() -> None:
+    builder_source = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "__init__.py"
+    ).read_text(encoding="utf-8")
+    export_function = next(
+        node
+        for node in ast.parse(builder_source).body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "export_tflite_model_flatbuffer_direct"
+    )
+    parent_by_id = {
+        id(child): parent
+        for parent in ast.walk(export_function)
+        for child in ast.iter_child_nodes(parent)
+    }
+    kwargs_reads = [
+        node
+        for node in ast.walk(export_function)
+        if isinstance(node, ast.Name)
+        and node.id == "kwargs"
+        and isinstance(node.ctx, ast.Load)
+    ]
+    assert len(kwargs_reads) == 1
+    boundary_call = parent_by_id[id(kwargs_reads[0])]
+    assert isinstance(boundary_call, ast.Call)
+    assert isinstance(boundary_call.func, ast.Attribute)
+    assert isinstance(boundary_call.func.value, ast.Name)
+    assert boundary_call.func.value.id == "ConversionRequest"
+    assert boundary_call.func.attr == "from_kwargs"
+
+    raw_kwargs_gets = [
+        node
+        for node in ast.walk(export_function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "kwargs"
+        and node.func.attr == "get"
+    ]
+    assert raw_kwargs_gets == []
+    request_gets = [
+        node
+        for node in ast.walk(export_function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "request"
+        and node.func.attr == "get"
+    ]
+    assert request_gets
+
+
 def test_op_coverage_writer_is_called_only_when_requested() -> None:
     builder_source = (
         REPO_ROOT / "onnx2tf" / "tflite_builder" / "__init__.py"

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -598,6 +598,57 @@ def test_lowerer_boundary_batchmatmul_unary_pair_reuses_pass_state_scope() -> No
     assert len(helper_invocations) == 4
 
 
+def test_lowerer_channel_slice_pad_mul_pair_reuses_pass_state_scope() -> None:
+    lowering_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowering_tree = ast.parse(lowering_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowering_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+    helper_name = "_run_channel_slice_pad_mul_layout_pass_cluster"
+    helper = next(
+        node
+        for node in lowerer.body
+        if isinstance(node, ast.FunctionDef) and node.name == helper_name
+    )
+    expected_order = [
+        "run_channel_slice_merge_layout_cleanup",
+        "run_pad_mul_layout_cleanup",
+    ]
+    calls = {
+        node.func.id: node
+        for node in ast.walk(helper)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in expected_order
+    }
+
+    assert [
+        call.func.id
+        for call in sorted(calls.values(), key=lambda candidate: candidate.lineno)
+    ] == expected_order
+    for name in expected_order:
+        scope_keyword = next(
+            keyword
+            for keyword in calls[name].keywords
+            if keyword.arg == "state_scope"
+        )
+        assert isinstance(scope_keyword.value, ast.Name)
+        assert scope_keyword.value.id == "state_scope"
+
+    helper_invocations = [
+        node
+        for node in ast.walk(lowerer)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == helper_name
+    ]
+    assert len(helper_invocations) == 3
+
+
 def test_reporting_implementation_stays_out_of_lowering_module() -> None:
     reporting_path = REPO_ROOT / "onnx2tf" / "tflite_builder" / "reporting.py"
     lowering_path = (
@@ -3042,7 +3093,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
     ]
 
     assert {call.func.id for call in calls if isinstance(call.func, ast.Name)} == runner_names
-    assert len(calls) == 164
+    assert len(calls) == 160
     for call in calls:
         diagnostics_keywords = [
             keyword for keyword in call.keywords if keyword.arg == "diagnostics"
@@ -3107,7 +3158,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_pad_mul_layout_cleanup"
     ]
-    assert len(pad_mul_calls) == 3
+    assert len(pad_mul_calls) == 1
 
     channel_slice_merge_calls = [
         call
@@ -3115,7 +3166,7 @@ def test_ordered_model_ir_runner_calls_record_session_diagnostics() -> None:
         if isinstance(call.func, ast.Name)
         and call.func.id == "run_channel_slice_merge_layout_cleanup"
     ]
-    assert len(channel_slice_merge_calls) == 3
+    assert len(channel_slice_merge_calls) == 1
 
     boundary_normalization_calls = [
         call

--- a/tests/test_flatbuffer_direct_artifact_preparation.py
+++ b/tests/test_flatbuffer_direct_artifact_preparation.py
@@ -9,6 +9,7 @@ import pytest
 from onnx2tf.tflite_builder.artifact_preparation import (
     isolate_float32_model_ir_for_tflite_write,
     resolve_requested_artifact_controls,
+    resolve_requested_exporter_controls,
 )
 from onnx2tf.tflite_builder.core.model_ir_pass_state import ModelIRPassState
 from onnx2tf.tflite_builder.ir import (
@@ -133,15 +134,88 @@ def test_requested_artifact_controls_preserve_existing_option_values() -> None:
         controls.quantization["min_numel"] = 1  # type: ignore[index]
 
 
+def test_unrequested_exporter_controls_do_not_read_related_options() -> None:
+    class _RejectingOptions(dict):
+        def get(self, key, default=None):
+            raise AssertionError(f"unrequested option was read: {key}")
+
+    controls = resolve_requested_exporter_controls(
+        _RejectingOptions(),
+        output_folder_path="artifacts",
+        output_file_name="model",
+        saved_model_requested=False,
+        pytorch_requested=False,
+        calibration_inputs_requested=False,
+    )
+
+    assert controls.saved_model_output_folder_path == "artifacts"
+    assert controls.persist_saved_model_output is False
+    assert controls.pytorch_output_folder_path == "artifacts/model_pytorch"
+    assert controls.native_pytorch_generation_timeout_sec == 0
+    assert controls.custom_input_op_name_np_data_path is None
+    assert controls.shape_hints is None
+    assert controls.test_data_nhwc_path is None
+
+
+def test_requested_exporter_controls_preserve_values_and_dependencies() -> None:
+    controls = resolve_requested_exporter_controls(
+        {
+            "saved_model_output_folder_path": "saved",
+            "persist_saved_model_output": False,
+            "pytorch_output_folder_path": "torch",
+            "native_pytorch_generation_timeout_sec": "37",
+            "custom_input_op_name_np_data_path": [["input", "sample.npy"]],
+            "shape_hints": {"input": [1, 3, 8, 8]},
+            "test_data_nhwc_path": "sample.npy",
+        },
+        output_folder_path="artifacts",
+        output_file_name="model",
+        saved_model_requested=True,
+        pytorch_requested=True,
+        calibration_inputs_requested=False,
+    )
+
+    assert controls.saved_model_output_folder_path == "saved"
+    assert controls.persist_saved_model_output is False
+    assert controls.pytorch_output_folder_path == "torch"
+    assert controls.native_pytorch_generation_timeout_sec == 37
+    assert controls.custom_input_op_name_np_data_path == [["input", "sample.npy"]]
+    assert controls.shape_hints == {"input": [1, 3, 8, 8]}
+    assert controls.test_data_nhwc_path == "sample.npy"
+
+    calibration_only = resolve_requested_exporter_controls(
+        {"custom_input_op_name_np_data_path": "calibration.npy"},
+        output_folder_path="artifacts",
+        output_file_name="model",
+        saved_model_requested=False,
+        pytorch_requested=False,
+        calibration_inputs_requested=True,
+    )
+    assert calibration_only.custom_input_op_name_np_data_path == "calibration.npy"
+    assert calibration_only.native_pytorch_generation_timeout_sec == 0
+
+    with pytest.raises(ValueError):
+        resolve_requested_exporter_controls(
+            {"native_pytorch_generation_timeout_sec": "invalid"},
+            output_folder_path="artifacts",
+            output_file_name="model",
+            saved_model_requested=False,
+            pytorch_requested=True,
+            calibration_inputs_requested=False,
+        )
+
+
 def test_artifact_control_resolution_has_one_policy_owner() -> None:
     builder_source = (
         REPO_ROOT / "onnx2tf" / "tflite_builder" / "__init__.py"
     ).read_text(encoding="utf-8")
 
     assert builder_source.count("resolve_requested_artifact_controls(") == 1
+    assert builder_source.count("resolve_requested_exporter_controls(") == 1
     assert "def _resolve_quantization_controls" not in builder_source
     assert "ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_NUMEL" not in builder_source
     assert "ONNX2TF_FLATBUFFER_DIRECT_SPLIT_MAX_BYTES" not in builder_source
+    assert '"native_pytorch_generation_timeout_sec"' not in builder_source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flatbuffer_direct_artifact_preparation.py
+++ b/tests/test_flatbuffer_direct_artifact_preparation.py
@@ -107,6 +107,9 @@ def test_unrequested_artifact_controls_do_not_read_related_options(
 def test_requested_artifact_controls_preserve_existing_option_values() -> None:
     controls = resolve_requested_artifact_controls(
         {
+            "quant_type": "per-tensor",
+            "input_quant_dtype": "uint8",
+            "output_quant_dtype": "int16",
             "tflite_split_max_bytes": "2048",
             "tflite_split_target_bytes": 1536,
             "flatbuffer_direct_calibration_method": "percentile",
@@ -124,6 +127,9 @@ def test_requested_artifact_controls_preserve_existing_option_values() -> None:
     assert controls.split_max_bytes == 2048
     assert controls.split_target_bytes == 1536
     assert dict(controls.quantization or {}) == {
+        "quant_type": "per-tensor",
+        "input_quant_dtype": "uint8",
+        "output_quant_dtype": "int16",
         "calibration_method": "percentile",
         "calibration_percentile": 98.5,
         "min_numel": 17,
@@ -216,6 +222,9 @@ def test_artifact_control_resolution_has_one_policy_owner() -> None:
     assert "ONNX2TF_FLATBUFFER_DIRECT_QUANT_MIN_NUMEL" not in builder_source
     assert "ONNX2TF_FLATBUFFER_DIRECT_SPLIT_MAX_BYTES" not in builder_source
     assert '"native_pytorch_generation_timeout_sec"' not in builder_source
+    assert 'request.get("quant_type"' not in builder_source
+    assert 'request.get("input_quant_dtype"' not in builder_source
+    assert 'request.get("output_quant_dtype"' not in builder_source
 
 
 @pytest.mark.parametrize(

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -203,7 +203,13 @@ def test_lowerer_keeps_session_layout_current_before_first_post_pass(
     observed_layouts: dict[str, str] = {}
     original_cleanup = lowering_module.run_layout_transpose_cleanup
 
-    def _tracking_cleanup(model_ir, *, layout_state=None, diagnostics=None):
+    def _tracking_cleanup(
+        model_ir,
+        *,
+        layout_state=None,
+        diagnostics=None,
+        state_scope=None,
+    ):
         assert layout_state is not None
         if not observed_problems:
             observed_problems.append(layout_state.validate_against_model_ir(model_ir))
@@ -222,6 +228,7 @@ def test_lowerer_keeps_session_layout_current_before_first_post_pass(
             model_ir,
             layout_state=layout_state,
             diagnostics=diagnostics,
+            state_scope=state_scope,
         )
 
     monkeypatch.setattr(

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -7,6 +7,7 @@ import onnx
 import pytest
 from onnx import TensorProto, helper
 import onnx2tf.tflite_builder.core.validation as validation_module
+import onnx2tf.tflite_builder.lower_from_onnx2tf as lowering_module
 
 from onnx2tf.tflite_builder.core import (
     ConversionRequest,
@@ -134,6 +135,33 @@ def test_lowerer_private_sink_collects_internal_pass_diagnostics() -> None:
     assert all(event["stage"] == "model_ir_pass" for event in diagnostics)
     summary = summarize_model_ir_pass_diagnostics(diagnostics)
     assert summary["event_count"] == len(diagnostics)
+
+
+def test_lowerer_context_reuses_session_consumer_counts(monkeypatch) -> None:
+    captured_counts: dict[str, int] = {}
+    original_context = lowering_module.LoweringContext
+    model = _add_onnx_model()
+    model.graph.node.append(
+        helper.make_node("Identity", ["x"], ["side"], name="side")
+    )
+    model.graph.output.append(
+        helper.make_tensor_value_info("side", TensorProto.FLOAT, [1, 3])
+    )
+
+    class _TrackingLoweringContext(original_context):
+        def __init__(self, *args, **kwargs):
+            captured_counts.update(kwargs["tensor_consumer_count"])
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        lowering_module,
+        "LoweringContext",
+        _TrackingLoweringContext,
+    )
+
+    lower_onnx_to_ir(model, "session_consumer_counts")
+
+    assert captured_counts == {"x": 2, "y": 1}
 
 
 def test_layout_state_sync_rename_remove_and_validation() -> None:

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -15,6 +15,7 @@ from onnx2tf.tflite_builder.core import (
     ConversionSession,
     GraphIndex,
     LayoutState,
+    LoweringContext,
     ModelIRGraphIndex,
     ModelIRPassState,
     OrderedPassManager,
@@ -28,6 +29,7 @@ from onnx2tf.tflite_builder.core import (
 from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
 from onnx2tf.tflite_builder.dispatcher import dispatch_node
 from onnx2tf.tflite_builder.lower_from_onnx2tf import lower_onnx_to_ir
+from onnx2tf.tflite_builder.op_builders.shared import make_transpose
 
 
 def _add_onnx_model() -> onnx.ModelProto:
@@ -237,6 +239,101 @@ def test_lowerer_keeps_session_layout_current_before_first_post_pass(
         "rank3_resize_output_nhwc": "NHWC",
         "rank3_resize_output_nwc": "NWC",
     }
+
+
+def _inverse_transpose_lowering_context() -> LoweringContext:
+    model_ir = ModelIR(
+        name="inverse_transpose_context",
+        tensors={
+            "source": TensorIR(
+                "source",
+                "FLOAT32",
+                [1, 3, 2, 2],
+                [1, 3, 2, 2],
+            ),
+            "bridge": TensorIR(
+                "bridge",
+                "FLOAT32",
+                [1, 2, 2, 3],
+                [1, 2, 2, 3],
+            ),
+            "side": TensorIR(
+                "side",
+                "FLOAT32",
+                [1, 2, 2, 3],
+                [1, 2, 2, 3],
+            ),
+            "restored": TensorIR(
+                "restored",
+                "FLOAT32",
+                [1, 3, 2, 2],
+                [1, 3, 2, 2],
+            ),
+        },
+    )
+    context = LoweringContext(
+        model_ir=model_ir,
+        shape_map={},
+        dtype_map={},
+        constants={},
+        tensor_consumer_count={},
+    )
+    perm_name = context.add_const_tensor(
+        "to_nhwc_perm",
+        np.asarray([0, 2, 3, 1], dtype=np.int32),
+    )
+    context.add_operator(
+        OperatorIR(
+            op_type="TRANSPOSE",
+            inputs=["source", perm_name],
+            outputs=["bridge"],
+        )
+    )
+    return context
+
+
+def test_inverse_transpose_elision_removes_lowering_indexes() -> None:
+    context = _inverse_transpose_lowering_context()
+
+    result = make_transpose(
+        context,
+        "bridge",
+        "restored",
+        [0, 3, 1, 2],
+        allow_elide_inverse_chain=True,
+    )
+
+    assert result == "source"
+    assert context.model_ir.operators == []
+    assert "bridge" not in context.ir_tensor_producers
+    assert context.ir_tensor_consumer_count == {}
+
+
+def test_inverse_transpose_elision_preserves_synthetic_fanout() -> None:
+    context = _inverse_transpose_lowering_context()
+    context.add_operator(
+        OperatorIR(
+            op_type="IDENTITY",
+            inputs=["bridge"],
+            outputs=["side"],
+        )
+    )
+
+    result = make_transpose(
+        context,
+        "bridge",
+        "restored",
+        [0, 3, 1, 2],
+        allow_elide_inverse_chain=True,
+    )
+
+    assert result == "source"
+    assert [str(op.op_type) for op in context.model_ir.operators] == [
+        "TRANSPOSE",
+        "IDENTITY",
+    ]
+    assert context.ir_tensor_producers["bridge"] is context.model_ir.operators[0]
+    assert context.ir_tensor_consumer_count["bridge"] == 1
 
 
 def test_layout_state_sync_rename_remove_and_validation() -> None:

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -5,7 +5,7 @@ import copy
 import numpy as np
 import onnx
 import pytest
-from onnx import TensorProto, helper
+from onnx import TensorProto, helper, numpy_helper
 import onnx2tf.tflite_builder.core.validation as validation_module
 import onnx2tf.tflite_builder.lower_from_onnx2tf as lowering_module
 
@@ -53,6 +53,36 @@ def _add_model_ir() -> ModelIR:
         operators=[OperatorIR(op_type="ADD", inputs=["x", "y"], outputs=["z"])],
         inputs=["x", "y"],
         outputs=["z"],
+    )
+
+
+def _rank3_resize_onnx_model() -> onnx.ModelProto:
+    x = helper.make_tensor_value_info("x", TensorProto.FLOAT, [1, 2, 4])
+    y = helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 2, 8])
+    roi = numpy_helper.from_array(np.asarray([], dtype=np.float32), name="roi")
+    scales = numpy_helper.from_array(
+        np.asarray([1.0, 1.0, 2.0], dtype=np.float32),
+        name="scales",
+    )
+    resize = helper.make_node(
+        "Resize",
+        ["x", "roi", "scales"],
+        ["y"],
+        name="rank3_resize",
+        mode="nearest",
+        coordinate_transformation_mode="asymmetric",
+        nearest_mode="floor",
+    )
+    graph = helper.make_graph(
+        [resize],
+        "rank3_resize_graph",
+        [x],
+        [y],
+        initializer=[roi, scales],
+    )
+    return helper.make_model(
+        graph,
+        opset_imports=[helper.make_opsetid("", 13)],
     )
 
 
@@ -162,6 +192,51 @@ def test_lowerer_context_reuses_session_consumer_counts(monkeypatch) -> None:
     lower_onnx_to_ir(model, "session_consumer_counts")
 
     assert captured_counts == {"x": 2, "y": 1}
+
+
+def test_lowerer_keeps_session_layout_current_before_first_post_pass(
+    monkeypatch,
+) -> None:
+    observed_problems: list[list[str]] = []
+    observed_layouts: dict[str, str] = {}
+    original_cleanup = lowering_module.run_layout_transpose_cleanup
+
+    def _tracking_cleanup(model_ir, *, layout_state=None, diagnostics=None):
+        assert layout_state is not None
+        if not observed_problems:
+            observed_problems.append(layout_state.validate_against_model_ir(model_ir))
+            observed_layouts.update(
+                {
+                    name: layout_state.logical_of(name)
+                    for name in (
+                        "rank3_resize_input_nwc",
+                        "rank3_resize_input_nhwc",
+                        "rank3_resize_output_nhwc",
+                        "rank3_resize_output_nwc",
+                    )
+                }
+            )
+        return original_cleanup(
+            model_ir,
+            layout_state=layout_state,
+            diagnostics=diagnostics,
+        )
+
+    monkeypatch.setattr(
+        lowering_module,
+        "run_layout_transpose_cleanup",
+        _tracking_cleanup,
+    )
+
+    lower_onnx_to_ir(_rank3_resize_onnx_model(), "session_layout_handoff")
+
+    assert observed_problems == [[]]
+    assert observed_layouts == {
+        "rank3_resize_input_nwc": "NWC",
+        "rank3_resize_input_nhwc": "NHWC",
+        "rank3_resize_output_nhwc": "NHWC",
+        "rank3_resize_output_nwc": "NWC",
+    }
 
 
 def test_layout_state_sync_rename_remove_and_validation() -> None:

--- a/tests/test_flatbuffer_direct_mean_layout.py
+++ b/tests/test_flatbuffer_direct_mean_layout.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import numpy as np
 
 from onnx2tf.tflite_builder.core.graph import ModelIRGraphIndex
+from onnx2tf.tflite_builder.core.model_ir_pass_state import (
+    ModelIRPassStateScope,
+    summarize_model_ir_pass_diagnostics,
+)
 from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
 from onnx2tf.tflite_builder.lower_from_onnx2tf import (
     _optimize_transpose_mean_mul_reshape_add_conv_nhwc_chains,
@@ -197,6 +201,84 @@ def test_mean_mul_add_conv_runner_records_transaction(monkeypatch) -> None:
     assert diagnostics[0]["changed"] is True
     assert diagnostics[0]["metrics"]["snapshot_count"] == 1
     assert refresh_count == 1
+
+
+def test_adjacent_mean_runners_reuse_one_lazy_pass_state(monkeypatch) -> None:
+    model_ir = _model(fanout=False)
+    diagnostics: list[dict[str, object]] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    passthrough_stats = run_transpose_mean_passthrough_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+    branch_stats = run_mean_mul_add_conv_layout_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+
+    assert passthrough_stats[
+        "optimized_transpose_mean_prepost_nhwc_passthrough_chains"
+    ] == 0
+    assert branch_stats[
+        "optimized_transpose_mean_mul_reshape_add_conv_nhwc_chains"
+    ] == 1
+    assert refresh_count == 1
+    assert [event["metrics"]["state_built"] for event in diagnostics] == [
+        True,
+        False,
+    ]
+    assert summarize_model_ir_pass_diagnostics(diagnostics)["totals"][
+        "state_build_count"
+    ] == 1
+
+
+def test_adjacent_mean_scope_stays_lazy_when_all_preflights_miss(
+    monkeypatch,
+) -> None:
+    model_ir = ModelIR(
+        "mean_scope_no_candidates",
+        operators=[OperatorIR("ADD", [], []) for _ in range(32)],
+    )
+    diagnostics: list[dict[str, object]] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    run_transpose_mean_passthrough_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+    run_mean_mul_add_conv_layout_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+
+    assert refresh_count == 0
+    assert [event["metrics"]["state_built"] for event in diagnostics] == [
+        False,
+        False,
+    ]
 
 
 def test_transpose_mean_passthrough_runner_records_transaction(monkeypatch) -> None:

--- a/tests/test_flatbuffer_direct_pass_efficiency.py
+++ b/tests/test_flatbuffer_direct_pass_efficiency.py
@@ -456,6 +456,97 @@ def test_late_concat_layout_cluster_reuses_one_pass_state(monkeypatch) -> None:
     ]
 
 
+def test_shuffle_gather_cluster_reuses_one_pass_state(monkeypatch) -> None:
+    model_ir = ModelIR(
+        "shuffle_gather_scope_preflight_only",
+        operators=[
+            OperatorIR(op_type, [], [])
+            for op_type in [
+                "TRANSPOSE",
+                "CONCATENATION",
+                "RESHAPE",
+                "GATHER",
+                "RELU",
+                "ADD",
+            ]
+        ],
+    )
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    for runner in [
+        run_two_way_channel_shuffle_cleanup,
+        run_nhwc_channel_shuffle_cleanup,
+        run_nchw_channel_shuffle_cleanup,
+        run_transpose_gather_axis_cleanup,
+        run_layout_transpose_cleanup,
+        run_transpose_unary_fanout_bridge_cleanup,
+        run_transpose_unary_binary_fanout_bridge_cleanup,
+    ]:
+        runner(
+            model_ir,
+            diagnostics=diagnostics,
+            state_scope=state_scope,
+        )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 7
+    assert diagnostics[0]["metrics"]["state_built"] is True
+    assert all(
+        event["metrics"]["state_built"] is False
+        for event in diagnostics[1:]
+    )
+
+
+def test_unary_fanout_cluster_reuses_one_pass_state(monkeypatch) -> None:
+    model_ir = ModelIR(
+        "unary_fanout_scope_preflight_only",
+        operators=[
+            OperatorIR(op_type, [], [])
+            for op_type in ["TRANSPOSE", "RELU", "ADD"]
+        ],
+    )
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    for runner in [
+        run_transpose_unary_passthrough_cleanup,
+        run_transpose_unary_fanout_bridge_cleanup,
+        run_transpose_unary_binary_fanout_bridge_cleanup,
+    ]:
+        runner(
+            model_ir,
+            diagnostics=diagnostics,
+            state_scope=state_scope,
+        )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 3
+    assert diagnostics[0]["metrics"]["state_built"] is True
+    assert all(
+        event["metrics"]["state_built"] is False
+        for event in diagnostics[1:]
+    )
+
+
 def test_channel_slice_merge_guard_rejects_incomplete_prefix_before_snapshot(
     monkeypatch,
 ) -> None:

--- a/tests/test_flatbuffer_direct_pass_efficiency.py
+++ b/tests/test_flatbuffer_direct_pass_efficiency.py
@@ -6,6 +6,7 @@ from onnx2tf.tflite_builder.core.graph import ModelIRGraphIndex
 from onnx2tf.tflite_builder.core.model_ir_pass_state import (
     ModelIRPreflightResult,
     ModelIRPassState,
+    ModelIRPassStateScope,
     run_model_ir_pass_group,
 )
 from onnx2tf.tflite_builder.core.passes import PassPhase, PassSpec
@@ -295,6 +296,65 @@ def test_all_production_runner_preflights_avoid_heavy_no_candidate_work(
             "fingerprint_count": 0,
         }
         for event in diagnostics
+    )
+
+
+def test_adjacent_gate_runners_reuse_one_lazy_pass_state(monkeypatch) -> None:
+    operator_types = [
+        "TRANSPOSE",
+        "MEAN",
+        "REDUCE_MAX",
+        "CONCATENATION",
+        "MIRROR_PAD",
+        "TRANSPOSE",
+        "CONV_2D",
+        "MUL",
+        "ADD",
+        "LOGISTIC",
+        "SUB",
+        "RESHAPE",
+        "LEAKY_RELU",
+        "SCATTER_ND",
+        "CONV_3D",
+    ]
+    model_ir = ModelIR(
+        "gate_scope_preflight_only",
+        operators=[OperatorIR(op_type, [], []) for op_type in operator_types],
+    )
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    for runner in [
+        run_mixed_attention_layout_cleanup,
+        run_elementwise_gate_layout_cleanup,
+        run_pad_layout_cleanup,
+        run_dual_postconv_gate_layout_cleanup,
+        run_ndhwc_gate_layout_cleanup,
+        run_cost_volume_scatter_layout_cleanup,
+        run_add_concat_suffix_layout_cleanup,
+        run_dual_mul_concat_layout_cleanup,
+    ]:
+        runner(
+            model_ir,
+            diagnostics=diagnostics,
+            state_scope=state_scope,
+        )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 15
+    assert diagnostics[0]["metrics"]["state_built"] is True
+    assert all(
+        event["metrics"]["state_built"] is False
+        for event in diagnostics[1:]
     )
 
 

--- a/tests/test_flatbuffer_direct_pass_efficiency.py
+++ b/tests/test_flatbuffer_direct_pass_efficiency.py
@@ -21,6 +21,7 @@ from onnx2tf.tflite_builder.passes.boundary_input_layout import (
     run_boundary_input_layout_cleanup,
 )
 from onnx2tf.tflite_builder.passes.boundary_input_chains import (
+    run_boundary_input_batchmatmul_cleanup,
     run_boundary_input_normalization_cleanup,
 )
 from onnx2tf.tflite_builder.passes.channel_slice_layout import (
@@ -545,6 +546,54 @@ def test_unary_fanout_cluster_reuses_one_pass_state(monkeypatch) -> None:
         event["metrics"]["state_built"] is False
         for event in diagnostics[1:]
     )
+
+
+def test_boundary_batchmatmul_unary_pair_reuses_one_pass_state(
+    monkeypatch,
+) -> None:
+    model_ir = ModelIR("boundary_batchmatmul_unary_scope_preflight_only")
+    model_ir.inputs = ["x"]
+    model_ir.tensors = {
+        "x": TensorIR("x", "FLOAT32", [1], [1]),
+        "perm": TensorIR("perm", "INT32", [1], [1]),
+        "transposed": TensorIR("transposed", "FLOAT32", [1], [1]),
+    }
+    model_ir.operators = [
+        OperatorIR("TRANSPOSE", ["x", "perm"], ["transposed"]),
+        OperatorIR("BATCH_MATMUL", [], []),
+        OperatorIR("ADD", [], []),
+    ]
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    run_boundary_input_batchmatmul_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+    run_input_unary_passthrough_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 4
+    assert [event["metrics"]["state_built"] for event in diagnostics] == [
+        True,
+        False,
+        False,
+        False,
+    ]
 
 
 def test_channel_slice_merge_guard_rejects_incomplete_prefix_before_snapshot(

--- a/tests/test_flatbuffer_direct_pass_efficiency.py
+++ b/tests/test_flatbuffer_direct_pass_efficiency.py
@@ -405,6 +405,57 @@ def test_late_ndhwc_cost_volume_pair_reuses_one_pass_state(monkeypatch) -> None:
     ]
 
 
+def test_late_concat_layout_cluster_reuses_one_pass_state(monkeypatch) -> None:
+    model_ir = ModelIR(
+        "late_concat_layout_scope_preflight_only",
+        operators=[
+            OperatorIR(op_type, [], [])
+            for op_type in [
+                "TRANSPOSE",
+                "CONCATENATION",
+                "DEQUANTIZE",
+                "QUANTIZE",
+                "MEAN",
+                "SUB",
+                "MUL",
+            ]
+        ],
+    )
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    for runner in [
+        run_axis3_const_concat_layout_cleanup,
+        run_dequant_concat_quantize_layout_cleanup,
+        run_layernorm_statistics_layout_cleanup,
+        run_layout_transpose_cleanup,
+    ]:
+        runner(
+            model_ir,
+            diagnostics=diagnostics,
+            state_scope=state_scope,
+        )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 5
+    assert [event["metrics"]["state_built"] for event in diagnostics] == [
+        True,
+        False,
+        False,
+        False,
+        False,
+    ]
+
+
 def test_channel_slice_merge_guard_rejects_incomplete_prefix_before_snapshot(
     monkeypatch,
 ) -> None:

--- a/tests/test_flatbuffer_direct_pass_efficiency.py
+++ b/tests/test_flatbuffer_direct_pass_efficiency.py
@@ -358,6 +358,53 @@ def test_adjacent_gate_runners_reuse_one_lazy_pass_state(monkeypatch) -> None:
     )
 
 
+def test_late_ndhwc_cost_volume_pair_reuses_one_pass_state(monkeypatch) -> None:
+    model_ir = ModelIR(
+        "late_ndhwc_cost_volume_scope_preflight_only",
+        operators=[
+            OperatorIR(op_type, [], [])
+            for op_type in [
+                "TRANSPOSE",
+                "RESHAPE",
+                "LEAKY_RELU",
+                "MUL",
+                "SCATTER_ND",
+                "CONV_3D",
+            ]
+        ],
+    )
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    run_ndhwc_gate_layout_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+    run_cost_volume_scatter_layout_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 3
+    assert [event["metrics"]["state_built"] for event in diagnostics] == [
+        True,
+        True,
+        False,
+    ]
+
+
 def test_channel_slice_merge_guard_rejects_incomplete_prefix_before_snapshot(
     monkeypatch,
 ) -> None:

--- a/tests/test_flatbuffer_direct_pass_efficiency.py
+++ b/tests/test_flatbuffer_direct_pass_efficiency.py
@@ -596,6 +596,54 @@ def test_boundary_batchmatmul_unary_pair_reuses_one_pass_state(
     ]
 
 
+def test_channel_slice_pad_mul_pair_reuses_one_pass_state(monkeypatch) -> None:
+    model_ir = ModelIR(
+        "channel_slice_pad_mul_scope_preflight_only",
+        operators=[
+            OperatorIR(op_type, [], [])
+            for op_type in [
+                "TRANSPOSE",
+                "MUL",
+                "ADD",
+                "SLICE",
+                "SLICE",
+                "PAD",
+            ]
+        ],
+    )
+    diagnostics: list[dict] = []
+    refresh_count = 0
+    original_refresh = ModelIRGraphIndex.refresh
+
+    def counted_refresh(graph_index: ModelIRGraphIndex) -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        original_refresh(graph_index)
+
+    monkeypatch.setattr(ModelIRGraphIndex, "refresh", counted_refresh)
+    state_scope = ModelIRPassStateScope(model_ir)
+
+    run_channel_slice_merge_layout_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+    run_pad_mul_layout_cleanup(
+        model_ir,
+        diagnostics=diagnostics,
+        state_scope=state_scope,
+    )
+
+    assert refresh_count == 1
+    assert len(diagnostics) == 4
+    assert [event["metrics"]["state_built"] for event in diagnostics] == [
+        True,
+        True,
+        True,
+        False,
+    ]
+
+
 def test_channel_slice_merge_guard_rejects_incomplete_prefix_before_snapshot(
     monkeypatch,
 ) -> None:

--- a/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
+++ b/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
@@ -37,6 +37,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_terminal_classifier_tail_layout,
     _propagate_cf_local_response_norm_output,
     _propagate_cf_prelu_output,
+    _record_rewritten_static_shape,
 )
 from onnx2tf.tflite_builder.pytorch_source_parser import (
     _parse_apply_pool2d_assign_with_shape,
@@ -105,6 +106,34 @@ def test_fast_precanonicalize_context_collects_module_and_alias_evidence() -> No
         )
         == "cf"
     )
+
+
+def test_rewritten_static_shape_records_target_or_trailing_literal_only() -> None:
+    context = _build_fast_precanonicalize_repair_context([])
+    assert _record_rewritten_static_shape(
+        "        resized = _apply_resize(source, [5, 7], method='nearest', "
+        "target_shape=[1, 8, 5, 7], align_corners=False, "
+        "half_pixel_centers=False, channel_last=False)",
+        "resized",
+        context,
+    )
+    assert context.static_shapes["resized"] == [1, 8, 5, 7]
+
+    assert _record_rewritten_static_shape(
+        "        aligned = _align_tensor_to_target_shape("
+        "torch.add(left, right), [1, 16, 3, 4])",
+        "aligned",
+        context,
+    )
+    assert context.static_shapes["aligned"] == [1, 16, 3, 4]
+
+    context.static_shapes["unchanged"] = [1, 2, 3, 4]
+    assert not _record_rewritten_static_shape(
+        "        unchanged = _apply_pool2d(source, target_shape=dynamic_shape)",
+        "unchanged",
+        context,
+    )
+    assert context.static_shapes["unchanged"] == [1, 2, 3, 4]
 
 
 def test_channel_last_spatial_consumer_detects_direct_rank4_slice() -> None:

--- a/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
+++ b/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
@@ -35,6 +35,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_split_axis_from_consumers,
     _repair_singleton_reshape_cf_binary_at,
     _repair_terminal_classifier_tail_layout,
+    _propagate_cf_local_response_norm_output,
     _propagate_cf_prelu_output,
 )
 from onnx2tf.tflite_builder.pytorch_source_parser import (
@@ -821,6 +822,60 @@ def test_prelu_and_gather_slice_propagate_channel_first_layout() -> None:
 
     assert {"prelu_out", "gathered"} <= cf_like_names
     assert lines == ["        gathered = prelu_out[:, [0, 2], :, :]"]
+
+
+def test_local_response_norm_propagates_only_channel_first_layout_and_shape() -> None:
+    cf_line = (
+        "        normalized_nhwc = F.local_response_norm("
+        "input_cf, size=5, alpha=0.0001, beta=0.75, k=1.0)"
+    )
+    cf_context = _build_fast_precanonicalize_repair_context([cf_line])
+    cf_context.static_shapes["input_cf"] = [1, 8, 5, 7]
+    cf_names = {"input_cf"}
+    nhwc_names = {"normalized_nhwc"}
+
+    assert _propagate_cf_local_response_norm_output(
+        cf_line,
+        cf_names,
+        nhwc_names,
+        cf_context,
+    )
+    assert "normalized_nhwc" in cf_names
+    assert "normalized_nhwc" not in nhwc_names
+    assert cf_context.static_shapes["normalized_nhwc"] == [1, 8, 5, 7]
+
+    suffix_line = (
+        "        suffix_out = F.local_response_norm("
+        "source_out_cf, size=3, alpha=0.1, beta=0.5, k=2.0)"
+    )
+    suffix_context = _build_fast_precanonicalize_repair_context([suffix_line])
+    suffix_names: set[str] = set()
+    assert _propagate_cf_local_response_norm_output(
+        suffix_line,
+        suffix_names,
+        set(),
+        suffix_context,
+    )
+    assert "suffix_out" in suffix_names
+    assert "suffix_out" not in suffix_context.static_shapes
+
+    nhwc_line = (
+        "        unchanged = F.local_response_norm("
+        "input_nhwc, size=5, alpha=0.0001, beta=0.75, k=1.0)"
+    )
+    nhwc_context = _build_fast_precanonicalize_repair_context([nhwc_line])
+    nhwc_context.static_shapes["input_nhwc"] = [1, 5, 7, 8]
+    negative_cf_names: set[str] = set()
+    negative_nhwc_names = {"input_nhwc", "unchanged"}
+    assert not _propagate_cf_local_response_norm_output(
+        nhwc_line,
+        negative_cf_names,
+        negative_nhwc_names,
+        nhwc_context,
+    )
+    assert negative_cf_names == set()
+    assert negative_nhwc_names == {"input_nhwc", "unchanged"}
+    assert "unchanged" not in nhwc_context.static_shapes
 
 
 def test_depth_to_space_gather_uses_indexed_layout_evidence() -> None:

--- a/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
+++ b/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
@@ -20,6 +20,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _repair_cf_pool_neighbor_layout_at,
     _repair_cf_gather_slice_at,
     _repair_cf_reduce_max_axis,
+    _repair_cf_resize_from_input_and_bn_evidence,
     _repair_cf_resize_target_shape,
     _repair_cf_softmax_axis,
     _repair_concat_axis_from_input_layouts,
@@ -165,6 +166,97 @@ def test_resize_and_pool_repairs_normalize_channel_first_targets() -> None:
     )
     assert pooled_name == "pooled"
     assert pooled is not None and "target_shape=[1, 3, 20, 30]" in pooled
+
+
+def test_resize_input_evidence_preserves_bn_and_noop_decisions() -> None:
+    positive_cases = [
+        (
+            [
+                "        self.register_buffer('scale', torch.zeros("
+                "[1, 8, 1, 1], dtype=torch.float32), persistent=True)",
+                "        resized = _apply_resize("
+                "source_cf, [5, 7], method='nearest', "
+                "target_shape=[1, 5, 7, 8], align_corners=False, "
+                "half_pixel_centers=False, channel_last=True)",
+                "        normalized = _align_tensor_to_target_shape("
+                "torch.mul(resized, self.scale), [1, 5, 7, 8])",
+            ],
+            1,
+            "target_shape=[1, 8, 5, 7]",
+        ),
+        (
+            [
+                "        self.register_buffer('scale', torch.zeros("
+                "[8], dtype=torch.float32), persistent=True)",
+                "        resized = _apply_resize("
+                "source_cf, [5, 7], method='nearest', "
+                "target_shape=[1, 5, 7, 8], align_corners=False, "
+                "half_pixel_centers=False, channel_last=True)",
+                "        normalized = _align_tensor_to_target_shape("
+                "torch.add(resized, torch.reshape("
+                "self.scale, [1, 8, 1, 1])), [1, 8, 5, 7])",
+            ],
+            1,
+            "target_shape=[1, 8, 5, 7]",
+        ),
+        (
+            [
+                "        resized = _apply_resize("
+                "source_cf, [5, 7], method='nearest', "
+                "target_shape=[1, 5, 7, 16], align_corners=False, "
+                "half_pixel_centers=False, channel_last=True)",
+                "        return resized",
+            ],
+            0,
+            "target_shape=[1, 16, 5, 7]",
+        ),
+    ]
+    for lines, resize_index, expected_shape in positive_cases:
+        rewritten, lhs_name = _repair_cf_resize_from_input_and_bn_evidence(
+            lines[resize_index],
+            resize_index,
+            lines,
+            {"source_cf"},
+            set(),
+            _build_fast_precanonicalize_repair_context(lines),
+        )
+        assert rewritten is not None and expected_shape in rewritten
+        assert "channel_last=False" in rewritten
+        assert lhs_name == "resized"
+
+    negative_cases = [
+        (
+            [
+                "        resized = _apply_resize("
+                "source_nhwc, [5, 7], method='nearest', "
+                "target_shape=[1, 5, 7, 16], align_corners=False, "
+                "half_pixel_centers=False, channel_last=True)",
+                "        return resized",
+            ],
+            set(),
+            {"source_nhwc"},
+        ),
+        (
+            [
+                "        resized = _apply_resize("
+                "source_cf, [5, 7], method='nearest', "
+                "target_shape=[1, 1, 5, 7], align_corners=False, "
+                "half_pixel_centers=False, channel_last=False)",
+                "        return resized",
+            ],
+            {"source_cf"},
+            set(),
+        ),
+    ]
+    for lines, cf_names, nhwc_names in negative_cases:
+        assert _repair_cf_resize_from_input_and_bn_evidence(
+            lines[0],
+            0,
+            lines,
+            cf_names,
+            nhwc_names,
+            _build_fast_precanonicalize_repair_context(lines),
+        ) == (None, None)
 
 
 def test_nhwc_pool_layout_uses_consumer_and_immediate_bridge_evidence() -> None:

--- a/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
+++ b/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
@@ -15,6 +15,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _infer_unique_channel_count_from_rank4_shape,
     _repair_binary_alignment_layout,
     _repair_binary_alignment_from_downstream_evidence,
+    _repair_aligned_bn_constant_layout,
     _repair_aligned_scalar_binary_shape_at,
     _repair_cf_pool_target_shape,
     _repair_cf_pool_neighbor_layout_at,
@@ -257,6 +258,89 @@ def test_resize_input_evidence_preserves_bn_and_noop_decisions() -> None:
             nhwc_names,
             _build_fast_precanonicalize_repair_context(lines),
         ) == (None, None)
+
+
+def test_aligned_bn_constant_layout_preserves_direct_and_reshaped_guards() -> None:
+    direct_positive_lines = [
+        "        self.register_buffer('BatchNormalization_scale', torch.zeros("
+        "[8], dtype=torch.float32), persistent=True)",
+        "        out = _align_tensor_to_target_shape(torch.mul("
+        "source_cf, self.BatchNormalization_scale), [1, 5, 7, 8])",
+    ]
+    direct_rewrite, direct_lhs = _repair_aligned_bn_constant_layout(
+        direct_positive_lines[1],
+        {"source_cf"},
+        _build_fast_precanonicalize_repair_context(direct_positive_lines),
+    )
+    assert direct_rewrite == (
+        "        out = _align_tensor_to_target_shape(torch.mul(source_cf, "
+        "torch.reshape(self.BatchNormalization_scale, [1, 8, 1, 1])), "
+        "[1, 8, 5, 7])"
+    )
+    assert direct_lhs == "out"
+
+    reshaped_line = (
+        "        out = _align_tensor_to_target_shape(torch.add(source_cf, "
+        "torch.reshape(self.batch_normalization_bias, [1, 8, 1, 1])), "
+        "[1, 5, 7, 8])"
+    )
+    reshaped_rewrite, reshaped_lhs = _repair_aligned_bn_constant_layout(
+        reshaped_line,
+        {"source_cf"},
+        _build_fast_precanonicalize_repair_context([reshaped_line]),
+    )
+    assert reshaped_rewrite == (
+        "        out = _align_tensor_to_target_shape(torch.add(source_cf, "
+        "torch.reshape(self.batch_normalization_bias, [1, 8, 1, 1])), "
+        "[1, 8, 5, 7])"
+    )
+    assert reshaped_lhs == "out"
+
+    direct_negative_cases = [
+        (
+            [
+                "        self.register_buffer('scale', torch.zeros("
+                "[8], dtype=torch.float32), persistent=True)",
+                "        out = _align_tensor_to_target_shape(torch.mul("
+                "source_cf, self.scale), [1, 5, 7, 8])",
+            ],
+            {"source_cf"},
+        ),
+        (
+            [
+                "        self.register_buffer('BatchNormalization_scale', "
+                "torch.zeros([4], dtype=torch.float32), persistent=True)",
+                "        out = _align_tensor_to_target_shape(torch.add("
+                "source_cf, self.BatchNormalization_scale), [1, 5, 7, 8])",
+            ],
+            {"source_cf"},
+        ),
+        (
+            [
+                "        self.register_buffer('BatchNormalization_scale', "
+                "torch.zeros([8], dtype=torch.float32), persistent=True)",
+                "        out = _align_tensor_to_target_shape(torch.add("
+                "source_nhwc, self.BatchNormalization_scale), [1, 5, 7, 8])",
+            ],
+            set(),
+        ),
+    ]
+    for case_lines, cf_names in direct_negative_cases:
+        assert _repair_aligned_bn_constant_layout(
+            case_lines[1],
+            cf_names,
+            _build_fast_precanonicalize_repair_context(case_lines),
+        ) == (None, None)
+
+    reshaped_non_bn = (
+        "        out = _align_tensor_to_target_shape(torch.add(source_cf, "
+        "torch.reshape(self.scale, [1, 8, 1, 1])), [1, 5, 7, 8])"
+    )
+    assert _repair_aligned_bn_constant_layout(
+        reshaped_non_bn,
+        {"source_cf"},
+        _build_fast_precanonicalize_repair_context([reshaped_non_bn]),
+    ) == (None, None)
 
 
 def test_nhwc_pool_layout_uses_consumer_and_immediate_bridge_evidence() -> None:

--- a/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
+++ b/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
@@ -700,12 +700,14 @@ def test_nhwc_average_pool_binary_bridge_normalizes_the_whole_chain() -> None:
         "        concat_out = _apply_concat([mul_out, peer], axis=3, target_shape=[1, 4, 1, 16], fused='NONE')",
     ]
     context = _build_fast_precanonicalize_repair_context(lines)
+    cf_names = {"pool_out_nhwc", "lhs", "rhs", "mul_out"}
+    nhwc_names = {"input_nhwc"}
 
     changed, updated_names = _repair_nhwc_average_pool_binary_bridge(
         0,
         lines,
-        set(),
-        {"input_nhwc"},
+        cf_names,
+        nhwc_names,
         context,
     )
 
@@ -715,6 +717,35 @@ def test_nhwc_average_pool_binary_bridge_normalizes_the_whole_chain() -> None:
     assert "channel_last=True" in lines[0]
     assert "scale.permute(0, 2, 3, 1).contiguous()" in lines[1]
     assert "target_shape(torch.mul(lhs, rhs), [1, 4, 1, 8])" in lines[2]
+    assert updated_names <= nhwc_names
+    assert updated_names.isdisjoint(cf_names)
+    assert all(
+        context.static_shapes[name] == [1, 8, 4, 1]
+        for name in updated_names
+    )
+
+    no_op_lines = [
+        "        pool_out_nhwc = _apply_pool2d("
+        "input_nhwc, filter_height=2, filter_width=2, stride_h=2, "
+        "stride_w=2, padding='VALID', target_shape=[1, 8, 4, 1], "
+        "is_max_pool=True, channel_last=False)",
+        "        return pool_out_nhwc",
+        "        unused = pool_out_nhwc",
+    ]
+    no_op_context = _build_fast_precanonicalize_repair_context(no_op_lines)
+    no_op_context.static_shapes["sentinel"] = [1, 2, 3, 4]
+    no_op_cf_names = {"sentinel"}
+    no_op_nhwc_names = {"input_nhwc"}
+    assert _repair_nhwc_average_pool_binary_bridge(
+        0,
+        no_op_lines,
+        no_op_cf_names,
+        no_op_nhwc_names,
+        no_op_context,
+    ) == (False, set())
+    assert no_op_cf_names == {"sentinel"}
+    assert no_op_nhwc_names == {"input_nhwc"}
+    assert no_op_context.static_shapes["sentinel"] == [1, 2, 3, 4]
 
 
 def test_binary_alignment_repair_normalizes_channel_first_target() -> None:

--- a/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
+++ b/tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py
@@ -14,6 +14,7 @@ from onnx2tf.tflite_builder.pytorch_fast_precanonicalize_policy import (
     _has_immediate_rank4_permute_source,
     _infer_unique_channel_count_from_rank4_shape,
     _repair_binary_alignment_layout,
+    _repair_binary_alignment_from_downstream_evidence,
     _repair_aligned_scalar_binary_shape_at,
     _repair_cf_pool_target_shape,
     _repair_cf_pool_neighbor_layout_at,
@@ -380,6 +381,95 @@ def test_aligned_scalar_binary_shape_uses_neighbor_consensus() -> None:
         "        scaled = _align_tensor_to_target_shape("
         "torch.mul(base, 2.0), [1, 2, 3, 4])"
     )
+
+
+def test_binary_alignment_uses_only_exact_downstream_cf_evidence() -> None:
+    positive_cases = [
+        (
+            [
+                "        fused = _align_tensor_to_target_shape("
+                "torch.add(left_in, right_in), [1, 5, 7, 16])",
+                "        normalized = _align_tensor_to_target_shape("
+                "torch.mul(fused, self.scale), [1, 5, 7, 16])",
+                "        return normalized",
+            ],
+            "        fused = _align_tensor_to_target_shape("
+            "torch.add(left_in, right_in), [1, 16, 5, 7])",
+        ),
+        (
+            [
+                "        fused = _align_tensor_to_target_shape("
+                "torch.maximum(left_in, right_in), [1, 5, 7, 16])",
+                "        return fused",
+            ],
+            "        fused = _align_tensor_to_target_shape("
+            "torch.maximum(left_in, right_in), [1, 16, 5, 7])",
+        ),
+        (
+            [
+                "        fused = _align_tensor_to_target_shape("
+                "torch.sub(left_in, right_in), [1, 5, 7, 16])",
+                "        resized = _apply_resize("
+                "fused, [10, 14], method='nearest', "
+                "target_shape=[1, 5, 7, 16], align_corners=False, "
+                "half_pixel_centers=False, channel_last=False)",
+                "        return resized",
+            ],
+            "        fused = _align_tensor_to_target_shape("
+            "torch.sub(left_in, right_in), [1, 16, 5, 7])",
+        ),
+    ]
+    for lines, expected in positive_cases:
+        context = _build_fast_precanonicalize_repair_context(lines)
+        rewritten, lhs_name = _repair_binary_alignment_from_downstream_evidence(
+            lines[0],
+            0,
+            lines,
+            set(),
+            set(),
+            context,
+        )
+        assert rewritten == expected
+        assert lhs_name == "fused"
+
+    negative_cases = [
+        [
+            "        fused = _align_tensor_to_target_shape("
+            "torch.add(left_in, right_in), [1, 5, 7, 16])",
+            "        normalized = _align_tensor_to_target_shape("
+            "torch.mul(fused, self.scale), [1, 5, 7, 8])",
+            "        return normalized",
+        ],
+        [
+            "        fused = _align_tensor_to_target_shape("
+            "torch.sub(left_in, right_in), [1, 5, 7, 16])",
+            "        resized = _apply_resize("
+            "fused, [10, 14], method='nearest', "
+            "target_shape=[1, 5, 7, 16], align_corners=False, "
+            "half_pixel_centers=False, channel_last=True)",
+            "        return resized",
+        ],
+        [
+            "        fused = _align_tensor_to_target_shape("
+            "torch.add(left_in, right_nhwc), [1, 5, 7, 16])",
+            "        return fused",
+        ],
+        [
+            "        fused = _align_tensor_to_target_shape("
+            "torch.add(left_in, right_in), [1, 1, 5, 7])",
+            "        return fused",
+        ],
+    ]
+    for lines in negative_cases:
+        context = _build_fast_precanonicalize_repair_context(lines)
+        assert _repair_binary_alignment_from_downstream_evidence(
+            lines[0],
+            0,
+            lines,
+            set(),
+            set(),
+            context,
+        ) == (None, None)
 
 
 def test_immediate_rank4_permute_source_requires_exact_permutation() -> None:


### PR DESCRIPTION
## Summary

This pull request continues the staged refactoring of the TensorFlow-free `flatbuffer_direct` pipeline. It makes three related areas smaller and safer without changing the public CLI/Python API or the existing conversion order:

1. generated PyTorch-source repair policy is extracted from the large exporter orchestrator into focused, Torch-free policy functions;
2. normalized conversion requests, requested-artifact controls, Session-owned graph state, and lowering mutation APIs become explicit internal boundaries;
3. adjacent registered ModelIR passes reuse one lazily constructed differential graph index when no untracked mutation occurs between them.

The branch contains 13 coherent commits and changes 22 files (`+2,062 / -555`). The work is intentionally incremental: existing rule order, match grammar, defaults, output names, return structures, diagnostics, exception behavior, and artifact semantics are preserved. No dependency was added, and normal direct TFLite conversion remains free of TensorFlow imports.

## Why this change is needed

The direct conversion pipeline has accumulated many interacting rules, repeated option parsing, and repeated graph-state construction. That creates three practical risks:

- a local rule change can accidentally alter later rule eligibility because ordering and state mutation are implicit;
- optional exporters can influence unrelated conversions by parsing settings even when their artifacts were not requested;
- graph producer/consumer/layout state can become stale or be rebuilt repeatedly during lowering and post-lowering passes.

This pull request reduces those risks through narrow ownership boundaries and characterization tests. It does not attempt a single large rewrite of the full converter.

## Detailed changes

### 1. Extracted ordered PyTorch fast-precanonicalization policy

Six behavior-sensitive rule families were moved from `pytorch_exporter.py` into `pytorch_fast_precanonicalize_policy.py`:

- downstream-evidence repair for aligned binary shapes;
- Resize repair using input layout and direct or reshaped BatchNorm evidence;
- aligned BatchNorm constant normalization;
- Local Response Normalization layout and static-shape propagation;
- common recording of literal rewritten static shapes;
- NHWC AveragePool bridge state updates.

The exporter still owns orchestration and preserves the original scan order. The new policy owner contains the match, guard, rewrite, and state-update decisions for each family. This keeps the remaining exporter code readable while preventing policy logic and generated-source parsers from being duplicated.

Important preserved behaviors include:

- general binary and Resize repair still run before their narrower evidence-based fallbacks;
- former loop `continue` behavior is represented by an explicit short-circuit result;
- only the same narrow generated-statement grammar is accepted;
- direct BatchNorm constants still require registered matching channel evidence;
- already-reshaped BatchNorm constants retain their distinct, narrower legacy guard;
- LRN propagation remains state-only and does not mark source text as changed;
- dynamic or unparseable shapes do not replace known static-shape state;
- NHWC AveragePool bridge layout and shape updates remain at the same point in the ordered scan.

The audited fast-precanonicalization orchestrator is now 294 lines, down from 482 lines at the start of this continuation.

### 2. Enforced one normalized request boundary

`ConversionRequest.from_kwargs` is now the only raw-`kwargs` boundary in the direct exporter. All downstream reads use the immutable normalized request mapping or the typed `ArtifactPlan`.

This mechanically replaced 36 raw option reads while retaining:

- all existing option names and default values;
- current coercion and validation behavior;
- current downstream arguments and return values;
- existing public API and exception behavior.

An AST-based architecture test prevents raw `kwargs` access from being reintroduced below this boundary.

### 3. Avoided preparation of unrequested artifacts

`artifact_preparation.py` now resolves exporter-specific controls only for requested artifacts. It owns the settings for:

- SavedModel and PyTorch output paths;
- PyTorch model persistence;
- native-code-generation timeout;
- input-shape and test-data settings;
- custom calibration input data;
- quantization type;
- input and output quantization dtypes.

A TFLite-only request therefore does not parse unused SavedModel, PyTorch, or calibration settings. For example, an invalid unused PyTorch timeout can no longer fail an unrelated TFLite-only conversion. Requested artifacts keep the existing paths, defaults, optional dependencies, and behavior. Resolved control mappings are immutable.

### 4. Restored Session-owned consumer counts

The `ConversionSession` migration had eliminated a duplicate ONNX scan, but `LoweringContext` was still receiving an empty compatibility consumer-count dictionary. The lowering boundary now receives `ConversionSession.tensor_consumer_count`, backed by the authoritative `GraphIndex`.

This restores the fan-out safety contract used by inverse-Transpose elision, including repeated occurrences of the same input tensor, without rebuilding another whole-graph consumer map.

### 5. Synchronized lowering-time layout mutations

`LoweringContext.set_tensor_layout()` is now the single lowering-time mutation boundary for logical and physical layout. It updates both `TensorIR` metadata and the Session-owned `LayoutState` immediately.

Shape-family edge-Pad passthroughs, integer-linear Resize casts, and rank-three Resize adapters no longer assign layout fields directly. This fixes observed stale layout state before the first post-lowering pass without adding an eager full-ModelIR synchronization scan.

An architecture test rejects future direct logical/physical layout assignment from op builders.

### 6. Protected synthetic inverse-Transpose fan-out

`LoweringContext.add_operator()` and `remove_operator()` now maintain differential producer and consumer counts for the partial ModelIR. Operator removal is centralized at this boundary.

Inverse-Transpose elision now distinguishes:

- an ONNX edge, whose authoritative count comes from the Session graph index; and
- a synthetic edge, whose count comes from the current partial ModelIR plus the pending inverse use.

An exclusive inverse pair is still removed. If an already-emitted synthetic side consumer needs the producer, the producer is retained. This fixes stale producer-index and dead-edge risks without scanning the partial graph after every emitted operator.

An architecture test prevents op builders from directly mutating `model_ir.operators`.

### 7. Reused pass state across an adjacent registered-pass cluster

A lazy, identity-bound `ModelIRPassStateScope` now allows adjacent registered pass groups to share one differentially maintained `ModelIRGraphIndex` and `LayoutState`.

The first production use covers six repeated lowering clusters while preserving the exact existing runner order:

1. transpose/Mean cleanup;
2. Mean/Mul/Add/Conv attention cleanup;
3. optional LayerNorm cleanup;
4. terminal Mean cleanup;
5. squeeze-and-excitation convolution cleanup;
6. squeeze-and-excitation fully connected cleanup;
7. optional convolution-attention cleanup.

The scope is deliberately bounded: it ends before every legacy helper that mutates ModelIR outside the differential index. It is also lazy, so if every model-only preflight misses, no graph index is constructed. Depending on enabled optional passes, a cluster that previously constructed up to seven identical indexes now constructs at most one.

Diagnostics retain their existing meaning: only the group that actually constructs state reports `state_built: true`; later groups reusing it report `false`, so aggregate build counts remain accurate.

## Compatibility and dependency boundaries

This pull request intentionally preserves:

- existing CLI and Python API signatures;
- default backend and option defaults;
- artifact names, paths, return structures, and report formats;
- generated-source rule order and matching eligibility;
- quantization defaults and requested-artifact semantics;
- optional TensorFlow and PyTorch behavior when explicitly requested;
- TensorFlow-free normal `flatbuffer_direct` TFLite conversion.

No package, optional extra, or generated schema was added.

## Validation

All recorded validation used `uv`, a single pytest process, and single-process inference where artifact execution was involved. Host `PYTHONPATH` and `LD_LIBRARY_PATH` were removed for the focused environment where required.

### Policy extraction and architecture ownership

```text
env -u PYTHONPATH -u LD_LIBRARY_PATH \
  OMP_NUM_THREADS=1 MKL_NUM_THREADS=1 \
  uv run pytest -q \
  tests/test_flatbuffer_direct_pytorch_fast_precanonicalize_policy.py \
  tests/test_flatbuffer_direct_architecture.py

124 passed
```

This selection covers positive rewrites and no-op guards for downstream evidence, direct and reshaped BatchNorm constants, Resize layout evidence, LRN propagation, literal static-shape recording, NHWC Pool bridges, channel mismatches, mixed layouts, dynamic shapes, and short-circuit behavior.

### Normalized request boundary

```text
uv run pytest -q \
  tests/test_flatbuffer_direct_core.py \
  tests/test_flatbuffer_direct_architecture.py

126 passed
```

The AST gate proves that the exporter has zero `kwargs.get` calls and exactly one raw `kwargs` read: the argument to `ConversionRequest.from_kwargs`.

### Requested-artifact preparation

```text
uv run pytest -q \
  tests/test_flatbuffer_direct_artifact_preparation.py \
  tests/test_flatbuffer_direct_core.py \
  tests/test_flatbuffer_direct_architecture.py

145 passed
```

A raising mapping proves that unrequested exporter and quantization settings are not accessed. Requested values, legacy defaults, calibration-only inputs, timeout coercion, and immutable mappings are covered.

### Session consumer-count handoff

```text
uv run pytest -q \
  tests/test_flatbuffer_direct_core.py \
  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_transpose_quantize_transpose_optimization \
  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_transpose_quantize_transpose_fanout_optimization \
  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_transpose_quantize_transpose_preserves_dynamic_batch_signature

32 passed
```

The Session fixture verifies exact consumer counts for a tensor reused by Add and Identity.

### Lowering-time layout synchronization

```text
uv run pytest -q \
  tests/test_flatbuffer_direct_core.py \
  tests/test_pad_edge_lowering.py \
  tests/test_flatbuffer_direct_resize_integer_linear.py \
  tests/test_flatbuffer_direct_architecture.py::test_op_builders_mutate_layout_only_through_lowering_context

33 passed
```

The rank-three Resize hook inspects `LayoutState` before the first post-lowering pass. Focused edge-Pad and integer-linear Resize tests also serialize and execute their TFLite artifacts sequentially.

### Synthetic fan-out protection

```text
uv run pytest -q \
  tests/test_flatbuffer_direct_core.py \
  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_elides_inverse_transpose_chain_at_generation \
  tests/test_tflite_builder_direct.py::test_flatbuffer_direct_no_dead_operator_outputs_after_prune \
  tests/test_flatbuffer_direct_architecture.py::test_op_builders_mutate_operator_list_only_through_lowering_context

35 passed
```

Focused context cases prove both sides of the contract: an exclusive inverse pair is removed with its differential index entries, while a synthetic bridge consumed by another operator retains its producer.

### Adjacent pass-state reuse

```text
uv run pytest -q \
  tests/test_flatbuffer_direct_mean_layout.py \
  tests/test_flatbuffer_direct_layernorm_layout.py \
  tests/test_flatbuffer_direct_terminal_mean_layout.py \
  tests/test_flatbuffer_direct_se_layout.py \
  tests/test_flatbuffer_direct_core.py \
  tests/test_flatbuffer_direct_pass_efficiency.py \
  tests/test_flatbuffer_direct_architecture.py::test_lowerer_mean_attention_cluster_reuses_one_pass_state_scope

65 passed
```

The reuse characterization observes one `ModelIRGraphIndex.refresh()` across two matching adjacent runners and diagnostic construction flags `[true, false]`. The all-preflight-miss case observes zero refreshes and `[false, false]`. The architecture gate fixes runner order, the shared scope keyword, and all six production invocations.

Changed modules pass Python syntax compilation. Scoped Ruff checks pass for the modified owners and tests, with documented ignores only for pre-existing findings in legacy files. `git diff --check` passes.

## Known limitations and remaining work

- No Tier corpus or broad real-model conversion run was performed for these mechanical checkpoints, following the current instruction to keep conversion tests minimal. Broad model-level regression safety is therefore not claimed here.
- The optional TensorFlow suite was not synchronized or run.
- Whole-file Ruff on `pytorch_exporter.py` still reports pre-existing compatibility re-export, unused scaffold, and undefined-name findings. The changed policy owners and focused tests pass their scoped checks, and the exporter passes syntax compilation.
- The larger Goal remains incomplete: additional contiguous registered-pass clusters can reuse state only after proving that their scope contains no raw ModelIR mutation; artifact-matrix coverage and broader Tier performance/accuracy gates remain future work.

## Suggested review order

1. Review `pytorch_fast_precanonicalize_policy.py` together with its focused characterization tests, then confirm the unchanged call order in `pytorch_exporter.py`.
2. Review `ConversionRequest` usage and `artifact_preparation.py` to verify the requested-only option boundary.
3. Review the `ConversionSession` consumer-count handoff and `LoweringContext` layout/operator mutation APIs.
4. Review the inverse-Transpose synthetic fan-out regression tests.
5. Review `ModelIRPassStateScope`, the bounded Mean/attention cluster, and the index-construction characterization.
6. Review `docs/flatbuffer_direct_architecture.md` and the continuation handoff for preserved contracts and declared limitations.

## Commits

- `3ac19b40` Extract downstream binary layout repair
- `008e4ad0` Extract Resize BN evidence repair
- `80d1d6a5` Extract aligned BatchNorm constant repair
- `91a0a52d` Extract local response norm layout propagation
- `b00774a7` Centralize rewritten static shape recording
- `95fbd0cb` Co-locate NHWC bridge state updates
- `907c91fa` Enforce direct conversion request boundary
- `5848cc28` Guard optional exporter settings by request
- `e3c03e3d` Guard quantization type options by request
- `4f3d20b0` Restore session consumer counts in lowering
- `6e8a8486` Synchronize lowering layout state mutations
- `e7c1457d` Protect synthetic transpose fanout during lowering
- `2a2968cc` Reuse pass state across mean attention cluster
