### PR TITLE
Optimize flatbuffer_direct pass diagnostics and SINet reconciliation

### DIFF
--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -9660,3 +9660,13 @@ Session path performs no rebuild across repeated groups, while the destructive-
 mutation fixture performs exactly one. The internal type is not re-exported by
 the public core package, and diagnostics remain the same mutable list contract
 for existing consumers.
+
+The next graph-scan boundary is the absolute-final SINet cleanup. Six bounded,
+transactional SINet owners execute in a fixed terminal order, each followed by
+an unconditional static-shape reconciliation. Every owner already returns one
+complete mutation counter and has positive, no-op, rejection, and idempotence
+fixtures. A strict expected-failure architecture contract now maps each owner
+to its exact counter and requires its following reconciliation to be guarded by
+that counter. This preserves all six pass calls and their order while allowing
+the common zero-owner path to avoid six full operator/tensor reconciliation
+scans. Production remains unchanged at this characterization checkpoint.

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -9615,3 +9615,18 @@ context or an explicit callback composition around it; no orchestration
 dataclass independently repeats ModelIR, LayoutState, or diagnostics. QLinear's
 five argument contracts and SINet's three invocation/callback contracts remain
 unchanged.
+
+The next non-context efficiency boundary is ModelIR pass diagnostic numbering.
+`run_model_ir_pass_group()` currently scans the complete diagnostic history to
+select the next group number, then scans the growing history again for every
+pass result to calculate global `sequence` and per-pass `invocation` values.
+This preserves correct numbering but makes bookkeeping quadratic in the number
+of recorded pass events. The frozen contract ignores non-`model_ir_pass`
+events, assigns the next group after the maximum existing `group_sequence`,
+numbers new events after the existing ModelIR-pass event count, and advances
+each pass ID independently. A strict expected-failure efficiency fixture proves
+that the current implementation performs four history iterations for a
+three-result group where one initialization scan is sufficient. The next
+bounded implementation step may cache those three counters from one initial
+scan, but must preserve the exact event schema, append order, caller-owned list,
+failure diagnostics, and summary output.

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -9670,3 +9670,12 @@ to its exact counter and requires its following reconciliation to be guarded by
 that counter. This preserves all six pass calls and their order while allowing
 the common zero-owner path to avoid six full operator/tensor reconciliation
 scans. Production remains unchanged at this characterization checkpoint.
+
+The six absolute-final SINet reconciliations are now guarded by their exact
+owner counters. Every owner still runs once in the same terminal position with
+the same LayoutState; only a zero result skips the immediately following
+static-shape reconciliation. A synthetic lowerer contract proves that enabling
+any one counter adds exactly one reconciliation relative to the all-zero path,
+and the complete owner suites retain their positive/no-op/idempotence behavior.
+The common non-SINet path therefore avoids six full reconciliation scans without
+changing any rewrite or cross-owner ordering.

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -9638,3 +9638,14 @@ local counters as new events are appended. The caller-owned diagnostic list,
 non-pass records, event schema, append order, group semantics, failure path,
 and summary remain unchanged. The strict scan-count fixture is green, reducing
 one group with `P` results from `P + 1` full history iterations to one.
+
+Cross-group numbering is the adjacent characterized boundary. The ordinary
+list-compatible API must retain its one-scan fallback because callers may
+mutate an arbitrary list between invocations. The production
+`ConversionSession`, however, owns the same append-only diagnostics object for
+the complete conversion. A strict expected-failure contract now requires that
+Session-owned diagnostics retain numbering state across groups, lazily rebuild
+that state once after an arbitrary list mutation, and keep subsequent group
+numbering at constant bookkeeping cost. It also freezes list compatibility and
+the same sequence, invocation, and group values across two repeated pass
+groups. Production remains unchanged at this characterization checkpoint.

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -9649,3 +9649,14 @@ that state once after an arbitrary list mutation, and keep subsequent group
 numbering at constant bookkeeping cost. It also freezes list compatibility and
 the same sequence, invocation, and group values across two repeated pass
 groups. Production remains unchanged at this characterization checkpoint.
+
+The Session-owned cross-group ledger is now implemented as a private
+list-compatible core type. Append, extend, and insert update a valid numbering
+snapshot incrementally; replacement, deletion, multiplication, pop, and remove
+invalidate it; clear restores an empty valid snapshot. The next pass group
+rebuilds invalid state once and subsequent groups reuse it. Ordinary external
+lists continue through the prior one-scan fallback. The production append-only
+Session path performs no rebuild across repeated groups, while the destructive-
+mutation fixture performs exactly one. The internal type is not re-exported by
+the public core package, and diagnostics remain the same mutable list contract
+for existing consumers.

--- a/docs/flatbuffer_direct_architecture.md
+++ b/docs/flatbuffer_direct_architecture.md
@@ -9630,3 +9630,11 @@ three-result group where one initialization scan is sufficient. The next
 bounded implementation step may cache those three counters from one initial
 scan, but must preserve the exact event schema, append order, caller-owned list,
 failure diagnostics, and summary output.
+
+The diagnostic-numbering boundary now performs exactly that one initialization
+scan. It derives the existing ModelIR-pass event count, the maximum existing
+group sequence, and per-pass invocation counts together, then advances the
+local counters as new events are appended. The caller-owned diagnostic list,
+non-pass records, event schema, append order, group semantics, failure path,
+and summary remain unchanged. The strict scan-count fixture is green, reducing
+one group with `P` results from `P + 1` full history iterations to one.

--- a/docs/flatbuffer_direct_handoff_fb_refactor7.md
+++ b/docs/flatbuffer_direct_handoff_fb_refactor7.md
@@ -172,3 +172,38 @@ or generalize any SINet pass, and do not alter LayoutState handling.
 Characterization validation is `514 passed` across the six complete owner
 suites, plus one strict architecture xfail for the currently unconditional
 reconciliations. Focused Ruff and whitespace checks pass.
