### PR TITLE
Fix depthwise Conv detection after NCHW->NHWC input transpose (Legacy converter)

### DIFF
--- a/onnx2tf/ops/Conv.py
+++ b/onnx2tf/ops/Conv.py
@@ -280,6 +280,10 @@ def make_node(
         print(error_msg)
         assert False, error_msg
 
+    # Refresh after the NCHW->NHWC workaround above: the depthwise test below reads
+    # input_tensor_shape[-1], so a stale shape turns depthwise convs into grouped convs.
+    input_tensor_shape = input_tensor.shape
+
     # DepthwiseConv2D
     #   1. rank=4
     #   2. group>1


### PR DESCRIPTION
## Issue

`Conv.make_node()` reads `input_tensor_shape` before the workaround that transposes
an NCHW input to NHWC, and never refreshes it.

The depthwise test compares `group` against `input_tensor_shape[-1]`. For a transposed
input this compares the channel count against a spatial dimension, the test fails, and
the node falls through to the grouped-conv path — producing a filter of shape
`[C, K, K, 1]` instead of a `DepthwiseConv2D`.

Symptom: in a MobileNet/ConvNeXt-style network only the *first* depthwise conv of each
stage converts correctly (it consumes a conv output directly), while the following ones
are silently degraded (they consume a residual `Add` whose input required the transpose).

The ONNX model is valid — depthwise is `Conv` with `group=C` and weight `[C, 1, K, K]`.

## Fix

Refresh `input_tensor_shape` from `input_tensor` right before the depthwise test.