+
+## Absolute-final SINet reconciliation implementation checkpoint
+
+All six owners remain in their original terminal order and execute with the
+same main ModelIR and Session LayoutState. Each return value is now assigned,
+and only a positive value under its established mutation counter triggers the
+existing immediately following `_reconcile_static_tensor_shapes()` call. No
+owner was merged, skipped, generalized, or moved.
+
+The architecture xfail is green. A synthetic Add lowerer fixture replaces the
+six owners with controlled counters: the all-zero case establishes the base
+reconciliation count, and each of the six one-changed cases adds exactly one
+call. The fixture confirms both zero-owner scan elimination and positive-owner
+maintenance wiring without requiring real-model inference.
+
+Sequential validation completed as follows:
+
+- six complete SINet owner suites, core, pass efficiency, architecture, and
+  TensorFlow-import-blocked optional boundary: `844 passed in 29.04s`;
+- focused runtime counter wiring: passed for the all-zero baseline and all six
+  individual changed counters;
+- focused Ruff, Python compilation, and whitespace checks: passed, excluding
+  only the lowerer's two pre-existing F401 findings.
+
+No public API, CLI behavior, artifact, dependency, pass call/order, LayoutState,
+GraphIndex, corpus exclusion, operation-count tier, inference concurrency, or
+TensorFlow boundary changed. No real-model conversion ran because the 514
+positive/no-op owner fixtures plus lowerer wiring test cover this maintenance-
+scan-only change.
+
+At resume, inventory the other unconditional static-shape reconciliations near
+this terminal block. Do not assume their runners expose complete mutation
+counters: characterize each return contract and positive/no-op coverage before
+guarding another scan. Commit and push only; do not create or update a pull
+request.

--- a/docs/flatbuffer_direct_handoff_fb_refactor7.md
+++ b/docs/flatbuffer_direct_handoff_fb_refactor7.md
@@ -86,3 +86,26 @@ inventory. Select another non-context unit only when it has an explicit
 ownership or measurable scan/allocation cost, and characterize its behavior
 before production changes. Continue with coherent commits and pushes only; do
 not create or update a pull request.
+
+## Cross-group diagnostic-ledger characterization checkpoint
+
+The first implementation removes repeated history scans inside one pass group,
+but an ordinary diagnostics list must still be scanned once at the start of
+every group. That safe fallback is required for arbitrary caller-owned lists,
+which may have changed between calls. Production is different:
+`ConversionSession` owns one diagnostics object for the complete conversion and
+only appends through the pass runner or `record_diagnostic()`.
+
+A new strict expected-failure contract requires the Session-owned object to
+retain its ModelIR-pass event count, maximum group, and per-pass invocation
+counts across group calls. The fixture deliberately performs slice assignment
+first, proving that arbitrary list mutation invalidates the ledger and causes
+exactly one lazy rebuild. Two subsequent groups must reuse the rebuilt state
+while preserving sequences `2, 3`, invocations `2, 3`, and groups `5, 6`.
+
+No production source changed. At implementation, introduce a private
+list-compatible diagnostic ledger owned only by `ConversionSession`. Normal
+append/extend/insert operations may update valid counters incrementally;
+replacement or removal operations must invalidate them. Arbitrary external
+lists passed to `run_model_ir_pass_group()` must retain the existing one-scan
+fallback. Do not expose the internal type through the public core API.

--- a/docs/flatbuffer_direct_handoff_fb_refactor7.md
+++ b/docs/flatbuffer_direct_handoff_fb_refactor7.md
@@ -109,3 +109,38 @@ append/extend/insert operations may update valid counters incrementally;
 replacement or removal operations must invalidate them. Arbitrary external
 lists passed to `run_model_ir_pass_group()` must retain the existing one-scan
 fallback. Do not expose the internal type through the public core API.
+
+## Cross-group diagnostic-ledger implementation checkpoint
+
+`ConversionSession.diagnostics` now defaults to the private list-compatible
+`ModelIRPassDiagnostics` type. It maintains the ModelIR-pass event count,
+maximum group sequence, and pass-ID invocation counts incrementally for append-
+only production use. `run_model_ir_pass_group()` reads a copied numbering
+snapshot from this ledger in constant time; arbitrary external lists continue
+to use the characterized one-scan fallback.
+
+List compatibility is explicit. Append, extend, and insert update valid state.
+Slice/item replacement, deletion, multiplication, pop, and remove invalidate
+state without changing the list operation; the next group lazily rebuilds it
+once. Clear resets an empty valid ledger. Malformed externally appended entries
+invalidate rather than raising early, preserving error timing until the next
+numbering read. The type is deliberately absent from `core.__all__`.
+
+Sequential validation completed as follows:
+
+- focused diagnostic/pass-group contracts, including zero rebuilds for the
+  ordinary Session append path and one rebuild after slice replacement: pass;
+- complete core, pass-efficiency, architecture, and TensorFlow-import-blocked
+  gate: `328 passed in 26.75s`;
+- focused Ruff, Python compilation, and whitespace checks: passed.
+
+No model conversion ran because pass execution and ModelIR are unaffected. No
+public API, CLI behavior, artifact, dependency, pass ID/order, GraphIndex,
+LayoutState, corpus policy, inference concurrency, or TensorFlow boundary
+changed.
+
+At resume, move beyond diagnostic bookkeeping and inventory the remaining
+direct lowerer-to-pass/core boundaries again. Select a non-context unit with a
+measurable graph scan, state allocation, or duplicated ownership contract;
+characterize it before changing production. Commit and push coherent units
+only, and do not create or update a pull request.

--- a/docs/flatbuffer_direct_handoff_fb_refactor7.md
+++ b/docs/flatbuffer_direct_handoff_fb_refactor7.md
@@ -52,3 +52,37 @@ strict xfail only after the efficiency fixture passes, then run the complete
 core, pass-efficiency, architecture, and TensorFlow-import-blocked gates. Keep
 real-model conversion minimal because this unit cannot affect ModelIR or
 artifacts. Commit and push only; do not create or update a pull request.
+
+## Diagnostic-numbering implementation checkpoint
+
+`run_model_ir_pass_group()` now scans an existing diagnostics list exactly
+once. That scan initializes the total ModelIR-pass event count, maximum group
+sequence, and a per-pass invocation-count map. `_record_event()` increments
+those local counters while appending, rather than iterating over the complete
+and growing history again for every pass result.
+
+The implementation preserves the characterized behavior for unrelated
+diagnostics, missing or negative legacy group values, repeated pass IDs,
+multiple results in one group, skipped passes, cycles, and invariant failures.
+It does not change pass execution, ModelIR, LayoutState, GraphIndex, result
+details, diagnostic fields, summary schema, or the identity of the caller's
+list.
+
+Sequential validation completed as follows:
+
+- focused numbering and pass-group contracts: `7 passed`;
+- complete core, pass-efficiency, architecture, and TensorFlow-import-blocked
+  gate: `324 passed in 27.74s`;
+- the scan-count fixture changed from one strict xfail to pass and observes one
+  history iteration for a three-result group;
+- focused Ruff, Python compilation, and whitespace checks: passed.
+
+No real-model conversion was run because this unit cannot change ModelIR or an
+artifact. No public API, CLI behavior, dependency, pass order, corpus policy,
+inference concurrency, or TensorFlow boundary changed.
+
+At resume, return to the remaining direct lowerer-to-pass and core contract
+inventory. Select another non-context unit only when it has an explicit
+ownership or measurable scan/allocation cost, and characterize its behavior
+before production changes. Continue with coherent commits and pushes only; do
+not create or update a pull request.

--- a/docs/flatbuffer_direct_handoff_fb_refactor7.md
+++ b/docs/flatbuffer_direct_handoff_fb_refactor7.md
@@ -144,3 +144,31 @@ direct lowerer-to-pass/core boundaries again. Select a non-context unit with a
 measurable graph scan, state allocation, or duplicated ownership contract;
 characterize it before changing production. Commit and push coherent units
 only, and do not create or update a pull request.
+
+## Absolute-final SINet reconciliation characterization checkpoint
+
+The next non-context graph-scan cost is the terminal sequence of six SINet
+owners:
+
+- late residual Add/Mul/Add/PReLU;
+- deep-skip pre-Add/Concat/PReLU fan-out;
+- deep-skip dual-Resize affine recovery;
+- shared-post PReLU fan-out;
+- deep-skip Concat/Resize affine tail;
+- final Concat/Resize affine bridge.
+
+Each owner is already bounded and transactional, returns one exact rewrite
+counter, and has positive/no-op/idempotence coverage. The lowerer nevertheless
+runs `_reconcile_static_tensor_shapes()` unconditionally after every owner.
+Thus the zero-owner path performs six unnecessary full reconciliation scans.
+
+A strict expected-failure architecture fixture freezes the exact owner order,
+counter key, immediate guard, and single reconciliation body for all six
+owners. Production is unchanged in this checkpoint. At implementation, assign
+each existing result and run its existing immediate reconciliation only when
+the corresponding counter is greater than zero. Do not merge, reorder, skip,
+or generalize any SINet pass, and do not alter LayoutState handling.
+
+Characterization validation is `514 passed` across the six complete owner
+suites, plus one strict architecture xfail for the currently unconditional
+reconciliations. Focused Ruff and whitespace checks pass.

--- a/docs/flatbuffer_direct_handoff_fb_refactor7.md
+++ b/docs/flatbuffer_direct_handoff_fb_refactor7.md
@@ -1,0 +1,54 @@
+# `fb-refactor7` handoff
+
+## Current state
+
+- Branch: `fb-refactor7`.
+- Starting checkpoint: `d3369d9a`, the merge of the completed
+  `fb-refactor6` work into `main`.
+- Pull requests are outside the continuation workflow. Continue with coherent
+  commits and pushes to `origin/fb-refactor7` only.
+- Inference remains strictly sequential. No model-inference ProcessPool or
+  parallel worker is permitted.
+
+## Diagnostic-numbering characterization checkpoint
+
+The first `fb-refactor7` unit inventories a non-context core efficiency issue
+without changing production code. `run_model_ir_pass_group()` calculates the
+next diagnostic group with one full history scan, but `_record_event()` then
+rescans the complete and growing history for every result to derive global
+`sequence` and per-pass `invocation`. A group with `P` results therefore uses
+`P + 1` diagnostic-list iterations and accumulates quadratic bookkeeping cost
+across a conversion with many pass events.
+
+The new semantic fixture freezes all externally visible numbering rules:
+
+- non-`model_ir_pass` records are preserved and excluded from numbering;
+- the next `group_sequence` is one greater than the maximum existing group;
+- `sequence` counts all existing ModelIR-pass records, independent of stored
+  legacy sequence values;
+- `invocation` counts only records with the same pass ID;
+- every event produced by one group receives the same group number.
+
+A strict expected-failure efficiency fixture supplies a list subclass that
+counts history iterations. The current implementation performs four scans for
+one three-result group; the required implementation performs exactly one. The
+focused characterization result is `2 passed, 1 xfailed`.
+
+No production source, public API, artifact, pass order, graph index, layout,
+diagnostic schema, dependency, TensorFlow boundary, corpus policy, or model
+conversion changed in this checkpoint.
+
+## Next action
+
+In `run_model_ir_pass_group()`, scan existing diagnostics once to initialize:
+
+1. the existing ModelIR-pass event count;
+2. the maximum group sequence;
+3. per-pass invocation counts.
+
+Update those counters locally as events are appended. Preserve exact behavior
+for ordinary, skipped, cycle-stopped, and invariant-failure events. Remove the
+strict xfail only after the efficiency fixture passes, then run the complete
+core, pass-efficiency, architecture, and TensorFlow-import-blocked gates. Keep
+real-model conversion minimal because this unit cannot affect ModelIR or
+artifacts. Commit and push only; do not create or update a pull request.

--- a/onnx2tf/tflite_builder/core/model_ir_pass_state.py
+++ b/onnx2tf/tflite_builder/core/model_ir_pass_state.py
@@ -396,16 +396,27 @@ def run_model_ir_pass_group(
 
     preflight_operators_visited = 0
     state_built = False
-    group_sequence = 1
+    diagnostic_sequence = 0
+    diagnostic_invocations: Dict[str, int] = {}
+    maximum_group_sequence: Optional[int] = None
     if diagnostics is not None:
-        group_sequence += max(
-            (
-                int(event.get("group_sequence", 0))
-                for event in diagnostics
-                if str(event.get("stage", "")) == "model_ir_pass"
-            ),
-            default=0,
-        )
+        for event in diagnostics:
+            if str(event.get("stage", "")) != "model_ir_pass":
+                continue
+            diagnostic_sequence += 1
+            code = str(event.get("code", ""))
+            diagnostic_invocations[code] = int(
+                diagnostic_invocations.get(code, 0) + 1
+            )
+            event_group_sequence = int(event.get("group_sequence", 0))
+            if (
+                maximum_group_sequence is None
+                or event_group_sequence > maximum_group_sequence
+            ):
+                maximum_group_sequence = event_group_sequence
+    group_sequence = int(
+        1 + (maximum_group_sequence if maximum_group_sequence is not None else 0)
+    )
 
     def _record_event(
         event: Dict[str, Any],
@@ -413,21 +424,17 @@ def run_model_ir_pass_group(
         snapshot_count: int = 0,
         fingerprint_count: int = 0,
     ) -> None:
+        nonlocal diagnostic_sequence
         if diagnostics is None:
             return
         code = str(event.get("code", ""))
-        sequence = 1
-        invocation = 1
-        for existing in diagnostics:
-            if str(existing.get("stage", "")) != "model_ir_pass":
-                continue
-            sequence += 1
-            if str(existing.get("code", "")) == code:
-                invocation += 1
+        diagnostic_sequence += 1
+        invocation = int(diagnostic_invocations.get(code, 0) + 1)
+        diagnostic_invocations[code] = invocation
         diagnostics.append(
             {
                 **event,
-                "sequence": sequence,
+                "sequence": diagnostic_sequence,
                 "invocation": invocation,
                 "group_sequence": group_sequence,
                 "metrics": {

--- a/onnx2tf/tflite_builder/core/model_ir_pass_state.py
+++ b/onnx2tf/tflite_builder/core/model_ir_pass_state.py
@@ -11,6 +11,7 @@ import numpy as np
 
 from onnx2tf.tflite_builder.core.graph import ModelIRGraphIndex
 from onnx2tf.tflite_builder.core.layout import LayoutState
+from onnx2tf.tflite_builder.core.pass_diagnostics import ModelIRPassDiagnostics
 from onnx2tf.tflite_builder.core.passes import (
     OrderedPassManager,
     PassInvariantError,
@@ -399,7 +400,13 @@ def run_model_ir_pass_group(
     diagnostic_sequence = 0
     diagnostic_invocations: Dict[str, int] = {}
     maximum_group_sequence: Optional[int] = None
-    if diagnostics is not None:
+    if isinstance(diagnostics, ModelIRPassDiagnostics):
+        (
+            diagnostic_sequence,
+            maximum_group_sequence,
+            diagnostic_invocations,
+        ) = diagnostics.model_ir_numbering_snapshot()
+    elif diagnostics is not None:
         for event in diagnostics:
             if str(event.get("stage", "")) != "model_ir_pass":
                 continue

--- a/onnx2tf/tflite_builder/core/pass_diagnostics.py
+++ b/onnx2tf/tflite_builder/core/pass_diagnostics.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional, Union
+
+
+class ModelIRPassDiagnostics(list[Dict[str, Any]]):
+    """List-compatible diagnostics with lazily maintained pass numbering."""
+
+    def __init__(
+        self,
+        values: Iterable[Dict[str, Any]] = (),
+    ) -> None:
+        super().__init__(values)
+        self._model_ir_numbering_valid = len(self) == 0
+        self._model_ir_event_count = 0
+        self._maximum_model_ir_group_sequence: Optional[int] = None
+        self._model_ir_invocations: Dict[str, int] = {}
+
+    def _invalidate_model_ir_numbering(self) -> None:
+        self._model_ir_numbering_valid = False
+
+    def _reset_empty_model_ir_numbering(self) -> None:
+        self._model_ir_numbering_valid = True
+        self._model_ir_event_count = 0
+        self._maximum_model_ir_group_sequence = None
+        self._model_ir_invocations = {}
+
+    def _update_model_ir_numbering_for_append(
+        self,
+        event: Dict[str, Any],
+    ) -> None:
+        if not self._model_ir_numbering_valid:
+            return
+        if not isinstance(event, dict):
+            self._invalidate_model_ir_numbering()
+            return
+        try:
+            if str(event.get("stage", "")) != "model_ir_pass":
+                return
+            group_sequence = int(event.get("group_sequence", 0))
+        except (TypeError, ValueError, OverflowError):
+            self._invalidate_model_ir_numbering()
+            return
+        code = str(event.get("code", ""))
+        self._model_ir_event_count += 1
+        self._model_ir_invocations[code] = int(
+            self._model_ir_invocations.get(code, 0) + 1
+        )
+        if (
+            self._maximum_model_ir_group_sequence is None
+            or group_sequence > self._maximum_model_ir_group_sequence
+        ):
+            self._maximum_model_ir_group_sequence = group_sequence
+
+    def _rebuild_model_ir_numbering(self) -> None:
+        event_count = 0
+        maximum_group_sequence: Optional[int] = None
+        invocations: Dict[str, int] = {}
+        for event in list.__iter__(self):
+            if str(event.get("stage", "")) != "model_ir_pass":
+                continue
+            event_count += 1
+            code = str(event.get("code", ""))
+            invocations[code] = int(invocations.get(code, 0) + 1)
+            group_sequence = int(event.get("group_sequence", 0))
+            if (
+                maximum_group_sequence is None
+                or group_sequence > maximum_group_sequence
+            ):
+                maximum_group_sequence = group_sequence
+        self._model_ir_event_count = event_count
+        self._maximum_model_ir_group_sequence = maximum_group_sequence
+        self._model_ir_invocations = invocations
+        self._model_ir_numbering_valid = True
+
+    def model_ir_numbering_snapshot(
+        self,
+    ) -> tuple[int, Optional[int], Dict[str, int]]:
+        if not self._model_ir_numbering_valid:
+            self._rebuild_model_ir_numbering()
+        return (
+            int(self._model_ir_event_count),
+            self._maximum_model_ir_group_sequence,
+            dict(self._model_ir_invocations),
+        )
+
+    def append(self, event: Dict[str, Any]) -> None:
+        list.append(self, event)
+        self._update_model_ir_numbering_for_append(event)
+
+    def extend(self, values: Iterable[Dict[str, Any]]) -> None:
+        appended = list(values)
+        list.extend(self, appended)
+        for event in appended:
+            self._update_model_ir_numbering_for_append(event)
+
+    def insert(self, index: int, event: Dict[str, Any]) -> None:
+        list.insert(self, index, event)
+        self._update_model_ir_numbering_for_append(event)
+
+    def __iadd__(
+        self,
+        values: Iterable[Dict[str, Any]],
+    ) -> ModelIRPassDiagnostics:
+        self.extend(values)
+        return self
+
+    def __imul__(self, value: int) -> ModelIRPassDiagnostics:
+        list.__imul__(self, value)
+        if len(self) == 0:
+            self._reset_empty_model_ir_numbering()
+        else:
+            self._invalidate_model_ir_numbering()
+        return self
+
+    def __setitem__(
+        self,
+        index: Union[int, slice],
+        value: Union[Dict[str, Any], Iterable[Dict[str, Any]]],
+    ) -> None:
+        list.__setitem__(self, index, value)
+        if len(self) == 0:
+            self._reset_empty_model_ir_numbering()
+        else:
+            self._invalidate_model_ir_numbering()
+
+    def __delitem__(self, index: Union[int, slice]) -> None:
+        list.__delitem__(self, index)
+        if len(self) == 0:
+            self._reset_empty_model_ir_numbering()
+        else:
+            self._invalidate_model_ir_numbering()
+
+    def pop(self, index: int = -1) -> Dict[str, Any]:
+        value = list.pop(self, index)
+        if len(self) == 0:
+            self._reset_empty_model_ir_numbering()
+        else:
+            self._invalidate_model_ir_numbering()
+        return value
+
+    def remove(self, value: Dict[str, Any]) -> None:
+        list.remove(self, value)
+        if len(self) == 0:
+            self._reset_empty_model_ir_numbering()
+        else:
+            self._invalidate_model_ir_numbering()
+
+    def clear(self) -> None:
+        list.clear(self)
+        self._reset_empty_model_ir_numbering()

--- a/onnx2tf/tflite_builder/core/session.py
+++ b/onnx2tf/tflite_builder/core/session.py
@@ -8,6 +8,7 @@ import numpy as np
 from onnx2tf.tflite_builder.core.graph import GraphIndex
 from onnx2tf.tflite_builder.core.layout import LayoutState
 from onnx2tf.tflite_builder.core.model_ir_pass_context import ModelIRPassContext
+from onnx2tf.tflite_builder.core.pass_diagnostics import ModelIRPassDiagnostics
 from onnx2tf.tflite_builder.ir import ModelIR
 
 
@@ -23,7 +24,9 @@ class ConversionSession:
     graph_index: GraphIndex = field(init=False)
     layout_state: LayoutState = field(init=False)
     model_ir_pass_context: ModelIRPassContext = field(init=False)
-    diagnostics: List[Dict[str, Any]] = field(default_factory=list)
+    diagnostics: List[Dict[str, Any]] = field(
+        default_factory=ModelIRPassDiagnostics
+    )
 
     def __post_init__(self) -> None:
         self.graph_index = GraphIndex(self.onnx_model)

--- a/onnx2tf/tflite_builder/lower_from_onnx2tf.py
+++ b/onnx2tf/tflite_builder/lower_from_onnx2tf.py
@@ -5466,38 +5466,86 @@ def lower_onnx_to_ir(
     # Keep this after the final shape reconciliation: earlier than this,
     # SiNet-specific residual branches are not yet in their terminal form and
     # the strict matcher can fire on upstream blocks instead.
-    _optimize_sinet_late_residual_pre_add_mul_add_prelu_chains(
-        model_ir,
-        layout_state=session.layout_state,
+    final_sinet_late_residual_stats = (
+        _optimize_sinet_late_residual_pre_add_mul_add_prelu_chains(
+            model_ir,
+            layout_state=session.layout_state,
+        )
     )
-    _reconcile_static_tensor_shapes(model_ir)
-    _optimize_sinet_deep_skip_pre_add_concat_prelu_fanout_chains(
-        model_ir,
-        layout_state=session.layout_state,
+    if int(
+        final_sinet_late_residual_stats.get(
+            "optimized_sinet_late_residual_pre_add_mul_add_prelu_chains",
+            0,
+        )
+    ) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
+    final_sinet_preadd_fanout_stats = (
+        _optimize_sinet_deep_skip_pre_add_concat_prelu_fanout_chains(
+            model_ir,
+            layout_state=session.layout_state,
+        )
     )
-    _reconcile_static_tensor_shapes(model_ir)
-    _optimize_sinet_deep_skip_dual_resize_affine_transpose_chains(
-        model_ir,
-        layout_state=session.layout_state,
+    if int(
+        final_sinet_preadd_fanout_stats.get(
+            "optimized_sinet_deep_skip_pre_add_concat_prelu_fanout_chains",
+            0,
+        )
+    ) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
+    final_sinet_dual_resize_stats = (
+        _optimize_sinet_deep_skip_dual_resize_affine_transpose_chains(
+            model_ir,
+            layout_state=session.layout_state,
+        )
     )
-    _reconcile_static_tensor_shapes(model_ir)
-    _optimize_sinet_shared_post_prelu_transpose_fanout_chains(
-        model_ir,
-        layout_state=session.layout_state,
+    if int(
+        final_sinet_dual_resize_stats.get(
+            "optimized_sinet_deep_skip_dual_resize_affine_transpose_chains",
+            0,
+        )
+    ) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
+    final_sinet_shared_post_stats = (
+        _optimize_sinet_shared_post_prelu_transpose_fanout_chains(
+            model_ir,
+            layout_state=session.layout_state,
+        )
     )
-    _reconcile_static_tensor_shapes(model_ir)
-    _optimize_sinet_deep_skip_concat_resize_affine_tail_chains(
-        model_ir,
-        layout_state=session.layout_state,
+    if int(
+        final_sinet_shared_post_stats.get(
+            "optimized_sinet_shared_post_prelu_transpose_fanout_chains",
+            0,
+        )
+    ) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
+    final_sinet_deep_skip_stats = (
+        _optimize_sinet_deep_skip_concat_resize_affine_tail_chains(
+            model_ir,
+            layout_state=session.layout_state,
+        )
     )
-    _reconcile_static_tensor_shapes(model_ir)
+    if int(
+        final_sinet_deep_skip_stats.get(
+            "optimized_sinet_deep_skip_concat_resize_affine_tail_chains",
+            0,
+        )
+    ) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
     # Keep this after all late SiNet residual/deep-skip folds: those passes can
     # still recreate the mid-stage concat+resize affine NHWC/NCHW bridge.
-    _optimize_sinet_concat_resize_affine_transpose_chains(
-        model_ir,
-        layout_state=session.layout_state,
+    final_sinet_concat_resize_stats = (
+        _optimize_sinet_concat_resize_affine_transpose_chains(
+            model_ir,
+            layout_state=session.layout_state,
+        )
     )
-    _reconcile_static_tensor_shapes(model_ir)
+    if int(
+        final_sinet_concat_resize_stats.get(
+            "optimized_sinet_concat_resize_affine_transpose_chains",
+            0,
+        )
+    ) > 0:
+        _reconcile_static_tensor_shapes(model_ir)
     final_high_rank_bmm_stats = _compress_static_high_rank_batch_matmul(
         model_ir,
         layout_state=session.layout_state,

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-import pytest
-
 from onnx2tf.tflite_builder._pytorch_exporter_native_codegen_pipeline import (
     _NATIVE_CODEGEN_FUNCTION_SOURCE,
 )
@@ -6309,10 +6307,6 @@ def test_indexed_sinet_concat_resize_owner_is_bounded_and_transactional() -> Non
         assert layout_keyword.value.attr == "layout_state"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="absolute-final SINet passes reconcile shapes even when their counters are zero",
-)
 def test_absolute_final_sinet_reconciles_only_after_changed_passes() -> None:
     lowerer_path = (
         REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"

--- a/tests/test_flatbuffer_direct_architecture.py
+++ b/tests/test_flatbuffer_direct_architecture.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 from onnx2tf.tflite_builder._pytorch_exporter_native_codegen_pipeline import (
     _NATIVE_CODEGEN_FUNCTION_SOURCE,
 )
@@ -6305,6 +6307,74 @@ def test_indexed_sinet_concat_resize_owner_is_bounded_and_transactional() -> Non
         )
         assert isinstance(layout_keyword.value, ast.Attribute)
         assert layout_keyword.value.attr == "layout_state"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="absolute-final SINet passes reconcile shapes even when their counters are zero",
+)
+def test_absolute_final_sinet_reconciles_only_after_changed_passes() -> None:
+    lowerer_path = (
+        REPO_ROOT / "onnx2tf" / "tflite_builder" / "lower_from_onnx2tf.py"
+    )
+    lowerer_tree = ast.parse(lowerer_path.read_text(encoding="utf-8"))
+    lowerer = next(
+        node
+        for node in lowerer_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "lower_onnx_to_ir"
+    )
+    expected_stats = {
+        "_optimize_sinet_late_residual_pre_add_mul_add_prelu_chains": (
+            "optimized_sinet_late_residual_pre_add_mul_add_prelu_chains"
+        ),
+        "_optimize_sinet_deep_skip_pre_add_concat_prelu_fanout_chains": (
+            "optimized_sinet_deep_skip_pre_add_concat_prelu_fanout_chains"
+        ),
+        "_optimize_sinet_deep_skip_dual_resize_affine_transpose_chains": (
+            "optimized_sinet_deep_skip_dual_resize_affine_transpose_chains"
+        ),
+        "_optimize_sinet_shared_post_prelu_transpose_fanout_chains": (
+            "optimized_sinet_shared_post_prelu_transpose_fanout_chains"
+        ),
+        "_optimize_sinet_deep_skip_concat_resize_affine_tail_chains": (
+            "optimized_sinet_deep_skip_concat_resize_affine_tail_chains"
+        ),
+        "_optimize_sinet_concat_resize_affine_transpose_chains": (
+            "optimized_sinet_concat_resize_affine_transpose_chains"
+        ),
+    }
+
+    for pass_name, stats_key in expected_stats.items():
+        assignment_index = next(
+            index
+            for index, statement in enumerate(lowerer.body)
+            if isinstance(statement, ast.Assign)
+            and isinstance(statement.value, ast.Call)
+            and isinstance(statement.value.func, ast.Name)
+            and statement.value.func.id == pass_name
+        )
+        guard = lowerer.body[assignment_index + 1]
+        assert isinstance(guard, ast.If)
+        assert guard.orelse == []
+        get_calls = [
+            node
+            for node in ast.walk(guard.test)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "get"
+        ]
+        assert len(get_calls) == 1
+        assert isinstance(get_calls[0].args[0], ast.Constant)
+        assert get_calls[0].args[0].value == stats_key
+        assert len(guard.body) == 1
+        reconcile = guard.body[0]
+        assert isinstance(reconcile, ast.Expr)
+        assert isinstance(reconcile.value, ast.Call)
+        assert isinstance(reconcile.value.func, ast.Name)
+        assert reconcile.value.func.id == "_reconcile_static_tensor_shapes"
+        assert len(reconcile.value.args) == 1
+        assert isinstance(reconcile.value.args[0], ast.Name)
+        assert reconcile.value.args[0].id == "model_ir"
 
 
 def test_indexed_sinet_tail_concat_owner_reuses_indexed_branch_contracts() -> None:

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -1302,6 +1302,62 @@ def test_pass_diagnostic_ledger_rebuilds_after_destructive_list_mutations() -> N
     assert diagnostics.model_ir_numbering_snapshot() == (0, None, {})
 
 
+def test_final_sinet_counters_gate_shape_reconciliation(monkeypatch) -> None:
+    pass_counters = {
+        "_optimize_sinet_late_residual_pre_add_mul_add_prelu_chains": (
+            "optimized_sinet_late_residual_pre_add_mul_add_prelu_chains"
+        ),
+        "_optimize_sinet_deep_skip_pre_add_concat_prelu_fanout_chains": (
+            "optimized_sinet_deep_skip_pre_add_concat_prelu_fanout_chains"
+        ),
+        "_optimize_sinet_deep_skip_dual_resize_affine_transpose_chains": (
+            "optimized_sinet_deep_skip_dual_resize_affine_transpose_chains"
+        ),
+        "_optimize_sinet_shared_post_prelu_transpose_fanout_chains": (
+            "optimized_sinet_shared_post_prelu_transpose_fanout_chains"
+        ),
+        "_optimize_sinet_deep_skip_concat_resize_affine_tail_chains": (
+            "optimized_sinet_deep_skip_concat_resize_affine_tail_chains"
+        ),
+        "_optimize_sinet_concat_resize_affine_transpose_chains": (
+            "optimized_sinet_concat_resize_affine_transpose_chains"
+        ),
+    }
+    original_reconcile = lowering_module._reconcile_static_tensor_shapes
+    reconcile_count = 0
+
+    def counted_reconcile(*args, **kwargs):
+        nonlocal reconcile_count
+        reconcile_count += 1
+        return original_reconcile(*args, **kwargs)
+
+    monkeypatch.setattr(
+        lowering_module,
+        "_reconcile_static_tensor_shapes",
+        counted_reconcile,
+    )
+
+    def run_with_changed_pass(changed_pass: str | None) -> int:
+        nonlocal reconcile_count
+        for pass_name, counter_name in pass_counters.items():
+            changed = pass_name == changed_pass
+
+            def pass_result(*args, _counter=counter_name, _changed=changed, **kwargs):
+                return {_counter: int(_changed)}
+
+            monkeypatch.setattr(lowering_module, pass_name, pass_result)
+        reconcile_count = 0
+        lower_onnx_to_ir(
+            _add_onnx_model(),
+            output_file_name=f"sinet_reconcile_{changed_pass or 'none'}",
+        )
+        return reconcile_count
+
+    unchanged_count = run_with_changed_pass(None)
+    for pass_name in pass_counters:
+        assert run_with_changed_pass(pass_name) == unchanged_count + 1
+
+
 def test_dispatcher_records_onnx_provenance() -> None:
     class _Entry:
         @staticmethod

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -1109,10 +1109,6 @@ def test_model_ir_pass_diagnostics_preserve_existing_numbering_contract() -> Non
     ) == (4, 1, 8)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="diagnostic numbering currently rescans the full history per pass event",
-)
 def test_model_ir_pass_diagnostic_numbering_scans_existing_history_once() -> None:
     class CountingDiagnostics(list):
         def __init__(self, values) -> None:

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -1143,6 +1143,57 @@ def test_model_ir_pass_diagnostic_numbering_scans_existing_history_once() -> Non
     assert diagnostics.iteration_count == 1
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason="ConversionSession diagnostics do not retain numbering state across groups",
+)
+def test_conversion_session_reuses_pass_diagnostic_ledger_across_groups(
+    monkeypatch,
+) -> None:
+    session = ConversionSession(
+        onnx_model=_add_onnx_model(),
+        model_ir=_add_model_ir(),
+        shape_map={},
+        dtype_map={},
+        constants={},
+    )
+    diagnostics = session.diagnostics
+    ledger_type = type(diagnostics)
+    original_rebuild = getattr(ledger_type, "_rebuild_model_ir_numbering")
+    rebuild_count = 0
+
+    def counted_rebuild(ledger) -> None:
+        nonlocal rebuild_count
+        rebuild_count += 1
+        original_rebuild(ledger)
+
+    monkeypatch.setattr(
+        ledger_type,
+        "_rebuild_model_ir_numbering",
+        counted_rebuild,
+    )
+    diagnostics[:] = [
+        {
+            "stage": "model_ir_pass",
+            "code": "cleanup.repeated",
+            "group_sequence": 4,
+        }
+    ]
+    spec = PassSpec(
+        pass_id="cleanup.repeated",
+        phase=PassPhase.POST_LOWERING_CLEANUP,
+        callback=lambda state: {"changed": False},
+    )
+
+    run_model_ir_pass_group(session.model_ir, specs=[spec], diagnostics=diagnostics)
+    run_model_ir_pass_group(session.model_ir, specs=[spec], diagnostics=diagnostics)
+
+    assert rebuild_count == 1
+    assert [event["sequence"] for event in diagnostics[1:]] == [2, 3]
+    assert [event["invocation"] for event in diagnostics[1:]] == [2, 3]
+    assert [event["group_sequence"] for event in diagnostics[1:]] == [5, 6]
+
+
 def test_dispatcher_records_onnx_provenance() -> None:
     class _Entry:
         @staticmethod

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -26,6 +26,7 @@ from onnx2tf.tflite_builder.core import (
     summarize_model_ir_pass_diagnostics,
     validate_model_ir_invariants,
 )
+from onnx2tf.tflite_builder.core.pass_diagnostics import ModelIRPassDiagnostics
 from onnx2tf.tflite_builder.ir import ModelIR, OperatorIR, TensorIR
 from onnx2tf.tflite_builder.dispatcher import dispatch_node
 from onnx2tf.tflite_builder.lower_from_onnx2tf import lower_onnx_to_ir
@@ -1143,10 +1144,6 @@ def test_model_ir_pass_diagnostic_numbering_scans_existing_history_once() -> Non
     assert diagnostics.iteration_count == 1
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="ConversionSession diagnostics do not retain numbering state across groups",
-)
 def test_conversion_session_reuses_pass_diagnostic_ledger_across_groups(
     monkeypatch,
 ) -> None:
@@ -1192,6 +1189,117 @@ def test_conversion_session_reuses_pass_diagnostic_ledger_across_groups(
     assert [event["sequence"] for event in diagnostics[1:]] == [2, 3]
     assert [event["invocation"] for event in diagnostics[1:]] == [2, 3]
     assert [event["group_sequence"] for event in diagnostics[1:]] == [5, 6]
+
+
+def test_conversion_session_append_only_diagnostics_need_no_ledger_rebuild(
+    monkeypatch,
+) -> None:
+    session = ConversionSession(
+        onnx_model=_add_onnx_model(),
+        model_ir=_add_model_ir(),
+        shape_map={},
+        dtype_map={},
+        constants={},
+    )
+    rebuild_count = 0
+    original_rebuild = ModelIRPassDiagnostics._rebuild_model_ir_numbering
+
+    def counted_rebuild(ledger) -> None:
+        nonlocal rebuild_count
+        rebuild_count += 1
+        original_rebuild(ledger)
+
+    monkeypatch.setattr(
+        ModelIRPassDiagnostics,
+        "_rebuild_model_ir_numbering",
+        counted_rebuild,
+    )
+    session.record_diagnostic(stage="lowering", code="note", message="kept")
+    spec = PassSpec(
+        pass_id="cleanup.repeated",
+        phase=PassPhase.POST_LOWERING_CLEANUP,
+        callback=lambda state: {"changed": False},
+    )
+
+    run_model_ir_pass_group(
+        session.model_ir,
+        specs=[spec],
+        diagnostics=session.diagnostics,
+    )
+    run_model_ir_pass_group(
+        session.model_ir,
+        specs=[spec],
+        diagnostics=session.diagnostics,
+    )
+
+    assert rebuild_count == 0
+    assert [event["sequence"] for event in session.diagnostics[1:]] == [1, 2]
+    assert [event["invocation"] for event in session.diagnostics[1:]] == [1, 2]
+    assert [event["group_sequence"] for event in session.diagnostics[1:]] == [1, 2]
+
+
+def test_pass_diagnostic_ledger_tracks_append_only_list_mutations() -> None:
+    diagnostics = ModelIRPassDiagnostics()
+    diagnostics.append({"stage": "lowering", "code": "ignored"})
+    diagnostics.extend(
+        [
+            {
+                "stage": "model_ir_pass",
+                "code": "cleanup.first",
+                "group_sequence": -2,
+            },
+            {
+                "stage": "model_ir_pass",
+                "code": "cleanup.first",
+                "group_sequence": 3,
+            },
+        ]
+    )
+    diagnostics.insert(
+        0,
+        {
+            "stage": "model_ir_pass",
+            "code": "cleanup.second",
+            "group_sequence": 2,
+        },
+    )
+
+    assert diagnostics.model_ir_numbering_snapshot() == (
+        3,
+        3,
+        {"cleanup.first": 2, "cleanup.second": 1},
+    )
+
+
+def test_pass_diagnostic_ledger_rebuilds_after_destructive_list_mutations() -> None:
+    diagnostics = ModelIRPassDiagnostics(
+        [
+            {
+                "stage": "model_ir_pass",
+                "code": "cleanup.first",
+                "group_sequence": 8,
+            },
+            {
+                "stage": "model_ir_pass",
+                "code": "cleanup.second",
+                "group_sequence": 5,
+            },
+        ]
+    )
+    diagnostics.pop(0)
+    diagnostics[0] = {
+        "stage": "model_ir_pass",
+        "code": "cleanup.replaced",
+        "group_sequence": -4,
+    }
+
+    assert diagnostics.model_ir_numbering_snapshot() == (
+        1,
+        -4,
+        {"cleanup.replaced": 1},
+    )
+    diagnostics.clear()
+    assert diagnostics.model_ir_numbering_snapshot() == (0, None, {})
 
 
 def test_dispatcher_records_onnx_provenance() -> None:

--- a/tests/test_flatbuffer_direct_core.py
+++ b/tests/test_flatbuffer_direct_core.py
@@ -1066,6 +1066,87 @@ def test_model_ir_pass_diagnostics_number_repeated_invocations() -> None:
     }
 
 
+def test_model_ir_pass_diagnostics_preserve_existing_numbering_contract() -> None:
+    model_ir = _add_model_ir()
+    diagnostics = [
+        {"stage": "lowering", "code": "unrelated"},
+        {
+            "stage": "model_ir_pass",
+            "code": "cleanup.first",
+            "group_sequence": 4,
+        },
+        {
+            "stage": "model_ir_pass",
+            "code": "cleanup.other",
+            "group_sequence": 7,
+        },
+    ]
+    specs = [
+        PassSpec(
+            pass_id="cleanup.first",
+            phase=PassPhase.POST_LOWERING_CLEANUP,
+            callback=lambda state: {"changed": False},
+        ),
+        PassSpec(
+            pass_id="cleanup.second",
+            phase=PassPhase.POST_LOWERING_CLEANUP,
+            callback=lambda state: {"changed": False},
+        ),
+    ]
+
+    run_model_ir_pass_group(model_ir, specs=specs, diagnostics=diagnostics)
+
+    first, second = diagnostics[-2:]
+    assert (first["sequence"], first["invocation"], first["group_sequence"]) == (
+        3,
+        2,
+        8,
+    )
+    assert (
+        second["sequence"],
+        second["invocation"],
+        second["group_sequence"],
+    ) == (4, 1, 8)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="diagnostic numbering currently rescans the full history per pass event",
+)
+def test_model_ir_pass_diagnostic_numbering_scans_existing_history_once() -> None:
+    class CountingDiagnostics(list):
+        def __init__(self, values) -> None:
+            super().__init__(values)
+            self.iteration_count = 0
+
+        def __iter__(self):
+            self.iteration_count += 1
+            return super().__iter__()
+
+    model_ir = _add_model_ir()
+    diagnostics = CountingDiagnostics(
+        [
+            {
+                "stage": "model_ir_pass",
+                "code": "cleanup.first",
+                "group_sequence": 5,
+            }
+        ]
+    )
+    specs = [
+        PassSpec(
+            pass_id=pass_id,
+            phase=PassPhase.POST_LOWERING_CLEANUP,
+            callback=lambda state: {"changed": False},
+        )
+        for pass_id in ["cleanup.first", "cleanup.second", "cleanup.third"]
+    ]
+
+    run_model_ir_pass_group(model_ir, specs=specs, diagnostics=diagnostics)
+
+    assert diagnostics.iteration_count == 1
+
+
 def test_dispatcher_records_onnx_provenance() -> None:
     class _Entry:
         @staticmethod


### PR DESCRIPTION
## Summary

This pull request improves two internal hot paths in the TensorFlow-independent `flatbuffer_direct` conversion pipeline while preserving the existing public contract and transformation order:

1. it removes repeated full-history scans from ModelIR pass diagnostic numbering; and
2. it avoids six unconditional full ModelIR shape-reconciliation scans when none of the terminal SINet optimization owners changed the graph.

The work was developed as six small characterization/implementation commits so that the externally visible behavior was frozen before each production optimization.

## Diagnostic numbering improvements

### Previous behavior

`run_model_ir_pass_group()` scanned the existing diagnostics list to determine the next group number, then rescanned the complete and growing history for every emitted pass result to derive the global sequence number and per-pass invocation number. Even after removing the per-event rescans, a normal diagnostics list still required one complete scan at the beginning of every pass group.

That produced avoidable quadratic bookkeeping cost over conversions with many pass events and many small pass groups.

### New behavior

- A single initialization scan now derives all three numbering values together:
  - the total number of existing ModelIR-pass events;
  - the maximum existing group sequence; and
  - per-pass invocation counts.
- Event recording updates local counters instead of rescanning diagnostic history.
- `ConversionSession.diagnostics` now uses a private, list-compatible `ModelIRPassDiagnostics` ledger.
- The Session-owned append-only production path reuses a copied numbering snapshot in constant time across pass groups.
- Arbitrary caller-owned lists retain the safe one-scan fallback.
- List compatibility is preserved:
  - append, extend, and insert update a valid ledger incrementally;
  - replacement, deletion, multiplication, pop, and remove invalidate it;
  - the next numbering read rebuilds the state exactly once;
  - clear restores a valid empty ledger.
- Malformed externally appended records invalidate the cached state instead of changing existing error timing.
- The new ledger remains private and is not exported through the public core API.

The existing semantics for unrelated diagnostics, missing or negative legacy group values, repeated pass IDs, skipped passes, cycle stops, and invariant failures are all retained.

## Terminal SINet reconciliation improvements

The final lowerer sequence contains six bounded and transactional SINet optimization owners. Each owner already reports an exact mutation counter, but the lowerer previously called `_reconcile_static_tensor_shapes()` unconditionally after every owner. Models that matched none of these specialized patterns therefore paid for six unnecessary full operator/tensor reconciliation scans.

This change:

- keeps every owner call in exactly the same terminal position and order;
- passes the same Session `LayoutState`;
- captures each owner's existing result;
- invokes the immediately following shape reconciliation only when that owner's exact mutation counter is positive; and
- does not merge, skip, reorder, or generalize any SINet optimization.

A synthetic lowerer contract verifies that the all-zero path establishes the baseline reconciliation count and that enabling any one of the six counters adds exactly one reconciliation. The complete owner suites continue to cover positive, no-op, and idempotent behavior.

## Compatibility and safety

This pull request does not change:

- the CLI or Python public API;
- default backend selection or command-line defaults;
- artifact names, formats, or return values;
- ModelIR transformation ordering;
- pass IDs or diagnostic schema;
- GraphIndex or LayoutState behavior;
- quantization, splitting, exporters, or report generation;
- project dependencies;
- corpus exclusions or operation-count tier definitions;
- sequential inference policy; or
- the TensorFlow import boundary for normal `flatbuffer_direct` conversion.

The optimization is internal bookkeeping and scan elimination only. No TensorFlow dependency was introduced.

## Validation

All tests were executed sequentially in the existing `uv` environment.

- Complete diagnostic/core/pass-efficiency/architecture/TensorFlow-import-blocked gate after the diagnostic ledger implementation:
  - **328 passed in 26.75s**
- Six complete SINet owner suites plus core, pass-efficiency, architecture, and TensorFlow-import-blocked optional-boundary tests after the final reconciliation optimization:
  - **844 passed in 29.04s**
- Focused diagnostic numbering, cross-group ledger invalidation/rebuild, and reconciliation counter-wiring tests:
  - passed
- Ruff on the modified tests:
  - passed
- Ruff on the lowerer with its two pre-existing F401 findings excluded:
  - passed
- Python compilation of the modified Python modules:
  - passed
- Git whitespace validation:
  - passed

No real-model inference conversion was run for these two units because the diagnostic change cannot affect ModelIR or artifacts, while the reconciliation change is covered by 514 positive/no-op owner fixtures, the synthetic lowerer maintenance-wiring contract, and the full 844-test sequential gate.

## Documentation

The architecture document records the frozen diagnostic-numbering semantics, the private ledger behavior, and the terminal SINet counter guards. A branch handoff document records the completed checkpoints, validation evidence, non-goals, and the next safe investigation boundary.
